### PR TITLE
fix(api): register missing HTTP verbs on several ES-compat endpoints

### DIFF
--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -276,9 +276,9 @@ pub fn build_es_compat_router(state: AppState) -> Router {
             "/_count",
             get(es_compat::count_docs_global).post(es_compat::count_docs_global),
         )
-        .route("/:index/_refresh", post(es_compat::refresh_index))
-        .route("/:index/_analyze", post(es_compat::analyze_text))
-        .route("/_analyze", post(es_compat::analyze_text_global))
+        .route("/:index/_refresh", post(es_compat::refresh_index).get(es_compat::refresh_index))
+        .route("/:index/_analyze", post(es_compat::analyze_text).get(es_compat::analyze_text))
+        .route("/_analyze", post(es_compat::analyze_text_global).get(es_compat::analyze_text_global))
         // ── Document operations ────────────────────────────────────────────
         .route("/:index/_doc", post(es_compat::index_doc_auto))
         // POST with an explicit id is the same index op as PUT (auto-create
@@ -342,7 +342,7 @@ pub fn build_es_compat_router(state: AppState) -> Router {
             get(es_compat::field_caps).post(es_compat::field_caps),
         )
         // ── Multi-search ───────────────────────────────────────────────────
-        .route("/_msearch", post(es_compat::msearch))
+        .route("/_msearch", post(es_compat::msearch).get(es_compat::msearch))
         // Index-scoped multi-search — the path index defaults header lines
         // that omit `index`.
         .route(
@@ -483,9 +483,9 @@ pub fn build_es_compat_router(state: AppState) -> Router {
         .route("/_nodes", get(es_compat::nodes_info))
         .route("/_nodes/:node_id/stats", get(es_compat::node_stats_by_id))
         // ── Index clone / shrink / split ────────────────────────────────────
-        .route("/:index/_clone/:target", post(es_compat::clone_index))
-        .route("/:index/_shrink/:target", post(es_compat::shrink_index))
-        .route("/:index/_split/:target", post(es_compat::split_index))
+        .route("/:index/_clone/:target", post(es_compat::clone_index).put(es_compat::clone_index))
+        .route("/:index/_shrink/:target", post(es_compat::shrink_index).put(es_compat::shrink_index))
+        .route("/:index/_split/:target", post(es_compat::split_index).put(es_compat::split_index))
         // ── Enrich Policies ─────────────────────────────────────────────────
         .route(
             "/_enrich/policy/:name",


### PR DESCRIPTION
Several ES-compat endpoints only register one HTTP verb where real Elasticsearch accepts more than one, causing 405s for clients that use the other verb:

- `_refresh`, `_analyze` (index-scoped + global), `_msearch`: only POST, real ES also accepts GET
- `_clone`, `_shrink`, `_split` (the resize-index family): only POST, real ES also accepts PUT

**Concrete impact**: this blocks Kibana's saved-object migration, which issues `PUT .../_clone/...` during startup and gets a 405 today — a fatal migration error before Kibana renders anything. Repro'd against a local Kibana 8.13 instance.

**Fix**: chain the missing verb onto the existing `MethodRouter` for each affected route in `build_es_compat_router` (`router.rs`). No behavior change for the already-working verb; purely additive.

Tested: `cargo build --release -p xerj-api` clean, verified via curl that `PUT .../_clone/...` now returns 200 instead of 405.