### PR TITLE
fix(api): /_xpack reports real auth state instead of hardcoded true

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -21409,7 +21409,7 @@ pub async fn xpack_info(State(state): State<AppState>) -> impl IntoResponse {
         "features": {
             "security": {
                 "available": true,
-                "enabled": true,
+                "enabled": state.config.auth.enabled,
                 "ssl": { "http": { "enabled": false }, "transport": { "enabled": false } }
             },
             "monitoring": { "available": true, "enabled": true },
@@ -21486,7 +21486,7 @@ pub async fn xpack_usage(State(state): State<AppState>) -> impl IntoResponse {
     Json(json!({
         "security": {
             "available": true,
-            "enabled": true,
+            "enabled": state.config.auth.enabled,
             "audit": { "enabled": false },
             "ip_filtering": { "pki": { "enabled": false } },
             "roles": { "native": { "size": 0, "dls": false, "fls": false }, "file": { "size": 0, "dls": false, "fls": false } },


### PR DESCRIPTION
`GET /_xpack` and `GET /_xpack/usage` hardcode `features.security.enabled = true`, regardless of how the server was actually started — including under `--insecure`.

**Why this matters**: Kibana decides whether to show its login screen based on this flag, not on `_security/_authenticate`. So with `--insecure` (auth genuinely disabled), Kibana still always renders the login form — and worse, login itself then fails with a 500 on user-profile activation, since XERJ is telling Kibana security is on while behaving as if it's off.

**Fix**: both endpoints now read `state.config.auth.enabled` instead of a hardcoded `true`.

**Verified**: with this change and `--insecure`, Kibana 8.13 skips the login screen entirely and lands directly on the app — confirmed against a local Kibana instance.