### PR TITLE
fix(api): field_caps resolves real glob wildcards, not just bare */_all

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -15059,7 +15059,11 @@ pub async fn field_caps(
     Query(params): Query<FieldCapsParams>,
     _body: Option<Json<Value>>,
 ) -> impl IntoResponse {
-    // Support "*" as a wildcard for all indices.
+    // Support "*" as a wildcard for all indices, plus real glob patterns
+    // (e.g. "wiki-test*") via the same resolver used by bulk/aliases/etc —
+    // the old inline logic only special-cased bare "*"/"_all" and treated
+    // any other wildcard as a literal (non-existent) index/alias name,
+    // silently returning empty field caps for wildcarded index patterns.
     let resolved_indices: Vec<String> = if index == "*" || index == "_all" {
         state
             .engine
@@ -15069,10 +15073,7 @@ pub async fn field_caps(
             .map(|i| i.name)
             .collect()
     } else {
-        index
-            .split(',')
-            .flat_map(|n| state.engine.resolve_alias(n.trim()))
-            .collect()
+        resolve_index_selector(&state, &index).await
     };
 
     let fields_filter = params.fields.as_deref().unwrap_or("*");


### PR DESCRIPTION
`field_caps` had its own inline index-resolution logic that only special-cased the literal wildcards `*` and `_all` (all indices). Any other wildcard pattern (e.g. `wiki-test*`) fell through to `resolve_alias(n.trim())`, which looks up an exact alias name — so a real glob pattern was treated as a literal, nonexistent index/alias name and silently returned empty field caps.

**Why this matters**: this is the root cause of Kibana's (and likely OpenSearch Dashboards') index pattern / data view creation failing with wildcarded patterns — the UI's field-discovery call against a pattern like `wiki-test*` comes back with `"fields": {}` even though the underlying indices exist and match.

**Repro** (clean A/B):
```
GET /wiki-test/_field_caps   -> all fields returned correctly
GET /wiki-test*/_field_caps  -> "indices": ["wiki-test*"] (literally unresolved), "fields": {}
```

**Fix**: delegate to `resolve_index_selector()`, the same glob-aware resolver (via `glob_match_simple`) already used by bulk/aliases/delete-by-query elsewhere in this file — no new logic, just reusing what already works correctly there.

Tested: `cargo build --release -p xerj-api` clean, verified via curl that wildcarded `_field_caps` now returns real fields instead of an empty object.