### PR TITLE
fix(index): keep semantic vectors out of full-text indexes

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1984,13 +1984,19 @@ impl Index {
             let analyzer = mem
                 .default_analyzer()
                 .expect("standard analyzer always present");
+            let excluded_fts_fields = crate::memtable::semantic_derived_vector_fields(schema);
             let p_t = std::time::Instant::now();
             let analyzed: Vec<Vec<(String, Vec<xerj_fts::analyzer::Token>)>> = crate::ingest_pool()
                 .install(|| {
                     sources
                         .par_iter()
                         .map(|source| {
-                            crate::memtable::analyze_doc(source.as_ref(), schema, &analyzer)
+                            crate::memtable::analyze_doc_excluding(
+                                source.as_ref(),
+                                schema,
+                                &analyzer,
+                                &excluded_fts_fields,
+                            )
                         })
                         .collect()
                 });
@@ -2251,6 +2257,9 @@ impl Index {
         let registry = Arc::clone(&self.registry);
         let data_dir = self.data_dir.clone();
         let field_configs = self.flush_signal.field_configs(&self.schema);
+        let excluded_fts_fields = self
+            .flush_signal
+            .semantic_derived_vector_fields(&self.schema);
         let dataset_version = Arc::clone(&self.dataset_version);
         let query_cache = Arc::clone(&self.query_cache);
         let warm_caches = self.publish_warm_caches();
@@ -2278,6 +2287,7 @@ impl Index {
                 registry,
                 data_dir,
                 field_configs,
+                excluded_fts_fields,
                 on_drained,
                 warm_caches,
             )
@@ -2499,9 +2509,12 @@ impl Index {
         // memtable, writes the segment file + FTS index, swaps the snapshot,
         // and checkpoints the WAL.  The drained memtable is dropped, freeing
         // all RAM.
-        let field_configs = {
+        let (field_configs, excluded_fts_fields) = {
             let schema = self.schema.read().await;
-            build_fts_field_configs(&schema.schema)
+            (
+                build_fts_field_configs(&schema.schema),
+                crate::memtable::semantic_derived_vector_fields(&schema.schema),
+            )
         };
         // Explicit refresh: wait behind any in-flight concurrent flushes
         // (semaphore has 4 permits) so the user-visible flush sees a
@@ -2522,6 +2535,7 @@ impl Index {
                 Arc::clone(&self.registry),
                 self.data_dir.clone(),
                 field_configs.clone(),
+                excluded_fts_fields.clone(),
                 || {}, // serial refresh path — no permit to drop early
                 self.publish_warm_caches(),
             )
@@ -2627,6 +2641,10 @@ impl Index {
                 let _ = field_configs_once.set(cfg.clone());
                 cfg
             };
+            let excluded_fts_fields = {
+                let schema = self.schema.read().await;
+                crate::memtable::semantic_derived_vector_fields(&schema.schema)
+            };
 
             let flush_signal_cb = Arc::clone(&self.flush_signal);
             tokio::spawn(async move {
@@ -2649,6 +2667,7 @@ impl Index {
                     registry,
                     data_dir,
                     field_configs,
+                    excluded_fts_fields,
                     on_drained,
                     warm_caches,
                 )
@@ -2853,9 +2872,12 @@ impl Index {
         // Resolve per-field analyzer configs once for FTS rebuild.  See
         // `build_fts_field_configs` — keyword/numeric fields must use the
         // `keyword` analyzer or the FST drops their values to stop-words.
-        let field_configs = {
+        let (field_configs, excluded_fts_fields) = {
             let schema = self.schema.read().await;
-            build_fts_field_configs(&schema.schema)
+            (
+                build_fts_field_configs(&schema.schema),
+                crate::memtable::semantic_derived_vector_fields(&schema.schema),
+            )
         };
         // Kept for the legacy "if !text_fields.is_empty()" branch — empty
         // here because the merge path now indexes ALL source fields, not
@@ -2955,6 +2977,7 @@ impl Index {
             let store_for_task = Arc::clone(&self.store);
             let registry_for_task = Arc::clone(&self.registry);
             let field_configs_for_task = field_configs.clone();
+            let excluded_fts_fields_for_task = excluded_fts_fields.clone();
             let segments_dir_for_task = segments_dir.clone();
             let batch_for_task = batch;
             let metas_for_task = metas;
@@ -3271,15 +3294,8 @@ impl Index {
                             Err(_) => continue,
                         };
                         let source = doc_value.get("_source").cloned().unwrap_or(Value::Null);
-                        let mut fields: HashMap<String, String> = HashMap::new();
-                        if let Some(obj) = source.as_object() {
-                            for (key, val) in obj {
-                                let text = extract_field_text(val);
-                                if !text.is_empty() {
-                                    fields.insert(key.clone(), text);
-                                }
-                            }
-                        }
+                        let fields =
+                            extract_fts_fields_excluding(&source, &excluded_fts_fields_for_task);
                         fts_input.push((id_str, fields, source));
                     }
 
@@ -9803,9 +9819,12 @@ impl Index {
 
     /// Flush the memtable to a new segment on disk, then build the FTS index.
     pub async fn flush(&self) -> Result<()> {
-        let field_configs = {
+        let (field_configs, excluded_fts_fields) = {
             let schema = self.schema.read().await;
-            build_fts_field_configs(&schema.schema)
+            (
+                build_fts_field_configs(&schema.schema),
+                crate::memtable::semantic_derived_vector_fields(&schema.schema),
+            )
         };
         // M5.15 — PARALLEL final flush.
         //
@@ -9830,6 +9849,7 @@ impl Index {
             let registry = Arc::clone(&self.registry);
             let data_dir = self.data_dir.clone();
             let field_configs = field_configs.clone();
+            let excluded_fts_fields = excluded_fts_fields.clone();
             let warm_caches = self.publish_warm_caches();
             shard_futures.push(tokio::spawn(async move {
                 let permit = sema.acquire_owned().await.ok();
@@ -9847,6 +9867,7 @@ impl Index {
                     registry,
                     data_dir,
                     field_configs,
+                    excluded_fts_fields,
                     on_drained,
                     warm_caches,
                 )
@@ -10537,7 +10558,11 @@ fn read_doc_values_sidecar(
 fn build_fts_field_configs(schema: &Schema) -> HashMap<String, xerj_fts::index::FieldIndexConfig> {
     use xerj_fts::index::FieldIndexConfig;
     let mut out = HashMap::new();
+    let excluded = crate::memtable::semantic_derived_vector_fields(schema);
     for f in &schema.fields {
+        if excluded.contains(&f.name) {
+            continue;
+        }
         let analyzer = match f.field_type {
             FieldType::Text => "standard",
             // Everything else is exact-match.  We use the registered
@@ -10574,6 +10599,25 @@ fn extract_field_text(val: &Value) -> String {
         Value::Object(_) => serde_json::to_string(val).unwrap_or_default(),
         Value::Null => String::new(),
     }
+}
+
+fn extract_fts_fields_excluding(
+    source: &Value,
+    excluded: &std::collections::HashSet<String>,
+) -> HashMap<String, String> {
+    let mut fields = HashMap::new();
+    if let Some(obj) = source.as_object() {
+        for (key, val) in obj {
+            if excluded.contains(key) {
+                continue;
+            }
+            let text = extract_field_text(val);
+            if !text.is_empty() {
+                fields.insert(key.clone(), text);
+            }
+        }
+    }
+    fields
 }
 
 // ── Short-circuit count helper ───────────────────────────────────────────────
@@ -14879,6 +14923,7 @@ async fn do_flush_shard(
     registry: Arc<AnalyzerRegistry>,
     data_dir: PathBuf,
     field_configs: HashMap<String, xerj_fts::index::FieldIndexConfig>,
+    excluded_fts_fields: std::collections::HashSet<String>,
     on_drained: impl FnOnce() + Send + 'static,
     // Publish-time cache warm (see `warm_segment_at_publish`): the index's
     // read-path caches, threaded through because this is a free fn without
@@ -14983,7 +15028,10 @@ async fn do_flush_shard(
                         } else {
                             std::sync::Arc::new(serde_json::Value::Null)
                         };
-                        let fields = crate::memtable::extract_text_fields_from(&val);
+                        let fields = crate::memtable::extract_text_fields_from_excluding(
+                            &val,
+                            &excluded_fts_fields,
+                        );
                         (doc_id.clone(), fields, val)
                     })
                     .collect()
@@ -15268,6 +15316,19 @@ impl SyncFlushCoord {
         });
         *self.field_configs_cache.write() = Some(cfg.clone());
         cfg
+    }
+
+    fn semantic_derived_vector_fields(
+        &self,
+        schema: &Arc<RwLock<ManagedSchema>>,
+    ) -> std::collections::HashSet<String> {
+        let Some(rt) = self.rt.as_ref() else {
+            return std::collections::HashSet::new();
+        };
+        rt.block_on(async {
+            let guard = schema.read().await;
+            crate::memtable::semantic_derived_vector_fields(&guard.schema)
+        })
     }
 }
 

--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -84,9 +84,19 @@ struct MemEntry {
 /// flush (`drain_with_sources`, `drain`) and by the rare
 /// `get_source` query path — neither is on the hot ingest loop.
 pub fn extract_text_fields_from(source: &Value) -> HashMap<String, String> {
+    extract_text_fields_from_excluding(source, &std::collections::HashSet::new())
+}
+
+pub fn extract_text_fields_from_excluding(
+    source: &Value,
+    excluded: &std::collections::HashSet<String>,
+) -> HashMap<String, String> {
     let mut out = HashMap::new();
     if let Some(obj) = source.as_object() {
         for (key, val) in obj {
+            if excluded.contains(key) {
+                continue;
+            }
             let text = extract_text_value(val);
             if !text.is_empty() {
                 out.insert(key.clone(), text);
@@ -3139,9 +3149,17 @@ impl Default for FtsMemtable {
 ///
 /// Hoisted out of `FtsMemtable::insert` so [`analyze_doc`] can run the
 /// identical walk outside the shard write lock.
-fn collect_text_fields(v: &Value, prefix: &str, out: &mut HashMap<String, String>) {
+fn collect_text_fields(
+    v: &Value,
+    prefix: &str,
+    out: &mut HashMap<String, String>,
+    excluded: &std::collections::HashSet<String>,
+) {
     if let Value::Object(obj) = v {
         for (k, val) in obj {
+            if prefix.is_empty() && excluded.contains(k) {
+                continue;
+            }
             let path = if prefix.is_empty() {
                 k.clone()
             } else {
@@ -3157,7 +3175,7 @@ fn collect_text_fields(v: &Value, prefix: &str, out: &mut HashMap<String, String
                             out.insert(path.clone(), t);
                         }
                     }
-                    collect_text_fields(val, &path, out);
+                    collect_text_fields(val, &path, out, excluded);
                 }
                 Value::Array(arr) => {
                     let joined: String = arr
@@ -3192,6 +3210,16 @@ pub fn analyze_doc(
     schema: &Schema,
     analyzer: &AnalyzerPipeline,
 ) -> Vec<(String, Vec<Token>)> {
+    let excluded = semantic_derived_vector_fields(schema);
+    analyze_doc_excluding(source, schema, analyzer, &excluded)
+}
+
+pub fn analyze_doc_excluding(
+    source: &Value,
+    schema: &Schema,
+    analyzer: &AnalyzerPipeline,
+    excluded: &std::collections::HashSet<String>,
+) -> Vec<(String, Vec<Token>)> {
     let mut text_fields: HashMap<String, String> = HashMap::new();
 
     // Index fields that are defined as Text in the schema.
@@ -3209,7 +3237,7 @@ pub fn analyze_doc(
     // Also index any string-valued field not in the schema (dynamic
     // mapping) — see `collect_text_fields`.
     if source.is_object() {
-        collect_text_fields(source, "", &mut text_fields);
+        collect_text_fields(source, "", &mut text_fields, excluded);
     }
 
     text_fields
@@ -3219,6 +3247,94 @@ pub fn analyze_doc(
             (field_name, tokens)
         })
         .collect()
+}
+
+/// Exact internal fields generated from semantic embedding mappings.
+///
+/// This is schema-derived: similarly named user fields are unaffected unless
+/// an embedding config explicitly designates them as its target.
+pub fn semantic_derived_vector_fields(schema: &Schema) -> std::collections::HashSet<String> {
+    let mut excluded = std::collections::HashSet::new();
+    for field in &schema.fields {
+        let Some(embedding) = &field.embedding else {
+            continue;
+        };
+        let target = embedding
+            .target_field
+            .clone()
+            .unwrap_or_else(|| format!("{}_vector", field.name));
+        excluded.insert(target.clone());
+        excluded.insert(format!("{target}_chunks"));
+    }
+    excluded
+}
+
+#[cfg(test)]
+mod semantic_derived_vector_exclusion_tests {
+    use super::*;
+    use serde_json::json;
+    use xerj_common::types::{EmbeddingConfig, FieldConfig, FieldType};
+
+    #[test]
+    fn derives_default_and_custom_targets_without_suffix_guessing() {
+        let mut schema = Schema::empty();
+        schema
+            .add_field(
+                FieldConfig::new("body", FieldType::Text).with_embedding(EmbeddingConfig {
+                    endpoint: None,
+                    model: None,
+                    target_field: None,
+                }),
+            )
+            .unwrap();
+        schema
+            .add_field(FieldConfig::new("summary", FieldType::Text).with_embedding(
+                EmbeddingConfig {
+                    endpoint: None,
+                    model: None,
+                    target_field: Some("summary_model_output".to_string()),
+                },
+            ))
+            .unwrap();
+        schema
+            .add_field(FieldConfig::new("user_vector", FieldType::Text))
+            .unwrap();
+
+        let excluded = semantic_derived_vector_fields(&schema);
+        assert_eq!(
+            excluded,
+            std::collections::HashSet::from([
+                "body_vector".to_string(),
+                "body_vector_chunks".to_string(),
+                "summary_model_output".to_string(),
+                "summary_model_output_chunks".to_string(),
+            ])
+        );
+
+        let source = json!({
+            "body": "cash and equivalents",
+            "page": 7,
+            "user_vector": [1.0, 2.0],
+            "body_vector_backup": [3.0, 4.0],
+            "body_vector": [0.1, 0.2],
+            "body_vector_chunks": [[0.1, 0.2], [0.3, 0.4]],
+            "summary_model_output": [0.5, 0.6],
+            "summary_model_output_chunks": [[0.5, 0.6], [0.7, 0.8]]
+        });
+        let fields = extract_text_fields_from_excluding(&source, &excluded);
+        assert_eq!(fields.get("page").map(String::as_str), Some("7"));
+        assert_eq!(
+            fields.get("user_vector").map(String::as_str),
+            Some("1.0 2.0")
+        );
+        assert_eq!(
+            fields.get("body_vector_backup").map(String::as_str),
+            Some("3.0 4.0")
+        );
+        for derived in &excluded {
+            assert!(!fields.contains_key(derived));
+        }
+    }
 }
 
 /// Extract a string value from a JSON value for text indexing.

--- a/engine/crates/xerj-engine/tests/integration.rs
+++ b/engine/crates/xerj-engine/tests/integration.rs
@@ -19,6 +19,102 @@ fn make_engine(dir: &TempDir) -> Engine {
     Engine::new(config).expect("engine::new")
 }
 
+#[tokio::test]
+async fn test_semantic_vectors_stay_stored_but_not_fts_indexed_after_merge_and_reopen() {
+    fn collect_names(dir: &std::path::Path, out: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_dir() {
+                collect_names(&entry.path(), out);
+            } else {
+                out.push(entry.file_name().to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    async fn assert_queries(idx: &xerj_engine::Index) {
+        let semantic = idx
+            .search(&make_search(json!({
+                "semantic": {"field": "content", "query": "quarterly liquidity", "k": 10}
+            })))
+            .await
+            .unwrap();
+        assert_eq!(semantic.total.value, 2);
+        assert!(semantic.hits.iter().all(|hit| {
+            hit.source.get("custom_embedding").is_some()
+                && hit.source.get("custom_embedding_chunks").is_some()
+        }));
+
+        let lexical = idx
+            .search(&make_search(json!({
+                "match": {"content": "working capital"}
+            })))
+            .await
+            .unwrap();
+        assert_eq!(lexical.total.value, 2);
+
+        let page = idx
+            .search(&make_search(json!({
+                "term": {"page": 7}
+            })))
+            .await
+            .unwrap();
+        assert_eq!(page.total.value, 1);
+    }
+
+    let dir = TempDir::new().unwrap();
+    let mut schema = Schema::empty();
+    let mut content = FieldConfig::new("content", FieldType::Text);
+    content.options.dimensions = Some(16);
+    content.options.similarity = Some("cosine".to_string());
+    content.embedding = Some(xerj_common::types::EmbeddingConfig {
+        endpoint: None,
+        model: None,
+        target_field: Some("custom_embedding".to_string()),
+    });
+    schema.fields.push(content);
+    schema
+        .fields
+        .push(FieldConfig::new("page", FieldType::Long));
+
+    {
+        let engine = make_engine(&dir);
+        engine.create_index("sem-fts-exclusion", schema).unwrap();
+        let idx = engine.get_index("sem-fts-exclusion").unwrap();
+        let long_body = format!(
+            "quarterly liquidity evidence {}",
+            "cash assets liabilities working capital ".repeat(80)
+        );
+
+        idx.index_document(Some("a".into()), json!({"content": long_body, "page": 7}))
+            .await
+            .unwrap();
+        idx.refresh().await.unwrap();
+        idx.index_document(Some("b".into()), json!({"content": long_body, "page": 8}))
+            .await
+            .unwrap();
+        idx.refresh().await.unwrap();
+        idx.force_merge(1).await.unwrap();
+
+        assert_queries(&idx).await;
+    }
+
+    let mut names = Vec::new();
+    collect_names(dir.path(), &mut names);
+    assert!(names.iter().any(|name| name.ends_with(".content.fst")));
+    assert!(names.iter().any(|name| name.ends_with(".page.fst")));
+    assert!(!names
+        .iter()
+        .any(|name| name.ends_with(".custom_embedding.fst")));
+    assert!(!names
+        .iter()
+        .any(|name| name.ends_with(".custom_embedding_chunks.fst")));
+
+    let reopened = make_engine(&dir);
+    let idx = reopened.get_index("sem-fts-exclusion").unwrap();
+    assert_queries(&idx).await;
+}
+
 fn make_search(query_json: Value) -> SearchRequest {
     parse_request(&json!({ "query": query_json, "size": 100 })).expect("parse_request")
 }


### PR DESCRIPTION
## Summary

Prevent schema-designated semantic embedding outputs from being analyzed and persisted as full-text fields.

**XERJ mistakenly treated generated embedding vectors as lexical fields and included their decimal values in the full-text index corpus, even though semantic retrieval never uses those lexical structures.**

Semantic mappings generate:

- one pooled vector at `target_field` (default: `<source>_vector`); and
- for multi-chunk text, one array of passage vectors at `<target>_chunks`.

Before this change, XERJ's generic dynamic-field walkers flattened both arrays to decimal strings and sent every float through lexical analysis during active ingest, flush, and merge. The resulting terms, postings, and FSTs were unrelated to semantic retrieval and created severe write and memory amplification.


This is a backend-independent engine fix. ONNX testing exposed the defect at scale, but ONNX Runtime did not create or retain these FST structures. Candle and other embedding producers use the same downstream index paths.

## Failure evidence

A full FinanceBench diagnostic run was stopped by the kernel OOM killer at 65.7k indexed records:

| Artifact/state | Observed value |
|---|---:|
| `body_vector.fst` | 486 MiB |
| `body_vector_chunks.fst` | 1.852 GiB |
| Generated-vector FSTs combined | **2.338 GiB** |
| Entire partial index | 3.449 GiB |
| Compressed source segments | 1.051 GiB |
| Server RSS at OOM | 32.66 GiB |

The generated-vector FSTs represented 68% of the partial index. Merge reconstruction also held decoded source, flattened decimal strings, and rebuilt postings concurrently, magnifying retained memory.

These are diagnostic measurements from the failed run. They prove that semantic payloads were entering FTS and were a major OOM contributor; they are **not** a post-fix throughput or peak-RSS benchmark.

## Root cause

The active memtable, flush, and merge paths all contain generic source walkers. Unknown and dynamically inferred fields are intentionally made searchable. That fallback is useful for ordinary values, but it did not distinguish auto-generated semantic payloads from user text.

Consequently:

1. Each 384-dimensional pooled vector became hundreds of decimal tokens.
2. Each multi-passage chunk-vector array became thousands of decimal tokens.
3. Flush emitted FST/posting/norm/meta files for those fields.
4. Merge decoded the stored arrays, formatted them again, and rebuilt the same useless lexical structures.

The HNSW/vector path does not consume these FSTs.

## What this changes

The engine derives an exact exclusion set from the schema:

- the configured `embedding.target_field`, or `<source>_vector` when omitted;
- the corresponding `<target>_chunks` field.

That set is applied consistently to:

- active batch/memtable analysis;
- synchronous refresh flushes;
- background and final flushes;
- merge-time FTS reconstruction; and
- FTS field configuration.

Exclusion occurs before numeric arrays are converted to decimal strings, so the large temporary strings and lexical postings are not allocated.

This is deliberately schema-derived. There is no `_vector` suffix heuristic. A similarly named ordinary field remains lexically indexed unless an embedding mapping explicitly designates it as the embedding output.

## What does not change

- Pooled and per-chunk vectors remain in stored `_source`.
- Semantic/vector retrieval continues to use those vectors.
- Ordinary text and numeric fields continue to receive FTS indexes.
- The embedding model and output values do not change.
- Explicit generic vector fields that are not semantic embedding targets are outside this patch.
- No ONNX-, Candle-, autoindex-, PDF-, or passage-response code is changed.

## Upgrade and recovery behavior

This prevents generated-vector FSTs on new flushes and on segments rebuilt by merge. It does not immediately rewrite existing segments.

For an already affected index:

1. **Safest:** re-autoindex/reindex into a fresh index using the fixed binary, validate counts and queries, then switch over.
2. A controlled full merge can rebuild FTS using the new rules, but an existing bloated index may require substantial transient memory during that merge. Do not treat force-merge as a memory-free migration.

Stored vector arrays are intentionally retained. This patch removes the accidental lexical copies; it is not a binary-vector-sidecar redesign and does not claim to eliminate every semantic-ingest memory cost.

## Automated regression

`test_semantic_vectors_stay_stored_but_not_fts_indexed_after_merge_and_reopen` exercises the real lifecycle:

1. Create a semantic field with a custom target.
2. Index a long multi-chunk document and flush.
3. Index a second document and flush, producing two disk segments.
4. Force-merge to one segment.
5. Verify semantic search returns both documents.
6. Verify pooled and chunk vectors remain stored.
7. Verify ordinary lexical and numeric queries still work.
8. Verify ordinary `content` and `page` FSTs exist.
9. Verify pooled and chunk target FSTs do not exist.
10. Drop and reopen the engine and repeat retrieval assertions.

The focused helper test additionally covers default and explicit targets, multiple semantic fields, and similarly named non-designated fields.

## Manual reproduction and verification

Run the following first on the parent commit and then on this branch. Use a fresh data directory for each run:

```bash
cd engine
cargo build --release -j 32 -p xerj-server

XERJ_REPRO_DATA=$(mktemp -d /tmp/xerj-vector-fst.XXXXXX)
./target/release/xerj \
  --data-dir "$XERJ_REPRO_DATA" \
  --insecure >"$XERJ_REPRO_DATA/server.log" 2>&1 &
XERJ_REPRO_PID=$!
trap 'kill "$XERJ_REPRO_PID" 2>/dev/null || true' EXIT

until curl -sf http://127.0.0.1:9200 >/dev/null; do sleep 0.2; done

curl -sfX PUT http://127.0.0.1:9200/semantic-fst-repro \
  -H 'content-type: application/json' \
  -d '{"mappings":{"properties":{"body":{"type":"semantic_text"},"page":{"type":"long"}}}}'

BODY=$(for _ in $(seq 1 200); do
  printf '%s ' 'quarterly liquidity cash assets liabilities working capital'
done)

for ID in a b; do
  PAGE=7
  [ "$ID" = b ] && PAGE=8
  curl -sfX PUT \
    "http://127.0.0.1:9200/semantic-fst-repro/_doc/$ID" \
    -H 'content-type: application/json' \
    --data-binary "{\"body\":\"$BODY\",\"page\":$PAGE}"
  curl -sfX POST \
    http://127.0.0.1:9200/semantic-fst-repro/_flush
done

curl -sfX POST \
  'http://127.0.0.1:9200/semantic-fst-repro/_forcemerge?max_num_segments=1'

curl -sfX POST http://127.0.0.1:9200/semantic-fst-repro/_search \
  -H 'content-type: application/json' \
  -d '{"query":{"semantic":{"field":"body","query":"quarterly liquidity","k":10}}}'

find "$XERJ_REPRO_DATA/semantic-fst-repro" -type f \
  \( -name '*.body.fst' \
     -o -name '*.page.fst' \
     -o -name '*.body_vector.fst' \
     -o -name '*.body_vector_chunks.fst' \) \
  -printf '%s %f\n' | sort -n
```

Expected on the parent commit:

- semantic search succeeds;
- stored pooled/chunk vectors exist;
- `body_vector.fst` and/or `body_vector_chunks.fst` are emitted.

Expected on this branch:

- the same semantic query returns both documents;
- `body.fst` and `page.fst` are emitted;
- neither generated-vector FST is emitted.

The explicit `POST /_flush` is required: `refresh=true` makes documents searchable but is not a substitute for materializing disk segments.

## Validation performed

- Full `xerj-engine` suite:
  - 128 unit tests passed;
  - 92 integration tests passed;
  - 65 ES compatibility tests passed;
  - chaos, restart, product-experience, storage-hardening, and doc tests passed.
- New semantic lifecycle regression passed.
- Existing semantic flush regression passed.
- `cargo clippy -p xerj-engine --no-default-features --lib --tests -- -D warnings` passed.
- Package-scoped rustfmt and `git diff --check` passed.
- Fresh release server plus complete ES-YAML gate: **1,360 passed / 0 failed / 3 skipped**.

The existing Painless long-expression test requires a larger test-thread stack in this environment, so the broad suite was run with `RUST_MIN_STACK=16777216`. The test passes under that setting; this patch does not touch the evaluator.

## Known related issue, intentionally separate

Embedding target names form a designated output namespace, but mapping collision validation and `PUT _mapping` transactionality need separate work. During review we confirmed that `PUT _mapping` currently discards some incremental schema errors and lacks a cross-index disk transaction. Mixing that API redesign into this storage fix would substantially expand its risk and review surface.

This patch therefore treats the configured target and chunk target consistently as embedding outputs for FTS exclusion. A follow-up should add explicit collision rejection and durable mapping-update error propagation