### PR TITLE
fix(api): _bulk reports real per-item _seq_no/_version, not a timestamp

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -11913,13 +11913,27 @@ async fn process_bulk_body(
                 "_source": s,
             })
         });
+        // Real per-item `_seq_no` / `_version` — same resolvers `_mget` and
+        // GET `_doc` use (were hardcoded `_version: 1` / a wall-clock
+        // timestamp masquerading as `_seq_no`).
+        let (version, seq_no) = state
+            .engine
+            .get_index(&item.index)
+            .ok()
+            .map(|idx| {
+                (
+                    idx.lookup_version(&item.id).unwrap_or(1),
+                    idx.lookup_seq_no(&item.id).unwrap_or(0),
+                )
+            })
+            .unwrap_or((1, 0));
         let item_result = EsBulkItemResult {
             index: item.index,
             id: item.id,
-            version: 1,
+            version,
             result: item.result.unwrap_or_else(|| "deleted".to_string()),
             shards: crate::responses::EsShards::single_success(),
-            seq_no: current_timestamp_micros(),
+            seq_no,
             primary_term: 1,
             status: item.status,
             get,
@@ -12280,13 +12294,6 @@ fn native_type_to_es(ft: &FieldType) -> &'static str {
         FieldType::Object => "object",
         FieldType::Nested => "nested",
     }
-}
-
-fn current_timestamp_micros() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_micros() as u64
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `_bulk` item responses set `_seq_no` to `current_timestamp_micros()` — a wall-clock value, not an actual sequence number — and hardcoded `_version: 1` on every item, regardless of how many times a doc had actually been written. ES clients that rely on `_seq_no`/`_version` for optimistic-concurrency writes (e.g. `if_seq_no`/`if_primary_term`) after a bulk ingest would get bogus values.
- Same fix pattern already used by `_mget` and `GET /{index}/_doc/{id}` in this file: resolve the real values via `idx.lookup_version(&item.id)` / `idx.lookup_seq_no(&item.id)` on the item's target index, falling back to `1`/`0` when the doc can't be resolved (mirrors the existing fallback used by those two endpoints).
- Removed `current_timestamp_micros()`, now dead code with no other callers.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy -p xerj-api --no-deps` (no warnings)
- [x] `cargo fmt -p xerj-api -- --check`
- [x] Manual end-to-end against a local server (isolated port/data dir): bulk-indexed the same `_id` twice plus a second doc once, and the per-item `_version`/`_seq_no` in the `_bulk` response matched exactly what `GET /{index}/_doc/{id}` reports as ground truth for both docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)