### PR TITLE
fix(api): add POST /_index_template/_simulate (body-only template preview)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -26961,12 +26961,16 @@ pub async fn delete_legacy_template(
 // POST /_index_template/_simulate_index/{name}
 // ─────────────────────────────────────────────────────────────────────────────
 
-pub async fn simulate_index_template(
-    State(state): State<AppState>,
-    Path(index_name): Path<String>,
-) -> impl IntoResponse {
-    // Pattern matcher mirroring how stored v2 templates are matched at
-    // index-creation time: supports `*`/`_all` plus leading/trailing `*`.
+/// Every stored template whose `index_patterns` matches `index_name`, using
+/// the same simplified `*`/`_all`/leading-or-trailing-`*` semantics real v2
+/// templates use at index-creation time. Shared by both simulate endpoints —
+/// `simulate_index_template` calls it with a real index name, while
+/// `simulate_index_template_body` calls it once per pattern in the candidate
+/// (unsaved) template, since there's no concrete index name to test against.
+fn templates_matching_index_name(
+    state: &AppState,
+    index_name: &str,
+) -> Vec<(String, i32, Value, Value, Vec<String>)> {
     let matches_pattern = |pat: &str| -> bool {
         if pat == "*" || pat == "_all" {
             return true;
@@ -26980,7 +26984,6 @@ pub async fn simulate_index_template(
         }
     };
 
-    // Collect every stored template whose patterns match the index name.
     let mut matching: Vec<(String, i32, Value, Value, Vec<String>)> = Vec::new();
     for entry in state.engine.templates.iter() {
         let t = entry.value();
@@ -26994,6 +26997,15 @@ pub async fn simulate_index_template(
             ));
         }
     }
+    matching
+}
+
+pub async fn simulate_index_template(
+    State(state): State<AppState>,
+    Path(index_name): Path<String>,
+) -> impl IntoResponse {
+    // Collect every stored template whose patterns match the index name.
+    let mut matching = templates_matching_index_name(&state, &index_name);
 
     // Highest priority wins; ties resolve by name for a stable result.
     matching.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
@@ -27021,6 +27033,75 @@ pub async fn simulate_index_template(
         },
         "overlapping": overlapping,
         "matched": matched_name
+    }))
+    .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Simulate an unsaved index template body
+// POST /_index_template/_simulate
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Body-only variant of `_simulate_index/{name}`: Kibana's index template
+/// wizard (and the alerting / ECS data-quality-dashboard plugins) call this
+/// to preview a template BEFORE it's saved — there's no stored name or
+/// concrete index to resolve against, so the template definition being
+/// previewed (same shape `PUT /_index_template/{name}` accepts) is the
+/// request body itself.
+pub async fn simulate_index_template_body(
+    State(state): State<AppState>,
+    Json(body): Json<IndexTemplateBody>,
+) -> impl IntoResponse {
+    let settings = body
+        .template
+        .as_ref()
+        .and_then(|t| t.settings.clone())
+        .or(body.settings.clone())
+        .unwrap_or(json!({}));
+    let mappings = body
+        .template
+        .as_ref()
+        .and_then(|t| t.mappings.clone())
+        .or(body.mappings.clone())
+        .unwrap_or(json!({}));
+    let priority = body.priority.unwrap_or(0);
+
+    // The candidate template has no index yet to test stored templates
+    // against, so its own patterns stand in for one — same matcher
+    // `simulate_index_template` uses, run once per candidate pattern and
+    // deduped by template name (a stored template can match more than one
+    // candidate pattern).
+    let mut matching: Vec<(String, i32, Value, Value, Vec<String>)> = Vec::new();
+    for cp in &body.index_patterns {
+        for m in templates_matching_index_name(&state, cp) {
+            if !matching.iter().any(|(name, ..)| *name == m.0) {
+                matching.push(m);
+            }
+        }
+    }
+
+    // Same priority merge as `simulate_index_template`: highest priority
+    // wins, ties resolve by name — except the candidate itself only loses to
+    // a stored template that strictly outranks it, since it's the one being
+    // previewed and isn't in `matching` to compete on its own.
+    matching.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let (resolved_settings, resolved_mappings) = match matching.first() {
+        Some((_, top_priority, s, m, _)) if *top_priority > priority => (s.clone(), m.clone()),
+        _ => (settings, mappings),
+    };
+
+    let overlapping: Vec<Value> = matching
+        .iter()
+        .map(|(name, _, _, _, patterns)| json!({ "name": name, "index_patterns": patterns }))
+        .collect();
+
+    Json(json!({
+        "template": {
+            "settings": resolved_settings,
+            "mappings": resolved_mappings,
+            "aliases": {}
+        },
+        "overlapping": overlapping
     }))
     .into_response()
 }

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -679,6 +679,13 @@ pub fn build_es_compat_router(state: AppState) -> Router {
             "/_index_template/_simulate_index/:name",
             post(es_compat::simulate_index_template),
         )
+        // Body-only variant: previews an unsaved template definition (no
+        // index name) — this is what Kibana's index template wizard calls
+        // to validate a template before it's created.
+        .route(
+            "/_index_template/_simulate",
+            post(es_compat::simulate_index_template_body),
+        )
         // ── More _cat endpoints ────────────────────────────────────────────────────
         .route("/_cat/tasks", get(es_compat::cat_tasks))
         .route("/_cat/repositories", get(es_compat::cat_repositories))


### PR DESCRIPTION
## Summary
- Only `POST /_index_template/_simulate_index/{name}` existed — it simulates a *stored* template against a real index name. Kibana's index template wizard (and the alerting / `ecsDataQualityDashboard` plugins) call the body-only variant, `POST /_index_template/_simulate`, to preview an *unsaved* template definition before it's created — that route 404'd. Verified empirically: not blocking for the rest of the UI, but breaks template validation in the wizard.
- `simulate_index_template`'s pattern-matching loop is extracted into a shared `templates_matching_index_name(state, index_name)` helper (same `*`/`_all`/leading-or-trailing-`*` semantics, unchanged behavior for the existing endpoint).
- The new `simulate_index_template_body` handler takes the candidate template as the request body (same `IndexTemplateBody` shape `PUT /_index_template/{name}` already accepts — nested `template: {settings, mappings}` or flat top-level `settings`/`mappings`). Since there's no concrete index name yet, it runs the same matcher once per pattern in the candidate's own `index_patterns`, dedupes by template name, and applies the same highest-priority-wins merge `simulate_index_template` uses — the candidate only loses to a stored template that strictly outranks it, since it's the one being previewed.
- Response shape matches ES: `{"template": {"settings", "mappings", "aliases"}, "overlapping": [...]}` (no `"matched"` field — there's no concrete index being resolved, only patterns).

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy -p xerj-api --no-deps` (no warnings)
- [x] `cargo fmt -p xerj-api -- --check`
- [x] Manual end-to-end against a local server (isolated port/data dir):
  - [x] Simulate with no stored templates → candidate's own settings/mappings echoed back, `overlapping: []`
  - [x] Simulate against a stored lower-priority overlapping template → candidate wins, stored template listed in `overlapping`
  - [x] Simulate against a stored higher-priority overlapping template → stored template's settings win, both overlapping templates listed
  - [x] Regression: `POST /_index_template/_simulate_index/{name}` still returns identical output (including `"matched"`) after the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)