### PR TITLE
fix(api): add GET/POST /_security/user/_has_privileges

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -21631,6 +21631,97 @@ pub async fn security_authenticate(State(_state): State<AppState>) -> impl IntoR
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// GET/POST /_security/user/_has_privileges
+// GET/POST /_security/user/{user}/_has_privileges
+// ─────────────────────────────────────────────────────────────────────────────
+// Route didn't exist at all — every call 404'd. Kibana's app shell calls this
+// right after login (during the same bootstrap pass as `_authenticate`,
+// `/_cluster/health`, `/_xpack`) to decide what UI to show the current user;
+// its client doesn't handle a 404 here gracefully and the whole page request
+// blows up with a generic 500 ("[Internal Server Error]: undefined" — Kibana
+// swallows the real cause before it reaches the client), which is a much
+// harder failure to diagnose than the 404 itself since nothing about
+// privileges appears in the error shown to the user.
+//
+// Same single-owner identity model as `security_authenticate` — xerj has no
+// per-user privilege enforcement, every authenticated caller is the one
+// built-in superuser — so answering "yes" to every privilege asked about
+// isn't a lie, it's what's actually true: nothing is denied. Echoes back
+// every cluster/index/application privilege named in the request body as
+// granted, keyed exactly the way ES's response is shaped.
+pub async fn security_has_privileges(
+    State(_state): State<AppState>,
+    body: Option<Json<Value>>,
+) -> impl IntoResponse {
+    let body = body.map(|Json(v)| v).unwrap_or(json!({}));
+
+    let mut cluster = serde_json::Map::new();
+    if let Some(names) = body.get("cluster").and_then(Value::as_array) {
+        for name in names.iter().filter_map(Value::as_str) {
+            cluster.insert(name.to_string(), Value::Bool(true));
+        }
+    }
+
+    let mut index = serde_json::Map::new();
+    if let Some(reqs) = body.get("index").and_then(Value::as_array) {
+        for req in reqs {
+            let names = req.get("names").and_then(Value::as_array);
+            let privileges = req.get("privileges").and_then(Value::as_array);
+            let (Some(names), Some(privileges)) = (names, privileges) else {
+                continue;
+            };
+            let mut priv_map = serde_json::Map::new();
+            for p in privileges.iter().filter_map(Value::as_str) {
+                priv_map.insert(p.to_string(), Value::Bool(true));
+            }
+            for name in names.iter().filter_map(Value::as_str) {
+                index.insert(name.to_string(), Value::Object(priv_map.clone()));
+            }
+        }
+    }
+
+    let mut application = serde_json::Map::new();
+    if let Some(reqs) = body.get("application").and_then(Value::as_array) {
+        for req in reqs {
+            let app = req.get("application").and_then(Value::as_str);
+            let privileges = req.get("privileges").and_then(Value::as_array);
+            let (Some(app), Some(privileges)) = (app, privileges) else {
+                continue;
+            };
+            let mut priv_map = serde_json::Map::new();
+            for p in privileges.iter().filter_map(Value::as_str) {
+                priv_map.insert(p.to_string(), Value::Bool(true));
+            }
+            let resources: Vec<String> = req
+                .get("resources")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(Value::as_str)
+                        .map(String::from)
+                        .collect()
+                })
+                .filter(|v: &Vec<String>| !v.is_empty())
+                .unwrap_or_else(|| vec!["*".to_string()]);
+            let mut resource_map = serde_json::Map::new();
+            for r in resources {
+                resource_map.insert(r, Value::Object(priv_map.clone()));
+            }
+            application.insert(app.to_string(), Value::Object(resource_map));
+        }
+    }
+
+    Json(json!({
+        "username": "xerj",
+        "has_all_requested": true,
+        "cluster": cluster,
+        "index": index,
+        "application": application,
+    }))
+    .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // POST /_security/api_key — create API key (stub: returns admin key)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -276,9 +276,18 @@ pub fn build_es_compat_router(state: AppState) -> Router {
             "/_count",
             get(es_compat::count_docs_global).post(es_compat::count_docs_global),
         )
-        .route("/:index/_refresh", post(es_compat::refresh_index).get(es_compat::refresh_index))
-        .route("/:index/_analyze", post(es_compat::analyze_text).get(es_compat::analyze_text))
-        .route("/_analyze", post(es_compat::analyze_text_global).get(es_compat::analyze_text_global))
+        .route(
+            "/:index/_refresh",
+            post(es_compat::refresh_index).get(es_compat::refresh_index),
+        )
+        .route(
+            "/:index/_analyze",
+            post(es_compat::analyze_text).get(es_compat::analyze_text),
+        )
+        .route(
+            "/_analyze",
+            post(es_compat::analyze_text_global).get(es_compat::analyze_text_global),
+        )
         // ── Document operations ────────────────────────────────────────────
         .route("/:index/_doc", post(es_compat::index_doc_auto))
         // POST with an explicit id is the same index op as PUT (auto-create
@@ -342,7 +351,10 @@ pub fn build_es_compat_router(state: AppState) -> Router {
             get(es_compat::field_caps).post(es_compat::field_caps),
         )
         // ── Multi-search ───────────────────────────────────────────────────
-        .route("/_msearch", post(es_compat::msearch).get(es_compat::msearch))
+        .route(
+            "/_msearch",
+            post(es_compat::msearch).get(es_compat::msearch),
+        )
         // Index-scoped multi-search — the path index defaults header lines
         // that omit `index`.
         .route(
@@ -483,9 +495,18 @@ pub fn build_es_compat_router(state: AppState) -> Router {
         .route("/_nodes", get(es_compat::nodes_info))
         .route("/_nodes/:node_id/stats", get(es_compat::node_stats_by_id))
         // ── Index clone / shrink / split ────────────────────────────────────
-        .route("/:index/_clone/:target", post(es_compat::clone_index).put(es_compat::clone_index))
-        .route("/:index/_shrink/:target", post(es_compat::shrink_index).put(es_compat::shrink_index))
-        .route("/:index/_split/:target", post(es_compat::split_index).put(es_compat::split_index))
+        .route(
+            "/:index/_clone/:target",
+            post(es_compat::clone_index).put(es_compat::clone_index),
+        )
+        .route(
+            "/:index/_shrink/:target",
+            post(es_compat::shrink_index).put(es_compat::shrink_index),
+        )
+        .route(
+            "/:index/_split/:target",
+            post(es_compat::split_index).put(es_compat::split_index),
+        )
         // ── Enrich Policies ─────────────────────────────────────────────────
         .route(
             "/_enrich/policy/:name",

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -540,6 +540,14 @@ pub fn build_es_compat_router(state: AppState) -> Router {
             get(es_compat::security_authenticate),
         )
         .route(
+            "/_security/user/_has_privileges",
+            get(es_compat::security_has_privileges).post(es_compat::security_has_privileges),
+        )
+        .route(
+            "/_security/user/:user/_has_privileges",
+            get(es_compat::security_has_privileges).post(es_compat::security_has_privileges),
+        )
+        .route(
             "/_security/api_key",
             post(es_compat::security_create_api_key),
         )


### PR DESCRIPTION
## Summary
- Found live testing against a real Kibana instance, after the `_security/privilege` and `_security/profile/_activate` fixes (#16, #17): login succeeded and profile activation worked, but the app shell's first page load still 500'd with a generic, unhelpful `"[Internal Server Error]: undefined"` — Kibana strips the real cause before it ever reaches the client.
- Root-caused by enabling `LOGGING_ROOT_LEVEL=all` on the Kibana container and diffing its request log immediately before/after the 500: the failing call was `POST /_security/user/_has_privileges` returning 404, one step before the 500 in Kibana's own bootstrap sequence (`_authenticate` → spaces lookup → `_has_privileges` → `/_xpack` → `/_nodes`). The route didn't exist at all in xerj — zero references anywhere in the crate.
- Same single-owner identity model as `security_authenticate`: xerj has no per-user privilege enforcement — every authenticated caller is the one built-in superuser — so answering "yes" to every privilege named in the request is what's actually true, not a lie: nothing is denied. Implements `GET`/`POST /_security/user/_has_privileges` and the `{user}`-scoped variants, per the real ES API shape (`cluster`/`index`/`application` request arrays → `username`/`has_all_requested`/`cluster`/`index`/`application` response, each requested privilege echoed back as granted).

## Test plan
- [x] `cargo build --release -p xerj-api`
- [x] `cargo clippy -p xerj-api --no-deps` (no warnings)
- [x] `cargo fmt -p xerj-api -- --check`
- [x] Confirmed current (pre-fix) behavior directly against a running instance: `POST /_security/user/_has_privileges` → 404
- [x] End-to-end against a live Kibana 8.13 container: with this fix (plus #16 and #17), the login → `/app/home` page load chain no longer 500s at this step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
