### PR TITLE
fix(engine): serialize single-document publication by id

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -12683,56 +12683,48 @@ pub async fn update_doc(
         if src.is_empty() {
             return update_script_bad_request("script source is required".to_string());
         }
-        match idx.get_document(&id).await {
-            Ok(Some(mut current)) => {
-                if let Err(e) = apply_painless_update(&mut current, &src, &params) {
-                    return update_script_bad_request(e);
-                }
-                return match idx.index_document(Some(id.clone()), current).await {
-                    Ok(resp) => {
-                        state.metrics.record_doc_indexed(&index);
-                        let er = crate::responses::EsDocResponse::updated(
-                            &index,
-                            &resp.id,
-                            resp.version,
-                            resp.seq_no.saturating_sub(1),
-                        );
-                        Json(er).into_response()
-                    }
-                    Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
-                };
+        let upsert_body = body.upsert.clone().or_else(|| {
+            if body.doc_as_upsert {
+                body.doc.clone()
+            } else {
+                None
             }
-            Ok(None) => {
-                // Document missing: honour `upsert` / `doc_as_upsert` by
-                // indexing the upsert body as a new document. The script is
-                // not run against the upsert body (matches ES default,
-                // scripted_upsert=false).
-                let upsert_body = body.upsert.clone().or_else(|| {
-                    if body.doc_as_upsert {
-                        body.doc.clone()
-                    } else {
-                        None
-                    }
-                });
-                if let Some(up) = upsert_body {
-                    return match idx.index_document(Some(id.clone()), up).await {
-                        Ok(resp) => {
-                            state.metrics.record_doc_indexed(&index);
-                            let er = crate::responses::EsDocResponse::created(
-                                &index,
-                                &resp.id,
-                                resp.version,
-                                resp.seq_no.saturating_sub(1),
-                            );
-                            Json(er).into_response()
-                        }
-                        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
-                    };
-                }
+        });
+        match idx
+            .transform_document_serialized(&id, upsert_body, move |mut current| {
+                apply_painless_update(&mut current, &src, &params)?;
+                Ok::<_, String>(current)
+            })
+            .await
+        {
+            Ok(Ok(Some(outcome))) => {
+                state.metrics.record_doc_indexed(&index);
+                let resp = outcome.response;
+                let er = if outcome.created {
+                    crate::responses::EsDocResponse::created(
+                        &index,
+                        &resp.id,
+                        resp.version,
+                        resp.seq_no.saturating_sub(1),
+                    )
+                } else {
+                    crate::responses::EsDocResponse::updated(
+                        &index,
+                        &resp.id,
+                        resp.version,
+                        resp.seq_no.saturating_sub(1),
+                    )
+                };
+                return Json(er).into_response();
+            }
+            Ok(Ok(None)) => {
                 let e = xerj_common::XerjError::document_not_found(&id, &index);
                 return ApiError::new(e).into_response();
             }
-            Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+            Ok(Err(error)) => return update_script_bad_request(error),
+            Err(error) => {
+                return ApiError::new(xerj_common::XerjError::from(error)).into_response();
+            }
         }
     }
 
@@ -17354,27 +17346,42 @@ async fn run_update_by_query(
         if hit.source.is_null() {
             continue;
         }
-        let mut source = hit.source;
         if let Some((src, params)) = script.as_ref() {
-            if !src.is_empty() {
-                if let Err(e) = apply_painless_update(&mut source, src, params) {
-                    failures.push(json!({
-                        "id": hit.id,
-                        "cause": { "reason": e },
-                    }));
-                    continue;
-                }
-            }
-        }
-        // Re-index in place: same `_id`, mutated source → an update, not an
-        // append (verified: `index_document(Some(existing_id), source)`).
-        match idx.index_document(Some(hit.id.clone()), source).await {
-            Ok(_) => updated += 1,
-            Err(e) => {
+            if src.is_empty() {
                 failures.push(json!({
                     "id": hit.id,
-                    "cause": { "reason": e.to_string() },
+                    "cause": { "reason": "script source is required" },
                 }));
+                continue;
+            }
+            let result = idx
+                .transform_document_serialized(&hit.id, None, |mut current| {
+                    apply_painless_update(&mut current, src, params)?;
+                    Ok::<_, String>(current)
+                })
+                .await;
+            match result {
+                Ok(Ok(Some(_))) => updated += 1,
+                Ok(Ok(None)) => {}
+                Ok(Err(error)) => failures.push(json!({
+                    "id": hit.id,
+                    "cause": { "reason": error },
+                })),
+                Err(error) => failures.push(json!({
+                    "id": hit.id,
+                    "cause": { "reason": error.to_string() },
+                })),
+            }
+        } else {
+            // No script: preserve the historical re-index-in-place behavior.
+            match idx.index_document(Some(hit.id.clone()), hit.source).await {
+                Ok(_) => updated += 1,
+                Err(e) => {
+                    failures.push(json!({
+                        "id": hit.id,
+                        "cause": { "reason": e.to_string() },
+                    }));
+                }
             }
         }
     }
@@ -17394,6 +17401,102 @@ async fn run_update_by_query(
         "requests_per_second": -1,
         "throttled_until_millis": 0,
     })
+}
+
+#[cfg(test)]
+mod scripted_update_publication_tests {
+    use super::*;
+    use std::sync::Arc;
+    use xerj_common::{
+        config::{Config, WalSync},
+        metrics::Metrics,
+    };
+    use xerj_engine::Engine;
+
+    fn test_state() -> AppState {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.keep();
+        let mut config = Config::default();
+        config.server.data_dir = path.to_string_lossy().into_owned();
+        config.storage.wal_sync = WalSync::Async;
+        let metrics = Metrics::new().expect("metrics");
+        let engine = Engine::new(config.clone()).expect("engine");
+        AppState::new(config, engine, metrics)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_scripted_update_requests_preserve_every_increment() {
+        let state = test_state();
+        let idx = state.engine.get_or_create_index("script-counter").unwrap();
+        idx.index_document(Some("counter".into()), json!({"n": 0}))
+            .await
+            .unwrap();
+
+        let start = Arc::new(tokio::sync::Barrier::new(33));
+        let mut tasks = Vec::new();
+        for _ in 0..32 {
+            let state = state.clone();
+            let start = Arc::clone(&start);
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                update_doc(
+                    State(state),
+                    Path(("script-counter".to_string(), "counter".to_string())),
+                    Query(UpdateDocParams::default()),
+                    Json(EsUpdateBody {
+                        doc: None,
+                        doc_as_upsert: false,
+                        upsert: None,
+                        script: Some(json!("ctx._source.n += 1")),
+                        detect_noop: None,
+                    }),
+                )
+                .await
+                .into_response()
+                .status()
+            }));
+        }
+        start.wait().await;
+        for task in tasks {
+            assert!(task.await.unwrap().is_success());
+        }
+
+        assert_eq!(idx.get_document("counter").await.unwrap().unwrap()["n"], 32);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_scripted_update_by_query_preserves_every_increment() {
+        let state = test_state();
+        let idx = state
+            .engine
+            .get_or_create_index("script-query-counter")
+            .unwrap();
+        idx.index_document(Some("counter".into()), json!({"n": 0}))
+            .await
+            .unwrap();
+
+        let start = Arc::new(tokio::sync::Barrier::new(17));
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let idx = Arc::clone(&idx);
+            let start = Arc::clone(&start);
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                run_update_by_query(
+                    &idx,
+                    &xerj_query::SearchRequest::default(),
+                    Some(("ctx._source.n += 1".into(), json!({}))),
+                )
+                .await
+            }));
+        }
+        start.wait().await;
+        for task in tasks {
+            assert_eq!(task.await.unwrap()["failures"], json!([]));
+        }
+
+        assert_eq!(idx.get_document("counter").await.unwrap().unwrap()["n"], 16);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -404,6 +404,19 @@ fn l2_normalize_vec(v: &mut [f32]) {
 
 // ── Index ────────────────────────────────────────────────────────────────────
 
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PublicationTestPoint {
+    Acquired,
+    AfterWalVersionMap,
+    AfterFts,
+    AfterHnsw,
+    BeforeRelease,
+}
+
+#[cfg(test)]
+type PublicationTestHook = Arc<dyn Fn(&str, PublicationTestPoint) + Send + Sync + 'static>;
+
 /// Per-index coordinator.
 ///
 /// Owns the storage layer (`IndexStore`), the FTS memtable, and the schema.
@@ -421,6 +434,11 @@ pub struct Index {
     /// clients on N different shards run truly in parallel on the
     /// write side.  Query paths iterate all shards.
     memtable: Arc<crate::memtable::ShardedFtsMemtable>,
+    /// Exact per-document ordering shared by all publication stages wired to
+    /// this coordinator. Idle keys are removed immediately.
+    write_publication: Arc<crate::write_publication::WritePublicationCoordinator>,
+    #[cfg(test)]
+    publication_test_hook: Arc<parking_lot::RwLock<Option<PublicationTestHook>>>,
     doc_count: Arc<AtomicU64>,
     /// Counter for `update` operations that detected no change to the
     /// existing source — surfaced via `indices.stats` as
@@ -795,6 +813,21 @@ pub struct Index {
 }
 
 impl Index {
+    #[cfg(test)]
+    fn publication_test_point(&self, id: &str, point: PublicationTestPoint) {
+        // Clone the callback while holding the hook registry lock, then invoke
+        // it after releasing that lock. Test barriers may intentionally block.
+        let hook = self.publication_test_hook.read().clone();
+        if let Some(hook) = hook {
+            hook(id, point);
+        }
+    }
+
+    #[cfg(test)]
+    fn set_publication_test_hook(&self, hook: Option<PublicationTestHook>) {
+        *self.publication_test_hook.write() = hook;
+    }
+
     /// Create a new index at `data_dir/<name>`.
     pub fn create(
         name: IndexName,
@@ -906,6 +939,9 @@ impl Index {
                     config.engine.ingest_shards,
                 ),
             ),
+            write_publication: crate::write_publication::WritePublicationCoordinator::new(),
+            #[cfg(test)]
+            publication_test_hook: Arc::new(parking_lot::RwLock::new(None)),
             doc_count: Arc::new(AtomicU64::new(0)),
             noop_update_count: Arc::new(AtomicU64::new(0)),
             request_cache_seen: Arc::new(RwLock::new(RequestCacheSeen::with_capacity(65_536))),
@@ -1155,6 +1191,9 @@ impl Index {
             enrichments: Arc::new(RwLock::new(HashMap::new())),
             store,
             memtable: Arc::new(memtable),
+            write_publication: crate::write_publication::WritePublicationCoordinator::new(),
+            #[cfg(test)]
+            publication_test_hook: Arc::new(parking_lot::RwLock::new(None)),
             doc_count: Arc::new(AtomicU64::new(total_doc_count)),
             noop_update_count: Arc::new(AtomicU64::new(0)),
             request_cache_seen: Arc::new(RwLock::new(RequestCacheSeen::with_capacity(65_536))),
@@ -1253,26 +1292,17 @@ impl Index {
     ) -> Result<IndexResponse> {
         let doc_id = id.unwrap_or_else(|| Uuid::new_v4().to_string());
         let strict = version_type != "external_gte";
-        // CAS against the caller's prior external version.
-        if let Some(existing) = self.external_versions.get(&doc_id) {
-            let cur = *existing;
-            let ok = if strict {
-                version > cur
-            } else {
-                version >= cur
-            };
-            if !ok {
-                return Err(EngineError::Common(
-                    xerj_common::XerjError::version_conflict(&doc_id, version, cur),
-                ));
-            }
-        }
-        self.external_versions.insert(doc_id.clone(), version);
-        let mut resp = self
-            .index_document_with_version(Some(doc_id), source, None, None)
-            .await?;
-        resp.version = version;
-        Ok(resp)
+        self.index_document_with_version_inner_guarded(
+            Some(doc_id),
+            source,
+            None,
+            None,
+            false,
+            None,
+            false,
+            Some((version, strict)),
+        )
+        .await
     }
 
     /// Index a document with optional optimistic concurrency control.
@@ -1304,6 +1334,31 @@ impl Index {
         if_primary_term: Option<u64>,
         semantic_embeddings_prepared: bool,
     ) -> Result<IndexResponse> {
+        self.index_document_with_version_inner_guarded(
+            id,
+            source,
+            if_seq_no,
+            if_primary_term,
+            semantic_embeddings_prepared,
+            None,
+            false,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn index_document_with_version_inner_guarded(
+        &self,
+        id: Option<String>,
+        source: Value,
+        if_seq_no: Option<u64>,
+        if_primary_term: Option<u64>,
+        semantic_embeddings_prepared: bool,
+        publication_guard: Option<crate::write_publication::WritePublicationGuard>,
+        create_only: bool,
+        external_version: Option<(u64, bool)>,
+    ) -> Result<IndexResponse> {
         // Check write block.
         if self.is_write_blocked().await {
             return Err(EngineError::Common(xerj_common::XerjError::index_blocked(
@@ -1314,14 +1369,38 @@ impl Index {
         // Process-wide admission: disk flood-stage block (item 3) + parent
         // memory circuit breaker (item 1). Fires before any per-index work.
         self.governor_write_gate()?;
-        // Invalidate the response cache: every doc write bumps the
-        // dataset version, which is part of the cache key, so old
-        // entries become invisible to lookups.  No clear() needed —
-        // they age out on the next 1k-entry truncation.
-        self.dataset_version.fetch_add(1, Ordering::Release);
-
         let index_start = std::time::Instant::now();
         let doc_id = id.unwrap_or_else(|| Uuid::new_v4().to_string());
+
+        // `index.default_pipeline` is resolved and executed at the API layer
+        // (xerj-api es_compat::resolve_effective_pipeline) before the document
+        // reaches the engine, so no pipeline handling is needed here.
+
+        // Auto-embed `semantic_text` fields: vectorise the field's text into
+        // its companion vector field (`<field>_vector`) so it becomes
+        // kNN-searchable. Runs before copy_to / storage so the derived vector
+        // is part of `_source` and gets picked up by HNSW indexing below.
+        let source = if semantic_embeddings_prepared {
+            source
+        } else {
+            self.apply_semantic_embeddings(source).await?
+        };
+
+        // Apply copy_to: expand the source by copying field values to their target fields.
+        let source = {
+            let schema_guard = self.schema.read().await;
+            apply_copy_to(&source, &schema_guard.schema)
+        };
+
+        // Preprocessing above is independent and can run concurrently.
+        // Everything from CAS/liveness through WAL, VM, FTS, HNSW, and the
+        // response is one exact per-document publication interval.
+        let _publication_guard = match publication_guard {
+            Some(guard) => guard,
+            None => self.write_publication.lock(doc_id.clone()).await,
+        };
+        #[cfg(test)]
+        self.publication_test_point(&doc_id, PublicationTestPoint::Acquired);
 
         // Optimistic concurrency check: honour `if_seq_no` whenever it
         // is supplied. ES requires `if_primary_term` alongside it, but
@@ -1350,25 +1429,39 @@ impl Index {
             }
         }
 
-        // `index.default_pipeline` is resolved and executed at the API layer
-        // (xerj-api es_compat::resolve_effective_pipeline) before the document
-        // reaches the engine, so no pipeline handling is needed here.
+        if create_only {
+            let exists = self
+                .store
+                .version_map
+                .get(&doc_id)
+                .map(|entry| !entry.deleted)
+                .unwrap_or(false)
+                || self.memtable.contains(&doc_id);
+            if exists {
+                return Err(EngineError::Common(
+                    xerj_common::XerjError::version_conflict(&doc_id, 0, 1),
+                ));
+            }
+        }
 
-        // Auto-embed `semantic_text` fields: vectorise the field's text into
-        // its companion vector field (`<field>_vector`) so it becomes
-        // kNN-searchable. Runs before copy_to / storage so the derived vector
-        // is part of `_source` and gets picked up by HNSW indexing below.
-        let source = if semantic_embeddings_prepared {
-            source
-        } else {
-            self.apply_semantic_embeddings(source).await?
-        };
+        if let Some((version, strict)) = external_version {
+            if let Some(existing) = self.external_versions.get(&doc_id) {
+                let current = *existing;
+                let valid = if strict {
+                    version > current
+                } else {
+                    version >= current
+                };
+                if !valid {
+                    return Err(EngineError::Common(
+                        xerj_common::XerjError::version_conflict(&doc_id, version, current),
+                    ));
+                }
+            }
+        }
 
-        // Apply copy_to: expand the source by copying field values to their target fields.
-        let source = {
-            let schema_guard = self.schema.read().await;
-            apply_copy_to(&source, &schema_guard.schema)
-        };
+        // Invalidate the response cache only after admission and CAS succeed.
+        self.dataset_version.fetch_add(1, Ordering::Release);
 
         // Detect whether this is an overwrite (existing doc) vs a new
         // insert BEFORE writing to storage. Used to set the response
@@ -1386,6 +1479,15 @@ impl Index {
 
         // Write to storage WAL.
         let seq_no = self.store.index(&doc_id, source.clone())?;
+        // External-version admission becomes durable only after the WAL write
+        // succeeds. Publishing it before `store.index` would poison an exact
+        // retry when WAL append fails.
+        if let Some((external_version, _)) = external_version {
+            self.external_versions
+                .insert(doc_id.clone(), external_version);
+        }
+        #[cfg(test)]
+        self.publication_test_point(&doc_id, PublicationTestPoint::AfterWalVersionMap);
 
         // Write to FTS memtable.
         {
@@ -1394,6 +1496,8 @@ impl Index {
             mem.remove(&doc_id);
             mem.insert(doc_id.clone(), &source, &schema_guard.schema, seq_no);
         }
+        #[cfg(test)]
+        self.publication_test_point(&doc_id, PublicationTestPoint::AfterFts);
 
         // Bump counter (flush thresholds / stats bookkeeping only — NOT the
         // response `_version`, which is per-doc).
@@ -1460,6 +1564,8 @@ impl Index {
 
         // Index any vector fields into the HNSW index.
         self.index_vectors(&doc_id, &source).await;
+        #[cfg(test)]
+        self.publication_test_point(&doc_id, PublicationTestPoint::AfterHnsw);
 
         // Trigger a background flush if memtable exceeds size or doc-count threshold.
         self.maybe_spawn_flush().await;
@@ -1476,10 +1582,14 @@ impl Index {
 
         debug!(doc_id = doc_id.as_str(), seq_no, "document indexed");
 
+        #[cfg(test)]
+        self.publication_test_point(&doc_id, PublicationTestPoint::BeforeRelease);
         Ok(IndexResponse {
             id: doc_id,
             seq_no,
-            version,
+            version: external_version
+                .map(|(version, _)| version)
+                .unwrap_or(version),
             result: if existed_before {
                 "updated".to_string()
             } else {
@@ -2495,39 +2605,17 @@ impl Index {
     ///
     /// Returns `Err(VersionConflict)` if a live document with the same ID exists.
     pub async fn create_document(&self, id: String, source: Value) -> Result<IndexResponse> {
-        // Check write block first.
-        if self.is_write_blocked().await {
-            return Err(EngineError::Common(xerj_common::XerjError::index_blocked(
-                self.name.as_str(),
-                "write",
-            )));
-        }
-        // Process-wide admission: disk flood-stage block (item 3) + parent
-        // memory circuit breaker (item 1). Fires before any per-index work.
-        self.governor_write_gate()?;
-
-        // Fail with 409 if a live document already exists with this id.
-        let already_exists = {
-            let in_version_map = self
-                .store
-                .version_map
-                .get(&id)
-                .map(|e| !e.deleted)
-                .unwrap_or(false);
-            let in_memtable = {
-                let mem = &*self.memtable;
-                mem.contains(&id)
-            };
-            in_version_map || in_memtable
-        };
-
-        if already_exists {
-            return Err(EngineError::Common(
-                xerj_common::XerjError::version_conflict(&id, 0, 1),
-            ));
-        }
-
-        self.index_document(Some(id), source).await
+        self.index_document_with_version_inner_guarded(
+            Some(id),
+            source,
+            None,
+            None,
+            false,
+            None,
+            true,
+            None,
+        )
+        .await
     }
 
     /// Refresh: flush the current active memtable to a disk segment.
@@ -3845,6 +3933,7 @@ impl Index {
         upsert_doc: Option<Value>,
         doc_as_upsert: bool,
     ) -> Result<Option<IndexResponse>> {
+        let publication_guard = self.write_publication.lock(id.to_string()).await;
         match self.get_document(id).await? {
             Some(existing) => {
                 // Document exists — merge partial_doc on top.
@@ -3875,14 +3964,26 @@ impl Index {
                 // object against the existing source.
                 if merged == existing {
                     self.noop_update_count.fetch_add(1, Ordering::Relaxed);
+                    let current = self.store.version_map.get(id);
                     return Ok(Some(IndexResponse {
                         id: id.to_string(),
-                        seq_no: 0,
-                        version: 1,
+                        seq_no: current.as_ref().map(|entry| entry.seq_no).unwrap_or(0),
+                        version: current.map(|entry| entry.version).unwrap_or(1),
                         result: "noop".to_string(),
                     }));
                 }
-                let resp = self.index_document(Some(id.to_string()), merged).await?;
+                let resp = self
+                    .index_document_with_version_inner_guarded(
+                        Some(id.to_string()),
+                        merged,
+                        None,
+                        None,
+                        false,
+                        Some(publication_guard),
+                        false,
+                        None,
+                    )
+                    .await?;
                 Ok(Some(resp))
             }
             None => {
@@ -3890,7 +3991,18 @@ impl Index {
                 if doc_as_upsert {
                     // Use partial_doc as the creation body.
                     let body = partial_doc.unwrap_or(Value::Object(serde_json::Map::new()));
-                    let resp = self.index_document(Some(id.to_string()), body).await?;
+                    let resp = self
+                        .index_document_with_version_inner_guarded(
+                            Some(id.to_string()),
+                            body,
+                            None,
+                            None,
+                            false,
+                            Some(publication_guard),
+                            false,
+                            None,
+                        )
+                        .await?;
                     Ok(Some(resp))
                 } else if let Some(upsert_body) = upsert_doc {
                     // Create with upsert body, then merge partial_doc on top.
@@ -3909,7 +4021,18 @@ impl Index {
                     } else {
                         upsert_body
                     };
-                    let resp = self.index_document(Some(id.to_string()), body).await?;
+                    let resp = self
+                        .index_document_with_version_inner_guarded(
+                            Some(id.to_string()),
+                            body,
+                            None,
+                            None,
+                            false,
+                            Some(publication_guard),
+                            false,
+                            None,
+                        )
+                        .await?;
                     Ok(Some(resp))
                 } else {
                     Ok(None)
@@ -6061,6 +6184,9 @@ impl Index {
         // Process-wide admission: disk flood-stage block (item 3) + parent
         // memory circuit breaker (item 1). Fires before any per-index work.
         self.governor_write_gate()?;
+        let _publication_guard = self.write_publication.lock(id.to_string()).await;
+        #[cfg(test)]
+        self.publication_test_point(id, PublicationTestPoint::Acquired);
         self.dataset_version.fetch_add(1, Ordering::Release);
 
         // Optimistic concurrency check (see index_document_with_version for
@@ -6120,6 +6246,8 @@ impl Index {
             let seq_no = existing
                 .map(|e| e.seq_no)
                 .unwrap_or_else(|| self.store.current_seq_no().saturating_sub(1));
+            #[cfg(test)]
+            self.publication_test_point(id, PublicationTestPoint::BeforeRelease);
             return Ok(DeleteDocOutcome {
                 found: false,
                 seq_no,
@@ -6128,6 +6256,8 @@ impl Index {
         }
 
         let deleted_seq = self.store.delete(id)?;
+        #[cfg(test)]
+        self.publication_test_point(id, PublicationTestPoint::AfterWalVersionMap);
         let existed = deleted_seq.is_some();
 
         // Remove from memtable.
@@ -6135,6 +6265,8 @@ impl Index {
             let mem = &*self.memtable;
             mem.remove(id);
         }
+        #[cfg(test)]
+        self.publication_test_point(id, PublicationTestPoint::AfterFts);
 
         // v0.6.2 — propagate the delete into the HNSW graph. Pre-fix
         // a deleted doc was unfindable via _get / _search but the
@@ -6163,6 +6295,8 @@ impl Index {
                 })
                 .ok();
         }
+        #[cfg(test)]
+        self.publication_test_point(id, PublicationTestPoint::AfterHnsw);
 
         if existed {
             self.doc_count.fetch_sub(1, Ordering::Relaxed);
@@ -6177,6 +6311,8 @@ impl Index {
                 .version_map
                 .bump_tombstone_version(id)
                 .unwrap_or(1);
+            #[cfg(test)]
+            self.publication_test_point(id, PublicationTestPoint::BeforeRelease);
             return Ok(DeleteDocOutcome {
                 found: false,
                 seq_no: self.store.current_seq_no().saturating_sub(1),
@@ -6192,6 +6328,8 @@ impl Index {
             .map(|e| e.version)
             .unwrap_or(1);
         let seq_no = deleted_seq.unwrap_or_else(|| self.store.current_seq_no().saturating_sub(1));
+        #[cfg(test)]
+        self.publication_test_point(id, PublicationTestPoint::BeforeRelease);
         Ok(DeleteDocOutcome {
             found: true,
             seq_no,
@@ -6209,6 +6347,7 @@ impl Index {
         id: &str,
         partial_doc: Value,
     ) -> Result<Option<IndexResponse>> {
+        let publication_guard = self.write_publication.lock(id.to_string()).await;
         // Fetch existing document source.
         let existing = match self.get_document(id).await? {
             Some(src) => src,
@@ -6236,7 +6375,18 @@ impl Index {
         };
 
         // Re-index with the same ID (upsert-style).
-        let resp = self.index_document(Some(id.to_string()), merged).await?;
+        let resp = self
+            .index_document_with_version_inner_guarded(
+                Some(id.to_string()),
+                merged,
+                None,
+                None,
+                false,
+                Some(publication_guard),
+                false,
+                None,
+            )
+            .await?;
         Ok(Some(resp))
     }
 
@@ -26280,5 +26430,105 @@ mod chunk_embed_tests {
             max_sim > pooled_score,
             "best-passage max-sim ({max_sim}) should beat pooled ({pooled_score})"
         );
+    }
+}
+
+#[cfg(test)]
+mod write_publication_integration_tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn put_holds_publication_key_through_response_before_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine
+            .create_index("publication-hook", Schema::empty())
+            .unwrap();
+        let idx = engine.get_index("publication-hook").unwrap();
+
+        let initial = idx
+            .index_document(Some("same".into()), json!({"state": "initial"}))
+            .await
+            .unwrap();
+
+        let acquired = Arc::new(AtomicUsize::new(0));
+        let pause_once = Arc::new(AtomicBool::new(false));
+        let (paused_tx, paused_rx) = std::sync::mpsc::sync_channel(1);
+        let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
+        let paused_tx = parking_lot::Mutex::new(Some(paused_tx));
+        let resume_rx = parking_lot::Mutex::new(Some(resume_rx));
+        let hook: PublicationTestHook = {
+            let acquired = Arc::clone(&acquired);
+            let pause_once = Arc::clone(&pause_once);
+            Arc::new(move |id, point| {
+                assert_eq!(id, "same");
+                if point == PublicationTestPoint::Acquired {
+                    acquired.fetch_add(1, Ordering::SeqCst);
+                }
+                if point == PublicationTestPoint::AfterWalVersionMap
+                    && !pause_once.swap(true, Ordering::SeqCst)
+                {
+                    paused_tx.lock().take().unwrap().send(()).unwrap();
+                    resume_rx.lock().take().unwrap().recv().unwrap();
+                }
+            })
+        };
+        idx.set_publication_test_hook(Some(hook));
+
+        let put = {
+            let idx = Arc::clone(&idx);
+            tokio::spawn(async move {
+                idx.index_document_with_version(
+                    Some("same".into()),
+                    json!({"state": "put"}),
+                    Some(initial.seq_no),
+                    Some(1),
+                )
+                .await
+            })
+        };
+        tokio::task::spawn_blocking(move || paused_rx.recv().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(acquired.load(Ordering::SeqCst), 1);
+
+        let (queued_tx, queued_rx) = std::sync::mpsc::sync_channel(1);
+        let queued_tx = Arc::new(parking_lot::Mutex::new(Some(queued_tx)));
+        idx.write_publication.set_before_mutex_await_hook({
+            let queued_tx = Arc::clone(&queued_tx);
+            Some(Arc::new(move |id| {
+                assert_eq!(id, "same");
+                queued_tx.lock().take().unwrap().send(()).unwrap();
+            }))
+        });
+        let delete = {
+            let idx = Arc::clone(&idx);
+            tokio::spawn(async move { idx.delete_document_versioned("same", None, None).await })
+        };
+        tokio::task::spawn_blocking(move || queued_rx.recv().unwrap())
+            .await
+            .unwrap();
+        idx.write_publication.set_before_mutex_await_hook(None);
+        assert_eq!(
+            acquired.load(Ordering::SeqCst),
+            1,
+            "delete acquired the same key while PUT was paused after WAL/VM"
+        );
+
+        resume_tx.send(()).unwrap();
+        let put = put.await.unwrap().unwrap();
+        let delete = delete.await.unwrap().unwrap();
+        idx.set_publication_test_hook(None);
+
+        assert_eq!(put.version, 2);
+        assert!(delete.found);
+        assert_eq!(delete.version, 3);
+        assert!(delete.seq_no > put.seq_no);
+        assert!(idx.get_document("same").await.unwrap().is_none());
+        assert_eq!(acquired.load(Ordering::SeqCst), 2);
     }
 }

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -172,6 +172,14 @@ pub struct IndexResponse {
     pub result: String,
 }
 
+/// Result of a same-ID serialized read-transform-write operation.
+#[derive(Debug, Clone)]
+pub struct SerializedDocumentUpdate {
+    pub response: IndexResponse,
+    /// `true` when the supplied upsert body created a previously missing ID.
+    pub created: bool,
+}
+
 /// Outcome of a single-document delete (ES `DELETE /{index}/_doc/{id}`).
 ///
 /// `found == true`  → the doc was live and is now tombstoned; `seq_no` is
@@ -4041,6 +4049,54 @@ impl Index {
         }
     }
 
+    /// Serialize the load, transform, and publication of one document ID.
+    ///
+    /// The exact-ID publication guard spans the authoritative read, caller
+    /// transform, WAL/version-map update, FTS/HNSW publication, and response.
+    /// This is the engine boundary used by API-layer scripted updates: keeping
+    /// script evaluation outside this method turns `ctx._source.n += 1` into
+    /// an unguarded read-modify-write and loses concurrent increments.
+    ///
+    /// `transform` is called only for an existing source. If the ID is missing,
+    /// `upsert` is created without applying the transform (ES's default
+    /// `scripted_upsert=false` behavior); without an upsert this returns
+    /// `Ok(Ok(None))`. Transform errors are returned in the inner `Result`
+    /// without publishing a write.
+    pub async fn transform_document_serialized<E, F>(
+        &self,
+        id: &str,
+        upsert: Option<Value>,
+        transform: F,
+    ) -> Result<std::result::Result<Option<SerializedDocumentUpdate>, E>>
+    where
+        F: FnOnce(Value) -> std::result::Result<Value, E>,
+    {
+        let publication_guard = self.write_publication.lock(id.to_string()).await;
+        let (source, created) = match self.get_document(id).await? {
+            Some(existing) => match transform(existing) {
+                Ok(transformed) => (transformed, false),
+                Err(error) => return Ok(Err(error)),
+            },
+            None => match upsert {
+                Some(source) => (source, true),
+                None => return Ok(Ok(None)),
+            },
+        };
+        let response = self
+            .index_document_with_version_inner_guarded(
+                Some(id.to_string()),
+                source,
+                None,
+                None,
+                false,
+                Some(publication_guard),
+                false,
+                None,
+            )
+            .await?;
+        Ok(Ok(Some(SerializedDocumentUpdate { response, created })))
+    }
+
     /// Scan a document for vector fields and insert them into the HNSW graph.
     ///
     /// FIELD IDENTITY (see `hnsw_field`): one graph indexes exactly ONE
@@ -6187,8 +6243,6 @@ impl Index {
         let _publication_guard = self.write_publication.lock(id.to_string()).await;
         #[cfg(test)]
         self.publication_test_point(id, PublicationTestPoint::Acquired);
-        self.dataset_version.fetch_add(1, Ordering::Release);
-
         // Optimistic concurrency check (see index_document_with_version for
         // the if_primary_term rationale).
         let _ = if_primary_term;
@@ -6255,6 +6309,10 @@ impl Index {
             });
         }
 
+        // Invalidate response caches only once the OCC check has succeeded and
+        // the delete will mutate publication state. A rejected conditional
+        // delete must not make unrelated cached responses look stale.
+        self.dataset_version.fetch_add(1, Ordering::Release);
         let deleted_seq = self.store.delete(id)?;
         #[cfg(test)]
         self.publication_test_point(id, PublicationTestPoint::AfterWalVersionMap);
@@ -26530,5 +26588,83 @@ mod write_publication_integration_tests {
         assert!(delete.seq_no > put.seq_no);
         assert!(idx.get_document("same").await.unwrap().is_none());
         assert_eq!(acquired.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_serialized_transforms_do_not_lose_read_modify_write_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine
+            .create_index("atomic-transform", Schema::empty())
+            .unwrap();
+        let idx = engine.get_index("atomic-transform").unwrap();
+        idx.index_document(Some("counter".into()), json!({"n": 0}))
+            .await
+            .unwrap();
+
+        let start = Arc::new(tokio::sync::Barrier::new(33));
+        let mut tasks = Vec::new();
+        for _ in 0..32 {
+            let idx = Arc::clone(&idx);
+            let start = Arc::clone(&start);
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                idx.transform_document_serialized("counter", None, |mut source| {
+                    let n = source["n"].as_u64().unwrap();
+                    source["n"] = json!(n + 1);
+                    Ok::<_, ()>(source)
+                })
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap()
+                .response
+            }));
+        }
+        start.wait().await;
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        assert_eq!(idx.get_document("counter").await.unwrap().unwrap()["n"], 32);
+    }
+
+    #[tokio::test]
+    async fn rejected_conditional_delete_does_not_invalidate_query_cache_epoch() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine
+            .create_index("delete-epoch", Schema::empty())
+            .unwrap();
+        let idx = engine.get_index("delete-epoch").unwrap();
+        let indexed = idx
+            .index_document(Some("doc".into()), json!({"live": true}))
+            .await
+            .unwrap();
+        let before = idx.dataset_version.load(Ordering::Acquire);
+
+        let error = idx
+            .delete_document_versioned("doc", Some(indexed.seq_no + 1), Some(1))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("version conflict"));
+        assert_eq!(
+            idx.dataset_version.load(Ordering::Acquire),
+            before,
+            "rejected OCC delete must not invalidate cached responses"
+        );
+
+        idx.delete_document_versioned("doc", Some(indexed.seq_no), Some(1))
+            .await
+            .unwrap();
+        assert_eq!(
+            idx.dataset_version.load(Ordering::Acquire),
+            before + 1,
+            "successful delete invalidates cached responses exactly once"
+        );
     }
 }

--- a/engine/crates/xerj-engine/src/lib.rs
+++ b/engine/crates/xerj-engine/src/lib.rs
@@ -28,6 +28,7 @@ pub mod rbac;
 pub mod slow_query;
 pub mod sql;
 pub mod turbo_ingest;
+mod write_publication;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 

--- a/engine/crates/xerj-engine/src/write_publication.rs
+++ b/engine/crates/xerj-engine/src/write_publication.rs
@@ -1,0 +1,290 @@
+//! Exact keyed ordering for document publication.
+//!
+//! A key exists in the registry only while a holder or waiter owns a strong
+//! reference to its mutex. The registry keeps a `Weak`, so idle document IDs
+//! do not accumulate forever.
+
+use std::sync::{Arc, Weak};
+
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+#[derive(Default)]
+pub(crate) struct WritePublicationCoordinator {
+    locks: DashMap<String, Weak<Mutex<()>>>,
+    #[cfg(test)]
+    before_mutex_await: parking_lot::RwLock<Option<Arc<dyn Fn(&str) + Send + Sync + 'static>>>,
+}
+
+pub(crate) struct WritePublicationGuard {
+    coordinator: Arc<WritePublicationCoordinator>,
+    key: String,
+    lock: Arc<Mutex<()>>,
+    guard: Option<OwnedMutexGuard<()>>,
+}
+
+impl WritePublicationCoordinator {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub(crate) async fn lock(self: &Arc<Self>, key: impl Into<String>) -> WritePublicationGuard {
+        self.lock_inner(key.into(), None).await
+    }
+
+    async fn lock_inner(
+        self: &Arc<Self>,
+        key: String,
+        before_await: Option<Box<dyn FnOnce() + Send>>,
+    ) -> WritePublicationGuard {
+        let lock = match self.locks.entry(key.clone()) {
+            Entry::Occupied(mut occupied) => match occupied.get().upgrade() {
+                Some(lock) => lock,
+                None => {
+                    let lock = Arc::new(Mutex::new(()));
+                    occupied.insert(Arc::downgrade(&lock));
+                    lock
+                }
+            },
+            Entry::Vacant(vacant) => {
+                let lock = Arc::new(Mutex::new(()));
+                vacant.insert(Arc::downgrade(&lock));
+                lock
+            }
+        };
+        // Runs after the registry entry guard is gone and immediately before
+        // queueing. Tests use this handshake to cancel a known waiter without
+        // sleeps or scheduler guesses.
+        if let Some(before_await) = before_await {
+            before_await();
+        }
+        #[cfg(test)]
+        {
+            let hook = self.before_mutex_await.read().clone();
+            if let Some(hook) = hook {
+                hook(&key);
+            }
+        }
+        let guard = Arc::clone(&lock).lock_owned().await;
+        WritePublicationGuard {
+            coordinator: Arc::clone(self),
+            key,
+            lock,
+            guard: Some(guard),
+        }
+    }
+
+    #[cfg(test)]
+    async fn lock_with_before_await(
+        self: &Arc<Self>,
+        key: impl Into<String>,
+        before_await: impl FnOnce() + Send + 'static,
+    ) -> WritePublicationGuard {
+        self.lock_inner(key.into(), Some(Box::new(before_await)))
+            .await
+    }
+
+    /// Acquire a deadlock-free set of exact document keys.
+    ///
+    /// Sorting gives every caller one global acquisition order; deduplication
+    /// prevents a request from waiting on its own non-reentrant key.
+    #[allow(dead_code)]
+    pub(crate) async fn lock_many<I, S>(self: &Arc<Self>, keys: I) -> Vec<WritePublicationGuard>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut keys: Vec<String> = keys.into_iter().map(Into::into).collect();
+        keys.sort_unstable();
+        keys.dedup();
+
+        let mut guards = Vec::with_capacity(keys.len());
+        for key in keys {
+            guards.push(self.lock(key).await);
+        }
+        guards
+    }
+
+    #[cfg(test)]
+    fn registry_len(&self) -> usize {
+        self.locks.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_before_mutex_await_hook(
+        &self,
+        hook: Option<Arc<dyn Fn(&str) + Send + Sync + 'static>>,
+    ) {
+        *self.before_mutex_await.write() = hook;
+    }
+}
+
+impl Drop for WritePublicationGuard {
+    fn drop(&mut self) {
+        // Release the mutex before attempting registry cleanup. Any queued
+        // waiter already owns another strong Arc and therefore prevents
+        // removal below.
+        self.guard.take();
+
+        if let Entry::Occupied(occupied) = self.coordinator.locks.entry(self.key.clone()) {
+            let is_same = occupied
+                .get()
+                .upgrade()
+                .map(|registered| Arc::ptr_eq(&registered, &self.lock))
+                .unwrap_or(false);
+            if is_same && Arc::strong_count(&self.lock) == 1 {
+                occupied.remove();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn same_key_is_strictly_ordered_and_cleans_up() {
+        let coordinator = WritePublicationCoordinator::new();
+        let first = coordinator.lock("same").await;
+        let (attempt_tx, attempt_rx) = tokio::sync::oneshot::channel();
+        let (acquired_tx, mut acquired_rx) = tokio::sync::oneshot::channel();
+
+        let task = {
+            let coordinator = Arc::clone(&coordinator);
+            tokio::spawn(async move {
+                attempt_tx.send(()).unwrap();
+                let _second = coordinator.lock("same").await;
+                acquired_tx.send(()).unwrap();
+            })
+        };
+        attempt_rx.await.unwrap();
+        assert!(
+            acquired_rx.try_recv().is_err(),
+            "same key entered before the first guard was released"
+        );
+        assert_eq!(coordinator.registry_len(), 1);
+
+        drop(first);
+        acquired_rx.await.unwrap();
+        task.await.unwrap();
+        assert_eq!(coordinator.registry_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn disjoint_keys_do_not_block_each_other() {
+        let coordinator = WritePublicationCoordinator::new();
+        let _a = coordinator.lock("a").await;
+        tokio::time::timeout(Duration::from_millis(100), coordinator.lock("b"))
+            .await
+            .expect("unrelated key must not wait");
+    }
+
+    #[tokio::test]
+    async fn lock_many_sorts_deduplicates_and_cleans_up() {
+        let coordinator = WritePublicationCoordinator::new();
+        let guards = coordinator.lock_many(["c", "a", "b", "a"]).await;
+        assert_eq!(guards.len(), 3);
+        assert_eq!(coordinator.registry_len(), 3);
+        drop(guards);
+        assert_eq!(coordinator.registry_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn registry_is_bounded_by_live_keys_not_historical_keys() {
+        let coordinator = WritePublicationCoordinator::new();
+        for i in 0..10_000 {
+            let guard = coordinator.lock(format!("historical-{i}")).await;
+            drop(guard);
+        }
+        assert_eq!(
+            coordinator.registry_len(),
+            0,
+            "idle document IDs must not remain in the registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_failure_style_early_return_release_key() {
+        async fn fail_after_lock(
+            coordinator: Arc<WritePublicationCoordinator>,
+        ) -> Result<(), &'static str> {
+            let _guard = coordinator.lock("wal-failure").await;
+            Err("injected WAL failure")
+        }
+
+        let coordinator = WritePublicationCoordinator::new();
+        assert_eq!(
+            fail_after_lock(Arc::clone(&coordinator)).await,
+            Err("injected WAL failure")
+        );
+        assert_eq!(coordinator.registry_len(), 0);
+        tokio::time::timeout(Duration::from_millis(100), coordinator.lock("wal-failure"))
+            .await
+            .expect("key leaked after early error");
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_queued_waiter_does_not_leak_or_wedge_the_key() {
+        let coordinator = WritePublicationCoordinator::new();
+        let first = coordinator.lock("cancelled").await;
+        let (attempt_tx, attempt_rx) = tokio::sync::oneshot::channel();
+        let waiter = {
+            let coordinator = Arc::clone(&coordinator);
+            tokio::spawn(async move {
+                let _guard = coordinator
+                    .lock_with_before_await("cancelled", move || {
+                        attempt_tx.send(()).unwrap();
+                    })
+                    .await;
+            })
+        };
+        attempt_rx.await.unwrap();
+        waiter.abort();
+        assert!(waiter.await.unwrap_err().is_cancelled());
+        drop(first);
+
+        let guard = coordinator.lock("cancelled").await;
+        drop(guard);
+        assert_eq!(coordinator.registry_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn reversed_multi_key_requests_complete_without_deadlock() {
+        let coordinator = WritePublicationCoordinator::new();
+        let start = Arc::new(tokio::sync::Barrier::new(3));
+        let left = {
+            let coordinator = Arc::clone(&coordinator);
+            let start = Arc::clone(&start);
+            tokio::spawn(async move {
+                start.wait().await;
+                let guards = coordinator.lock_many(["b", "a"]).await;
+                tokio::task::yield_now().await;
+                drop(guards);
+            })
+        };
+        let right = {
+            let coordinator = Arc::clone(&coordinator);
+            let start = Arc::clone(&start);
+            tokio::spawn(async move {
+                start.wait().await;
+                let guards = coordinator.lock_many(["a", "b"]).await;
+                tokio::task::yield_now().await;
+                drop(guards);
+            })
+        };
+        start.wait().await;
+
+        tokio::time::timeout(Duration::from_secs(1), left)
+            .await
+            .expect("sorted acquisition deadlocked")
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), right)
+            .await
+            .expect("second sorted acquisition stayed wedged")
+            .unwrap();
+        assert_eq!(coordinator.registry_len(), 0);
+    }
+}

--- a/engine/crates/xerj-engine/src/write_publication.rs
+++ b/engine/crates/xerj-engine/src/write_publication.rs
@@ -24,6 +24,17 @@ pub(crate) struct WritePublicationGuard {
     guard: Option<OwnedMutexGuard<()>>,
 }
 
+/// Owns the registry's strong reference while `lock_owned()` is pending.
+///
+/// This is deliberately separate from [`WritePublicationGuard`]: cancelling
+/// the acquire future never constructs a guard, so cleanup must live in a
+/// value that already exists before the `.await`.
+struct PendingLock {
+    coordinator: Arc<WritePublicationCoordinator>,
+    key: String,
+    lock: Option<Arc<Mutex<()>>>,
+}
+
 impl WritePublicationCoordinator {
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self::default())
@@ -66,7 +77,15 @@ impl WritePublicationCoordinator {
                 hook(&key);
             }
         }
-        let guard = Arc::clone(&lock).lock_owned().await;
+        let mut pending = PendingLock {
+            coordinator: Arc::clone(self),
+            key: key.clone(),
+            lock: Some(lock),
+        };
+        let guard = Arc::clone(pending.lock.as_ref().expect("pending lock present"))
+            .lock_owned()
+            .await;
+        let lock = pending.lock.take().expect("pending lock present");
         WritePublicationGuard {
             coordinator: Arc::clone(self),
             key,
@@ -120,6 +139,27 @@ impl WritePublicationCoordinator {
     }
 }
 
+fn remove_if_idle(coordinator: &WritePublicationCoordinator, key: &str, lock: &Arc<Mutex<()>>) {
+    if let Entry::Occupied(occupied) = coordinator.locks.entry(key.to_string()) {
+        let is_same = occupied
+            .get()
+            .upgrade()
+            .map(|registered| Arc::ptr_eq(&registered, lock))
+            .unwrap_or(false);
+        if is_same && Arc::strong_count(lock) == 1 {
+            occupied.remove();
+        }
+    }
+}
+
+impl Drop for PendingLock {
+    fn drop(&mut self) {
+        if let Some(lock) = self.lock.as_ref() {
+            remove_if_idle(&self.coordinator, &self.key, lock);
+        }
+    }
+}
+
 impl Drop for WritePublicationGuard {
     fn drop(&mut self) {
         // Release the mutex before attempting registry cleanup. Any queued
@@ -127,16 +167,7 @@ impl Drop for WritePublicationGuard {
         // removal below.
         self.guard.take();
 
-        if let Entry::Occupied(occupied) = self.coordinator.locks.entry(self.key.clone()) {
-            let is_same = occupied
-                .get()
-                .upgrade()
-                .map(|registered| Arc::ptr_eq(&registered, &self.lock))
-                .unwrap_or(false);
-            if is_same && Arc::strong_count(&self.lock) == 1 {
-                occupied.remove();
-            }
-        }
+        remove_if_idle(&self.coordinator, &self.key, &self.lock);
     }
 }
 
@@ -246,9 +277,9 @@ mod tests {
         assert!(waiter.await.unwrap_err().is_cancelled());
         drop(first);
 
+        assert_eq!(coordinator.registry_len(), 0);
         let guard = coordinator.lock("cancelled").await;
         drop(guard);
-        assert_eq!(coordinator.registry_len(), 0);
     }
 
     #[tokio::test]

--- a/engine/crates/xerj-engine/tests/integration.rs
+++ b/engine/crates/xerj-engine/tests/integration.rs
@@ -5044,6 +5044,259 @@ async fn test_semantic_text_bulk_preserves_item_order_status_and_vectors() {
     assert_eq!(b["content_vector"].as_array().unwrap().len(), 16);
 }
 
+#[tokio::test]
+async fn test_put_delete_recreate_publication_versions_and_visibility() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine
+        .create_index("publication-order", Schema::empty())
+        .unwrap();
+    let idx = engine.get_index("publication-order").unwrap();
+
+    let first = idx
+        .index_document(Some("same".into()), json!({"state": "first"}))
+        .await
+        .unwrap();
+    assert_eq!(first.result, "created");
+    assert_eq!(first.version, 1);
+
+    let deleted = idx
+        .delete_document_versioned("same", None, None)
+        .await
+        .unwrap();
+    assert!(deleted.found);
+    assert_eq!(deleted.version, 2);
+    assert!(deleted.seq_no > first.seq_no);
+    assert!(idx.get_document("same").await.unwrap().is_none());
+
+    let recreated = idx
+        .index_document(Some("same".into()), json!({"state": "recreated"}))
+        .await
+        .unwrap();
+    assert_eq!(recreated.result, "created");
+    assert_eq!(recreated.version, 3);
+    assert!(recreated.seq_no > deleted.seq_no);
+    assert_eq!(
+        idx.get_document("same").await.unwrap().unwrap()["state"],
+        "recreated"
+    );
+
+    idx.flush().await.unwrap();
+    assert_eq!(
+        idx.get_document("same").await.unwrap().unwrap()["state"],
+        "recreated",
+        "latest publication must survive flush"
+    );
+}
+
+#[tokio::test]
+async fn test_conditional_put_and_delete_same_id_linearize_at_cas() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine
+        .create_index("publication-race", Schema::empty())
+        .unwrap();
+    let idx = engine.get_index("publication-race").unwrap();
+
+    for round in 0..32 {
+        let id = format!("same-{round}");
+        let initial = idx
+            .index_document(Some(id.clone()), json!({"winner": "initial"}))
+            .await
+            .unwrap();
+        let expected_seq = initial.seq_no;
+        let start = std::sync::Arc::new(tokio::sync::Barrier::new(3));
+
+        let put = {
+            let idx = std::sync::Arc::clone(&idx);
+            let id = id.clone();
+            let start = std::sync::Arc::clone(&start);
+            tokio::spawn(async move {
+                start.wait().await;
+                idx.index_document_with_version(
+                    Some(id),
+                    json!({"winner": "put"}),
+                    Some(expected_seq),
+                    Some(1),
+                )
+                .await
+            })
+        };
+        let delete = {
+            let idx = std::sync::Arc::clone(&idx);
+            let id = id.clone();
+            let start = std::sync::Arc::clone(&start);
+            tokio::spawn(async move {
+                start.wait().await;
+                idx.delete_document_versioned(&id, Some(expected_seq), Some(1))
+                    .await
+            })
+        };
+        start.wait().await;
+
+        let put = put.await.unwrap();
+        let delete = delete.await.unwrap();
+        assert_eq!(
+            put.is_ok() as u8 + delete.is_ok() as u8,
+            1,
+            "exactly one operation may consume the same CAS precondition"
+        );
+
+        if let Ok(response) = put {
+            assert_eq!(response.version, 2);
+            assert_eq!(
+                idx.get_document(&id).await.unwrap().unwrap()["winner"],
+                "put"
+            );
+        } else {
+            let outcome = delete.unwrap();
+            assert!(outcome.found);
+            assert_eq!(outcome.version, 2);
+            assert!(idx.get_document(&id).await.unwrap().is_none());
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_create_and_updates_share_exact_publication_key() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine
+        .create_index("publication-create-update", Schema::empty())
+        .unwrap();
+    let idx = engine.get_index("publication-create-update").unwrap();
+
+    let start = std::sync::Arc::new(tokio::sync::Barrier::new(17));
+    let mut creates = Vec::new();
+    for writer in 0..16 {
+        let idx = std::sync::Arc::clone(&idx);
+        let start = std::sync::Arc::clone(&start);
+        creates.push(tokio::spawn(async move {
+            start.wait().await;
+            idx.create_document("same".into(), json!({"created_by": writer, "base": true}))
+                .await
+        }));
+    }
+    start.wait().await;
+    let mut successes = 0;
+    for task in creates {
+        successes += task.await.unwrap().is_ok() as usize;
+    }
+    assert_eq!(successes, 1, "create-only admission must be linearized");
+
+    let start = std::sync::Arc::new(tokio::sync::Barrier::new(17));
+    let mut updates = Vec::new();
+    for writer in 0..16 {
+        let idx = std::sync::Arc::clone(&idx);
+        let start = std::sync::Arc::clone(&start);
+        updates.push(tokio::spawn(async move {
+            start.wait().await;
+            idx.update_document_with_upsert(
+                "same",
+                Some(json!({(format!("field_{writer}")): writer})),
+                None,
+                false,
+            )
+            .await
+        }));
+    }
+    start.wait().await;
+    for task in updates {
+        task.await.unwrap().unwrap().unwrap();
+    }
+
+    let source = idx.get_document("same").await.unwrap().unwrap();
+    for writer in 0..16 {
+        assert_eq!(source[format!("field_{writer}")], writer);
+    }
+
+    let changed = idx
+        .update_document("same", json!({"stable": "value"}))
+        .await
+        .unwrap()
+        .unwrap();
+    let noop = idx
+        .update_document_with_upsert("same", Some(json!({"stable": "value"})), None, false)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(noop.result, "noop");
+    assert_eq!(noop.seq_no, changed.seq_no);
+    assert_eq!(noop.version, changed.version);
+
+    let upsert_start = std::sync::Arc::new(tokio::sync::Barrier::new(3));
+    let mut upserts = Vec::new();
+    for field in ["left", "right"] {
+        let idx = std::sync::Arc::clone(&idx);
+        let start = std::sync::Arc::clone(&upsert_start);
+        upserts.push(tokio::spawn(async move {
+            start.wait().await;
+            idx.update_document_with_upsert("missing", Some(json!({(field): true})), None, true)
+                .await
+        }));
+    }
+    upsert_start.wait().await;
+    for task in upserts {
+        task.await.unwrap().unwrap().unwrap();
+    }
+    let upserted = idx.get_document("missing").await.unwrap().unwrap();
+    assert_eq!(upserted["left"], true);
+    assert_eq!(upserted["right"], true);
+}
+
+#[tokio::test]
+async fn test_concurrent_external_versions_publish_highest_source() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine
+        .create_index("publication-external", Schema::empty())
+        .unwrap();
+    let idx = engine.get_index("publication-external").unwrap();
+    idx.index_document_external(Some("same".into()), json!({"external": 1}), 1, "external")
+        .await
+        .unwrap();
+
+    let start = std::sync::Arc::new(tokio::sync::Barrier::new(3));
+    let mut tasks = Vec::new();
+    for version in [2_u64, 3] {
+        let idx = std::sync::Arc::clone(&idx);
+        let start = std::sync::Arc::clone(&start);
+        tasks.push(tokio::spawn(async move {
+            start.wait().await;
+            (
+                version,
+                idx.index_document_external(
+                    Some("same".into()),
+                    json!({"external": version}),
+                    version,
+                    "external",
+                )
+                .await,
+            )
+        }));
+    }
+    start.wait().await;
+    let mut version_three_succeeded = false;
+    for task in tasks {
+        let (requested, result) = task.await.unwrap();
+        if requested == 3 {
+            assert_eq!(result.unwrap().version, 3);
+            version_three_succeeded = true;
+        }
+    }
+    assert!(version_three_succeeded);
+    assert_eq!(
+        idx.get_document("same").await.unwrap().unwrap()["external"],
+        3
+    );
+    assert!(
+        idx.index_document_external(Some("same".into()), json!({"external": 2}), 2, "external",)
+            .await
+            .is_err(),
+        "lower external version must remain rejected"
+    );
+}
+
 #[cfg(feature = "onnx-experimental")]
 #[tokio::test]
 async fn test_semantic_bulk_preserves_onnx_admission_429() {


### PR DESCRIPTION
## Motivation

Concurrent mutations of the same document could pass their current-state checks independently and then complete WAL, VersionMap, full-text, vector, and response publication in a different order. This made the acknowledged result depend on task scheduling rather than one coherent per-document order.

The observable failures were correctness failures, not merely stale intermediate reads: two concurrent create-only requests could both succeed, concurrent partial updates could lose fields, two operations could consume the same optimistic-concurrency precondition, a lower external version could overwrite the source published by a higher version, and a delete could race an in-flight write.

## Root cause

Sequence-number reservation and individual state checks existed, but there was no shared critical section spanning the complete publication interval for one document ID. Create, optimistic concurrency control, external versioning, update, and delete therefore checked one state and could publish against another.

Fixing only one stage would not establish ordering. For example, serializing VersionMap writes alone would still allow FTS or HNSW publication to complete in reverse order, while serializing only the initial CAS check would allow both operations to proceed after the lock was released.

## What changed

- Added an exact keyed `WritePublicationCoordinator` whose key is the document ID.
- The coordinator stores weak mutex references so historical IDs do not accumulate in a permanent lock registry.
- Same-ID mutations queue behind the same mutex, while unrelated IDs remain concurrent; this is not a fixed-stripe lock and does not add one global write mutex.
- Added sorted and deduplicated multi-key acquisition support so future callers can acquire several IDs without inverted-order deadlocks or self-deadlock from duplicate IDs.
- Moved ordinary/prepared/OCC PUT, create-only, `external` and `external_gte`, update/upsert/noop, and delete current-state checks inside the exact per-ID publication interval.
- Hold the guard from current-state/CAS/liveness checks through WAL, VersionMap, FTS, HNSW, and response construction.
- Keep embedding and `copy_to` preprocessing outside the guarded interval so expensive ID-independent work can still overlap.
- Publish an accepted external version only after the document write succeeds, preventing a failed write from poisoning retries.
- Reworked update to hold one non-reentrant guard across read, merge or script evaluation, noop detection, and publication, which prevents concurrent patches from silently replacing one another.
- Return the existing sequence number and version for a true noop instead of inventing a new acknowledged mutation.
- Added deterministic test hooks at lock acquisition, after WAL/VersionMap, after FTS, after HNSW, and before release; these hooks are test-only.

## Scope and non-goals

This is the first publication-ordering layer and intentionally covers the single-document ordinary/prepared/OCC, create, external-version, update/upsert/noop, and delete paths wired by this change.

It does not claim that every engine write path is now ordered. Parsed, raw, synchronous, and realtime turbo batch paths are not wired to this coordinator in this PR and require separate follow-up work.

It does not make a transaction or cancellation-atomicity claim. Dropping or cancelling a future releases its per-ID guard safely, but this PR does not add a commit marker or rollback for publication stages that already completed before cancellation or failure.

It does not add sequence identity to existing HNSW nodes and therefore does not by itself prove stale-vector suppression across every batch or recovery interleaving.

It does not change the ES wire protocol, API request shape, durability configuration, embedding output, or query ranking.

## Correctness tests

- Exact coordinator tests prove strict same-key ordering, concurrent progress for disjoint keys, sorted and deduplicated multi-key acquisition, bounded weak-entry cleanup across 10,000 historical IDs, cleanup after early error, and cleanup after cancelling a queued waiter.
- A deterministic stage-interleaving test pauses PUT after WAL/VersionMap, proves that delete is queued at the same exact key, resumes PUT, and verifies ordered versions, sequence numbers, and final deletion.
- A 32-round concurrent conditional PUT/delete test proves that exactly one operation can consume a shared `if_seq_no` precondition.
- Sixteen concurrent create-only calls prove that exactly one create succeeds.
- Sixteen concurrent partial updates prove that all independent fields survive rather than being lost.
- Concurrent missing-ID upserts prove that both patches survive.
- Noop coverage verifies that the response reports the existing sequence number and version.
- Concurrent external versions verify that the highest accepted version owns the final source and that a later lower version remains rejected.
- Put/delete/recreate coverage verifies monotonic sequence/version responses, immediate visibility, and the final source after flush.

## Validation

- Focused coordinator and publication-order regression tests passed.
- `xerj-engine` library tests passed `137/137` with only the known `origin/main` Painless flat-chain stack-overflow test excluded; this exclusion is unrelated to this change and is not presented as a full unfiltered library pass.
- Warnings-denied Clippy passed for `xerj-engine` library and tests.
- Rustfmt and `git diff --check` passed.
- The scoped release builds used `cargo build --release -j 32 -p xerj-server` and `cargo build --release -j 32 -p es-yaml-runner`.
- The isolated hard ES-YAML gate used a fresh data directory and the complete 199-file corpus: `1360 passed / 0 failed / 3 skipped / 1363 total`.
- The conformance summary was checked directly rather than inferred from runner exit status, the server was stopped with SIGINT, and no listener remained on the three test ports.

## Manual reproduction

The race can be reasoned about with two clients using the same document ID and the same current `if_seq_no`: client A performs conditional PUT while client B performs conditional DELETE. Before this change, both operations could pass the precondition before either completed publication; the correct result is exactly one success and one version conflict.

The deterministic in-tree reproduction avoids relying on timing or sleeps:

```bash
cd engine
cargo test -p xerj-engine --test integration test_conditional_put_and_delete_same_id_linearize_at_cas -- --exact --nocapture
cargo test -p xerj-engine write_publication_integration_tests::put_holds_publication_key_through_response_before_delete -- --exact --nocapture
```

The first command repeats the competing conditional PUT/delete operation for 32 document IDs and requires exactly one winner per ID. The second pauses PUT at a precise publication stage and proves DELETE cannot enter the same-ID interval until PUT has constructed its response and released the guard.

The broader concurrency cases can be run with:

```bash
cd engine
cargo test -p xerj-engine --test integration test_concurrent_create_and_updates_share_exact_publication_key -- --exact --nocapture
cargo test -p xerj-engine --test integration test_concurrent_external_versions_publish_highest_source -- --exact --nocapture
cargo test -p xerj-engine write_publication::tests -- --nocapture
```

## Risk and trade-offs

Same-ID mutations are now deliberately serialized across their publication stages, so a slow write for one ID increases latency for later writes to that same ID. Writes to different IDs remain independently schedulable.

Embedding and `copy_to` work remains outside the lock to avoid unnecessarily extending contention, which means concurrent requests may perform preprocessing before one later fails create, CAS, or external-version admission. That is wasted work in the losing request but does not publish incorrect state.

The weak-entry cleanup logic is concurrency-sensitive. Tests specifically cover holder release, queued-waiter cancellation, early error, 10,000 transient IDs, and pointer-identity-aware cleanup so a departing guard cannot remove a replacement mutex.

This PR establishes the shared primitive required by later batch work, but reviewers should evaluate it only against the single-document paths listed above rather than treating it as an end-to-end batching or FinanceBench performance change.