### PR TITLE
fix(api): complete OpenSearch Dashboards compatibility (product header + _cat/templates/{pattern})

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -84,19 +84,8 @@ const FALLBACK_OPENSEARCH_VERSION: &str = "2.11.0";
 ///    `EsVersion::default()`.
 fn resolve_compat_version(state: &AppState, headers: &axum::http::HeaderMap) -> EsVersion {
     let mut version = EsVersion::default();
-
     let cfg = &state.config.compat;
-    let user_agent = headers
-        .get(axum::http::header::USER_AGENT)
-        .and_then(|v| v.to_str().ok());
-
-    let is_opensearch = if !cfg.distribution.is_empty() {
-        cfg.distribution == "opensearch"
-    } else {
-        user_agent
-            .map(|ua| ua.to_ascii_lowercase().contains("opensearch"))
-            .unwrap_or(false)
-    };
+    let is_opensearch = is_opensearch_caller(state, headers);
 
     if is_opensearch {
         version.distribution = Some("opensearch".to_string());
@@ -112,6 +101,33 @@ fn resolve_compat_version(state: &AppState, headers: &axum::http::HeaderMap) -> 
     }
 
     version
+}
+
+/// Is THIS caller (or is xerj forced to treat every caller as) an
+/// OpenSearch client? Shared by `resolve_compat_version` (the `version`/
+/// `distribution` block) and `router::es_headers_middleware` (the
+/// `x-elastic-product` response header — a real OpenSearch server never
+/// sends this at all, so an OpenSearch-detected caller shouldn't receive
+/// an Elastic-specific product-identity marker, on general correctness
+/// grounds — this alone was NOT sufficient to get a real OpenSearch
+/// Dashboards container past its `.kibana` saved-objects-migration 404,
+/// see PR description for what was actually confirmed).
+///
+/// Same two-tier priority as `resolve_compat_version`: an explicit
+/// `--compat-distribution` override always wins; otherwise a
+/// case-insensitive "contains opensearch" match on `User-Agent` (verified
+/// empirically against real `opensearch-py`/`opensearch-js` — including
+/// OpenSearch Dashboards' own internal client).
+pub(crate) fn is_opensearch_caller(state: &AppState, headers: &axum::http::HeaderMap) -> bool {
+    let cfg = &state.config.compat;
+    if !cfg.distribution.is_empty() {
+        return cfg.distribution == "opensearch";
+    }
+    headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map(|ua| ua.to_ascii_lowercase().contains("opensearch"))
+        .unwrap_or(false)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -19089,13 +19089,94 @@ pub async fn head_index(
 // GET /_cat/templates — list templates in text format
 // ─────────────────────────────────────────────────────────────────────────────
 
-pub async fn cat_templates(State(state): State<AppState>) -> impl IntoResponse {
-    // name  index_patterns  order  version
+/// Query params for `/_cat/templates` (and its `{pattern}` variant).
+/// `format=json` returns a JSON array instead of the plain-text table —
+/// OpenSearch Dashboards' own `cat.templates()` call requests this.
+#[derive(Debug, Deserialize, Default)]
+pub struct CatTemplatesParams {
+    #[serde(default)]
+    pub format: Option<String>,
+}
+
+pub async fn cat_templates(
+    State(state): State<AppState>,
+    Query(params): Query<CatTemplatesParams>,
+) -> impl IntoResponse {
+    cat_templates_inner(state, None, params).await
+}
+
+/// `GET /_cat/templates/{pattern}` — the pattern-scoped variant.
+///
+/// Previously unrouted, so a wildcard-pattern call (e.g. OpenSearch
+/// Dashboards' own startup check for `opensearch_dashboards_index_template*`)
+/// fell through to the router's bare 404 fallback: no body at all, not even
+/// an ES-shaped JSON error. `opensearch-js`'s `cat.templates()` can't parse
+/// an empty body and throws — found empirically, this is what actually
+/// crashes OSD's saved-objects migration, not the (perfectly well-formed)
+/// `.kibana` 404 it hits right before this call.
+///
+/// Same `_cat` selector semantics as `/_cat/indices/{pattern}`: a WILDCARD
+/// matching nothing is an empty 200, never a 404 — a concrete template name
+/// matching nothing does 404, but templates have no equivalent of `_all`
+/// index-not-found semantics worth enforcing here since nothing currently
+/// creates a naming collision risk.
+pub async fn cat_templates_pattern(
+    State(state): State<AppState>,
+    Path(pattern): Path<String>,
+    Query(params): Query<CatTemplatesParams>,
+) -> impl IntoResponse {
+    cat_templates_inner(state, Some(pattern), params).await
+}
+
+async fn cat_templates_inner(
+    state: AppState,
+    pattern: Option<String>,
+    params: CatTemplatesParams,
+) -> axum::response::Response {
+    let matches_pattern = |name: &str| match pattern.as_deref() {
+        None => true,
+        Some(pat) => pat
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .any(|p| p == "_all" || p == "*" || p == name || glob_match_simple(p, name)),
+    };
+
+    let mut rows: Vec<(String, Vec<String>, i32)> = state
+        .engine
+        .templates
+        .iter()
+        .filter(|entry| matches_pattern(entry.key()))
+        .map(|entry| {
+            let t = entry.value();
+            (entry.key().clone(), t.index_patterns.clone(), t.priority)
+        })
+        .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if params.format.as_deref() == Some("json") {
+        let arr: Vec<Value> = rows
+            .iter()
+            .map(|(name, index_patterns, priority)| {
+                json!({
+                    "name": name,
+                    "index_patterns": format!("[{}]", index_patterns.join(", ")),
+                    "order": priority.to_string(),
+                    "version": "",
+                })
+            })
+            .collect();
+        return Json(arr).into_response();
+    }
+
     let mut lines: Vec<String> = Vec::new();
-    for entry in state.engine.templates.iter() {
-        let t = entry.value();
-        let patterns = t.index_patterns.join(",");
-        lines.push(format!("{} {} {} -", entry.key(), patterns, t.priority));
+    for (name, index_patterns, priority) in &rows {
+        lines.push(format!(
+            "{} {} {} -",
+            name,
+            index_patterns.join(","),
+            priority
+        ));
     }
     let body = if lines.is_empty() {
         String::new()

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -372,6 +372,10 @@ pub fn build_es_compat_router(state: AppState) -> Router {
         .route("/_tasks/:task_id/_cancel", post(es_compat::cancel_task))
         // ── Cat templates ──────────────────────────────────────────────────
         .route("/_cat/templates", get(es_compat::cat_templates))
+        .route(
+            "/_cat/templates/:pattern",
+            get(es_compat::cat_templates_pattern),
+        )
         // ── Ingest pipelines ───────────────────────────────────────────────
         .route(
             "/_ingest/pipeline",

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -9,7 +9,7 @@
 //! to both.
 
 use axum::{
-    extract::{DefaultBodyLimit, Request},
+    extract::{DefaultBodyLimit, Request, State},
     http::{HeaderValue, Method},
     middleware::{self, Next},
     response::Response,
@@ -753,8 +753,11 @@ pub fn build_es_compat_router(state: AppState) -> Router {
         // Shared state
         .with_state(state.clone())
         // Middleware stack (applied outermost-last)
-        .layer(middleware::from_fn_with_state(state, auth_middleware))
-        .layer(middleware::from_fn(es_headers_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ))
+        .layer(middleware::from_fn_with_state(state, es_headers_middleware))
         .layer(middleware::from_fn(request_id_middleware))
         .layer(trace_layer(access_log))
         .layer(cors)
@@ -772,18 +775,34 @@ pub fn build_es_compat_router(state: AppState) -> Router {
 /// Middleware that sets ES-compatible product headers on every response.
 ///
 /// Kibana and other Elastic clients verify the presence of `X-Elastic-Product`
-/// before trusting the response.  A `Warning` header is included for
-/// compatibility with tools that check for deprecation notices.
-async fn es_headers_middleware(req: Request, next: Next) -> Response {
+/// before trusting the response. A real OpenSearch server never sends this
+/// header at all, so a caller detected (or forced, see
+/// [`es_compat::is_opensearch_caller`]) as OpenSearch must NOT receive it —
+/// some OpenSearch-ecosystem clients treat an unexpected product header as
+/// just another response header, but there's no reason to send an
+/// Elastic-specific identity marker to a client we've already decided isn't
+/// Elastic. A `Warning` header is included for Elastic callers only, for the
+/// same reason.
+async fn es_headers_middleware(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let is_opensearch = es_compat::is_opensearch_caller(&state, req.headers());
     let mut resp = next.run(req).await;
     let headers = resp.headers_mut();
-    headers.insert(
-        "x-elastic-product",
-        HeaderValue::from_static("Elasticsearch"),
-    );
-    // RFC 7234 warning header — signals no specific deprecation for now.
-    if let Ok(v) = HeaderValue::from_str("299 Elasticsearch-8.13.0 \"\"") {
-        headers.insert("warning", v);
+    if is_opensearch {
+        headers.remove("x-elastic-product");
+        headers.remove("warning");
+    } else {
+        headers.insert(
+            "x-elastic-product",
+            HeaderValue::from_static("Elasticsearch"),
+        );
+        // RFC 7234 warning header — signals no specific deprecation for now.
+        if let Ok(v) = HeaderValue::from_str("299 Elasticsearch-8.13.0 \"\"") {
+            headers.insert("warning", v);
+        }
     }
     resp
 }


### PR DESCRIPTION
## Summary

Follow-up to #28. Two fixes, discovered while root-causing the real OSD `.kibana` saved-objects-migration crash that #28 explicitly left open:

**1. `x-elastic-product` was sent unconditionally, even to detected-OpenSearch callers.** A real OpenSearch server never sends this header at all — Elastic clients use its presence as a product-verification check, so it should only go to callers we've identified as Elastic. Made `es_headers_middleware` distribution-aware, reusing #28's detection (extracted into a shared `is_opensearch_caller()`).

**2. The actual root cause of the crash: `GET /_cat/templates/{pattern}` wasn't routed at all.** OSD's `opensearch-js` client calls `GET /_cat/templates/opensearch_dashboards_index_template*?format=json` to check for its own index template before creating one. Only the bare `/_cat/templates` (no pattern) was routed — the pattern-scoped call fell through to the router's default fallback: **no body at all**, not even xerj's usual ES-shaped JSON error. `opensearch-js` can't parse an empty body and throws a fatal, unrecoverable error — exactly the empty-body symptom (`meta.body: ''`, `content-length: '0'`) reported in #28.

## How #1 was found to be insufficient, and how #2 was actually found

#28 (correctly) suspected the `.kibana` 404 as the crash trigger, since it was the last request logged before the crash. It turned out to be a red herring — `GET /.kibana` was already returning a perfectly well-formed ES-shaped 404 JSON body, confirmed twice (curl, and xerj's own access log).

To settle this properly, rather than trust an intermediate proxy tool again (a naive Python HTTP-parsing proxy used earlier gave an inconclusive, possibly-misleading result), a **raw, non-interpreting TCP relay** (`asyncio`-based, byte passthrough with no HTTP parsing at all) was placed between a real OSD 2.11.1 container and xerj, capturing the exact bytes exchanged. That capture showed the actual failing exchange clearly:
```
GET /_cat/templates/opensearch_dashboards_index_template*?format=json HTTP/1.1
...
HTTP/1.1 404 Not Found
content-length: 0
date: ...
(no body)
```
— not `.kibana` at all. Added `GET /_cat/templates/{pattern}`, mirroring the existing `/_cat/indices/{pattern}` selector semantics (comma-separated names/globs, wildcard-matching-nothing is an empty `200`, never a `404`) and the `format=json` convention already used elsewhere in the `_cat` family.

## Verified end-to-end against real containers — zero flags/config on xerj

- **OpenSearch Dashboards 2.11.1**: saved-objects migration completes (`Creating index .kibana_1`, `Pointing alias .kibana to .kibana_1`, `Finished in 77ms`), server starts, `GET /api/status` reports `status.overall.state: "green"`, `GET /app/home` returns a real page.
- **OpenSearch Dashboards 3.6.0**: same result — `status: "green"`.

Both were stuck in the exact same crash before this PR. This is the actual completion of the auto-sense OpenSearch compatibility work started in #28, not a new/separate feature.

## Test plan
- [x] `cargo build --release -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] curl: `x-elastic-product`/`warning` correctly present/absent per detected distribution, unchanged for Elasticsearch/Kibana callers
- [x] curl: `GET /_cat/templates/{pattern}` — no match → `200 []`; match → real entries; plain-text `/_cat/templates` unchanged in shape
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] Real OpenSearch Dashboards 2.11.1 container: full startup, `status: green`, `/app/home` serves
- [x] Real OpenSearch Dashboards 3.6.0 container: full startup, `status: green`, `/app/home` serves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
