### PR TITLE
fix(api): resolve aliases on single-index endpoints; persist aliases across restart

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -1077,8 +1077,17 @@ async fn get_index_inner(
             }
             continue;
         }
-        // Exact name.
-        if all.iter().any(|info| info.name == part) {
+        // Exact name — could be a real index, or an alias pointing at one
+        // (ES/OpenSearch accept both interchangeably on GET /{index}; e.g.
+        // Kibana/OSD resolve `.kibana` — always an alias, never a bare
+        // index — through this exact endpoint).
+        if let Some(targets) = state.engine.aliases.get(part) {
+            for n in targets.value() {
+                if !selected.contains(n) {
+                    selected.push(n.clone());
+                }
+            }
+        } else if all.iter().any(|info| info.name == part) {
             if !selected.contains(&part.to_string()) {
                 selected.push(part.to_string());
             }
@@ -14434,8 +14443,23 @@ async fn resolve_index_selector(state: &AppState, spec: &str) -> Vec<String> {
             }
             continue;
         }
-        // Exact name — include whether or not it exists; the caller decides.
-        if !out.contains(&part.to_string()) {
+        // Exact name — could be a real index, OR an alias pointing at one
+        // (real ES/OpenSearch accept both interchangeably on every
+        // single-index endpoint: GET/_mapping/_settings/etc.). Resolve to
+        // the underlying real index name(s) so callers keying their
+        // response by `name` (e.g. get_mapping's `index_mappings` lookup)
+        // hit the actually-stored entry instead of silently missing and
+        // falling back to a schema-derived reconstruction that drops
+        // fields like mappings._meta. Falls back to the literal name
+        // (include whether or not it exists; the caller decides) when it
+        // isn't a known alias either.
+        if let Some(targets) = state.engine.aliases.get(part) {
+            for n in targets.value() {
+                if !out.contains(n) {
+                    out.push(n.clone());
+                }
+            }
+        } else if !out.contains(&part.to_string()) {
             out.push(part.to_string());
         }
     }

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -465,6 +465,14 @@ impl Engine {
         // requests (i.e. here in `new`), and is cheap (one small JSON file).
         engine.load_persisted_api_keys();
 
+        // Restore persisted aliases so e.g. `.kibana` (always an alias,
+        // never a bare index) still resolves after a restart — see
+        // `load_persisted_aliases`'s doc comment for the concrete failure
+        // this caused (OpenSearch Dashboards stuck indefinitely on every
+        // restart, mistaking a missing-alias 404 for a still-in-progress
+        // migration by another instance).
+        engine.load_persisted_aliases();
+
         // Spawn the PIT sweeper. Pre-v0.6.2 PITs accumulated forever;
         // every open without close was a memory leak. The sweeper
         // walks `engine.pits` every `pit.sweep_interval_secs` and
@@ -967,12 +975,75 @@ impl Engine {
 
     // ── Alias methods ─────────────────────────────────────────────────────────
 
+    /// Path of the persisted alias catalog (`<data_dir>/aliases.json`).
+    fn aliases_path(&self) -> PathBuf {
+        self.data_dir.join("aliases.json")
+    }
+
+    /// Serialize the current `aliases` map to `<data_dir>/aliases.json`
+    /// atomically (temp-file + rename), mirroring `flush_api_keys`. Every
+    /// alias mutation snapshots the full map; a write failure is logged but
+    /// non-fatal (the alias still works in-memory until the next restart).
+    fn flush_aliases(&self) {
+        let snapshot: std::collections::HashMap<String, Vec<String>> = self
+            .aliases
+            .iter()
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect();
+        let bytes = match serde_json::to_vec_pretty(&snapshot) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "failed to serialize aliases for persistence");
+                return;
+            }
+        };
+        if let Err(e) = crate::index::write_file_atomic(&self.aliases_path(), &bytes) {
+            warn!(error = %e, "failed to persist aliases.json (aliases work until restart)");
+        }
+    }
+
+    /// Load persisted aliases from `<data_dir>/aliases.json` into the
+    /// in-memory map on boot. A missing file is normal (fresh node / no
+    /// aliases ever created); a corrupt file is logged and ignored.
+    ///
+    /// Without this, `.kibana` (always an alias, never a bare index —
+    /// Kibana/OpenSearch Dashboards create it via `PUT .kibana_1` +
+    /// `POST _aliases`) silently stopped resolving on every restart: the
+    /// backing index's data survived, but the alias pointing at it didn't,
+    /// so `GET /.kibana` 404'd and OSD's saved-objects migrator concluded
+    /// the migration was still in progress (never actually completing) —
+    /// found empirically via a real OpenSearch Dashboards container stuck
+    /// on "Another OpenSearch Dashboards instance appears to be migrating
+    /// the index" on every restart, indefinitely.
+    fn load_persisted_aliases(&self) {
+        let path = self.aliases_path();
+        let Ok(bytes) = std::fs::read(&path) else {
+            return;
+        };
+        match serde_json::from_slice::<std::collections::HashMap<String, Vec<String>>>(&bytes) {
+            Ok(map) => {
+                let n = map.len();
+                for (alias, indices) in map {
+                    self.aliases.insert(alias, indices);
+                }
+                if n > 0 {
+                    info!(count = n, "restored persisted aliases");
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "ignoring corrupt aliases.json");
+            }
+        }
+    }
+
     /// Add an alias pointing to an index.
     pub fn add_alias(&self, alias: &str, index: &str) {
         let mut entry = self.aliases.entry(alias.to_string()).or_default();
         if !entry.contains(&index.to_string()) {
             entry.push(index.to_string());
         }
+        drop(entry);
+        self.flush_aliases();
     }
 
     /// Remove an alias's association with an index.
@@ -982,6 +1053,7 @@ impl Engine {
         }
         // Clean up empty alias entries.
         self.aliases.retain(|_, v| !v.is_empty());
+        self.flush_aliases();
     }
 
     /// Resolve a name: if it's an alias, return the aliased index names;
@@ -1023,6 +1095,7 @@ impl Engine {
         for a in empty_aliases {
             self.aliases.remove(&a);
         }
+        self.flush_aliases();
 
         self.closed_indices.remove(name);
         self.index_settings.remove(name);
@@ -1283,6 +1356,8 @@ impl Engine {
             if !entry.contains(&new_backing) {
                 entry.push(new_backing.clone());
             }
+            drop(entry);
+            self.flush_aliases();
         } else {
             self.add_alias(name, &new_backing);
         }
@@ -1309,6 +1384,7 @@ impl Engine {
 
         // Remove the alias.
         self.aliases.remove(name);
+        self.flush_aliases();
 
         // Delete every backing index.
         for backing in &ds.backing_indices {


### PR DESCRIPTION
## Summary

Follow-up to #28/#29. Root-caused a real, reproducible OpenSearch Dashboards bug: a **fresh** OSD container, pointed at an xerj instance that already has a fully migrated `.kibana` index, gets stuck indefinitely on:

```
Another OpenSearch Dashboards instance appears to be migrating the index.
Waiting for that migration to complete.
```

— even though there is only ever one real instance. This blocks OSD from starting at all on any second/subsequent run against existing data.

## Root cause — two compounding bugs, found via a raw byte-level TCP relay between a real OSD 3.6.0 container and xerj (same technique used for the earlier `_cat/templates` fix)

**1. Single-index endpoints never resolved an alias to its underlying real index.** `.kibana` is *always* an alias, never a bare index — OSD/Kibana create `.kibana_1` then `POST _aliases` to point `.kibana` at it. So:
- `GET /.kibana` → 404 `index_not_found_exception`, even though `.kibana` was a registered alias.
- `GET /.kibana/_mapping` → 200, but missing `mappings._meta.migrationMappingPropertyHashes` entirely — silently falling back to a schema-derived reconstruction instead of the actually-stored mapping blob.

`_meta.migrationMappingPropertyHashes` is exactly the field OSD's savedobjects migrator reads to decide "already migrated, adopt it" vs "someone else is migrating, wait." Both gaps meant it could never see a completed migration. Fixed by resolving aliases in `get_index_inner`'s inline selector and the shared `resolve_index_selector` (used by `get_mapping`/`get_settings`/etc.) — matching real ES/OpenSearch, which accept a real index name or an alias name interchangeably on every single-index endpoint.

**2. The actual root cause: `engine.aliases` was never persisted to disk.** Index *data* survives an xerj restart (confirmed working all night); the alias pointing at it didn't. So even after (1) was fixed and an alias was manually recreated via `_aliases`, a real restart of xerj wiped it again, and the next OSD container hit the identical stuck state. Added `aliases.json` persistence — atomic temp+rename, the same pattern already used for `es_mapping.json` (per-index) and `api_keys.json` (global): flushed on every mutation (`add_alias`, `remove_alias`, `delete_index`'s cleanup, data-stream rollover/delete), loaded once at `Engine::new()` before the server accepts requests.

## Verified end-to-end

Real OpenSearch Dashboards 3.6.0 container, repeated across **three separate xerj restarts in a row**: no manual alias recreation, no lock warning, straight to `Server running` / `status.overall.state: "green"` every single time. Previously this needed manual `_aliases` API intervention after every restart, indefinitely.

## Test plan
- [x] `cargo build --release -p xerj-engine -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] curl: `GET /.kibana` and `GET /.kibana/_mapping` correctly resolve through the alias, `_meta` intact
- [x] curl: create index + alias, restart xerj, alias survives (`_cat/aliases`, `GET /.kibana` both correct) with zero manual intervention
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] Real OpenSearch Dashboards 3.6.0 container: 3 consecutive xerj restarts, each followed by a fresh OSD container — clean startup every time, no manual fixup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
