### PR TITLE
fix(api): explicit top-level _source param wins over stored_fields suppression

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8583,7 +8583,19 @@ pub async fn search(
                 .and_then(|src| src.get("enabled").and_then(Value::as_bool))
                 .map(|b| !b)
                 .unwrap_or(false);
-            let source = if suppress_source_for_stored
+            // `stored_fields` implicitly suppressing `_source` (unless the
+            // list literally contains `"_source"`) is only a DEFAULT for
+            // when the caller left `_source` unspecified. When the request
+            // also carries its own explicit top-level `_source` parameter
+            // (true/false/{includes,excludes} — e.g. Discover's actual
+            // query, which sends `stored_fields: ["*"]` AND `_source:
+            // {excludes: []}` in the same request), that explicit value
+            // always wins — found empirically: without this, `_source`
+            // came back completely absent from every Discover row despite
+            // the request explicitly asking to include it, which starved
+            // every column except the couple of fields separately pulled
+            // in via `docvalue_fields`.
+            let source = if (suppress_source_for_stored && body.source.is_none())
                 || source_body_disabled
                 || source_mapping_disabled
                 || h.source.is_null()


### PR DESCRIPTION
## Summary

OpenSearch Dashboards' Discover panel showed almost every column empty for every row — only the couple of fields pulled in via `docvalue_fields` (the date/time columns) ever had values.

## Root cause

`stored_fields` implicitly suppresses `_source` in the response unless the array literally contains the string `"_source"`. That's correct as a **default** — but only when the caller left the top-level `_source` request parameter unspecified. xerj applied the suppression unconditionally, regardless of whether the request also carried its own explicit `_source` parameter.

Discover's real row-list query does exactly that combination — captured via a raw, non-interpreting TCP relay placed between a real OSD 3.6.0 container and xerj:

```json
{
  "stored_fields": ["*"],
  "docvalue_fields": [{"field": "order_date", "format": "date_time"}, ...],
  "_source": {"excludes": []}
}
```

Real ES/OpenSearch honor the explicit `_source` value regardless of what `stored_fields` says. Replaying this exact captured request against xerj confirmed the hit came back with `fields` (just the 2 docvalue-requested columns) but **no `_source` key in the response at all** — byte-for-byte the cause of every other Discover column showing empty.

## Fix

Only let `stored_fields`'s implicit suppression apply when the request's own `_source` parameter is absent (`body.source.is_none()`). An explicit `_source` value — `true`/`false`/`{includes,excludes}` — always wins, matching real ES semantics.

## Test plan
- [x] `cargo build --release -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] Replayed the exact captured Discover request against a local test index: `_source` now comes back complete with all fields
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
