### PR TITLE
fix(query): match_phrase/match_phrase_prefix accept scalar (bool/number) query values

### DIFF
--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -439,10 +439,13 @@ fn parse_match_phrase(params: &Value) -> Result<QueryNode> {
     let (field, value) = obj.iter().next().unwrap();
     let field = field.clone();
 
-    if let Some(query) = value.as_str() {
+    // Shorthand forms: `match_phrase: {field: "value"}`, `match_phrase:
+    // {field: 42}`, `match_phrase: {field: true}` — ES silently stringifies
+    // non-strings, same as `match` (see `scalar_to_string`).
+    if let Some(query) = scalar_to_string(value) {
         return Ok(QueryNode::MatchPhrase {
             field,
-            query: query.to_string(),
+            query,
             slop: 0,
             analyzer: None,
             boost: None,
@@ -453,7 +456,14 @@ fn parse_match_phrase(params: &Value) -> Result<QueryNode> {
         .as_object()
         .ok_or_else(|| qerr("`match_phrase` field value must be a string or object"))?;
 
-    let query = string_field(vobj, "query")?;
+    // Inside the object form, `query` can also be a number / bool — e.g.
+    // OpenSearch Dashboards filtering on a boolean field sends
+    // `match_phrase: {field: {query: true}}` verbatim (found empirically,
+    // this is what a real OSD dashboard filter on a bool field produces).
+    let query = vobj
+        .get("query")
+        .and_then(scalar_to_string)
+        .ok_or_else(|| qerr("`match_phrase.query` must be a non-empty scalar"))?;
     let slop = vobj.get("slop").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
     let analyzer = vobj
         .get("analyzer")
@@ -1775,10 +1785,13 @@ fn parse_match_phrase_prefix(params: &Value) -> Result<QueryNode> {
     let (field, raw) = obj.iter().next().unwrap();
     let field = field.clone();
 
-    if let Some(query) = raw.as_str() {
+    // Shorthand forms: `match_phrase_prefix: {field: "value"}`, `{field:
+    // 42}`, `{field: true}` — ES silently stringifies non-strings, same as
+    // `match` (see `scalar_to_string`).
+    if let Some(query) = scalar_to_string(raw) {
         return Ok(QueryNode::MatchPhrasePrefix {
             field,
-            query: query.to_string(),
+            query,
             max_expansions: 50,
         });
     }
@@ -1787,7 +1800,10 @@ fn parse_match_phrase_prefix(params: &Value) -> Result<QueryNode> {
         .as_object()
         .ok_or_else(|| qerr("`match_phrase_prefix` field value must be a string or object"))?;
 
-    let query = string_field(inner, "query")?;
+    let query = inner
+        .get("query")
+        .and_then(scalar_to_string)
+        .ok_or_else(|| qerr("`match_phrase_prefix.query` must be a non-empty scalar"))?;
     let max_expansions = inner
         .get("max_expansions")
         .and_then(Value::as_u64)


### PR DESCRIPTION
## Summary

OpenSearch Dashboards' dashboard filter panels threw a fatal, unrecoverable error on every request whenever a filter pill targeted a boolean field — e.g. filtering the stock "Flights" sample-data dashboard on `FlightDelay: true`. Surfaced client-side as a hard `search_phase_execution_exception: parse error: 'query' must be a non-empty string`, breaking every aggregation panel on the dashboard simultaneously (the filter is shared across all of them) — which is what actually looked like "the aggregations are broken."

## Root cause

`match` already coerces non-string JSON scalars via the existing `scalar_to_string()` helper — `match: {field: true}` behaves the same as `match: {field: "true"}`, matching real ES's documented leniency (a `match`/`match_phrase` query value can be a string, number, or boolean). `match_phrase` and `match_phrase_prefix` never got the same treatment:

- Object form (`match_phrase: {field: {query: <value>}}`) called the strict `string_field()` helper, which requires `.as_str()` to succeed — so `{"query": true}` (a JSON boolean) failed outright.
- Shorthand form (`match_phrase: {field: value}`) only checked `value.as_str()`, so even a bare `match_phrase: {field: true}` hit the same wall.

OpenSearch Dashboards' own filter-bar-to-DSL translation sends exactly `match_phrase: {FlightDelay: {query: true}}` for a boolean-field filter pill — confirmed directly from a real OSD 2.11.1 container's traffic (`x-opensearch-product-origin: opensearch-dashboards`).

## Fix

`parse_match_phrase` and `parse_match_phrase_prefix` now use the same `scalar_to_string()` lenient coercion `parse_match` already uses, for both the shorthand and object forms.

## Test plan
- [x] `cargo build --release -p xerj-query -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] `xerj-query` unit tests: 124 passed
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] curl: `match_phrase: {field: {query: true}}` on a real boolean field — no longer errors, returns a valid response

🤖 Generated with [Claude Code](https://claude.com/claude-code)
