### PR TITLE
fix(engine): term/match_phrase queries on boolean fields undercounted to 0

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -13051,8 +13051,26 @@ impl Index {
             if self.memtable.doc_count() == 0 {
                 0
             } else {
-                let target_str: Option<String> = value.as_str().map(String::from);
-                let target_num: Option<f64> = value.as_f64();
+                // `value.as_str()`/`.as_f64()` both return `None` for a
+                // JSON boolean, so a boolean-field term query previously
+                // never matched a single memtable-resident doc regardless
+                // of actual content — found empirically: `mem_doc_count`
+                // was non-zero (this branch DOES run) yet a real boolean
+                // filter still undercounted to a confident, wrong 0. Match
+                // `scored_fast_plan`'s `scoring_leaf` (already correct for
+                // this exact case) and the memtable's own on-insert
+                // encoding (`push_field`'s `Value::Bool` arm, which stores
+                // BOTH the 1.0/0.0 numeric form and the "true"/"false"
+                // keyword form) by coercing bool → both representations
+                // here too.
+                let target_str: Option<String> = match value {
+                    Value::Bool(b) => Some(b.to_string()),
+                    _ => value.as_str().map(String::from),
+                };
+                let target_num: Option<f64> = match value {
+                    Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+                    _ => value.as_f64(),
+                };
                 let mut m = 0u64;
                 if let Some(tgt) = target_num {
                     m += self.memtable.doc_values_numeric_count(field, tgt) as u64;
@@ -13089,7 +13107,17 @@ impl Index {
             other => other.to_string(),
         };
         let lowered = raw.to_ascii_lowercase();
-        let target_num: Option<f64> = value.as_f64();
+        // Same bool coercion as the memtable side above — `value.as_f64()`
+        // alone returns `None` for a JSON boolean, which used to make
+        // `served_by_dv` false for every segment whose on-disk column for
+        // this field is `Column::Numeric` (the boolean encoding
+        // `build_doc_value_columns` always uses), falling through to an
+        // FTS lookup that has no real content for a non-analyzed boolean
+        // field and confidently returns 0 instead of the correct count.
+        let target_num: Option<f64> = match value {
+            Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+            _ => value.as_f64(),
+        };
 
         let mut seg_matches: u64 = 0;
         for meta in &snap.segments {
@@ -21093,7 +21121,25 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
         } => {
             get_field_value(source, field)
                 .and_then(|v| match v {
-                    Value::String(s) => {
+                    // Real ES tokenizes whatever the field holds — a
+                    // `boolean`/numeric field's value is just its string
+                    // form ("true"/"false", "42") for phrase-matching
+                    // purposes. Pre-fix this arm only handled
+                    // `Value::String`, so a `match_phrase` against a
+                    // boolean field's `_source` value (a genuine JSON
+                    // `Bool`, never a `String`) fell to the `_ => None`
+                    // catch-all and NEVER matched any document, regardless
+                    // of value — found empirically alongside the parser-
+                    // level scalar-coercion fix for the *query* side
+                    // (xerj-query's `match_phrase`/`match_phrase_prefix`):
+                    // that fix stops the crash on `{query: true}`, but
+                    // without this one the (now-valid) query still
+                    // silently matched 0 documents.
+                    Value::String(_) | Value::Bool(_) | Value::Number(_) => {
+                        let s = match v {
+                            Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
                         let field_tokens: Vec<String> = s
                             .to_lowercase()
                             .split(|c: char| !c.is_alphanumeric())

--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -419,6 +419,28 @@ impl DocValues {
                 }
             }
             Value::Bool(b) => {
+                // Numeric column FIRST, matching the on-disk segment
+                // encoding (`build_doc_value_columns` in index.rs: a
+                // boolean is always the f64 bit-pattern of 1.0/0.0, never
+                // a keyword-only value) — the disk-segment builder reads
+                // straight from the same `Value` tree and has always
+                // gotten this right, but the memtable's own in-memory
+                // representation never populated `numeric` for booleans at
+                // all, only `keyword`. Any query still hitting a
+                // memtable-resident boolean doc through a numeric-column
+                // path (`ScoreEval::Bool`, `doc_values_numeric_count`,
+                // range/terms-agg fast paths) saw the field as absent —
+                // found empirically: a real OpenSearch Dashboards filter
+                // pill on a boolean field returned 0 hits against
+                // freshly-bulk-imported data (matches every
+                // real-world/OSD import shape — natural background flush,
+                // no explicit `_flush` — while the aggregation reading
+                // the SAME field correctly bucketed true/false, since
+                // aggregations use a different, disk-segment-only read
+                // path that was never affected).
+                let ncol = entry_no_clone(&mut self.numeric, field, Default::default);
+                pad_to(ncol, doc_index);
+                ncol.push(Some(if *b { 1.0 } else { 0.0 }));
                 let kcol = entry_no_clone(&mut self.keyword, field, Default::default);
                 pad_to(kcol, doc_index);
                 kcol.push(Some(b.to_string()));


### PR DESCRIPTION
## Summary

Root-caused a real bug behind OpenSearch Dashboards' dashboard filter panels: a `term`/`match_phrase` filter on a **boolean** field (e.g. the stock Flights sample-data dashboard filtering `FlightDelay: true`) always returned **0 hits**, while a `terms` aggregation on the exact same field correctly bucketed `true`/`false` counts. The asymmetry (aggregation right, filter wrong) pointed straight at the query/count path, not the stored data.

## Finding a reproduction was most of the effort

Neither a small hand-built index, an explicit `_flush`/`_forcemerge` after bulk import, nor a direct `_reindex` copy of the actual broken index's data ever reproduced it — all three came back correct. The real trigger turned out to be simpler than any of those guesses: **querying while the bulk-imported data is still memtable-resident** (before any explicit flush) — exactly what every real bulk import does, OpenSearch Dashboards' own sample-data importer included, since nothing in normal operation ever calls `_flush` itself.

Verified by bulk-importing OpenSearch Dashboards' own real flights sample dataset (fetched via `_reindex`/scroll from a real OSD-populated index) into a fresh index and querying it immediately with zero manual flush/merge — the same shape every real import produces.

## Root cause — two independent, compounding bugs in the memtable-resident query path (`try_shortcut_count`)

1. **`memtable.rs`'s `push_field`**: `Value::Bool` was stored *only* in the keyword column (`"true"`/`"false"` strings), never in the numeric column — unlike `Value::Number`, which correctly populates both. The on-disk segment builder (`build_doc_value_columns`) has always encoded booleans as the numeric f64 bit-pattern of `1.0`/`0.0`, matching `scored_fast_plan`'s `scoring_leaf` (already correct there). The memtable's own in-memory representation was the only inconsistent one.

2. **`try_shortcut_count`'s Bool handling**: `value.as_f64()` and `value.as_str()` both return `None` for a JSON boolean, so the memtable-side match count was unconditionally `0` regardless of actual content, and the segment-side numeric-column fast path never engaged either — falling through toward a confidently-wrong FTS lookup instead of a safe brute-force fallback. Fixed by coercing `Value::Bool` to both the `1.0`/`0.0` numeric form and the `"true"`/`"false"` string form up front, mirroring the fix already correct in `scoring_leaf`.

## A third, related bug: `match_phrase` on boolean fields

Same query shape OpenSearch Dashboards' filter bar actually sends for a boolean-field filter (see the xerj-query parser fix in #32): `doc_matches_query`'s brute-force `MatchPhrase` matcher only handled `Value::String` field values — a boolean or numeric `_source` value fell to the `_ => None` catch-all and never matched any document, regardless of value. Fixed by stringifying `Value::Bool`/`Value::Number` field values the same way `Value::String` already was, before tokenizing.

## Test plan
- [x] `cargo build --release -p xerj-engine -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] `xerj-engine` unit tests: 156 passed. Integration suites (`product_experience`, `rc4_w2_storage_hardening`, `search_context_ttl`, `shard_router_write_path`): 16 passed. 0 failed anywhere.
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] Bulk-imported the real flights sample dataset (10000 docs, 2511 true), zero manual flush, queried immediately: `term`, `match_phrase`, and `terms` agg on `FlightDelay` now all agree (2511 true / 7489 false) — `term`/`match_phrase` previously returned 0 unconditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
