### PR TITLE
fix(storage): bound per-shard WAL buffers to 64 KiB

### DIFF
--- a/engine/crates/xerj-storage/src/index_store.rs
+++ b/engine/crates/xerj-storage/src/index_store.rs
@@ -3214,6 +3214,44 @@ impl IndexStore {
 mod tests {
     use super::*;
 
+    /// Structural bound: 16 empty indices × 8 WAL shards each must retain
+    /// exactly `128 × 64 KiB` of userspace buffer capacity — not the old
+    /// `128 × 8 MiB` reservation.  Asserts `buffer_capacity()` (deterministic)
+    /// rather than process RSS.
+    #[test]
+    fn empty_multi_index_wal_buffers_have_a_bounded_total_capacity() {
+        let root = tempfile::tempdir().unwrap();
+        let mut stores = Vec::new();
+        let mut total_capacity = 0usize;
+
+        for index in 0..16 {
+            let store = IndexStore::open(
+                root.path().join(format!("index-{index}")),
+                IndexStoreConfig {
+                    sync_mode: SyncMode::Batched,
+                    wal_batch_ms: 0,
+                    num_wal_shards: 8,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            assert_eq!(store.wal_shards.len(), 8);
+            total_capacity += store
+                .wal_shards
+                .iter()
+                .map(|writer| writer.lock().unwrap().buffer_capacity())
+                .sum::<usize>();
+            stores.push(store);
+        }
+
+        assert_eq!(stores.len(), 16);
+        assert_eq!(total_capacity, 16 * 8 * 64 * 1024);
+        assert!(
+            total_capacity <= 8 * 1024 * 1024,
+            "128 idle WAL shards retained {total_capacity} bytes of buffers"
+        );
+    }
+
     fn open_test_store(dir: &Path) -> Arc<IndexStore> {
         IndexStore::open(
             dir,

--- a/engine/crates/xerj-storage/src/wal.rs
+++ b/engine/crates/xerj-storage/src/wal.rs
@@ -95,7 +95,17 @@ const WAL_FRAME_OVERHEAD: usize = 17;
 const WAL_MAX_ENTRY_LEN: u32 = 1 << 30; // 1 GiB
 
 /// BufWriter capacity shared by open/rotate/recovery reseats.
-const WAL_BUF_CAP: usize = 8 * 1024 * 1024;
+///
+/// Every append drains this userspace buffer before acknowledging the write,
+/// so a multi-megabyte capacity cannot batch across requests.  Keeping it at
+/// a conventional I/O-buffer size bounds idle retention when every index owns
+/// multiple WAL shards (the old 8 MiB capacity retained 1 GiB for 128 shards).
+///
+/// Capacity is an allocation/coalescing bound only: frame payloads may be
+/// larger than `WAL_BUF_CAP` (up to `WAL_MAX_ENTRY_LEN`).  Rust's `BufWriter`
+/// flushes and issues direct writes for oversized `write_all` slices, so
+/// correctness of large records is independent of this constant.
+const WAL_BUF_CAP: usize = 64 * 1024;
 
 // Op codes
 const OP_INDEX: u8 = 0x01;
@@ -328,6 +338,15 @@ pub struct WalWriter {
 }
 
 impl WalWriter {
+    /// Userspace `BufWriter` capacity for this writer (test/instrumentation).
+    ///
+    /// Always equals [`WAL_BUF_CAP`] after open, rotate, truncate-reseat, and
+    /// fresh-generation recovery.  Does not grow with record size.
+    #[cfg(test)]
+    pub(crate) fn buffer_capacity(&self) -> usize {
+        self.writer.capacity()
+    }
+
     /// Open (or create) the WAL in `dir`.
     ///
     /// If a WAL file for the latest generation already exists it is opened for
@@ -1835,6 +1854,11 @@ mod tests {
             source: serde_json::json!({"v": 2, "pad": "x".repeat(64)}),
         });
         assert!(err.is_err(), "append during ENOSPC must NACK");
+        assert_eq!(
+            w.buffer_capacity(),
+            WAL_BUF_CAP,
+            "truncate-and-reseat recovery must preserve the bounded capacity"
+        );
 
         // Space frees up (recovery reseated the writer on a clean fd, so
         // the fault is naturally gone) — C is acked.
@@ -1907,6 +1931,27 @@ mod tests {
         assert!(clean);
         assert_eq!(entries.len(), 2, "only a and c survive: {entries:?}");
         assert_eq!(entries[1].seq_no, seq_c);
+        assert_eq!(
+            w.buffer_capacity(),
+            WAL_BUF_CAP,
+            "batch error recovery must preserve the bounded capacity"
+        );
+        drop(w);
+
+        // Batched mode flushes each acknowledged append into the kernel even
+        // though it does not fsync inline. Reopen must retain every acked
+        // frame and use the same bounded writer capacity.
+        let reopened =
+            WalWriter::open(dir.path(), 64 * 1024 * 1024, SyncMode::Batched, seq_ctr).unwrap();
+        assert_eq!(reopened.buffer_capacity(), WAL_BUF_CAP);
+        drop(reopened);
+        let replayed: Vec<_> = WalReader::new(dir.path())
+            .replay()
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+        assert_eq!(replayed.len(), 2);
+        assert_eq!(replayed[1].seq_no, seq_c);
     }
 
     /// Crash-torn tail heal at open: a partial frame left at the file
@@ -2069,5 +2114,205 @@ mod tests {
         let reader = WalReader::new(dir.path());
         let entries: Vec<_> = reader.replay().unwrap().map(|r| r.unwrap()).collect();
         assert_eq!(entries.len(), 3);
+    }
+
+    #[test]
+    fn bounded_buffer_survives_append_rotate_and_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let seq_counter = Arc::new(AtomicU64::new(1));
+        let mut writer = WalWriter::open(
+            dir.path(),
+            64 * 1024 * 1024,
+            SyncMode::Strict,
+            Arc::clone(&seq_counter),
+        )
+        .unwrap();
+        assert_eq!(writer.buffer_capacity(), WAL_BUF_CAP);
+
+        let first = WalEntry::Index {
+            doc_id: "before-rotate".into(),
+            source: serde_json::json!({"payload": "durable"}),
+        };
+        assert_eq!(writer.append(&first).unwrap(), 1);
+        writer.rotate().unwrap();
+        assert_eq!(writer.buffer_capacity(), WAL_BUF_CAP);
+
+        let second = WalEntry::Index {
+            doc_id: "after-rotate".into(),
+            source: serde_json::json!({"payload": "also durable"}),
+        };
+        assert_eq!(writer.append(&second).unwrap(), 2);
+        drop(writer);
+
+        let reopened =
+            WalWriter::open(dir.path(), 64 * 1024 * 1024, SyncMode::Strict, seq_counter).unwrap();
+        assert_eq!(reopened.buffer_capacity(), WAL_BUF_CAP);
+        drop(reopened);
+
+        let entries: Vec<_> = WalReader::new(dir.path())
+            .replay()
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].seq_no, 1);
+        assert_eq!(entries[1].seq_no, 2);
+    }
+
+    /// Records smaller than, equal to, and much larger than `WAL_BUF_CAP`
+    /// must all survive append, forced rotation (truncation of generations),
+    /// reopen, and exact replay.  Capacity stays fixed regardless of payload.
+    #[test]
+    fn records_across_buffer_capacity_survive_append_rotate_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let seq_counter = Arc::new(AtomicU64::new(1));
+        let mut writer = WalWriter::open(
+            dir.path(),
+            // Force rotation after a few large frames.
+            256 * 1024,
+            SyncMode::Batched,
+            Arc::clone(&seq_counter),
+        )
+        .unwrap();
+        assert_eq!(writer.buffer_capacity(), WAL_BUF_CAP);
+
+        // High-entropy printable so LZ4 cannot collapse oversized payloads
+        // back under the buffer capacity.
+        let alphabet = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        let mk_payload = |n: usize, salt: u32| {
+            let mut state = salt;
+            let body: String = (0..n)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 17;
+                    state ^= state << 5;
+                    alphabet[state as usize % alphabet.len()] as char
+                })
+                .collect();
+            serde_json::json!({"body": body, "n": n})
+        };
+
+        let shapes: &[(usize, &str)] = &[
+            (64, "small"),
+            (WAL_BUF_CAP, "equal-cap"),
+            (WAL_BUF_CAP * 2 + 17, "2x-cap"),
+            (131_072, "131kib"),
+        ];
+        let mut expected_ids = Vec::new();
+        for (size, label) in shapes {
+            for copy in 0..3 {
+                let doc_id = format!("{label}-{copy}");
+                let seq = writer
+                    .append(&WalEntry::Index {
+                        doc_id: doc_id.clone(),
+                        source: mk_payload(*size, (size + copy) as u32 + 0x9e37_79b9),
+                    })
+                    .unwrap();
+                assert!(seq > 0);
+                expected_ids.push(doc_id);
+                assert_eq!(
+                    writer.buffer_capacity(),
+                    WAL_BUF_CAP,
+                    "capacity must not grow with record size {size}"
+                );
+            }
+        }
+        writer.force_rotate().unwrap();
+        assert_eq!(writer.buffer_capacity(), WAL_BUF_CAP);
+
+        // One more append after rotate to prove the new generation is live.
+        let final_id = "post-rotate".to_string();
+        writer
+            .append(&WalEntry::Index {
+                doc_id: final_id.clone(),
+                source: mk_payload(128, 7),
+            })
+            .unwrap();
+        expected_ids.push(final_id);
+        drop(writer);
+
+        let reopened = WalWriter::open(
+            dir.path(),
+            256 * 1024,
+            SyncMode::Batched,
+            Arc::clone(&seq_counter),
+        )
+        .unwrap();
+        assert_eq!(reopened.buffer_capacity(), WAL_BUF_CAP);
+        drop(reopened);
+
+        let replayed: Vec<_> = WalReader::new(dir.path())
+            .replay()
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+        let ids: Vec<String> = replayed
+            .iter()
+            .map(|e| match &e.entry {
+                WalEntry::Index { doc_id, .. } => doc_id.clone(),
+                other => panic!("unexpected entry {other:?}"),
+            })
+            .collect();
+        assert_eq!(ids, expected_ids);
+    }
+
+    /// Concurrent shard writers sharing one sequence counter must keep the
+    /// bounded capacity and produce an exact combined replay set.
+    #[test]
+    fn concurrent_shard_writers_preserve_capacity_and_exact_replay() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        let root = tempfile::tempdir().unwrap();
+        let seq = Arc::new(AtomicU64::new(1));
+        let barrier = Arc::new(Barrier::new(5));
+        let mut handles = Vec::new();
+        for shard in 0..4 {
+            let dir = root.path().join(format!("s{shard}"));
+            fs::create_dir_all(&dir).unwrap();
+            let seq = Arc::clone(&seq);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                let mut w =
+                    WalWriter::open(&dir, 64 * 1024 * 1024, SyncMode::Batched, seq).unwrap();
+                assert_eq!(w.buffer_capacity(), WAL_BUF_CAP);
+                barrier.wait();
+                for i in 0..50 {
+                    let pad = if i % 10 == 0 {
+                        "X".repeat(WAL_BUF_CAP + 256)
+                    } else {
+                        "y".repeat(32)
+                    };
+                    w.append(&WalEntry::Index {
+                        doc_id: format!("s{shard}-{i}"),
+                        source: serde_json::json!({"pad": pad}),
+                    })
+                    .unwrap();
+                }
+                w.sync().unwrap();
+                assert_eq!(w.buffer_capacity(), WAL_BUF_CAP);
+            }));
+        }
+        barrier.wait();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let mut total = 0usize;
+        for shard in 0..4 {
+            let dir = root.path().join(format!("s{shard}"));
+            let replayed: Vec<_> = WalReader::new(&dir)
+                .replay()
+                .unwrap()
+                .map(|e| e.unwrap())
+                .collect();
+            assert_eq!(replayed.len(), 50);
+            total += replayed.len();
+            let reopened =
+                WalWriter::open(&dir, 64 * 1024 * 1024, SyncMode::Batched, Arc::clone(&seq))
+                    .unwrap();
+            assert_eq!(reopened.buffer_capacity(), WAL_BUF_CAP);
+        }
+        assert_eq!(total, 200);
     }
 }


### PR DESCRIPTION
## Summary

Bound each per-shard WAL userspace `BufWriter` from **8 MiB to 64 KiB** via the shared `WAL_BUF_CAP` constant used by open, rotate, truncate-reseat recovery, and fresh-generation recovery.

Every acknowledged WAL append already drains the userspace buffer (Strict fsyncs; Batched flushes to the kernel). Multi-megabyte capacity therefore cannot batch across requests—it is pure idle allocator retention. With multi-shard defaults, empty indices reserved ~N × 8 MiB (256 writers ≈ **2.0 GiB** jemalloc allocated). After this change the same shape reserves ~N × 64 KiB (**~16 MiB**).

Frame payloads may still exceed 64 KiB (up to `WAL_MAX_ENTRY_LEN` = 1 GiB). Rust's `BufWriter` writes oversized slices directly; correctness is independent of capacity. Oversized records may use more write syscalls (measured below).

This is a storage-only change. No frame format, sync mode, sequence assignment, prune policy, server cache, ONNX, PDF, or semantic path changes.

## Usage / behavior

- **Default:** no configuration. All `WalWriter` construction paths pick up the new capacity.
- **Idle multi-index memory:** dramatically lower allocator reservation for empty/lightly used indices.
- **Normal small documents (< 64 KiB framed):** still one coalesced kernel write per append drain; throughput within pre-registered gates.
- **Large documents (> 64 KiB framed):** more write syscalls possible; throughput/p95 still pass in the measured incompressible 131 KiB shape.
- **Recovery / rotation / reopen:** capacity stays 64 KiB after every reseat path (unit-tested).

## Verified results (current `origin/main` = `1da511e`)

| Cell | Base (8 MiB) | Candidate (64 KiB) | Result |
|---|---:|---:|---|
| Empty 16×16 writers jemalloc Δ allocated | 2,147,503,496 B | 16,797,064 B | **−99.218%** (≤40 MiB gate) |
| Single-shard 1M docs/s median (n=5) | 168,663 | 164,673 | **0.976×** (≥0.95) |
| Single-shard p95 median | 4,588 ns | 4,598 ns | **1.002×** (≤1.05) |
| Eight-shard 1M docs/s median (n=5) | 715,809 | 729,993 | **1.020×** |
| Eight-shard p95 median | 4,707 ns | 4,728 ns | **1.004×** |
| Large 131 KiB ×1000 docs/s median (n=5) | 1,161 | 1,188 | **1.023×** |
| Large write syscalls | 1,372 | 3,372 | +145.8% (explicit tradeoff) |
| Replay/reopen exact | all trials | all trials | PASS |
| `cargo test -p xerj-storage --lib` | — | 88/88 | PASS |
| `cargo fmt --all --check` | — | clean | PASS |
| `clippy -p xerj-storage --all-targets -D warnings` | — | clean | PASS |
| ES-YAML conformance | — | **1360 / 0 / 3** | PASS |

Binary SHA-256 (A/B harness):

- base: `a97d2013a541be56619262624d491cdf0dc2a1299724c6a61c5bc690a178c881`
- candidate: `7c9312e0dc42f2ba407bef3cf86ff81a7e1473d00b727a93ce6e893032d1deae`

Server used for conformance: `f3132e00d4807fd20c6b98e3f3812ec9103ac958b9ef01f25c2de89b3aa73b56`

**Honest note on throughput:** an earlier three-run single-shard median of ~+9% on an older base is **not** reproduced on current main. The five-run median here is −2.4% and still clears the 95% gate. Do not cite +9% from this PR.

## Reproduction

```bash
# From a clean checkout at 1da511e vs this branch, build two harnesses that path-depend on xerj-storage.
# Harness source (identical for both arms):
#   /workspace/.tmp/wal-buffer-mainline-20260726T092103Z/harness-*/src/main.rs

# Empty reservation
./wal-buffer-bench-base empty /tmp/wal-empty-base
./wal-buffer-bench-cand empty /tmp/wal-empty-cand

# Append: SHARDS TOTAL SOURCE_BYTES MAX_SIZE
./wal-buffer-bench-base append /tmp/wal-c1-base 1 1000000 512 1048576
./wal-buffer-bench-cand append /tmp/wal-c1-cand 1 1000000 512 1048576
./wal-buffer-bench-base append /tmp/wal-c8-base 8 1000000 512 1048576
./wal-buffer-bench-cand append /tmp/wal-c8-cand 8 1000000 512 1048576
./wal-buffer-bench-base append /tmp/wal-lg-base 1 1000 131072 1048576
./wal-buffer-bench-cand append /tmp/wal-lg-cand 1 1000 131072 1048576

# Unit / style
cd engine
cargo test -p xerj-storage --lib
cargo fmt --all --check
cargo clippy -p xerj-storage --all-targets -- -D warnings

# Conformance (scoped server build; runner against live ES-compat port)
cargo build --release -j 32 -p xerj-server
./target/release/xerj --insecure --config /path/to/auth-off.toml --data-dir /tmp/xerj-conf
# es-yaml-runner --dir tests/es-compat-yaml/yaml --url http://127.0.0.1:<es_compat_port>
```

Raw artifacts + full hash manifest: `/workspace/.tmp/wal-buffer-mainline-20260726T092103Z/` and `/workspace/.tmp/wal-buffer-mainline-manifest.txt`.

## Risks

- **Large-record syscalls** increase when frames exceed 64 KiB (measured, throughput OK).
- Allocation is still **eager** (not lazy-until-first-write); idle shards retain 64 KiB each.
- Does **not** by itself meet the FinanceBench north star (≤8 GiB server RSS / 10 min neural autoindex). Unbounded segment caches, merge retention, and admission control remain separate work. This PR only removes a multi-GiB idle WAL reservation that was pure waste.

## Test plan

- [x] Unit: capacity after open/rotate/reopen; ENOSPC reseat capacity; records < / = / >> capacity; concurrent shards; IndexStore 16×8 structural bound
- [x] Scoped clippy + fmt
- [x] A/B empty + c1 + c8 + large (n=5 alternating) with binary hashes
- [x] ES-YAML 1360/0/3