### PR TITLE
fix(api): GET /_xpack respects --compat-version, was hardcoded 8.13.0

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -22116,13 +22116,28 @@ pub async fn xpack_info(State(state): State<AppState>) -> impl IntoResponse {
     let watcher_enabled = state
         .watcher_active
         .load(std::sync::atomic::Ordering::Relaxed);
+    // Must match GET / (`resolve_compat_version`'s `--compat-version`
+    // override) — found empirically: Kibana cross-checks the cluster
+    // version it saw on GET / against the version reported here before
+    // trusting the license block, so a mismatch (GET / correctly
+    // reporting an overridden older version, this endpoint still
+    // hardcoding "8.13.0") surfaces as an opaque "license not available"
+    // error rather than a version-mismatch message. `/_xpack` is
+    // Elastic-only (OpenSearch has no equivalent endpoint), so only the
+    // plain `--compat-version` override applies here, not the fuller
+    // OpenSearch auto-detection `resolve_compat_version` also does.
+    let reported_version = if state.config.compat.version.is_empty() {
+        "8.13.0".to_string()
+    } else {
+        state.config.compat.version.clone()
+    };
     Json(json!({
         "build": {
             "hash": "xerj",
             "date": "2024-01-01T00:00:00.000Z"
         },
         "version": {
-            "number": "8.13.0",
+            "number": reported_version,
             "build_flavor": "default",
             "build_type": "docker",
             "minimum_wire_compatibility_version": "7.17.0",


### PR DESCRIPTION
## Summary

Real Kibana OSS 7.10.2 (Apache 2.0 licensed image, `docker.elastic.co/kibana/kibana-oss:7.10.2`) refused to start with an opaque **"license not available"** error, even though `GET /` correctly reported the overridden `--compat-version 7.10.2` and `GET /_license` returned a well-formed basic license.

## Root cause

Kibana cross-checks the cluster version it saw via `GET /` against the version `GET /_xpack` reports before trusting the license block. `xpack_info()` had its own hardcoded `"8.13.0"` literal, never wired to `state.config.compat.version` — so a `--compat-version` override correctly changed `GET /` but left `GET /_xpack` silently reporting a newer, inconsistent version. That mismatch is what Kibana surfaces as "license not available" rather than a clearer version-mismatch error.

## Fix

Read `state.config.compat.version` in `xpack_info()`, falling back to the existing `"8.13.0"` default when unset (unchanged behavior for every caller not using the override) — the same override `resolve_compat_version` already applies to `GET /` and `GET /_nodes`. `/_xpack` is Elastic-only (OpenSearch has no equivalent endpoint), so only the plain version override applies here, not the fuller OpenSearch auto-detection `resolve_compat_version` also does.

## Test plan
- [x] `cargo build --release -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] curl: `GET /_xpack` and `GET /` now report the same overridden version
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] Real Kibana OSS 7.10.2 container against real sample data (OpenSearch's flights/ecommerce datasets, reindexed in): previously stuck on "license not available", now reaches `status.overall.state: "green"` and serves the UI normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
