### PR TITLE
fix(api): POST /{index}/_update never returned a get block

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -12863,12 +12863,67 @@ pub struct EsUpdateBody {
 pub struct UpdateDocParams {
     /// `refresh=true|wait_for` — accepted without error; memtable is always visible.
     pub refresh: Option<String>,
+    /// `_source=false` suppresses the `get` block; any other value (or bare
+    /// presence) requests it. Absent + no includes/excludes → no `get` block,
+    /// matching real ES (source is NOT returned by default on `_update`).
+    #[serde(rename = "_source")]
+    pub source: Option<String>,
+    /// Comma-separated fields to include in the `get._source` block.
+    #[serde(rename = "_source_includes")]
+    pub source_includes: Option<String>,
+    /// Comma-separated fields to exclude from the `get._source` block.
+    #[serde(rename = "_source_excludes")]
+    pub source_excludes: Option<String>,
+}
+
+/// Whether `_update`'s response should carry a `get` block, per the same
+/// `_source`/`_source_includes`/`_source_excludes` semantics `GET _doc` uses.
+/// Real ES clients (e.g. Kibana's SavedObjectsRepository, which reads
+/// `body.get._source` unconditionally after every update) rely on this.
+fn update_wants_get(params: &UpdateDocParams) -> bool {
+    match params.source.as_deref() {
+        Some("false") => false,
+        Some(_) => true,
+        None => params.source_includes.is_some() || params.source_excludes.is_some(),
+    }
+}
+
+/// Build the `get` block for an `_update` response by re-fetching the
+/// now-current document and applying the same includes/excludes filtering
+/// `GET _doc` uses.
+async fn build_update_get_field(
+    idx: &std::sync::Arc<xerj_engine::index::Index>,
+    id: &str,
+    params: &UpdateDocParams,
+) -> Value {
+    let source = idx.get_document(id).await.ok().flatten();
+    match source {
+        Some(source) => {
+            let includes: Vec<String> = params
+                .source_includes
+                .as_deref()
+                .map(|s| s.split(',').map(str::trim).map(String::from).collect())
+                .unwrap_or_default();
+            let excludes: Vec<String> = params
+                .source_excludes
+                .as_deref()
+                .map(|s| s.split(',').map(str::trim).map(String::from).collect())
+                .unwrap_or_default();
+            let filtered = if includes.is_empty() && excludes.is_empty() {
+                source
+            } else {
+                filter_source_object(&source, &includes, &excludes)
+            };
+            json!({ "found": true, "_source": filtered })
+        }
+        None => json!({ "found": false }),
+    }
 }
 
 pub async fn update_doc(
     State(state): State<AppState>,
     Path((index, id)): Path<(String, String)>,
-    Query(_params): Query<UpdateDocParams>,
+    Query(query_params): Query<UpdateDocParams>,
     Json(body): Json<EsUpdateBody>,
 ) -> impl IntoResponse {
     let idx = match state.engine.get_or_create_index(&index) {
@@ -12902,7 +12957,7 @@ pub async fn update_doc(
             Ok(Ok(Some(outcome))) => {
                 state.metrics.record_doc_indexed(&index);
                 let resp = outcome.response;
-                let er = if outcome.created {
+                let mut er = if outcome.created {
                     crate::responses::EsDocResponse::created(
                         &index,
                         &resp.id,
@@ -12917,6 +12972,9 @@ pub async fn update_doc(
                         resp.seq_no.saturating_sub(1),
                     )
                 };
+                if update_wants_get(&query_params) {
+                    er.get = Some(build_update_get_field(&idx, &resp.id, &query_params).await);
+                }
                 return Json(er).into_response();
             }
             Ok(Ok(None)) => {
@@ -12936,12 +12994,15 @@ pub async fn update_doc(
     {
         Ok(Some(resp)) => {
             state.metrics.record_doc_indexed(&index);
-            let er = crate::responses::EsDocResponse::updated(
+            let mut er = crate::responses::EsDocResponse::updated(
                 &index,
                 &resp.id,
                 resp.version,
                 resp.seq_no.saturating_sub(1),
             );
+            if update_wants_get(&query_params) {
+                er.get = Some(build_update_get_field(&idx, &resp.id, &query_params).await);
+            }
             Json(er).into_response()
         }
         Ok(None) => {

--- a/engine/crates/xerj-api/src/responses.rs
+++ b/engine/crates/xerj-api/src/responses.rs
@@ -126,6 +126,12 @@ pub struct EsDocResponse {
     pub seq_no: u64,
     #[serde(rename = "_primary_term")]
     pub primary_term: u64,
+    /// `_update`-only: the post-update document, present only when the
+    /// caller requested it via `_source`/`_source_includes`/`_source_excludes`
+    /// (real ES's `_update` response omits `get` entirely otherwise). Index
+    /// and create responses never set this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub get: Option<Value>,
 }
 
 impl EsDocResponse {
@@ -146,6 +152,7 @@ impl EsDocResponse {
             shards: EsShards::single_success(),
             seq_no,
             primary_term: 1,
+            get: None,
         }
     }
 
@@ -163,6 +170,7 @@ impl EsDocResponse {
             shards: EsShards::single_success(),
             seq_no,
             primary_term: 1,
+            get: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

`POST /{index}/_update` never returned a `get` block, which broke every real Kibana Saved Objects write (index patterns, dashboards, UI settings, ...) — Kibana's own `SavedObjectsRepository.update` always requests `_source_includes` on the update call and then reads `body.get._source` from the response unconditionally.

## Root cause

Real ES only includes `get` on an `_update` response when the caller passes `_source`, `_source_includes`, or `_source_excludes` — absent, there's no `get` field at all (source isn't returned by default, to save bandwidth). xerj's `update_doc` handler had no notion of a `get` block whatsoever, regardless of what the caller requested.

Kibana's SavedObjectsRepository always sends `_source_includes=namespace,namespaces,originId` and then does `const { originId } = body.get._source;` unconditionally after every save. With no `get` field at all, this throws `TypeError: Cannot read property '_source' of undefined` client-side — surfaced in practice as "Unable to update UI setting" and other silent save failures throughout the Saved Objects UI.

## Fix

- `UpdateDocParams` grows `_source`/`_source_includes`/`_source_excludes` (same semantics `GET _doc` already uses).
- `EsDocResponse` grows an optional `get` field, skipped when `None` — index/create responses are byte-for-byte unchanged.
- `update_doc` populates `get` (re-fetching the now-current document and applying the same includes/excludes filter `GET _doc` uses) whenever the caller requested it, for both the plain and scripted-update code paths.

## Test plan
- [x] `cargo build --release -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] `curl` reproduction of the exact request shape Kibana sends (`_source_includes=namespace,namespaces,originId`) — response now includes `"get":{"found":true,"_source":{...}}`, previously had no `get` field at all
- [x] Real Kibana OSS 7.10.2 instance that previously crashed with "Unable to update UI setting" on first save now saves UI settings and index-pattern edits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
