### PR TITLE
fix(engine): geo_point aggs/queries reject string-encoded lat/lon

### DIFF
--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -8571,11 +8571,22 @@ fn encode_geohash(lat: f64, lon: f64, precision: usize) -> String {
 ///   - "POINT (lon lat)"
 ///   - "lat,lon"
 ///   - GeoHash string (not parsed — returns None)
+/// Coerce a `lat`/`lon` object member to `f64`. Real ES accepts numeric
+/// OR string-encoded lat/lon inside a `{"lat": .., "lon": ..}` geo_point
+/// object (normalised to numbers at index time) — Kibana's own flights
+/// sample data ships exactly this shape (`{"lat": "50.033333", ...}`),
+/// which `.as_f64()` alone silently rejects (`None` for every doc, so
+/// every geo agg/query on that field returns empty).
+fn geo_coord(v: &Value) -> Option<f64> {
+    v.as_f64()
+        .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
+}
+
 fn parse_geo_point(v: &Value) -> Option<(f64, f64)> {
     match v {
         Value::Object(o) => {
-            let lat = o.get("lat")?.as_f64()?;
-            let lon = o.get("lon")?.as_f64()?;
+            let lat = geo_coord(o.get("lat")?)?;
+            let lon = geo_coord(o.get("lon")?)?;
             Some((lat, lon))
         }
         Value::Array(arr) if arr.len() == 2 => {
@@ -9872,8 +9883,10 @@ fn run_extended_stats<'d>(params: &Value, _docs: &'d [Value], cache: &mut FieldC
 fn extract_geo_point(v: &Value) -> Option<(f64, f64)> {
     match v {
         Value::Object(obj) => {
-            let lat = obj.get("lat").and_then(Value::as_f64)?;
-            let lon = obj.get("lon").and_then(Value::as_f64)?;
+            // See `geo_coord`: string-encoded lat/lon (Kibana's own flights
+            // sample data) must be accepted, not just numeric.
+            let lat = geo_coord(obj.get("lat")?)?;
+            let lon = geo_coord(obj.get("lon")?)?;
             Some((lat, lon))
         }
         Value::String(s) => {
@@ -9909,13 +9922,13 @@ fn run_geo_bounds(params: &Value, docs: &[Value]) -> Value {
     let mut max_lon = f64::NEG_INFINITY;
 
     for doc in docs {
-        if let Some(v) = doc.get(field) {
-            if let Some((lat, lon)) = extract_geo_point(v) {
-                min_lat = min_lat.min(lat);
-                max_lat = max_lat.max(lat);
-                min_lon = min_lon.min(lon);
-                max_lon = max_lon.max(lon);
-            }
+        // See `run_geo_centroid` — nested geo_point fields (e.g.
+        // `geoip.location`) are invisible to a flat `doc.get(field)`.
+        if let Some((lat, lon)) = extract_geo_point(get_nested_field(doc, field)) {
+            min_lat = min_lat.min(lat);
+            max_lat = max_lat.max(lat);
+            min_lon = min_lon.min(lon);
+            max_lon = max_lon.max(lon);
         }
     }
 
@@ -9943,12 +9956,14 @@ fn run_geo_centroid(params: &Value, docs: &[Value]) -> Value {
     let mut count = 0usize;
 
     for doc in docs {
-        if let Some(v) = doc.get(field) {
-            if let Some((lat, lon)) = extract_geo_point(v) {
-                sum_lat += lat;
-                sum_lon += lon;
-                count += 1;
-            }
+        // `get_nested_field`, not a flat `doc.get(field)` — geo_point
+        // fields are routinely nested (e.g. eCommerce's `geoip.location`),
+        // and a flat lookup never finds them (silent `null` centroid, which
+        // Kibana's map viz then crashes reading `.lon` off).
+        if let Some((lat, lon)) = extract_geo_point(get_nested_field(doc, field)) {
+            sum_lat += lat;
+            sum_lon += lon;
+            count += 1;
         }
     }
 

--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -8564,13 +8564,6 @@ fn encode_geohash(lat: f64, lon: f64, precision: usize) -> String {
     String::from_utf8(hash).unwrap_or_default()
 }
 
-/// Extract a (lat, lon) pair from an ES geo_point value.
-/// Accepts:
-///   - {"lat": 1.0, "lon": 2.0}
-///   - [lon, lat]  (GeoJSON)
-///   - "POINT (lon lat)"
-///   - "lat,lon"
-///   - GeoHash string (not parsed — returns None)
 /// Coerce a `lat`/`lon` object member to `f64`. Real ES accepts numeric
 /// OR string-encoded lat/lon inside a `{"lat": .., "lon": ..}` geo_point
 /// object (normalised to numbers at index time) — Kibana's own flights
@@ -8582,6 +8575,13 @@ fn geo_coord(v: &Value) -> Option<f64> {
         .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
 }
 
+/// Extract a (lat, lon) pair from an ES geo_point value.
+/// Accepts:
+///   - {"lat": 1.0, "lon": 2.0}
+///   - [lon, lat]  (GeoJSON)
+///   - "POINT (lon lat)"
+///   - "lat,lon"
+///   - GeoHash string (not parsed — returns None)
 fn parse_geo_point(v: &Value) -> Option<(f64, f64)> {
     match v {
         Value::Object(o) => {

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -20504,6 +20504,17 @@ fn postings_union_expand(
 /// Evaluate a query against a single stored document source value.
 ///
 /// Returns true if the document matches the query.
+/// Coerce a `lat`/`lon` object member to `f64`. Real ES accepts numeric OR
+/// string-encoded lat/lon inside a `{"lat": .., "lon": ..}` geo_point object
+/// (normalised to numbers at index time) — Kibana's own flights sample data
+/// ships exactly this shape (`{"lat": "50.033333", ...}`), which `.as_f64()`
+/// alone silently rejects, turning every `geo_distance`/`geo_bounding_box`
+/// query against that field into an unconditional non-match.
+fn geo_coord(v: &Value) -> Option<f64> {
+    v.as_f64()
+        .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
+}
+
 fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
     match q {
         QueryNode::MatchAll => true,
@@ -21164,8 +21175,8 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                     // Accept {"lat": f64, "lon": f64} or [lon, lat] or "lat,lon".
                     let (doc_lat, doc_lon) = match &v {
                         Value::Object(obj) => {
-                            let dlat = obj.get("lat").and_then(|x| x.as_f64())?;
-                            let dlon = obj.get("lon").and_then(|x| x.as_f64())?;
+                            let dlat = geo_coord(obj.get("lat")?)?;
+                            let dlon = geo_coord(obj.get("lon")?)?;
                             (dlat, dlon)
                         }
                         Value::Array(arr) if arr.len() == 2 => {
@@ -21363,8 +21374,8 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                 .and_then(|v| {
                     let (doc_lat, doc_lon) = match &v {
                         Value::Object(obj) => {
-                            let dlat = obj.get("lat").and_then(|x| x.as_f64())?;
-                            let dlon = obj.get("lon").and_then(|x| x.as_f64())?;
+                            let dlat = geo_coord(obj.get("lat")?)?;
+                            let dlon = geo_coord(obj.get("lon")?)?;
                             (dlat, dlon)
                         }
                         Value::Array(arr) if arr.len() == 2 => {

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -20501,9 +20501,6 @@ fn postings_union_expand(
     (count, positions)
 }
 
-/// Evaluate a query against a single stored document source value.
-///
-/// Returns true if the document matches the query.
 /// Coerce a `lat`/`lon` object member to `f64`. Real ES accepts numeric OR
 /// string-encoded lat/lon inside a `{"lat": .., "lon": ..}` geo_point object
 /// (normalised to numbers at index time) — Kibana's own flights sample data
@@ -20515,6 +20512,9 @@ fn geo_coord(v: &Value) -> Option<f64> {
         .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
 }
 
+/// Evaluate a query against a single stored document source value.
+///
+/// Returns true if the document matches the query.
 fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
     match q {
         QueryNode::MatchAll => true,


### PR DESCRIPTION
## Summary

Two independent geo_point bugs, both surfaced by real Kibana sample dashboards' map panels — both root-caused directly against a real, running Kibana OSS 7.10.2 instance.

## Bug 1 — string-encoded lat/lon rejected (flights `OriginLocation`)

`parse_geo_point`/`extract_geo_point` (aggs.rs) and the inline `geo_distance`/`geo_bounding_box` matchers (index.rs) only accepted **numeric** lat/lon inside a `{"lat": .., "lon": ..}` geo_point object, via `.as_f64()`. Real ES accepts numeric OR string-encoded lat/lon there (normalised to numbers at index time) — and Kibana's own flights sample data ships exactly the string-encoded shape (`{"lat": "50.033333", "lon": "8.570556"}`). `.as_f64()` silently rejects a JSON string, so `geohash_grid`/`geotile_grid`/`geo_bounds` and `geo_distance`/`geo_bounding_box` queries against that field always returned zero results/buckets.

Reproduced as an "Infinite extent for field `doc_count`: [Infinity, -Infinity]" client-side error on the flights sample dashboard's "Departures Count Map" panel — a map viz trying to compute a color-scale domain from zero buckets.

**Fix**: added a `geo_coord()` helper (duplicated in `aggs.rs` and `index.rs` — the two independent implementations of "parse a geo_point value") that falls back to string parsing.

## Bug 2 — nested geo_point field invisible to geo_centroid/geo_bounds (eCommerce `geoip.location`)

`run_geo_centroid`/`run_geo_bounds` (aggs.rs) resolved the target field via a flat `doc.get(field)` instead of the nested-path resolver `get_nested_field` every other aggregation in this file already uses. A **nested** geo_point field — eCommerce sample data's `geoip.location` — was therefore never found (count stayed 0, response was `{"location": null}`), which Kibana's map viz then crashed on reading `.lon` off a `null`.

Reproduced as "Cannot read properties of null (reading 'lon')" on the eCommerce sample dashboard's "Sales Count Map" panel.

**Fix**: both now use `get_nested_field`.

## Test plan
- [x] `cargo build --release -p xerj-engine -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] `geohash_grid` on flights' `OriginLocation`: now returns populated buckets (e.g. `6rbr2: 285`, `sr2ty: 278`, ...) — previously `{"buckets":[]}`
- [x] `geo_centroid` on eCommerce's `geoip.location`: now returns `{"lat":35.55,"lon":-9.08}` over all 4675 documents — previously `{"location": null, "count": 0}`
- [x] Both sample dashboards' map panels confirmed rendering against a real Kibana OSS 7.10.2 instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
