### PR TITLE
perf(engine): full-corpus agg path deep-cloned the memtable under lock

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -10902,11 +10902,21 @@ impl Index {
         let all_docs: Vec<Value> = if need_full_corpus {
             // `_id` is injected onto each source so `top_hits` / `_id`-keyed
             // aggs over the corpus still work (the fast path never provided it).
+            // Arc-share out of the memtable (cheap refcount bump under the
+            // per-shard read lock — same fix `all_docs_with_sources_arc`
+            // already applies for the fast-agg path, see its doc comment),
+            // then deep-clone into owned `Value` AFTER the lock is released.
+            // `run_aggs_with_all` needs owned `Value`, but this was previously
+            // deep-cloning the whole memtable WHILE holding the shard lock —
+            // the dominant `hydrate+corpus` cost under concurrent dashboard
+            // load, where several panel queries serialize on the same
+            // per-shard RwLock while each does a full O(doc) clone under it.
             let mut docs: Vec<Value> = self
                 .memtable
-                .all_docs_with_sources()
+                .all_docs_with_sources_arc()
                 .into_iter()
-                .map(|(id, mut v)| {
+                .map(|(id, v)| {
+                    let mut v = (*v).clone();
                     if let Some(o) = v.as_object_mut() {
                         o.entry("_id".to_string())
                             .or_insert_with(|| Value::String(id));


### PR DESCRIPTION
## Summary

`search_inner`'s `need_full_corpus` block (used whenever a request has `aggs` and the columnar fast-agg path doesn't apply) built its corpus by deep-cloning the entire memtable **while holding the per-shard RwLock read guard**, causing severe latency under concurrent dashboard load even on tiny datasets.

## Root cause

`memtable.all_docs_with_sources()` clones every buffered document's JSON tree, and the clone happens inside the `s.read()` critical section (per-shard `parking_lot::RwLock`). Under concurrent load — several Kibana dashboard panel queries firing within milliseconds of each other, all touching the same memtable-resident index — this serialises the shard lock across every concurrent request, each paying a full O(doc) clone under it. Measured 1.2–2.7s just for this phase on a ~1000-doc memtable, scaling with the size of the concurrent burst.

The exact same class of bug was already fixed for the fast-agg path via `all_docs_with_sources_arc()` (Arc-sharing: an O(1) refcount bump under the lock instead of an O(doc) deep clone) — see that function's own doc comment ("was deep-cloning the entire memtable per agg request... ~100-300ms/query at 1e5 buffered docs"). This `need_full_corpus` path just never got the same treatment.

## Fix

Arc-share out of the memtable under the lock, then deep-clone into the owned `Value` `run_aggs_with_all` needs **after** the lock is released. The expensive clone no longer holds up concurrent readers/writers on the same shard.

## Test plan
- [x] `cargo build --release -p xerj-engine -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps` — clean
- [x] `cargo test --release -p xerj-engine --lib` — 156/156 passed
- [x] 15 concurrent identical `date_histogram` aggregation queries against a real ~14k-doc memtable-resident index (`kibana_sample_data_logs`): went from 1.2–2.7s (with `slow_query` warnings logged) to a consistent ~150–170ms with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
