### PR TITLE
fix(engine): term/match_phrase on any .keyword multi-field matched 0 docs

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -24103,7 +24103,41 @@ fn get_field_value(source: &Value, field: &str) -> Option<Value> {
         }
     }
     let parts: Vec<&str> = field.split('.').collect();
-    get_field_value_parts(source, &parts)
+    if let Some(v) = get_field_value_parts(source, &parts) {
+        return Some(v);
+    }
+    // ES multi-field fallback: `<field>.<subfield>` (e.g. `category.keyword`,
+    // `name.raw`) refers to a multi-field that shares the parent field's
+    // source value — `_source` never stores a separate value for the
+    // sub-field. Without this, every `term`/`match_phrase`/etc. brute-scan
+    // match against a `.keyword` multi-field silently matched nothing
+    // (`get_field_value_parts` has no such field to walk into), even though
+    // a `terms` aggregation on the identical field worked fine — aggs
+    // resolve fields via `get_nested_field` (aggs.rs), which already has
+    // this exact fallback. Strip the trailing segment and retry against the
+    // parent, same as that function does.
+    //
+    // Only trust this fallback when the parent resolves to a LEAF value
+    // (scalar, or an array with no objects) — a real multi-field's parent
+    // is always a leaf text/keyword value. A genuine nested/object field
+    // (`obj.inner_field`) that's simply absent on this doc must NOT be
+    // masked by its parent object: returning the whole `obj` here would
+    // make `exists: {field: "obj.inner_field"}` wrongly report the field
+    // as present just because the parent object exists (regression caught
+    // by the ES-compat YAML `exists_query` suite).
+    if let Some(idx) = field.rfind('.') {
+        if let Some(v) = get_field_value(source, &field[..idx]) {
+            let is_leaf = match &v {
+                Value::Object(_) => false,
+                Value::Array(arr) => !arr.iter().any(Value::is_object),
+                _ => true,
+            };
+            if is_leaf {
+                return Some(v);
+            }
+        }
+    }
+    None
 }
 
 fn get_field_value_parts(cur: &Value, parts: &[&str]) -> Option<Value> {


### PR DESCRIPTION
## Summary

`term`/`match_phrase`/etc. queries against **any** `.keyword` multi-field (`category.keyword`, `manufacturer.keyword`, ...) silently matched zero documents, regardless of value — one of the single most common ES/Kibana operations, used by essentially every dashboard filter and "click cell to filter" interaction. Likely the most impactful fix in this batch.

## Root cause

`get_field_value` (index.rs, used by `doc_matches_query`'s brute-force scan path) had no fallback for ES multi-field names. `_source` only ever stores the *parent* field's raw value — there's never a literal `"category.keyword"` key to walk into — so a query on the dotted multi-field name could never resolve a value.

The identical field works fine in a `terms` aggregation, because aggregations resolve fields through `get_nested_field` (aggs.rs), which already strips the trailing multi-field segment and retries against the parent. The query side never got the same treatment.

Confirmed via real Kibana traffic (captured in `docker logs`) and direct `curl` reproduction: `term`/`match_phrase` on `manufacturer.keyword`, `customer_full_name.keyword`, `category.keyword` all returned 0 hits, on both scalar- and array-valued underlying fields, even though the identical field's `terms` aggregation bucketed correctly.

## Fix

Added the same "strip trailing segment, retry against parent" fallback to `get_field_value` — **guarded** so it only applies when the parent resolves to a leaf value (scalar, or an array with no objects). A real multi-field's parent is always a leaf text/keyword value.

An earlier, unguarded version of this fix caused a real regression (5 YAML `exists_query`/`flattened` test failures): a genuine nested/object field that's simply absent on a document must NOT be masked by returning its parent *object* — `exists: {field: "obj.inner_field"}` would otherwise wrongly report the field present just because the parent object exists. The `is_leaf` guard fixes that.

## Test plan
- [x] `cargo build --release -p xerj-engine -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps -- -D warnings` — clean
- [x] `cargo test --release -p xerj-engine --lib` — 156/156 passed
- [x] `term` on `manufacturer.keyword`/`customer_full_name.keyword`/`category.keyword`: now return correct non-zero counts (1370, 1, 2024, 1218, 1055, ...), matching their `terms`-aggregation buckets exactly — previously all 0
- [x] Full ES-compat YAML conformance suite: **1360 passed, 0 failed, 3 skipped** — no regressions (specifically re-verified the `exists_query`/`flattened` cases that an earlier unguarded version of this fix broke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
