### PR TITLE
fix(engine): match_phrase/match_phrase_prefix matched 0 on array fields

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -21119,81 +21119,97 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
         QueryNode::MatchPhrase {
             field, query, slop, ..
         } => {
-            get_field_value(source, field)
-                .and_then(|v| match v {
-                    // Real ES tokenizes whatever the field holds — a
-                    // `boolean`/numeric field's value is just its string
-                    // form ("true"/"false", "42") for phrase-matching
-                    // purposes. Pre-fix this arm only handled
-                    // `Value::String`, so a `match_phrase` against a
-                    // boolean field's `_source` value (a genuine JSON
-                    // `Bool`, never a `String`) fell to the `_ => None`
-                    // catch-all and NEVER matched any document, regardless
-                    // of value — found empirically alongside the parser-
-                    // level scalar-coercion fix for the *query* side
-                    // (xerj-query's `match_phrase`/`match_phrase_prefix`):
-                    // that fix stops the crash on `{query: true}`, but
-                    // without this one the (now-valid) query still
-                    // silently matched 0 documents.
-                    Value::String(_) | Value::Bool(_) | Value::Number(_) => {
-                        let s = match v {
-                            Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        };
-                        let field_tokens: Vec<String> = s
-                            .to_lowercase()
-                            .split(|c: char| !c.is_alphanumeric())
-                            .filter(|t| !t.is_empty())
-                            .map(str::to_string)
-                            .collect();
-                        let query_tokens: Vec<String> = query
-                            .to_lowercase()
-                            .split(|c: char| !c.is_alphanumeric())
-                            .filter(|t| !t.is_empty())
-                            .map(str::to_string)
-                            .collect();
-                        if query_tokens.is_empty() {
-                            return Some(true);
-                        }
-                        if query_tokens.len() > field_tokens.len() {
-                            return Some(false);
-                        }
-                        // slop=0: exact contiguous phrase match in order.
-                        if *slop == 0 {
-                            let found = field_tokens
-                                .windows(query_tokens.len())
-                                .any(|w| w == query_tokens.as_slice());
-                            return Some(found);
-                        }
-                        // slop>0: ES enforces in-order positions with at
-                        // most `slop` intervening tokens between adjacent
-                        // query tokens. Find each query token AFTER the
-                        // previous one and sum the gaps.
-                        let mut last_pos: Option<usize> = None;
-                        let mut total_gaps: i64 = 0;
-                        let mut ordered_ok = true;
-                        for qt in &query_tokens {
-                            let search_start = last_pos.map(|p| p + 1).unwrap_or(0);
-                            match field_tokens[search_start..]
-                                .iter()
-                                .position(|ft| ft == qt)
-                                .map(|off| search_start + off)
-                            {
-                                Some(pos) => {
-                                    if let Some(prev) = last_pos {
-                                        total_gaps += (pos as i64 - prev as i64 - 1).max(0);
-                                    }
-                                    last_pos = Some(pos);
-                                }
-                                None => {
-                                    ordered_ok = false;
-                                    break;
-                                }
+            let query_tokens: Vec<String> = query
+                .to_lowercase()
+                .split(|c: char| !c.is_alphanumeric())
+                .filter(|t| !t.is_empty())
+                .map(str::to_string)
+                .collect();
+            // Real ES tokenizes whatever the field holds — a
+            // `boolean`/numeric field's value is just its string form
+            // ("true"/"false", "42") for phrase-matching purposes. Pre-fix
+            // this arm only handled `Value::String`, so a `match_phrase`
+            // against a boolean field's `_source` value (a genuine JSON
+            // `Bool`, never a `String`) fell to the `_ => None` catch-all
+            // and NEVER matched any document, regardless of value — found
+            // empirically alongside the parser-level scalar-coercion fix
+            // for the *query* side (xerj-query's
+            // `match_phrase`/`match_phrase_prefix`): that fix stops the
+            // crash on `{query: true}`, but without this one the
+            // (now-valid) query still silently matched 0 documents.
+            fn matches_scalar(v: &Value, query_tokens: &[String], slop: u32) -> Option<bool> {
+                let s = match v {
+                    Value::String(s) => s.clone(),
+                    Value::Bool(_) | Value::Number(_) => v.to_string(),
+                    _ => return None,
+                };
+                let field_tokens: Vec<String> = s
+                    .to_lowercase()
+                    .split(|c: char| !c.is_alphanumeric())
+                    .filter(|t| !t.is_empty())
+                    .map(str::to_string)
+                    .collect();
+                if query_tokens.is_empty() {
+                    return Some(true);
+                }
+                if query_tokens.len() > field_tokens.len() {
+                    return Some(false);
+                }
+                // slop=0: exact contiguous phrase match in order.
+                if slop == 0 {
+                    let found = field_tokens
+                        .windows(query_tokens.len())
+                        .any(|w| w == query_tokens);
+                    return Some(found);
+                }
+                // slop>0: ES enforces in-order positions with at most
+                // `slop` intervening tokens between adjacent query tokens.
+                // Find each query token AFTER the previous one and sum the
+                // gaps.
+                let mut last_pos: Option<usize> = None;
+                let mut total_gaps: i64 = 0;
+                let mut ordered_ok = true;
+                for qt in query_tokens {
+                    let search_start = last_pos.map(|p| p + 1).unwrap_or(0);
+                    match field_tokens[search_start..]
+                        .iter()
+                        .position(|ft| ft == qt)
+                        .map(|off| search_start + off)
+                    {
+                        Some(pos) => {
+                            if let Some(prev) = last_pos {
+                                total_gaps += (pos as i64 - prev as i64 - 1).max(0);
                             }
+                            last_pos = Some(pos);
                         }
-                        Some(ordered_ok && total_gaps <= *slop as i64)
+                        None => {
+                            ordered_ok = false;
+                            break;
+                        }
                     }
-                    _ => None,
+                }
+                Some(ordered_ok && total_gaps <= slop as i64)
+            }
+            get_field_value(source, field)
+                .and_then(|v| match &v {
+                    // Multi-valued field (e.g. eCommerce's `manufacturer`/
+                    // `category` arrays): ES matches if ANY element
+                    // satisfies the phrase — pre-fix this arm only handled
+                    // scalars, so a `match_phrase` against ANY array-valued
+                    // field (whether the plain field or a `.keyword`
+                    // multi-field sharing its value) silently matched 0
+                    // documents regardless of value.
+                    Value::Array(arr) => {
+                        if arr
+                            .iter()
+                            .any(|e| matches_scalar(e, &query_tokens, *slop) == Some(true))
+                        {
+                            Some(true)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => matches_scalar(&v, &query_tokens, *slop),
                 })
                 .unwrap_or(false)
         }
@@ -21289,38 +21305,55 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
         }
 
         QueryNode::MatchPhrasePrefix { field, query, .. } => {
+            fn matches_str(s: &str, query: &str) -> Option<bool> {
+                let tokens: Vec<&str> = query.split_whitespace().collect();
+                if tokens.is_empty() {
+                    return Some(true);
+                }
+                let s_lower = s.to_lowercase();
+                let (prefix, exact_tokens) = match tokens.split_last() {
+                    Some(pair) => pair,
+                    None => return Some(true),
+                };
+                // All tokens except the last must appear as an ordered substring.
+                // Last token is a prefix match.
+                let phrase_without_last = exact_tokens.join(" ").to_lowercase();
+                let last_lower = prefix.to_lowercase();
+                if exact_tokens.is_empty() {
+                    // Only one token — prefix match on the whole query.
+                    Some(
+                        s_lower
+                            .split_whitespace()
+                            .any(|w| w.starts_with(last_lower.as_str())),
+                    )
+                } else {
+                    // Multi-token: check phrase prefix.
+                    if let Some(pos) = s_lower.find(&phrase_without_last) {
+                        let after = &s_lower[pos + phrase_without_last.len()..].trim_start();
+                        Some(after.starts_with(last_lower.as_str()))
+                    } else {
+                        Some(false)
+                    }
+                }
+            }
             get_field_value(source, field)
-                .and_then(|v| match v {
-                    Value::String(s) => {
-                        let tokens: Vec<&str> = query.split_whitespace().collect();
-                        if tokens.is_empty() {
-                            return Some(true);
-                        }
-                        let s_lower = s.to_lowercase();
-                        let (prefix, exact_tokens) = match tokens.split_last() {
-                            Some(pair) => pair,
-                            None => return Some(true),
-                        };
-                        // All tokens except the last must appear as an ordered substring.
-                        // Last token is a prefix match.
-                        let phrase_without_last = exact_tokens.join(" ").to_lowercase();
-                        let last_lower = prefix.to_lowercase();
-                        if exact_tokens.is_empty() {
-                            // Only one token — prefix match on the whole query.
-                            Some(
-                                s_lower
-                                    .split_whitespace()
-                                    .any(|w| w.starts_with(last_lower.as_str())),
-                            )
+                .and_then(|v| match &v {
+                    Value::String(s) => matches_str(s, query),
+                    // Multi-valued field: ES matches if ANY element
+                    // satisfies the phrase-prefix — pre-fix this arm only
+                    // handled a scalar string, so a `match_phrase_prefix`
+                    // against ANY array-valued field (or a `.keyword`
+                    // multi-field sharing an array field's value) silently
+                    // matched 0 documents regardless of value.
+                    Value::Array(arr) => {
+                        if arr.iter().any(|e| {
+                            e.as_str()
+                                .and_then(|s| matches_str(s, query))
+                                .unwrap_or(false)
+                        }) {
+                            Some(true)
                         } else {
-                            // Multi-token: check phrase prefix.
-                            if let Some(pos) = s_lower.find(&phrase_without_last) {
-                                let after =
-                                    &s_lower[pos + phrase_without_last.len()..].trim_start();
-                                Some(after.starts_with(last_lower.as_str()))
-                            } else {
-                                Some(false)
-                            }
+                            None
                         }
                     }
                     _ => None,

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -13051,8 +13051,26 @@ impl Index {
             if self.memtable.doc_count() == 0 {
                 0
             } else {
-                let target_str: Option<String> = value.as_str().map(String::from);
-                let target_num: Option<f64> = value.as_f64();
+                // `value.as_str()`/`.as_f64()` both return `None` for a
+                // JSON boolean, so a boolean-field term query previously
+                // never matched a single memtable-resident doc regardless
+                // of actual content — found empirically: `mem_doc_count`
+                // was non-zero (this branch DOES run) yet a real boolean
+                // filter still undercounted to a confident, wrong 0. Match
+                // `scored_fast_plan`'s `scoring_leaf` (already correct for
+                // this exact case) and the memtable's own on-insert
+                // encoding (`push_field`'s `Value::Bool` arm, which stores
+                // BOTH the 1.0/0.0 numeric form and the "true"/"false"
+                // keyword form) by coercing bool → both representations
+                // here too.
+                let target_str: Option<String> = match value {
+                    Value::Bool(b) => Some(b.to_string()),
+                    _ => value.as_str().map(String::from),
+                };
+                let target_num: Option<f64> = match value {
+                    Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+                    _ => value.as_f64(),
+                };
                 let mut m = 0u64;
                 if let Some(tgt) = target_num {
                     m += self.memtable.doc_values_numeric_count(field, tgt) as u64;
@@ -13089,7 +13107,17 @@ impl Index {
             other => other.to_string(),
         };
         let lowered = raw.to_ascii_lowercase();
-        let target_num: Option<f64> = value.as_f64();
+        // Same bool coercion as the memtable side above — `value.as_f64()`
+        // alone returns `None` for a JSON boolean, which used to make
+        // `served_by_dv` false for every segment whose on-disk column for
+        // this field is `Column::Numeric` (the boolean encoding
+        // `build_doc_value_columns` always uses), falling through to an
+        // FTS lookup that has no real content for a non-analyzed boolean
+        // field and confidently returns 0 instead of the correct count.
+        let target_num: Option<f64> = match value {
+            Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+            _ => value.as_f64(),
+        };
 
         let mut seg_matches: u64 = 0;
         for meta in &snap.segments {
@@ -21093,7 +21121,25 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
         } => {
             get_field_value(source, field)
                 .and_then(|v| match v {
-                    Value::String(s) => {
+                    // Real ES tokenizes whatever the field holds — a
+                    // `boolean`/numeric field's value is just its string
+                    // form ("true"/"false", "42") for phrase-matching
+                    // purposes. Pre-fix this arm only handled
+                    // `Value::String`, so a `match_phrase` against a
+                    // boolean field's `_source` value (a genuine JSON
+                    // `Bool`, never a `String`) fell to the `_ => None`
+                    // catch-all and NEVER matched any document, regardless
+                    // of value — found empirically alongside the parser-
+                    // level scalar-coercion fix for the *query* side
+                    // (xerj-query's `match_phrase`/`match_phrase_prefix`):
+                    // that fix stops the crash on `{query: true}`, but
+                    // without this one the (now-valid) query still
+                    // silently matched 0 documents.
+                    Value::String(_) | Value::Bool(_) | Value::Number(_) => {
+                        let s = match v {
+                            Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
                         let field_tokens: Vec<String> = s
                             .to_lowercase()
                             .split(|c: char| !c.is_alphanumeric())

--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -419,6 +419,28 @@ impl DocValues {
                 }
             }
             Value::Bool(b) => {
+                // Numeric column FIRST, matching the on-disk segment
+                // encoding (`build_doc_value_columns` in index.rs: a
+                // boolean is always the f64 bit-pattern of 1.0/0.0, never
+                // a keyword-only value) — the disk-segment builder reads
+                // straight from the same `Value` tree and has always
+                // gotten this right, but the memtable's own in-memory
+                // representation never populated `numeric` for booleans at
+                // all, only `keyword`. Any query still hitting a
+                // memtable-resident boolean doc through a numeric-column
+                // path (`ScoreEval::Bool`, `doc_values_numeric_count`,
+                // range/terms-agg fast paths) saw the field as absent —
+                // found empirically: a real OpenSearch Dashboards filter
+                // pill on a boolean field returned 0 hits against
+                // freshly-bulk-imported data (matches every
+                // real-world/OSD import shape — natural background flush,
+                // no explicit `_flush` — while the aggregation reading
+                // the SAME field correctly bucketed true/false, since
+                // aggregations use a different, disk-segment-only read
+                // path that was never affected).
+                let ncol = entry_no_clone(&mut self.numeric, field, Default::default);
+                pad_to(ncol, doc_index);
+                ncol.push(Some(if *b { 1.0 } else { 0.0 }));
                 let kcol = entry_no_clone(&mut self.keyword, field, Default::default);
                 pad_to(kcol, doc_index);
                 kcol.push(Some(b.to_string()));


### PR DESCRIPTION
## ⚠️ Stacked on #33

This branch is cut from `fix/boolean-numeric-column-matching` (open PR #33, not yet merged) because the `MatchPhrase` arm this fix touches is the same one #33 already modified (adding `Bool`/`Number` handling). The diff will show #33's commits until that PR merges — the actual new change here is the final commit only.

## Summary

`match_phrase`/`match_phrase_prefix` never matched any document on an **array-valued** field, regardless of query value. Likely the real root cause behind tonight's "filtering the eCommerce dashboard by category/manufacturer finds nothing" report — confirmed via real Kibana traffic that the UI's filter pills send `match_phrase`, not `term`.

## Root cause

`doc_matches_query`'s `MatchPhrase` arm only handled `Value::String`/`Bool`/`Number` field values — any `Value::Array` (eCommerce sample data's `manufacturer`/`category`, both arrays since an order can have multiple products) fell to the catch-all `_ => None`, so `match_phrase` never matched any document on an array-valued field, whether the plain field or a `.keyword` multi-field sharing its value. `MatchPhrasePrefix` had the identical gap (only handled a scalar `Value::String`).

This is a companion, independently-necessary fix alongside the `get_field_value` multi-field fallback (#44): that fix makes `.keyword` multi-fields resolvable at all; this one makes the resulting array value actually matchable by `match_phrase`.

`Match` (the standard, non-phrase `match` query) already handled `Value::Array` correctly — only `MatchPhrase`/`MatchPhrasePrefix` had the gap.

## Fix

ES matches an array field if ANY element satisfies the phrase (same semantics `Term`'s existing array-unwrap already uses). Both arms now try each array element against the phrase/phrase-prefix logic and match if any succeeds.

## Test plan
- [x] `cargo build --release -p xerj-engine -p xerj-api -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps -- -D warnings` — clean
- [x] `cargo test --release -p xerj-engine --lib` — 156/156 passed
- [x] Verified with the exact bool-wrapped query captured from real Kibana traffic: `match_phrase` on `manufacturer`/`manufacturer.keyword` both now return the correct 1370 hits (was 0), matching the field's `terms` aggregation bucket exactly
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
