### PR TITLE
fix(api): explicit _source param ignored when stored_fields present

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8570,6 +8570,16 @@ pub async fn search(
             // extraction, so the suppression is a response-time
             // decision not a data-layer decision.
             let source_body_disabled = matches!(body.source, Some(Value::Bool(false)));
+            // `stored_fields` only changes the *default* for `_source` to
+            // false when the caller left `_source` unspecified. An explicit
+            // top-level `_source` param (anything but `false`) always wins,
+            // e.g. Kibana Discover sends `stored_fields: ["*"]` together
+            // with `_source: {"excludes": []}` and still expects the full
+            // `_source` back.
+            let source_explicitly_requested = matches!(
+                &body.source,
+                Some(v) if !matches!(v, Value::Bool(false))
+            );
             let source_mapping_disabled = state
                 .engine
                 .index_mappings
@@ -8583,7 +8593,7 @@ pub async fn search(
                 .and_then(|src| src.get("enabled").and_then(Value::as_bool))
                 .map(|b| !b)
                 .unwrap_or(false);
-            let source = if suppress_source_for_stored
+            let source = if (suppress_source_for_stored && !source_explicitly_requested)
                 || source_body_disabled
                 || source_mapping_disabled
                 || h.source.is_null()


### PR DESCRIPTION
## Summary

`stored_fields` was silently overriding an explicit, non-`false` `_source` request — dropping `_source` from every hit even when the caller asked for it. This broke **every** Kibana Discover document view: Discover's main search request always sends `stored_fields: ["*"]` alongside an explicit `_source: {"excludes": []}`, expecting the full document back. With this bug, xerj returned hits with no `_source` at all, so Discover's row-expand JSON view and its "Available fields" sidebar only ever showed date/scripted fields (`@timestamp`, `timestamp`, a scripted `hour_of_day`) — real document fields like `agent`, `message`, `geo`, etc. never appeared, even though the field list ("Add filter") and the underlying data were both correct.

## Root cause

`parse_stored_fields()` only treats `_source` as "opted back in" when the literal string `"_source"` appears as an entry *inside* the `stored_fields` array (e.g. `stored_fields: ["field2", "_source"]`). It has no visibility into a separate, top-level `_source` parameter in the same request body.

At the hit-building site, the suppression flag from `parse_stored_fields` was applied unconditionally whenever `stored_fields` was present, with no check for whether the caller *also* supplied an explicit `_source` value. Real Elasticsearch semantics: `stored_fields` only changes the *default* for `_source` to `false` when `_source` is otherwise unspecified — an explicit `_source` (anything but `false`) always wins.

## Fix

Added a `source_explicitly_requested` check: an explicit, non-`false` top-level `_source` parameter now neutralizes the `stored_fields`-driven suppression. All existing behavior is preserved:
- `stored_fields` alone (no `_source` key) → still suppresses `_source` by default
- `stored_fields` + `_source` as an array entry → still opts back in (existing behavior)
- `_source: false` explicitly → still suppresses regardless of `stored_fields` (unchanged)
- New: `stored_fields: ["*"]` + top-level `"_source": {"excludes": []}` (or `true`, or an includes/excludes object) → now correctly keeps `_source`, matching real Elasticsearch and fixing the Kibana Discover case

## Test plan
- [x] `cargo build --release -p xerj-api -p xerj-engine -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps -- -D warnings` — clean
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] **Real-world verification**: captured the exact request body from Kibana OSS 7.10.2's own Inspector for a live Discover search (`stored_fields: ["*"]`, `script_fields`, `docvalue_fields`, `_source: {"excludes": []}`, `highlight`) and replayed it verbatim against a patched instance — `_source` is now present and complete on every hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
