### PR TITLE
fix(engine): terms aggregation ignores `script`, always returns empty buckets

### DIFF
--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -2521,15 +2521,56 @@ fn extract_date_ranges(doc: &Value, field: &str) -> Vec<(i64, i64)> {
 
 // ── Terms aggregation ─────────────────────────────────────────────────────────
 
+/// Resolve a terms agg's bucket key(s) for one doc, from either a `field`
+/// (the common case) or a Painless `script` (e.g. Kibana's script-bucketed
+/// terms aggs like a heatmap's hour-of-day axis). Scripts are evaluated with
+/// the same `crate::painless` engine already proven correct for
+/// `script_fields`/`top_hits` — this just wires it into the one place that
+/// previously only understood `field` and silently produced zero buckets
+/// for a script-only terms agg.
+fn terms_agg_bucket_keys(field_or_script: &FieldOrScript, doc: &Value) -> Vec<String> {
+    match field_or_script {
+        FieldOrScript::Field(field) => extract_field_values(doc, field),
+        FieldOrScript::Script { source, params } => {
+            let ctx = crate::painless::PainlessCtx::new(doc, params, 0.0);
+            match crate::painless::eval_painless(source, &ctx) {
+                Ok(pv) => flatten_to_strings(&painless_value_to_json(pv)),
+                Err(_) => vec![],
+            }
+        }
+    }
+}
+
+enum FieldOrScript {
+    Field(String),
+    Script { source: String, params: Value },
+}
+
 fn run_terms(
     params: &Value,
     sub_aggs: Option<&Value>,
     docs: &[Value],
     all_docs: &[Value],
 ) -> Value {
-    let field = match params.get("field").and_then(Value::as_str) {
-        Some(f) => f,
-        None => return json!({"buckets": []}),
+    let field_or_script = match params.get("field").and_then(Value::as_str) {
+        Some(f) => FieldOrScript::Field(f.to_string()),
+        None => match params.get("script") {
+            Some(script) => {
+                let Some(source) = script
+                    .get("source")
+                    .or_else(|| script.get("inline"))
+                    .and_then(Value::as_str)
+                else {
+                    return json!({"buckets": []});
+                };
+                let script_params = script.get("params").cloned().unwrap_or(json!({}));
+                FieldOrScript::Script {
+                    source: source.to_string(),
+                    params: script_params,
+                }
+            }
+            None => return json!({"buckets": []}),
+        },
     };
     // ES semantics: size=0 means "return all buckets" (no cap).
     // Any other value caps the result; the default is 10.
@@ -2561,7 +2602,7 @@ fn run_terms(
     let bucket_cap = max_buckets();
     for doc in docs {
         let weight = doc_count_weight(doc);
-        let vals = extract_field_values(doc, field);
+        let vals = terms_agg_bucket_keys(&field_or_script, doc);
         if vals.is_empty() {
             if let Some(ph) = &missing_placeholder {
                 // Bucket cap: skip new keys past the limit, but always
@@ -2590,7 +2631,7 @@ fn run_terms(
         .unwrap_or(1);
     if min_doc_count_preview == 0 {
         for doc in all_docs {
-            for term in extract_field_values(doc, field) {
+            for term in terms_agg_bucket_keys(&field_or_script, doc) {
                 if counts.contains_key(&term) || counts.len() < bucket_cap {
                     counts.entry(term).or_insert(0);
                 }
@@ -2744,7 +2785,7 @@ fn run_terms(
             .unwrap_or(false);
         docs.iter()
             .filter(|doc| {
-                let vals = extract_field_values(doc, field);
+                let vals = terms_agg_bucket_keys(&field_or_script, doc);
                 if is_missing_bucket {
                     vals.is_empty()
                 } else {
@@ -2795,7 +2836,7 @@ fn run_terms(
             let bucket_docs: Vec<Value> = docs
                 .iter()
                 .filter(|doc| {
-                    let vals = extract_field_values(doc, field);
+                    let vals = terms_agg_bucket_keys(&field_or_script, doc);
                     if is_missing_bucket {
                         vals.is_empty()
                     } else {


### PR DESCRIPTION
## Summary

`terms` aggregation required a top-level `field` param and bailed out to `{"buckets": []}` immediately when it was absent — it never checked for `script`, so any script-based terms aggregation silently returned zero buckets regardless of how many documents matched the query. This breaks any Kibana visualization that buckets by a Painless script rather than a plain field — a common pattern (e.g. a "Heat Map" viz bucketing by an hour-of-day script for its Y-axis).

## Root cause

```rust
let field = match params.get("field").and_then(Value::as_str) {
    Some(f) => f,
    None => return json!({"buckets": []}),
};
```

This is the very first thing `run_terms` does — it bails before touching `docs` at all if `field` is missing, with no branch anywhere in the function that looks at `params.get("script")`.

The rest of `run_terms` (ordering, `min_doc_count`, `include`/`exclude`, partitioning, sub-agg computation, `sum_other_doc_count`) is agnostic to *how* a bucket's string key was derived — it just needs `Vec<String>` per doc — so this only required a key-source abstraction slotted into the field-based call sites, reusing the Painless evaluation engine (`crate::painless::eval_painless`/`PainlessCtx`) already proven correct elsewhere in this codebase for `script_fields` (plain search) and `top_hits`' `runtime_mappings`.

## Fix

Added a small `FieldOrScript` enum and `terms_agg_bucket_keys()` helper:
- `field` present → unchanged behavior (`extract_field_values`)
- `field` absent, `script` present → evaluate the Painless script per-doc via the existing engine, flatten the result the same way a field value would be flattened
- neither present → unchanged `{"buckets": []}` fallback (correct ES behavior — a terms agg needs one or the other)

All four call sites inside `run_terms` that previously hardcoded `extract_field_values(doc, field)` (main counting loop, `min_doc_count: 0` background-fill loop, and both bucket-doc-membership closures used for sub-agg computation and final bucket assembly) now go through this abstraction.

## Scope note

This fixes the aggregation-dispatch gap specifically — `terms` was silently ignoring `script` entirely. It does **not** add any new Painless language features; a script's own semantics (e.g. date-value accessor methods) are a separate concern and out of scope here. The same "silently requires `field`, ignores `script`" pattern exists in most of the other bucket/metric aggregations in this file (`avg`, `sum`, `min`, `max`, `stats`, `cardinality`, `histogram`, `date_histogram`, `percentiles`) — `terms` was the one hit in practice and is fixed here; the rest are a known follow-up.

## Test plan
- [x] `cargo build --release -p xerj-api -p xerj-engine -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps -- -D warnings` — clean
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] Manual verification: `{"terms": {"script": {"source": "return 5;"}}}` now produces a real bucket (`key: 5.0, doc_count: N`) instead of an unconditional empty array

🤖 Generated with [Claude Code](https://claude.com/claude-code)
