### PR TITLE
fix(engine): Painless doc['field'].value has no date accessor methods

### DIFF
--- a/engine/crates/xerj-engine/src/painless.rs
+++ b/engine/crates/xerj-engine/src/painless.rs
@@ -1084,6 +1084,19 @@ fn eval_expr(
                     "toString" => return Ok(PainlessValue::String(s.clone())),
                     "toLowerCase" => return Ok(PainlessValue::String(s.to_lowercase())),
                     "toUpperCase" => return Ok(PainlessValue::String(s.to_uppercase())),
+                    // `doc['a_date_field'].value` returns the raw ISO string
+                    // (real ES returns a JodaCompatibleZonedDateTime, which
+                    // these getters read off directly) — so date accessor
+                    // methods here parse the string on demand instead. Only
+                    // dispatches for these specific getter names, so a
+                    // genuinely non-date string field still falls through
+                    // to the "unsupported member access" error below.
+                    "getHour" | "getMinute" | "getSecond" | "getDayOfMonth" | "getMonthValue"
+                    | "getYear" | "getDayOfWeek" => {
+                        if let Some(ms) = date_value_millis(s) {
+                            return date_component(ms, member);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -1202,6 +1215,35 @@ fn resolve_doc_member(
         }
         _ => Err(format!("unsupported doc member .{}", member)),
     }
+}
+
+/// Parse an ISO-8601-ish date string into epoch milliseconds (UTC),
+/// reusing the same parser aggregations use for date fields so a date's
+/// script-accessor components (getHour, getDayOfWeek, ...) agree with
+/// how the same value is bucketed elsewhere.
+fn date_value_millis(s: &str) -> Option<i64> {
+    crate::aggs::parse_date_ms(&Value::String(s.to_string()))
+}
+
+/// Extract one Java `ZonedDateTime`-style component (UTC) from an epoch-ms
+/// value, for the `doc['a_date_field'].value.getXxx()` accessor family.
+fn date_component(ms: i64, member: &str) -> Result<PainlessValue, String> {
+    use chrono::{Datelike, Timelike};
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+        .ok_or_else(|| format!("invalid date value for .{}", member))?;
+    let n = match member {
+        "getHour" => dt.hour(),
+        "getMinute" => dt.minute(),
+        "getSecond" => dt.second(),
+        "getDayOfMonth" => dt.day(),
+        "getMonthValue" => dt.month(),
+        "getYear" => dt.year() as u32,
+        // Java DayOfWeek: MONDAY=1 .. SUNDAY=7 (chrono's weekday() already
+        // uses the same Monday-first ordinal via num_days_from_monday).
+        "getDayOfWeek" => dt.weekday().num_days_from_monday() + 1,
+        _ => return Err(format!("unsupported date member .{}", member)),
+    };
+    Ok(PainlessValue::Number(n as f64))
 }
 
 fn get_doc_value(doc: &Value, field: &str) -> Value {


### PR DESCRIPTION
## Summary

`doc['a_date_field'].value` returns the raw ISO-8601 string as a plain Painless `String`, so any date accessor method chained onto it (`.getHour()`, `.getDayOfWeek()`, etc. — the standard Painless/Java `ZonedDateTime` API real Elasticsearch exposes there) fell through to the generic "unsupported member access" error, and the whole script silently failed. This blocks any Kibana visualization whose bucket or metric dimension is a date-component script — most visibly the sample "Heat Map" visualization, which buckets its Y-axis by `doc['timestamp'].value.getHour()`.

## Fix

When one of the common date-accessor getters (`getHour`, `getMinute`, `getSecond`, `getDayOfMonth`, `getMonthValue`, `getYear`, `getDayOfWeek`) is called on a `String` value, parse it as a date via the same parser aggregations already use for date fields (`aggs::parse_date_ms`) and extract the requested UTC component. A string that isn't a parseable date (or a getter outside this set) still falls through unchanged to the existing unsupported-member error — this only adds a narrow, additive dispatch, it doesn't change how any other String method resolves.

Paired with #50 (terms aggregation `script` support), this fully unblocks the sample Heat Map visualization's date-script Y-axis end to end.

## Test plan
- [x] `cargo build --release -p xerj-api -p xerj-engine -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps -- -D warnings` — clean
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] Manual verification: `doc['timestamp'].value.getHour()` via `script_fields` now returns the correct UTC hour (5, 14, 14 for three test timestamps) instead of silently producing no `fields` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
