### PR TITLE
fix(server): admin API key regenerates on every restart instead of persisting

### DIFF
--- a/engine/crates/xerj-server/src/main.rs
+++ b/engine/crates/xerj-server/src/main.rs
@@ -464,6 +464,25 @@ fn ensure_admin_key(cfg: &mut Config) -> Result<()> {
         return Ok(());
     }
 
+    let data_dir = Path::new(&cfg.server.data_dir);
+    let key_path = data_dir.join("admin.key");
+
+    // A prior run may have already persisted a key — reuse it instead of
+    // minting a fresh one on every restart. A regenerated key on each
+    // restart forces every client (Kibana/OSD, MCP configs, scripts) to be
+    // manually re-pointed at the new value, which is exactly what
+    // persisting to `admin.key` in the first place was meant to avoid.
+    // Only a well-formed 64-char hex string (the shape this function itself
+    // always produces) is trusted; anything else falls through to a fresh
+    // generation rather than risk starting up with a garbled credential.
+    if let Ok(existing) = std::fs::read_to_string(&key_path) {
+        let existing = existing.trim();
+        if existing.len() == 64 && existing.bytes().all(|b| b.is_ascii_hexdigit()) {
+            cfg.auth.admin_api_key = existing.to_string();
+            return Ok(());
+        }
+    }
+
     // Generate 32 random bytes → 64-char hex string
     let raw: Vec<u8> = (0..32).map(|_| rand::random::<u8>()).collect();
     let key: String = raw.iter().map(|b| format!("{b:02x}")).collect();
@@ -479,10 +498,9 @@ fn ensure_admin_key(cfg: &mut Config) -> Result<()> {
     println!("╚══════════════════════════════════════════════════╝");
     println!();
 
-    let data_dir = Path::new(&cfg.server.data_dir);
     if std::fs::create_dir_all(data_dir).is_ok() {
         // 0600 — this file IS the admin credential (RC4 W2 #21).
-        if let Err(e) = write_secret_file(&data_dir.join("admin.key"), key.as_bytes()) {
+        if let Err(e) = write_secret_file(&key_path, key.as_bytes()) {
             warn!("could not persist admin.key: {e}");
         }
     }


### PR DESCRIPTION
## Summary

`ensure_admin_key()` minted a fresh random key on every server startup whenever `config.auth.admin_api_key` was empty, regardless of whether `data_dir/admin.key` already existed on disk from a previous run. It wrote to that file, but never read it back first — persisting the key was pointless if the very next restart threw it away again.

## Why this matters (found via dogfooding, not synthetic testing)

Found while wiring xerj up as the backing store for an AI coding agent's own memory: xerj already ships an `xerj-mcp` MCP server exposing `xerj_memory_store`/`xerj_memory_recall` (BM25 + semantic recall, dedup, namespaces) alongside search tools, so instead of building a throwaway memory server, the plan is to have Claude Code use xerj for real, continuous, load-bearing work — the same "make it hurt to be broken" approach that surfaced most of the other fixes in this series over the same session.

Every xerj restart during that session invalidated the just-configured MCP credential. This is also the exact same pain that hit real Kibana/OSD containers all night: whatever's pointed at xerj's admin key has to be manually re-pointed after every single restart, or it's locked out — the persisted `admin.key` file existed specifically to prevent that, but never actually got read.

## Fix

Before generating a new key, check for a pre-existing `data_dir/admin.key`. If it's present and shaped like a key this function would have produced (64 hex chars), reuse it instead of overwriting it. Anything else (missing, truncated, garbled) falls through to fresh generation exactly as before — this only adds a reuse path; first-run and corrupted-file behavior is unchanged.

## Test plan
- [x] `cargo build --release -p xerj-server`
- [x] `cargo fmt --check` / `cargo clippy --no-deps -- -D warnings` — clean
- [x] Full ES-compat YAML conformance suite: 1360 passed, 0 failed, 3 skipped — no regressions
- [x] Manual verification: two consecutive server starts against the same `data_dir` now report the identical `admin.key` contents (previously: different every time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
