### PR TITLE
fix(api): decompress gzip-encoded request bodies (breaks real ES clients incl. Filebeat)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -216,6 +216,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +822,23 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -5168,12 +5197,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "1", features = ["full"] }
 # HTTP
 axum = { version = "0.7", features = ["macros"] }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace", "limit"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "limit", "decompression-gzip"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -19,6 +19,7 @@ use axum::{
 use tower_http::{
     classify::{ServerErrorsAsFailures, SharedClassifier},
     cors::{AllowOrigin, Any, CorsLayer},
+    decompression::RequestDecompressionLayer,
     limit::RequestBodyLimitLayer,
     trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
 };
@@ -158,6 +159,13 @@ pub fn build_native_router(state: AppState) -> Router {
         // gate — bulk ingests legitimately exceed 2MB.
         .layer(DefaultBodyLimit::disable())
         .layer(RequestBodyLimitLayer::new(body_limit))
+        // Outermost: transparently decompress gzip-encoded request bodies
+        // (Content-Encoding: gzip) before the size limit above sees them, so
+        // the limit bounds decompressed size, not wire size. Real ES clients
+        // routinely compress writes by default (Beats, Logstash, official
+        // client libraries) — without this every such request 400s/500s
+        // trying to JSON-parse raw gzip bytes.
+        .layer(RequestDecompressionLayer::new().gzip(true))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -770,6 +778,13 @@ pub fn build_es_compat_router(state: AppState) -> Router {
         // gate — bulk ingests legitimately exceed 2MB.
         .layer(DefaultBodyLimit::disable())
         .layer(RequestBodyLimitLayer::new(body_limit))
+        // Outermost: transparently decompress gzip-encoded request bodies
+        // (Content-Encoding: gzip) before the size limit above sees them, so
+        // the limit bounds decompressed size, not wire size. Real ES clients
+        // routinely compress writes by default (Beats, Logstash, official
+        // client libraries) — without this every such request 400s/500s
+        // trying to JSON-parse raw gzip bytes.
+        .layer(RequestDecompressionLayer::new().gzip(true))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- xerj's ES-compat and native HTTP routers had no `Content-Encoding: gzip` decompression, so any client that compresses request bodies (Beats' `output.elasticsearch`, Logstash, official ES client libraries) got its writes rejected as unparseable JSON.
- Reproduced end-to-end with the real `docker.elastic.co/beats/filebeat:8.13.4` image against a local build: with ILM enabled (Filebeat's default), the first setup call `PUT /_ilm/policy/filebeat` 400s trying to JSON-parse the raw gzip body, the ES output connection is marked permanently failed, and Filebeat backs off and retries forever - zero documents ever reach xerj. Confirmed in isolation with curl too, and the same failure reproduces on `POST /_bulk` itself.
- Adds `tower_http::decompression::RequestDecompressionLayer` (gzip) as the outermost layer on both routers, positioned after `RequestBodyLimitLayer` so the body-size guard bounds decompressed size, not wire size.

## Test plan
- [x] `cargo check -p xerj-api`
- [x] `curl -X PUT .../_ilm/policy/x -H 'Content-Encoding: gzip' --data-binary @body.gz` -> `200 OK` (was `400`)
- [x] `curl -X POST .../_bulk -H 'Content-Encoding: gzip' --data-binary @bulk.gz` -> `200 OK` (was `500`)
- [x] Full Filebeat 8.13.4 run, default `output.elasticsearch` config (ILM + index template + data stream untouched): ILM policy created, template loaded, data stream loaded, `PublishEvents: 3 events published`, all 3 documents queryable via `_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182SCHH1waRGiQq8K7ydKou
