### PR TITLE
feat(storage) Add bounded selected-row and field projection for stored V2 sections

### DIFF
--- a/engine/crates/xerj-storage/examples/stored_projection_probe.rs
+++ b/engine/crates/xerj-storage/examples/stored_projection_probe.rs
@@ -1,0 +1,190 @@
+//! Reproducible probe for selective ZBS2 row hydration.
+//!
+//! This is intentionally a small executable rather than a Criterion benchmark:
+//! each measured decode runs in a fresh process, and canonical output is written
+//! to a file so `sha256sum` can verify full/selective equality.
+
+use serde_json::{json, Value};
+use std::fs;
+use std::io::Cursor;
+use std::time::Instant;
+use xerj_storage::stored_codec::{
+    decode_stored, decode_stored_v2_rows, decode_stored_v2_rows_projected, encode_stored_v2,
+    StoredV2RowHydrationResult,
+};
+
+fn process_cpu_ticks() -> u64 {
+    fs::read_to_string("/proc/self/stat")
+        .ok()
+        .and_then(|stat| {
+            // comm is parenthesized and may contain spaces, so split after its
+            // final ')'. Fields 14 and 15 are then offsets 11 and 12.
+            let fields = stat
+                .rsplit_once(')')?
+                .1
+                .split_whitespace()
+                .collect::<Vec<_>>();
+            Some(fields.get(11)?.parse::<u64>().ok()? + fields.get(12)?.parse::<u64>().ok()?)
+        })
+        .unwrap_or(0)
+}
+
+fn peak_rss_bytes() -> u64 {
+    fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|status| {
+            status.lines().find_map(|line| {
+                line.strip_prefix("VmHWM:")
+                    .and_then(|tail| tail.split_whitespace().next())
+                    .and_then(|kb| kb.parse::<u64>().ok())
+                    .map(|kb| kb * 1024)
+            })
+        })
+        .unwrap_or(0)
+}
+
+fn target_json(id: Value, seq_no: Value, source: Value) -> Vec<u8> {
+    serde_json::to_vec(&json!({"_id": id, "_seq_no": seq_no, "_source": source})).unwrap()
+}
+
+fn measured<T>(operation: impl FnOnce() -> T) -> (T, u128, u64) {
+    let cpu_before = process_cpu_ticks();
+    let started = Instant::now();
+    let value = operation();
+    (
+        value,
+        started.elapsed().as_micros(),
+        process_cpu_ticks().saturating_sub(cpu_before),
+    )
+}
+
+fn generate(path: &str, rows: usize) {
+    let body = "finance evidence sentence ".repeat(160);
+    let docs: Vec<Value> = (0..rows)
+        .map(|row| {
+            json!({
+                "_id": format!("filing-{row}"),
+                "_seq_no": row,
+                "_source": {
+                    "company": if row % 3 == 0 { "Acme" } else { "Globex" },
+                    "year": 2015 + row % 10,
+                    "quarter": row % 4 + 1,
+                    "page": row % 140,
+                    "body": format!("{body}{row}"),
+                    "nested": {"amount": row as f64 / 7.0, "tags": ["finance", "report"]}
+                }
+            })
+        })
+        .collect();
+    let raw = serde_json::to_vec(&docs).unwrap();
+    let encoded = encode_stored_v2(&raw);
+    fs::write(path, &encoded).unwrap();
+    println!(
+        "rows={rows} decoded_bytes={} encoded_bytes={}",
+        raw.len(),
+        encoded.len()
+    );
+}
+
+fn full(path: &str, output: &str) {
+    let encoded = fs::read(path).unwrap();
+    let (decoded, wall_us, cpu_ticks) = measured(|| decode_stored(&encoded).unwrap());
+    let docs: Vec<Value> = serde_json::from_slice(&decoded).unwrap();
+    let row = &docs[docs.len() - 1];
+    let target = target_json(
+        row["_id"].clone(),
+        row["_seq_no"].clone(),
+        json!({"body": row["_source"]["body"]}),
+    );
+    fs::write(output, &target).unwrap();
+    println!(
+        "mode=full rows={} decoded_bytes={} output_bytes={} wall_us={wall_us} cpu_ticks={cpu_ticks} peak_rss_bytes={}",
+        docs.len(),
+        decoded.len(),
+        target.len(),
+        peak_rss_bytes()
+    );
+}
+
+fn selective(path: &str, output: &str, projected: bool) {
+    let encoded = fs::read(path).unwrap();
+    let ordinal = 19_999;
+    let (result, wall_us, cpu_ticks) = measured(|| {
+        if projected {
+            decode_stored_v2_rows_projected(&encoded, &[ordinal], &["body"]).unwrap()
+        } else {
+            decode_stored_v2_rows(&encoded, &[ordinal]).unwrap()
+        }
+    });
+    let StoredV2RowHydrationResult::Hydrated { rows, stats } = result else {
+        panic!("fixture was not selectively hydrated")
+    };
+    let row = rows.into_iter().next().unwrap();
+    let source = if projected {
+        Value::Object(row.source)
+    } else {
+        json!({"body": row.source["body"]})
+    };
+    let target = target_json(row.id, row.seq_no, source);
+    fs::write(output, &target).unwrap();
+    println!(
+        "mode={} rows=1 output_bytes={} visited={} selected_values={} decompressed_bytes={} wall_us={wall_us} cpu_ticks={cpu_ticks} peak_rss_bytes={}",
+        if projected { "projected" } else { "row" },
+        target.len(),
+        stats.encoded_rows_visited,
+        stats.selected_json_values,
+        stats.decompressed_buffer_bytes,
+        peak_rss_bytes()
+    );
+}
+
+fn zstd_compare(iterations: usize) {
+    let shapes = [
+        (
+            "repeated_text",
+            b"finance evidence sentence ".repeat(160_000),
+        ),
+        (
+            "json_numbers",
+            serde_json::to_vec(&(0..200_000).map(|n| n % 4096).collect::<Vec<_>>()).unwrap(),
+        ),
+        (
+            "packed_ids",
+            (0_u32..500_000).flat_map(u32::to_le_bytes).collect(),
+        ),
+    ];
+    for (name, bytes) in shapes {
+        for implementation in ["stream", "bulk"] {
+            let started = Instant::now();
+            let mut size = 0;
+            for _ in 0..iterations {
+                let encoded = if implementation == "stream" {
+                    zstd::encode_all(Cursor::new(&bytes), 3).unwrap()
+                } else {
+                    zstd::bulk::compress(&bytes, 3).unwrap()
+                };
+                size = encoded.len();
+                assert_eq!(zstd::decode_all(encoded.as_slice()).unwrap(), bytes);
+            }
+            println!(
+                "shape={name} input_bytes={} implementation={implementation} encoded_bytes={size} iterations={iterations} wall_us={}",
+                bytes.len(),
+                started.elapsed().as_micros()
+            );
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(String::as_str) {
+        Some("generate") => generate(&args[2], args[3].parse().unwrap()),
+        Some("full") => full(&args[2], &args[3]),
+        Some("row") => selective(&args[2], &args[3], false),
+        Some("projected") => selective(&args[2], &args[3], true),
+        Some("zstd-compare") => zstd_compare(args[2].parse().unwrap()),
+        _ => panic!(
+            "generate <fixture> <rows> | full|row|projected <fixture> <output> | zstd-compare <iterations>"
+        ),
+    }
+}

--- a/engine/crates/xerj-storage/src/stored_codec.rs
+++ b/engine/crates/xerj-storage/src/stored_codec.rs
@@ -59,9 +59,48 @@ use std::io::{Cursor, Write};
 
 mod row_hydration;
 pub use row_hydration::{
-    decode_stored_v2_rows, StoredV2HydratedRow, StoredV2RowHydrationResult,
-    StoredV2RowHydrationStats,
+    decode_stored_v2_rows, decode_stored_v2_rows_controlled, StoredV2HydratedRow,
+    StoredV2RowHydrationResult, StoredV2RowHydrationStats,
 };
+
+pub const STORED_DECODE_CHECK_INTERVAL: usize = 128;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StoredDecodePhase {
+    BeforeColumn,
+    Rows,
+    AfterColumn,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StoredDecodeCheckpoint {
+    pub phase: StoredDecodePhase,
+    pub column_index: usize,
+    pub rows_processed: usize,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum StoredDecodeRun<T> {
+    Complete(T),
+    Cancelled,
+}
+
+pub(crate) fn decode_cancelled<F>(
+    checkpoint: &mut F,
+    phase: StoredDecodePhase,
+    column_index: usize,
+    rows_processed: usize,
+) -> bool
+where
+    F: FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()> + ?Sized,
+{
+    checkpoint(StoredDecodeCheckpoint {
+        phase,
+        column_index,
+        rows_processed,
+    })
+    .is_break()
+}
 
 // ── V1: flat LZ4 over JSON (legacy) ───────────────────────────────────────
 
@@ -539,6 +578,756 @@ pub fn decode_stored(bytes: &[u8]) -> Result<Vec<u8>> {
             .map_err(|e| StorageError::Other(anyhow::anyhow!("LZ4 decompress failed: {e}")));
     }
     Ok(bytes.to_vec())
+}
+
+/// Values decoded from a requested subset of a ZBS2 stored section.
+///
+/// Column names use their on-disk names: `_id` and `_seq_no` are `__id` and
+/// `__seq_no`; source fields retain their original top-level names.
+#[derive(Debug, PartialEq)]
+pub struct StoredV2Projection {
+    pub num_docs: usize,
+    pub columns: HashMap<String, Vec<serde_json::Value>>,
+}
+
+/// Result of attempting a selective V2 decode.
+#[derive(Debug, PartialEq)]
+pub enum StoredV2ProjectionResult {
+    /// The section is a valid legacy/non-V2 shape. Callers may use the full
+    /// compatibility decoder.
+    NotV2,
+    /// The requested columns were decoded. Requested names absent from the
+    /// segment are absent from `columns`.
+    Projected(StoredV2Projection),
+}
+
+struct V2ColumnRef<'a> {
+    name: &'a str,
+    codec: ColCodec,
+    payload: &'a [u8],
+}
+
+struct V2Directory<'a> {
+    num_docs: usize,
+    columns: Vec<V2ColumnRef<'a>>,
+}
+
+/// Typed columns needed by an exact kNN scan.
+pub type StoredVectorRows = Vec<Option<Vec<f32>>>;
+pub type StoredVectorChunkRows = Vec<Option<Vec<Vec<f32>>>>;
+
+#[derive(Debug, PartialEq)]
+pub struct StoredV2KnnProjection {
+    pub num_docs: usize,
+    /// Invalid or missing identity cells are represented as `None`; the
+    /// engine's version/tombstone rules decide whether to skip those rows.
+    pub ids: Vec<Option<String>>,
+    pub seq_nos: Vec<Option<u64>>,
+    pub vectors: StoredVectorRows,
+    /// `None` means the optional chunks role was not requested or its named
+    /// column is absent. It is not a corruption signal.
+    pub vector_chunks: Option<StoredVectorChunkRows>,
+}
+
+/// Result of attempting the typed kNN projection.
+#[derive(Debug, PartialEq)]
+pub enum StoredV2KnnProjectionResult {
+    /// Legacy LZ4 or headerless JSON. The caller must use the compatibility
+    /// decoder.
+    NotV2,
+    /// A valid V2 section does not contain the requested vector column.
+    MissingVectorColumn,
+    /// The requested column exists but is not a finite numeric vector shape.
+    /// Callers may preserve compatibility by using the generic decoder.
+    UnsupportedVectorShape,
+    Projected(StoredV2KnnProjection),
+}
+
+/// Parse and validate the complete ZBS2 directory without decoding payloads.
+///
+/// Keeping framing validation separate from payload decoding allows callers
+/// to skip large unrelated columns while retaining the full decoder's
+/// truncation, UTF-8 and codec-id checks.
+fn parse_v2_directory(body: &[u8]) -> Result<V2Directory<'_>> {
+    let mut cur = Cursor::new(body);
+    let num_docs = cur
+        .read_u32::<LittleEndian>()
+        .map_err(|e| StorageError::Other(anyhow::anyhow!("v2 num_docs: {e}")))?
+        as usize;
+    let num_cols = cur
+        .read_u32::<LittleEndian>()
+        .map_err(|e| StorageError::Other(anyhow::anyhow!("v2 num_cols: {e}")))?
+        as usize;
+    let mut columns = Vec::with_capacity(num_cols);
+    let mut seen = std::collections::HashSet::with_capacity(num_cols);
+    for _ in 0..num_cols {
+        let name_len = cur
+            .read_u16::<LittleEndian>()
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("v2 name_len: {e}")))?
+            as usize;
+        let name_start = cur.position() as usize;
+        let name_end = name_start
+            .checked_add(name_len)
+            .filter(|end| *end <= body.len())
+            .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 truncated name")))?;
+        let name = std::str::from_utf8(&body[name_start..name_end])
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("v2 bad name utf8: {e}")))?;
+        if !seen.insert(name) {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "v2 duplicate column name: {name}"
+            )));
+        }
+        cur.set_position(name_end as u64);
+        let codec_id = cur
+            .read_u8()
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("v2 codec_id: {e}")))?;
+        let codec = ColCodec::from_u8(codec_id)
+            .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 unknown codec {codec_id}")))?;
+        let payload_len = cur
+            .read_u32::<LittleEndian>()
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("v2 payload_len: {e}")))?
+            as usize;
+        let payload_start = cur.position() as usize;
+        let payload_end = payload_start
+            .checked_add(payload_len)
+            .filter(|end| *end <= body.len())
+            .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 truncated payload")))?;
+        columns.push(V2ColumnRef {
+            name,
+            codec,
+            payload: &body[payload_start..payload_end],
+        });
+        cur.set_position(payload_end as u64);
+    }
+    if cur.position() as usize != body.len() {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "v2 trailing bytes after column payloads"
+        )));
+    }
+    Ok(V2Directory { num_docs, columns })
+}
+
+/// Decode only named columns from a V2 stored section.
+///
+/// This API does not change `decode_stored` or any engine behavior. It is the
+/// storage primitive for consumers that can operate on selected columns
+/// without reconstructing every `_source` object.
+pub fn decode_stored_v2_projection(
+    bytes: &[u8],
+    requested: &[&str],
+) -> Result<StoredV2ProjectionResult> {
+    if bytes.len() < 4 || &bytes[..4] != STORED_V2_MAGIC {
+        return Ok(StoredV2ProjectionResult::NotV2);
+    }
+    let directory = parse_v2_directory(&bytes[4..])?;
+    let requested: std::collections::HashSet<&str> = requested.iter().copied().collect();
+    let mut decoded = vec![None; directory.columns.len()];
+    let mut visiting = vec![false; directory.columns.len()];
+    let mut columns = HashMap::with_capacity(requested.len());
+    for index in 0..directory.columns.len() {
+        let column = &directory.columns[index];
+        if requested.contains(column.name) {
+            let values =
+                decode_projected_column(index, &directory, &mut decoded, &mut visiting, 0)?.clone();
+            columns.insert(column.name.to_string(), values);
+        }
+    }
+    Ok(StoredV2ProjectionResult::Projected(StoredV2Projection {
+        num_docs: directory.num_docs,
+        columns,
+    }))
+}
+
+fn decode_cross_dep_body(payload: &[u8]) -> Result<Vec<u8>> {
+    if payload.is_empty() {
+        return Err(StorageError::Other(anyhow::anyhow!("cross_dep empty")));
+    }
+    let body = if payload[0] == 1 {
+        zstd::decode_all(&payload[1..])
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep zstd decode: {e}")))?
+    } else if payload[0] == 0 {
+        payload[1..].to_vec()
+    } else {
+        Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep invalid compression flag {}",
+            payload[0]
+        )))?
+    };
+    Ok(body)
+}
+
+fn cross_dep_source_index(payload: &[u8]) -> Result<usize> {
+    let body = decode_cross_dep_body(payload)?;
+    Cursor::new(body)
+        .read_u32::<LittleEndian>()
+        .map(|value| value as usize)
+        .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep src_ix: {e}")))
+}
+
+fn decode_projected_column<'a>(
+    index: usize,
+    directory: &'a V2Directory<'a>,
+    decoded: &'a mut [Option<Vec<serde_json::Value>>],
+    visiting: &mut [bool],
+    depth: usize,
+) -> Result<&'a Vec<serde_json::Value>> {
+    const MAX_CROSS_DEP_DEPTH: usize = 256;
+    if depth > MAX_CROSS_DEP_DEPTH {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep dependency depth exceeds {MAX_CROSS_DEP_DEPTH}"
+        )));
+    }
+    if decoded.get(index).and_then(Option::as_ref).is_some() {
+        return Ok(decoded[index].as_ref().unwrap());
+    }
+    if index >= directory.columns.len() || index >= visiting.len() {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep source index {index} out of range"
+        )));
+    }
+    if visiting[index] {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep dependency cycle at column {index}"
+        )));
+    }
+    visiting[index] = true;
+    let column = &directory.columns[index];
+    let values = match column.codec {
+        ColCodec::RawJson => decode_raw_json(column.payload)?,
+        ColCodec::Lz4Json => decode_lz4_json(column.payload)?,
+        ColCodec::Constant => decode_constant(column.payload, directory.num_docs)?,
+        ColCodec::DictBitpack => decode_dict_bitpack(column.payload, directory.num_docs)?,
+        ColCodec::CrossDep => {
+            let source_index = cross_dep_source_index(column.payload)?;
+            let source =
+                decode_projected_column(source_index, directory, decoded, visiting, depth + 1)?
+                    .clone();
+            let mut dependencies = vec![Vec::new(); directory.columns.len()];
+            dependencies[source_index] = source;
+            decode_cross_dep(
+                column.payload,
+                directory.num_docs,
+                &dependencies,
+                &HashMap::new(),
+            )?
+            .ok_or_else(|| {
+                StorageError::Other(anyhow::anyhow!(
+                    "cross_dep source column {source_index} was not resolved"
+                ))
+            })?
+        }
+    };
+    visiting[index] = false;
+    if values.len() != directory.num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "v2 column {} row count {} != header {}",
+            column.name,
+            values.len(),
+            directory.num_docs
+        )));
+    }
+    decoded[index] = Some(values);
+    Ok(decoded[index].as_ref().unwrap())
+}
+
+fn decoded_json_column(column: &V2ColumnRef<'_>) -> Result<Option<Vec<u8>>> {
+    match column.codec {
+        ColCodec::RawJson => zstd::decode_all(column.payload)
+            .map(Some)
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("raw zstd decode: {e}"))),
+        ColCodec::Lz4Json => lz4_flex::decompress_size_prepended(column.payload)
+            .map(Some)
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("lz4 decode: {e}"))),
+        ColCodec::Constant => Ok(Some(column.payload.to_vec())),
+        ColCodec::DictBitpack | ColCodec::CrossDep => Ok(None),
+    }
+}
+
+fn finite_f32_vector(values: Vec<f64>) -> Option<Vec<f32>> {
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        let value = value as f32;
+        if !value.is_finite() {
+            return None;
+        }
+        out.push(value);
+    }
+    Some(out)
+}
+
+struct TypedVectorRowsVisitor<'a> {
+    expected_rows: usize,
+    column_index: usize,
+    checkpoint: &'a mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+    cancelled: &'a std::cell::Cell<bool>,
+}
+
+impl<'de> serde::de::Visitor<'de> for TypedVectorRowsVisitor<'_> {
+    type Value = Option<StoredVectorRows>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a vector column JSON array")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut out = Vec::with_capacity(self.expected_rows);
+        let mut supported = true;
+        for row in 0..self.expected_rows {
+            let Some(value) = seq.next_element::<serde_json::Value>()? else {
+                return Err(serde::de::Error::custom("vector column ended early"));
+            };
+            let typed = match value {
+                serde_json::Value::Null => None,
+                serde_json::Value::Array(values) => {
+                    let values = values
+                        .into_iter()
+                        .map(|value| value.as_f64())
+                        .collect::<Option<Vec<_>>>()
+                        .and_then(finite_f32_vector);
+                    let Some(values) = values else {
+                        supported = false;
+                        out.push(None);
+                        continue;
+                    };
+                    Some(values)
+                }
+                _ => {
+                    supported = false;
+                    None
+                }
+            };
+            out.push(typed);
+            let processed = row + 1;
+            if processed % STORED_DECODE_CHECK_INTERVAL == 0
+                && (self.checkpoint)(StoredDecodeCheckpoint {
+                    phase: StoredDecodePhase::Rows,
+                    column_index: self.column_index,
+                    rows_processed: processed,
+                })
+                .is_break()
+            {
+                self.cancelled.set(true);
+                return Err(serde::de::Error::custom("stored decode cancelled"));
+            }
+        }
+        if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+            return Err(serde::de::Error::custom("vector column has extra rows"));
+        }
+        Ok(supported.then_some(out))
+    }
+}
+
+fn decode_typed_vector_rows_controlled(
+    column: &V2ColumnRef<'_>,
+    num_docs: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Option<StoredVectorRows>, ()>> {
+    if column.codec == ColCodec::Constant {
+        return decode_typed_vector_rows(column, num_docs).map(Ok);
+    }
+    match column.codec {
+        ColCodec::RawJson => {
+            let decoder = zstd::stream::read::Decoder::new(column.payload).map_err(|error| {
+                StorageError::Other(anyhow::anyhow!("raw zstd decode: {error}"))
+            })?;
+            parse_typed_vector_reader(decoder, num_docs, column_index, checkpoint)
+        }
+        ColCodec::Lz4Json => {
+            let raw = lz4_flex::decompress_size_prepended(column.payload)
+                .map_err(|error| StorageError::Other(anyhow::anyhow!("lz4 decode: {error}")))?;
+            parse_typed_vector_reader(raw.as_slice(), num_docs, column_index, checkpoint)
+        }
+        _ => Ok(Ok(None)),
+    }
+}
+
+fn parse_typed_vector_reader<R: std::io::Read>(
+    reader: R,
+    num_docs: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Option<StoredVectorRows>, ()>> {
+    use serde::de::Deserializer as _;
+    let cancelled = std::cell::Cell::new(false);
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    let value = match deserializer.deserialize_seq(TypedVectorRowsVisitor {
+        expected_rows: num_docs,
+        column_index,
+        checkpoint,
+        cancelled: &cancelled,
+    }) {
+        Ok(value) => value,
+        Err(_) if cancelled.get() => return Ok(Err(())),
+        Err(error) => {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "vector json decode: {error}"
+            )));
+        }
+    };
+    if value.is_some() {
+        deserializer
+            .end()
+            .map_err(|error| StorageError::Other(anyhow::anyhow!("vector json decode: {error}")))?;
+    }
+    Ok(Ok(value))
+}
+
+fn decode_typed_vector_rows(
+    column: &V2ColumnRef<'_>,
+    num_docs: usize,
+) -> Result<Option<StoredVectorRows>> {
+    use serde_json::value::RawValue;
+    let Some(raw) = decoded_json_column(column)? else {
+        return Ok(None);
+    };
+    let rows: Vec<&RawValue> = if column.codec == ColCodec::Constant {
+        let row: &RawValue = serde_json::from_slice(&raw)
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("constant decode: {e}")))?;
+        vec![row; num_docs]
+    } else {
+        serde_json::from_slice(&raw)
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("vector json decode: {e}")))?
+    };
+    if rows.len() != num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "v2 vector row count {} != header {num_docs}",
+            rows.len()
+        )));
+    }
+    let mut out = Vec::with_capacity(num_docs);
+    for row in rows {
+        if row.get() == "null" {
+            out.push(None);
+            continue;
+        }
+        let Ok(values) = serde_json::from_str::<Vec<f64>>(row.get()) else {
+            return Ok(None);
+        };
+        let Some(vector) = finite_f32_vector(values) else {
+            return Ok(None);
+        };
+        out.push(Some(vector));
+    }
+    Ok(Some(out))
+}
+
+fn decode_typed_vector_chunk_rows(
+    column: &V2ColumnRef<'_>,
+    num_docs: usize,
+) -> Result<Option<StoredVectorChunkRows>> {
+    use serde_json::value::RawValue;
+    let Some(raw) = decoded_json_column(column)? else {
+        return Ok(None);
+    };
+    let rows: Vec<&RawValue> = if column.codec == ColCodec::Constant {
+        let row: &RawValue = serde_json::from_slice(&raw)
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("constant decode: {e}")))?;
+        vec![row; num_docs]
+    } else {
+        serde_json::from_slice(&raw)
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("vector chunks json decode: {e}")))?
+    };
+    if rows.len() != num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "v2 vector chunks row count {} != header {num_docs}",
+            rows.len()
+        )));
+    }
+    let mut out = Vec::with_capacity(num_docs);
+    for row in rows {
+        if row.get() == "null" {
+            out.push(None);
+            continue;
+        }
+        let Ok(chunks) = serde_json::from_str::<Vec<Vec<f64>>>(row.get()) else {
+            return Ok(None);
+        };
+        let mut typed = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
+            let Some(chunk) = finite_f32_vector(chunk) else {
+                return Ok(None);
+            };
+            typed.push(chunk);
+        }
+        out.push(Some(typed));
+    }
+    Ok(Some(out))
+}
+
+fn decode_typed_vector_chunk_rows_controlled(
+    column: &V2ColumnRef<'_>,
+    num_docs: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Option<StoredVectorChunkRows>, ()>> {
+    if column.codec == ColCodec::Constant {
+        return decode_typed_vector_chunk_rows(column, num_docs).map(Ok);
+    }
+    match column.codec {
+        ColCodec::RawJson => {
+            let decoder = zstd::stream::read::Decoder::new(column.payload).map_err(|error| {
+                StorageError::Other(anyhow::anyhow!("raw zstd decode: {error}"))
+            })?;
+            parse_typed_chunk_reader(decoder, num_docs, column_index, checkpoint)
+        }
+        ColCodec::Lz4Json => {
+            let raw = lz4_flex::decompress_size_prepended(column.payload)
+                .map_err(|error| StorageError::Other(anyhow::anyhow!("lz4 decode: {error}")))?;
+            parse_typed_chunk_reader(raw.as_slice(), num_docs, column_index, checkpoint)
+        }
+        _ => Ok(Ok(None)),
+    }
+}
+
+fn parse_typed_chunk_reader<R: std::io::Read>(
+    reader: R,
+    num_docs: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Option<StoredVectorChunkRows>, ()>> {
+    use serde::de::Deserializer as _;
+    struct Visitor<'a> {
+        rows: usize,
+        column: usize,
+        checkpoint: &'a mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+        cancelled: &'a std::cell::Cell<bool>,
+    }
+    impl<'de> serde::de::Visitor<'de> for Visitor<'_> {
+        type Value = Option<StoredVectorChunkRows>;
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("a vector chunks column JSON array")
+        }
+        fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut out = Vec::with_capacity(self.rows);
+            let mut supported = true;
+            for row in 0..self.rows {
+                let Some(value) = seq.next_element::<serde_json::Value>()? else {
+                    return Err(serde::de::Error::custom("vector chunks ended early"));
+                };
+                let typed = match value {
+                    serde_json::Value::Null => None,
+                    serde_json::Value::Array(chunks) => {
+                        let mut result = Vec::with_capacity(chunks.len());
+                        for chunk in chunks {
+                            let serde_json::Value::Array(values) = chunk else {
+                                supported = false;
+                                continue;
+                            };
+                            let vector = values
+                                .into_iter()
+                                .map(|value| value.as_f64())
+                                .collect::<Option<Vec<_>>>()
+                                .and_then(finite_f32_vector);
+                            let Some(vector) = vector else {
+                                supported = false;
+                                continue;
+                            };
+                            result.push(vector);
+                        }
+                        Some(result)
+                    }
+                    _ => {
+                        supported = false;
+                        None
+                    }
+                };
+                out.push(typed);
+                let processed = row + 1;
+                if processed % STORED_DECODE_CHECK_INTERVAL == 0
+                    && (self.checkpoint)(StoredDecodeCheckpoint {
+                        phase: StoredDecodePhase::Rows,
+                        column_index: self.column,
+                        rows_processed: processed,
+                    })
+                    .is_break()
+                {
+                    self.cancelled.set(true);
+                    return Err(serde::de::Error::custom("stored decode cancelled"));
+                }
+            }
+            if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                return Err(serde::de::Error::custom("vector chunks has extra rows"));
+            }
+            Ok(supported.then_some(out))
+        }
+    }
+    let cancelled = std::cell::Cell::new(false);
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    let value = match deserializer.deserialize_seq(Visitor {
+        rows: num_docs,
+        column: column_index,
+        checkpoint,
+        cancelled: &cancelled,
+    }) {
+        Ok(value) => value,
+        Err(_) if cancelled.get() => return Ok(Err(())),
+        Err(error) => {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "vector chunks json decode: {error}"
+            )));
+        }
+    };
+    if value.is_some() {
+        deserializer.end().map_err(|error| {
+            StorageError::Other(anyhow::anyhow!("vector chunks json decode: {error}"))
+        })?;
+    }
+    Ok(Ok(value))
+}
+
+/// Decode the identity and vector columns needed by exact kNN without
+/// reconstructing complete source documents.
+pub fn decode_stored_v2_knn_projection(
+    bytes: &[u8],
+    vector_field: &str,
+    vector_chunks_field: Option<&str>,
+) -> Result<StoredV2KnnProjectionResult> {
+    match decode_stored_v2_knn_projection_controlled(
+        bytes,
+        vector_field,
+        vector_chunks_field,
+        |_| std::ops::ControlFlow::Continue(()),
+    )? {
+        StoredDecodeRun::Complete(result) => Ok(result),
+        StoredDecodeRun::Cancelled => unreachable!("non-cancelling compatibility wrapper"),
+    }
+}
+
+pub fn decode_stored_v2_knn_projection_controlled<F>(
+    bytes: &[u8],
+    vector_field: &str,
+    vector_chunks_field: Option<&str>,
+    mut checkpoint: F,
+) -> Result<StoredDecodeRun<StoredV2KnnProjectionResult>>
+where
+    F: FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+{
+    if bytes.len() < 4 || &bytes[..4] != STORED_V2_MAGIC {
+        return Ok(StoredDecodeRun::Complete(
+            StoredV2KnnProjectionResult::NotV2,
+        ));
+    }
+    if matches!(vector_field, "__id" | "__seq_no")
+        || vector_chunks_field
+            .is_some_and(|field| matches!(field, "__id" | "__seq_no") || field == vector_field)
+    {
+        return Ok(StoredDecodeRun::Complete(
+            StoredV2KnnProjectionResult::UnsupportedVectorShape,
+        ));
+    }
+    let directory = parse_v2_directory(&bytes[4..])?;
+    let Some(vector_column) = directory
+        .columns
+        .iter()
+        .find(|column| column.name == vector_field)
+    else {
+        return Ok(StoredDecodeRun::Complete(
+            StoredV2KnnProjectionResult::MissingVectorColumn,
+        ));
+    };
+    let vector_index = directory
+        .columns
+        .iter()
+        .position(|column| std::ptr::eq(column, vector_column))
+        .unwrap();
+    if decode_cancelled(
+        &mut checkpoint,
+        StoredDecodePhase::BeforeColumn,
+        vector_index,
+        0,
+    ) {
+        return Ok(StoredDecodeRun::Cancelled);
+    }
+    let Some(vectors) = (match decode_typed_vector_rows_controlled(
+        vector_column,
+        directory.num_docs,
+        vector_index,
+        &mut checkpoint,
+    )? {
+        Ok(value) => value,
+        Err(()) => return Ok(StoredDecodeRun::Cancelled),
+    }) else {
+        return Ok(StoredDecodeRun::Complete(
+            StoredV2KnnProjectionResult::UnsupportedVectorShape,
+        ));
+    };
+    if decode_cancelled(
+        &mut checkpoint,
+        StoredDecodePhase::AfterColumn,
+        vector_index,
+        directory.num_docs,
+    ) {
+        return Ok(StoredDecodeRun::Cancelled);
+    }
+    let vector_chunks = match vector_chunks_field {
+        Some(field) => match directory.columns.iter().find(|column| column.name == field) {
+            Some(column) => {
+                let index = directory
+                    .columns
+                    .iter()
+                    .position(|candidate| std::ptr::eq(candidate, column))
+                    .unwrap();
+                if decode_cancelled(&mut checkpoint, StoredDecodePhase::BeforeColumn, index, 0) {
+                    return Ok(StoredDecodeRun::Cancelled);
+                }
+                let Some(chunks) = (match decode_typed_vector_chunk_rows_controlled(
+                    column,
+                    directory.num_docs,
+                    index,
+                    &mut checkpoint,
+                )? {
+                    Ok(value) => value,
+                    Err(()) => return Ok(StoredDecodeRun::Cancelled),
+                }) else {
+                    return Ok(StoredDecodeRun::Complete(
+                        StoredV2KnnProjectionResult::UnsupportedVectorShape,
+                    ));
+                };
+                if decode_cancelled(
+                    &mut checkpoint,
+                    StoredDecodePhase::AfterColumn,
+                    index,
+                    directory.num_docs,
+                ) {
+                    return Ok(StoredDecodeRun::Cancelled);
+                }
+                Some(chunks)
+            }
+            None => None,
+        },
+        None => None,
+    };
+    let (identity_num_docs, id_values, seq_values) =
+        match row_hydration::decode_v2_identity_columns_controlled(bytes, &mut checkpoint)? {
+            StoredDecodeRun::Complete(Some(values)) => values,
+            StoredDecodeRun::Complete(None) => {
+                return Ok(StoredDecodeRun::Complete(
+                    StoredV2KnnProjectionResult::UnsupportedVectorShape,
+                ));
+            }
+            StoredDecodeRun::Cancelled => return Ok(StoredDecodeRun::Cancelled),
+        };
+    let ids = id_values
+        .into_iter()
+        .map(|value| value.as_str().map(ToOwned::to_owned))
+        .collect();
+    let seq_nos = seq_values.into_iter().map(|value| value.as_u64()).collect();
+    Ok(StoredDecodeRun::Complete(
+        StoredV2KnnProjectionResult::Projected(StoredV2KnnProjection {
+            num_docs: identity_num_docs,
+            ids,
+            seq_nos,
+            vectors,
+            vector_chunks,
+        }),
+    ))
 }
 
 fn decode_stored_v2(body: &[u8]) -> Result<Vec<u8>> {
@@ -1369,6 +2158,634 @@ mod tests {
         let raw = br#"[{"_id":"a"}]"#;
         let decoded = decode_stored(raw).unwrap();
         assert_eq!(&decoded, raw);
+    }
+
+    fn projection_fixture() -> (Vec<serde_json::Value>, Vec<u8>) {
+        let docs: Vec<_> = (0..256)
+            .map(|i| {
+                json!({
+                    "_id": format!("doc-{i}"),
+                    "_seq_no": i,
+                    "_source": {
+                        "category": if i % 2 == 0 { "even" } else { "odd" },
+                        "embedding": [i as f64 / 10.0, 0.25, -0.5],
+                        "embedding_chunks": [
+                            [i as f64 / 10.0, 0.25, -0.5],
+                            [-0.0, 1.25e-10, -2]
+                        ],
+                        "large_unrequested": "the same payload repeated to compress well"
+                    }
+                })
+            })
+            .collect();
+        let encoded = encode_stored_v2(&serde_json::to_vec(&docs).unwrap());
+        assert_eq!(&encoded[..4], STORED_V2_MAGIC);
+        (docs, encoded)
+    }
+
+    fn handcrafted_v2(num_docs: u32, columns: &[(&str, u8, Vec<u8>)]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(STORED_V2_MAGIC);
+        out.write_u32::<LittleEndian>(num_docs).unwrap();
+        out.write_u32::<LittleEndian>(columns.len() as u32).unwrap();
+        for (name, codec, payload) in columns {
+            out.write_u16::<LittleEndian>(name.len() as u16).unwrap();
+            out.extend_from_slice(name.as_bytes());
+            out.push(*codec);
+            out.write_u32::<LittleEndian>(payload.len() as u32).unwrap();
+            out.extend_from_slice(payload);
+        }
+        out
+    }
+
+    fn raw_cross_dep(source_index: u32) -> Vec<u8> {
+        let mut payload = vec![0];
+        payload.write_u32::<LittleEndian>(source_index).unwrap();
+        payload
+    }
+
+    fn valid_cross_dep(source_index: u32, mode: i64) -> Vec<u8> {
+        let mut payload = raw_cross_dep(source_index);
+        payload.write_u32::<LittleEndian>(1).unwrap();
+        payload.write_i64::<LittleEndian>(mode).unwrap();
+        payload.write_u32::<LittleEndian>(0).unwrap();
+        payload
+    }
+
+    fn lz4_json(value: &serde_json::Value) -> Vec<u8> {
+        lz4_flex::compress_prepend_size(&serde_json::to_vec(value).unwrap())
+    }
+
+    fn typed_fixture_with_columns(
+        num_docs: usize,
+        vector_codec: ColCodec,
+        vector_payload: Vec<u8>,
+        chunks: Option<(ColCodec, Vec<u8>)>,
+    ) -> Vec<u8> {
+        let ids = json!((0..num_docs).map(|i| format!("id-{i}")).collect::<Vec<_>>());
+        let seq = json!((0..num_docs).collect::<Vec<_>>());
+        let mut columns = vec![
+            ("__id", ColCodec::Lz4Json as u8, lz4_json(&ids)),
+            ("__seq_no", ColCodec::Lz4Json as u8, lz4_json(&seq)),
+            ("embedding", vector_codec as u8, vector_payload),
+        ];
+        if let Some((codec, payload)) = chunks {
+            columns.push(("embedding_chunks", codec as u8, payload));
+        }
+        handcrafted_v2(num_docs as u32, &columns)
+    }
+
+    #[test]
+    fn v2_projection_decodes_only_requested_columns_with_full_decode_parity() {
+        let (docs, encoded) = projection_fixture();
+        let StoredV2ProjectionResult::Projected(projected) =
+            decode_stored_v2_projection(&encoded, &["__id", "embedding"]).unwrap()
+        else {
+            panic!("fixture should support projection");
+        };
+        assert_eq!(projected.num_docs, docs.len());
+        assert_eq!(projected.columns.len(), 2);
+        assert!(!projected.columns.contains_key("large_unrequested"));
+        for (row, expected) in docs.iter().enumerate() {
+            assert_eq!(projected.columns["__id"][row], expected["_id"]);
+            assert_eq!(
+                projected.columns["embedding"][row],
+                expected["_source"]["embedding"]
+            );
+        }
+        let StoredV2ProjectionResult::Projected(seq_projection) =
+            decode_stored_v2_projection(&encoded, &["__seq_no"]).unwrap()
+        else {
+            panic!("CROSS_DEP sequence column should resolve");
+        };
+        for (row, expected) in docs.iter().enumerate() {
+            assert_eq!(seq_projection.columns["__seq_no"][row], expected["_seq_no"]);
+        }
+    }
+
+    #[test]
+    fn v2_projection_does_not_decode_unrequested_payload() {
+        let (_, mut encoded) = projection_fixture();
+        let (payload_offset, payload_len) = {
+            let directory = parse_v2_directory(&encoded[4..]).unwrap();
+            let column = directory
+                .columns
+                .iter()
+                .find(|column| column.name == "large_unrequested")
+                .unwrap();
+            (
+                column.payload.as_ptr() as usize - encoded.as_ptr() as usize,
+                column.payload.len(),
+            )
+        };
+        encoded[payload_offset + payload_len / 2] ^= 0xff;
+
+        let StoredV2ProjectionResult::Projected(projected) =
+            decode_stored_v2_projection(&encoded, &["__id"]).unwrap()
+        else {
+            panic!("an unrelated corrupt payload must not be decoded");
+        };
+        assert_eq!(projected.columns["__id"].len(), 256);
+        assert!(
+            decode_stored(&encoded).is_err(),
+            "the full decoder must still observe corrupt unrequested payloads"
+        );
+    }
+
+    #[test]
+    fn v2_knn_projection_resolves_identity_and_typed_vectors() {
+        let (docs, encoded) = projection_fixture();
+        let StoredV2KnnProjectionResult::Projected(projected) =
+            decode_stored_v2_knn_projection(&encoded, "embedding", Some("embedding_chunks"))
+                .unwrap()
+        else {
+            panic!("fixture should support typed projection");
+        };
+        assert_eq!(projected.num_docs, 256);
+        assert_eq!(projected.ids[42].as_deref(), Some("doc-42"));
+        assert_eq!(projected.seq_nos[42], Some(42));
+        for row in [0, 1, 42, 255] {
+            let expected = docs[row]["_source"]["embedding"].as_array().unwrap();
+            let actual = projected.vectors[row].as_ref().unwrap();
+            for (actual, expected) in actual.iter().zip(expected) {
+                assert_eq!(
+                    actual.to_bits(),
+                    (expected.as_f64().unwrap() as f32).to_bits()
+                );
+            }
+        }
+        let chunks = projected.vector_chunks.as_ref().unwrap()[7]
+            .as_ref()
+            .unwrap();
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[1][0].to_bits(), (-0.0f32).to_bits());
+        assert_eq!(chunks[1][1].to_bits(), (1.25e-10f32).to_bits());
+        assert_eq!(chunks[1][2], -2.0);
+    }
+
+    #[test]
+    fn controlled_knn_projection_cancels_without_changing_compatibility_outcomes() {
+        let (_, encoded) = projection_fixture();
+        let mut observed = Vec::new();
+        let run = decode_stored_v2_knn_projection_controlled(
+            &encoded,
+            "embedding",
+            Some("embedding_chunks"),
+            |point| {
+                observed.push(point);
+                if point.phase == StoredDecodePhase::Rows && point.rows_processed == 128 {
+                    std::ops::ControlFlow::Break(())
+                } else {
+                    std::ops::ControlFlow::Continue(())
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!(run, StoredDecodeRun::Cancelled);
+        assert!(observed.iter().any(|point| {
+            point.phase == StoredDecodePhase::BeforeColumn && point.rows_processed == 0
+        }));
+
+        let controlled = decode_stored_v2_knn_projection_controlled(
+            &encoded,
+            "embedding",
+            Some("embedding_chunks"),
+            |_| std::ops::ControlFlow::Continue(()),
+        )
+        .unwrap();
+        assert_eq!(
+            controlled,
+            StoredDecodeRun::Complete(
+                decode_stored_v2_knn_projection(&encoded, "embedding", Some("embedding_chunks"))
+                    .unwrap()
+            )
+        );
+
+        assert_eq!(
+            decode_stored_v2_knn_projection_controlled(
+                &encode_stored_lz4(b"[]"),
+                "embedding",
+                None,
+                |_| std::ops::ControlFlow::Continue(())
+            )
+            .unwrap(),
+            StoredDecodeRun::Complete(StoredV2KnnProjectionResult::NotV2)
+        );
+    }
+
+    #[test]
+    fn controlled_knn_projection_stops_before_bad_row_129() {
+        let rows_with_bad_129 = |chunks: bool| {
+            let values: Vec<_> = (0..256)
+                .map(|row| {
+                    if row == 128 {
+                        json!("row-129-must-not-be-consumed")
+                    } else if chunks {
+                        json!([[1.0, 0.0]])
+                    } else {
+                        json!([1.0, 0.0])
+                    }
+                })
+                .collect();
+            zstd::encode_all(
+                Cursor::new(serde_json::to_vec(&values).unwrap()),
+                STORED_ZSTD_LEVEL,
+            )
+            .unwrap()
+        };
+        let constant_id = serde_json::to_vec(&json!("id")).unwrap();
+        let constant_seq = serde_json::to_vec(&json!(1)).unwrap();
+
+        for bad_column in ["embedding", "embedding_chunks"] {
+            let embedding = if bad_column == "embedding" {
+                rows_with_bad_129(false)
+            } else {
+                let values = vec![json!([1.0, 0.0]); 256];
+                zstd::encode_all(
+                    Cursor::new(serde_json::to_vec(&values).unwrap()),
+                    STORED_ZSTD_LEVEL,
+                )
+                .unwrap()
+            };
+            let chunks = if bad_column == "embedding_chunks" {
+                rows_with_bad_129(true)
+            } else {
+                let values = vec![json!([[1.0, 0.0]]); 256];
+                zstd::encode_all(
+                    Cursor::new(serde_json::to_vec(&values).unwrap()),
+                    STORED_ZSTD_LEVEL,
+                )
+                .unwrap()
+            };
+            let encoded = handcrafted_v2(
+                256,
+                &[
+                    ("__id", ColCodec::Constant as u8, constant_id.clone()),
+                    ("__seq_no", ColCodec::Constant as u8, constant_seq.clone()),
+                    ("embedding", ColCodec::RawJson as u8, embedding),
+                    ("embedding_chunks", ColCodec::RawJson as u8, chunks),
+                ],
+            );
+            let cancel_column = if bad_column == "embedding" { 2 } else { 3 };
+            assert_eq!(
+                decode_stored_v2_knn_projection_controlled(
+                    &encoded,
+                    "embedding",
+                    Some("embedding_chunks"),
+                    |point| {
+                        if point.column_index == cancel_column
+                            && point.phase == StoredDecodePhase::Rows
+                            && point.rows_processed == 128
+                        {
+                            std::ops::ControlFlow::Break(())
+                        } else {
+                            std::ops::ControlFlow::Continue(())
+                        }
+                    }
+                )
+                .unwrap(),
+                StoredDecodeRun::Cancelled,
+                "{bad_column} must cancel before consuming row 129"
+            );
+            assert_eq!(
+                decode_stored_v2_knn_projection_controlled(
+                    &encoded,
+                    "embedding",
+                    Some("embedding_chunks"),
+                    |_| std::ops::ControlFlow::Continue(())
+                )
+                .unwrap(),
+                StoredDecodeRun::Complete(StoredV2KnnProjectionResult::UnsupportedVectorShape),
+                "without cancellation {bad_column} must consume bad row 129"
+            );
+        }
+    }
+
+    #[test]
+    fn v2_knn_projection_has_explicit_legacy_missing_and_shape_outcomes() {
+        let legacy = encode_stored_lz4(br#"[{"_id":"legacy"}]"#);
+        assert_eq!(
+            decode_stored_v2_knn_projection(&legacy, "embedding", None).unwrap(),
+            StoredV2KnnProjectionResult::NotV2
+        );
+
+        let (_, encoded) = projection_fixture();
+        assert_eq!(
+            decode_stored_v2_knn_projection(&encoded, "missing", None).unwrap(),
+            StoredV2KnnProjectionResult::MissingVectorColumn
+        );
+
+        let malformed_docs: Vec<_> = (0..256)
+            .map(|i| {
+                json!({
+                    "_id": format!("bad-{i}"),
+                    "_seq_no": i,
+                    "_source": {
+                        "embedding": if i == 128 {
+                            json!([1.0, "not-a-number", 3.0])
+                        } else {
+                            json!([1.0, 2.0, 3.0])
+                        }
+                    }
+                })
+            })
+            .collect();
+        let malformed = encode_stored_v2(&serde_json::to_vec(&malformed_docs).unwrap());
+        assert_eq!(&malformed[..4], STORED_V2_MAGIC);
+        assert_eq!(
+            decode_stored_v2_knn_projection(&malformed, "embedding", None).unwrap(),
+            StoredV2KnnProjectionResult::UnsupportedVectorShape
+        );
+    }
+
+    #[test]
+    fn v2_projection_rejects_cross_dep_cycles_and_bad_source_indices() {
+        let cycle = handcrafted_v2(
+            1,
+            &[
+                ("a", ColCodec::CrossDep as u8, raw_cross_dep(1)),
+                ("b", ColCodec::CrossDep as u8, raw_cross_dep(0)),
+            ],
+        );
+        let error = decode_stored_v2_projection(&cycle, &["a"]).unwrap_err();
+        assert!(error.to_string().contains("dependency cycle"), "{error}");
+
+        let out_of_range = handcrafted_v2(1, &[("a", ColCodec::CrossDep as u8, raw_cross_dep(9))]);
+        let error = decode_stored_v2_projection(&out_of_range, &["a"]).unwrap_err();
+        assert!(error.to_string().contains("out of range"), "{error}");
+
+        let bad_flag = handcrafted_v2(1, &[("a", ColCodec::CrossDep as u8, vec![7, 0, 0, 0, 0])]);
+        let error = decode_stored_v2_projection(&bad_flag, &["a"]).unwrap_err();
+        assert!(
+            error.to_string().contains("invalid compression flag"),
+            "{error}"
+        );
+        assert!(
+            decode_stored(&bad_flag).is_err(),
+            "full and selective decoders must reject the same bad flag"
+        );
+    }
+
+    #[test]
+    fn v2_projection_resolves_forward_multihop_and_shared_dependencies() {
+        let id_payload = serde_json::to_vec(&vec!["doc"; 4]).unwrap();
+        let seq_payload = serde_json::to_vec(&vec![0, 1, 2, 3]).unwrap();
+        let encoded = handcrafted_v2(
+            4,
+            &[
+                (
+                    "__id",
+                    ColCodec::Lz4Json as u8,
+                    lz4_flex::compress_prepend_size(&id_payload),
+                ),
+                (
+                    "__seq_no",
+                    ColCodec::Lz4Json as u8,
+                    lz4_flex::compress_prepend_size(&seq_payload),
+                ),
+                ("a", ColCodec::CrossDep as u8, valid_cross_dep(3, 10)),
+                ("b", ColCodec::CrossDep as u8, valid_cross_dep(4, 5)),
+                ("base", ColCodec::Constant as u8, br#""key""#.to_vec()),
+                ("d", ColCodec::CrossDep as u8, valid_cross_dep(4, 20)),
+            ],
+        );
+        let StoredV2ProjectionResult::Projected(projected) =
+            decode_stored_v2_projection(&encoded, &["a", "d"]).unwrap()
+        else {
+            panic!("valid recursive dependencies should project");
+        };
+        assert_eq!(
+            projected
+                .columns
+                .keys()
+                .cloned()
+                .collect::<std::collections::HashSet<_>>(),
+            ["a".to_string(), "d".to_string()].into_iter().collect()
+        );
+        assert_eq!(projected.columns["a"], vec![json!(10); 4]);
+        assert_eq!(projected.columns["d"], vec![json!(20); 4]);
+
+        let full: Vec<serde_json::Value> =
+            serde_json::from_slice(&decode_stored(&encoded).unwrap()).unwrap();
+        for row in full {
+            assert_eq!(row["_source"]["a"], 10);
+            assert_eq!(row["_source"]["d"], 20);
+        }
+    }
+
+    #[test]
+    fn cross_dep_checked_exceptions_reject_truncation_overflow_and_trailing_bytes() {
+        let dependencies = vec![Vec::new(), vec![json!("key"); 4]];
+        let make = |exception_bytes: &[u8]| {
+            let mut payload = valid_cross_dep(1, 7);
+            let len = payload.len();
+            payload[len - 4..].copy_from_slice(&1u32.to_le_bytes());
+            payload.extend_from_slice(exception_bytes);
+            payload
+        };
+
+        let truncated = make(&[0x80]);
+        assert!(decode_cross_dep(&truncated, 4, &dependencies, &HashMap::new()).is_err());
+
+        let overlong = make(&[0x80; 11]);
+        assert!(decode_cross_dep(&overlong, 4, &dependencies, &HashMap::new()).is_err());
+
+        let out_of_range = make(&[4, 0]);
+        assert!(decode_cross_dep(&out_of_range, 4, &dependencies, &HashMap::new()).is_err());
+
+        let mut trailing = valid_cross_dep(1, 7);
+        trailing.push(0);
+        assert!(decode_cross_dep(&trailing, 4, &dependencies, &HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn v2_knn_projection_preserves_384d_f32_bits_and_rejects_overflow() {
+        let docs: Vec<_> = (0..256)
+            .map(|row| {
+                let vector: Vec<f64> = (0..384)
+                    .map(|dim| (row as f64 - dim as f64) / 997.0)
+                    .collect();
+                json!({
+                    "_id": format!("wide-{row}"),
+                    "_seq_no": row,
+                    "_source": {"embedding": vector}
+                })
+            })
+            .collect();
+        let encoded = encode_stored_v2(&serde_json::to_vec(&docs).unwrap());
+        assert_eq!(&encoded[..4], STORED_V2_MAGIC);
+        let StoredV2KnnProjectionResult::Projected(projected) =
+            decode_stored_v2_knn_projection(&encoded, "embedding", None).unwrap()
+        else {
+            panic!("384d vectors should project");
+        };
+        for row in [0, 127, 255] {
+            let actual = projected.vectors[row].as_ref().unwrap();
+            assert_eq!(actual.len(), 384);
+            for dim in [0, 1, 191, 383] {
+                let expected = docs[row]["_source"]["embedding"][dim].as_f64().unwrap() as f32;
+                assert_eq!(actual[dim].to_bits(), expected.to_bits());
+            }
+        }
+
+        let overflow_docs: Vec<_> = (0..256)
+            .map(|row| {
+                json!({
+                    "_id": format!("overflow-{row}"),
+                    "_seq_no": row,
+                    "_source": {"embedding": [1e39, 0.0]}
+                })
+            })
+            .collect();
+        let overflow = encode_stored_v2(&serde_json::to_vec(&overflow_docs).unwrap());
+        assert_eq!(
+            decode_stored_v2_knn_projection(&overflow, "embedding", None).unwrap(),
+            StoredV2KnnProjectionResult::UnsupportedVectorShape
+        );
+    }
+
+    #[test]
+    fn v2_knn_projection_forced_lz4_nulls_and_optional_missing_chunks() {
+        let vectors = json!([[1.0, -0.0], null, [], [3, 4]]);
+        let chunks = json!([[[1.0, 2.0]], null, [], [[3.0], [4.0, 5.0]]]);
+        let encoded = typed_fixture_with_columns(
+            4,
+            ColCodec::Lz4Json,
+            lz4_json(&vectors),
+            Some((ColCodec::Lz4Json, lz4_json(&chunks))),
+        );
+        let StoredV2KnnProjectionResult::Projected(projected) =
+            decode_stored_v2_knn_projection(&encoded, "embedding", Some("embedding_chunks"))
+                .unwrap()
+        else {
+            panic!("forced LZ4 vectors should project");
+        };
+        assert_eq!(
+            projected.vectors[0].as_ref().unwrap()[1].to_bits(),
+            (-0.0f32).to_bits()
+        );
+        assert_eq!(projected.vectors[1], None);
+        assert_eq!(projected.vectors[2], Some(Vec::new()));
+        assert_eq!(projected.vector_chunks.as_ref().unwrap()[1], None);
+        assert_eq!(
+            projected.vector_chunks.as_ref().unwrap()[3],
+            Some(vec![vec![3.0], vec![4.0, 5.0]])
+        );
+
+        let StoredV2KnnProjectionResult::Projected(missing_chunks) =
+            decode_stored_v2_knn_projection(&encoded, "embedding", Some("different_chunks"))
+                .unwrap()
+        else {
+            panic!("missing optional chunks must not block pooled vectors");
+        };
+        assert_eq!(missing_chunks.vector_chunks, None);
+    }
+
+    #[test]
+    fn v2_knn_projection_constant_vectors_and_identity_cell_semantics() {
+        let encoded = typed_fixture_with_columns(
+            4,
+            ColCodec::Constant,
+            br#"[1.5,-0.0]"#.to_vec(),
+            Some((ColCodec::Constant, b"null".to_vec())),
+        );
+        let StoredV2KnnProjectionResult::Projected(projected) =
+            decode_stored_v2_knn_projection(&encoded, "embedding", Some("embedding_chunks"))
+                .unwrap()
+        else {
+            panic!("constant vectors should project");
+        };
+        assert_eq!(projected.vectors, vec![Some(vec![1.5, -0.0]); 4]);
+        assert_eq!(projected.vector_chunks, Some(vec![None; 4]));
+
+        let wrong_identity = handcrafted_v2(
+            2,
+            &[
+                ("__id", ColCodec::Lz4Json as u8, lz4_json(&json!(["ok", 7]))),
+                (
+                    "__seq_no",
+                    ColCodec::Lz4Json as u8,
+                    lz4_json(&json!([0, -1])),
+                ),
+                (
+                    "embedding",
+                    ColCodec::Lz4Json as u8,
+                    lz4_json(&json!([[1.0], [2.0]])),
+                ),
+            ],
+        );
+        let StoredV2KnnProjectionResult::Projected(projected) =
+            decode_stored_v2_knn_projection(&wrong_identity, "embedding", None).unwrap()
+        else {
+            panic!("wrong identity cells are explicit None rows");
+        };
+        assert_eq!(projected.ids, vec![Some("ok".into()), None]);
+        assert_eq!(projected.seq_nos, vec![Some(0), None]);
+    }
+
+    #[test]
+    fn v2_knn_projection_rejects_reserved_or_colliding_role_names() {
+        let (_, encoded) = projection_fixture();
+        for (vector, chunks) in [
+            ("__id", None),
+            ("__seq_no", None),
+            ("embedding", Some("__id")),
+            ("embedding", Some("__seq_no")),
+            ("embedding", Some("embedding")),
+        ] {
+            assert_eq!(
+                decode_stored_v2_knn_projection(&encoded, vector, chunks).unwrap(),
+                StoredV2KnnProjectionResult::UnsupportedVectorShape
+            );
+        }
+    }
+
+    #[test]
+    fn v2_projection_enforces_dependency_depth_boundary() {
+        let chain = |edges: usize| {
+            let mut owned: Vec<(String, u8, Vec<u8>)> = (0..edges)
+                .map(|index| {
+                    (
+                        format!("c{index}"),
+                        ColCodec::CrossDep as u8,
+                        valid_cross_dep((index + 1) as u32, index as i64),
+                    )
+                })
+                .collect();
+            owned.push((
+                format!("c{edges}"),
+                ColCodec::Constant as u8,
+                br#""base""#.to_vec(),
+            ));
+            let borrowed: Vec<_> = owned
+                .iter()
+                .map(|(name, codec, payload)| (name.as_str(), *codec, payload.clone()))
+                .collect();
+            handcrafted_v2(1, &borrowed)
+        };
+
+        let at_limit = chain(256);
+        assert!(
+            decode_stored_v2_projection(&at_limit, &["c0"]).is_ok(),
+            "256 dependency edges are supported"
+        );
+        let over_limit = chain(257);
+        let error = decode_stored_v2_projection(&over_limit, &["c0"]).unwrap_err();
+        assert!(error.to_string().contains("depth exceeds 256"), "{error}");
+    }
+
+    #[test]
+    fn v2_projection_validates_framing_and_preserves_legacy_fallback() {
+        let (_, encoded) = projection_fixture();
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        assert!(decode_stored_v2_projection(&trailing, &["__id"]).is_err());
+
+        let legacy = encode_stored_lz4(br#"[{"_id":"legacy"}]"#);
+        assert_eq!(
+            decode_stored_v2_projection(&legacy, &["__id"]).unwrap(),
+            StoredV2ProjectionResult::NotV2
+        );
     }
 
     #[test]

--- a/engine/crates/xerj-storage/src/stored_codec.rs
+++ b/engine/crates/xerj-storage/src/stored_codec.rs
@@ -512,12 +512,8 @@ fn encode_v2_columns(
         }
         // Fallback: zstd over JSON-array of the column's values.
         let col_json = serde_json::to_vec(col).unwrap_or_default();
-        // `bulk::compress` records the source size in the frame header.
-        // Publish-time cache admission can therefore bound expansion before
-        // decoding; historical stream frames without a content size safely
-        // skip warming.
-        let zstd_payload =
-            zstd::bulk::compress(&col_json, STORED_ZSTD_LEVEL).unwrap_or_else(|_| col_json.clone());
+        let zstd_payload = zstd::encode_all(Cursor::new(&col_json), STORED_ZSTD_LEVEL)
+            .unwrap_or_else(|_| col_json.clone());
         // Choose RAW_JSON vs LZ4_JSON by size.
         let lz4_payload = lz4_flex::compress_prepend_size(&col_json);
         if lz4_payload.len() + 1 < zstd_payload.len() {
@@ -887,8 +883,26 @@ fn parse_v2_directory(body: &[u8]) -> Result<V2Directory<'_>> {
         .read_u32::<LittleEndian>()
         .map_err(|e| StorageError::Other(anyhow::anyhow!("v2 num_cols: {e}")))?
         as usize;
-    let mut columns = Vec::with_capacity(num_cols);
-    let mut seen = std::collections::HashSet::with_capacity(num_cols);
+    const MIN_COLUMN_FRAMING_BYTES: usize =
+        std::mem::size_of::<u16>() + std::mem::size_of::<u8>() + std::mem::size_of::<u32>();
+    let remaining = body.len().saturating_sub(cur.position() as usize);
+    if num_cols > remaining / MIN_COLUMN_FRAMING_BYTES {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "v2 num_cols {num_cols} exceeds the remaining directory framing"
+        )));
+    }
+    let mut columns = Vec::new();
+    columns.try_reserve_exact(num_cols).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "v2 cannot reserve directory for {num_cols} columns: {error}"
+        ))
+    })?;
+    let mut seen = std::collections::HashSet::new();
+    seen.try_reserve(num_cols).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "v2 cannot reserve duplicate-name set for {num_cols} columns: {error}"
+        ))
+    })?;
     for _ in 0..num_cols {
         let name_len = cur
             .read_u16::<LittleEndian>()
@@ -1089,19 +1103,6 @@ fn decode_projected_column<'a>(
     Ok(decoded[index].as_ref().unwrap())
 }
 
-fn decoded_json_column(column: &V2ColumnRef<'_>) -> Result<Option<Vec<u8>>> {
-    match column.codec {
-        ColCodec::RawJson => zstd::decode_all(column.payload)
-            .map(Some)
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("raw zstd decode: {e}"))),
-        ColCodec::Lz4Json => lz4_flex::decompress_size_prepended(column.payload)
-            .map(Some)
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("lz4 decode: {e}"))),
-        ColCodec::Constant => Ok(Some(column.payload.to_vec())),
-        ColCodec::DictBitpack | ColCodec::CrossDep => Ok(None),
-    }
-}
-
 fn finite_f32_vector(values: Vec<f64>) -> Option<Vec<f32>> {
     let mut out = Vec::with_capacity(values.len());
     for value in values {
@@ -1132,7 +1133,9 @@ impl<'de> serde::de::Visitor<'de> for TypedVectorRowsVisitor<'_> {
     where
         A: serde::de::SeqAccess<'de>,
     {
-        let mut out = Vec::with_capacity(self.expected_rows);
+        let mut out = Vec::new();
+        out.try_reserve_exact(self.expected_rows)
+            .map_err(serde::de::Error::custom)?;
         let mut supported = true;
         for row in 0..self.expected_rows {
             let Some(value) = seq.next_element::<serde_json::Value>()? else {
@@ -1149,6 +1152,14 @@ impl<'de> serde::de::Visitor<'de> for TypedVectorRowsVisitor<'_> {
                     let Some(values) = values else {
                         supported = false;
                         out.push(None);
+                        if checkpoint_decoded_row(
+                            row,
+                            self.column_index,
+                            self.checkpoint,
+                            self.cancelled,
+                        ) {
+                            return Err(serde::de::Error::custom("stored decode cancelled"));
+                        }
                         continue;
                     };
                     Some(values)
@@ -1159,16 +1170,7 @@ impl<'de> serde::de::Visitor<'de> for TypedVectorRowsVisitor<'_> {
                 }
             };
             out.push(typed);
-            let processed = row + 1;
-            if processed % STORED_DECODE_CHECK_INTERVAL == 0
-                && (self.checkpoint)(StoredDecodeCheckpoint {
-                    phase: StoredDecodePhase::Rows,
-                    column_index: self.column_index,
-                    rows_processed: processed,
-                })
-                .is_break()
-            {
-                self.cancelled.set(true);
+            if checkpoint_decoded_row(row, self.column_index, self.checkpoint, self.cancelled) {
                 return Err(serde::de::Error::custom("stored decode cancelled"));
             }
         }
@@ -1179,6 +1181,56 @@ impl<'de> serde::de::Visitor<'de> for TypedVectorRowsVisitor<'_> {
     }
 }
 
+fn checkpoint_decoded_row(
+    zero_based_row: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+    cancelled: &std::cell::Cell<bool>,
+) -> bool {
+    let processed = zero_based_row + 1;
+    if processed.is_multiple_of(STORED_DECODE_CHECK_INTERVAL)
+        && checkpoint(StoredDecodeCheckpoint {
+            phase: StoredDecodePhase::Rows,
+            column_index,
+            rows_processed: processed,
+        })
+        .is_break()
+    {
+        cancelled.set(true);
+        return true;
+    }
+    false
+}
+
+fn repeat_constant_rows_controlled<T: Clone>(
+    row: T,
+    num_docs: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Vec<T>, ()>> {
+    let mut out = Vec::new();
+    out.try_reserve_exact(num_docs).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "cannot reserve {num_docs} constant stored rows: {error}"
+        ))
+    })?;
+    for zero_based_row in 0..num_docs {
+        out.push(row.clone());
+        let processed = zero_based_row + 1;
+        if processed.is_multiple_of(STORED_DECODE_CHECK_INTERVAL)
+            && checkpoint(StoredDecodeCheckpoint {
+                phase: StoredDecodePhase::Rows,
+                column_index,
+                rows_processed: processed,
+            })
+            .is_break()
+        {
+            return Ok(Err(()));
+        }
+    }
+    Ok(Ok(out))
+}
+
 fn decode_typed_vector_rows_controlled(
     column: &V2ColumnRef<'_>,
     num_docs: usize,
@@ -1186,7 +1238,25 @@ fn decode_typed_vector_rows_controlled(
     checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
 ) -> Result<std::result::Result<Option<StoredVectorRows>, ()>> {
     if column.codec == ColCodec::Constant {
-        return decode_typed_vector_rows(column, num_docs).map(Ok);
+        let row = match serde_json::from_slice::<serde_json::Value>(column.payload)
+            .map_err(|error| StorageError::Other(anyhow::anyhow!("constant decode: {error}")))?
+        {
+            serde_json::Value::Null => None,
+            serde_json::Value::Array(values) => {
+                let Some(values) = values
+                    .into_iter()
+                    .map(|value| value.as_f64())
+                    .collect::<Option<Vec<_>>>()
+                    .and_then(finite_f32_vector)
+                else {
+                    return Ok(Ok(None));
+                };
+                Some(values)
+            }
+            _ => return Ok(Ok(None)),
+        };
+        return repeat_constant_rows_controlled(row, num_docs, column_index, checkpoint)
+            .map(|result| result.map(Some));
     }
     match column.codec {
         ColCodec::RawJson => {
@@ -1235,88 +1305,6 @@ fn parse_typed_vector_reader<R: std::io::Read>(
     Ok(Ok(value))
 }
 
-fn decode_typed_vector_rows(
-    column: &V2ColumnRef<'_>,
-    num_docs: usize,
-) -> Result<Option<StoredVectorRows>> {
-    use serde_json::value::RawValue;
-    let Some(raw) = decoded_json_column(column)? else {
-        return Ok(None);
-    };
-    let rows: Vec<&RawValue> = if column.codec == ColCodec::Constant {
-        let row: &RawValue = serde_json::from_slice(&raw)
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("constant decode: {e}")))?;
-        vec![row; num_docs]
-    } else {
-        serde_json::from_slice(&raw)
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("vector json decode: {e}")))?
-    };
-    if rows.len() != num_docs {
-        return Err(StorageError::Other(anyhow::anyhow!(
-            "v2 vector row count {} != header {num_docs}",
-            rows.len()
-        )));
-    }
-    let mut out = Vec::with_capacity(num_docs);
-    for row in rows {
-        if row.get() == "null" {
-            out.push(None);
-            continue;
-        }
-        let Ok(values) = serde_json::from_str::<Vec<f64>>(row.get()) else {
-            return Ok(None);
-        };
-        let Some(vector) = finite_f32_vector(values) else {
-            return Ok(None);
-        };
-        out.push(Some(vector));
-    }
-    Ok(Some(out))
-}
-
-fn decode_typed_vector_chunk_rows(
-    column: &V2ColumnRef<'_>,
-    num_docs: usize,
-) -> Result<Option<StoredVectorChunkRows>> {
-    use serde_json::value::RawValue;
-    let Some(raw) = decoded_json_column(column)? else {
-        return Ok(None);
-    };
-    let rows: Vec<&RawValue> = if column.codec == ColCodec::Constant {
-        let row: &RawValue = serde_json::from_slice(&raw)
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("constant decode: {e}")))?;
-        vec![row; num_docs]
-    } else {
-        serde_json::from_slice(&raw)
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("vector chunks json decode: {e}")))?
-    };
-    if rows.len() != num_docs {
-        return Err(StorageError::Other(anyhow::anyhow!(
-            "v2 vector chunks row count {} != header {num_docs}",
-            rows.len()
-        )));
-    }
-    let mut out = Vec::with_capacity(num_docs);
-    for row in rows {
-        if row.get() == "null" {
-            out.push(None);
-            continue;
-        }
-        let Ok(chunks) = serde_json::from_str::<Vec<Vec<f64>>>(row.get()) else {
-            return Ok(None);
-        };
-        let mut typed = Vec::with_capacity(chunks.len());
-        for chunk in chunks {
-            let Some(chunk) = finite_f32_vector(chunk) else {
-                return Ok(None);
-            };
-            typed.push(chunk);
-        }
-        out.push(Some(typed));
-    }
-    Ok(Some(out))
-}
-
 fn decode_typed_vector_chunk_rows_controlled(
     column: &V2ColumnRef<'_>,
     num_docs: usize,
@@ -1324,7 +1312,38 @@ fn decode_typed_vector_chunk_rows_controlled(
     checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
 ) -> Result<std::result::Result<Option<StoredVectorChunkRows>, ()>> {
     if column.codec == ColCodec::Constant {
-        return decode_typed_vector_chunk_rows(column, num_docs).map(Ok);
+        let row = match serde_json::from_slice::<serde_json::Value>(column.payload)
+            .map_err(|error| StorageError::Other(anyhow::anyhow!("constant decode: {error}")))?
+        {
+            serde_json::Value::Null => None,
+            serde_json::Value::Array(chunks) => {
+                let mut typed = Vec::new();
+                typed.try_reserve_exact(chunks.len()).map_err(|error| {
+                    StorageError::Other(anyhow::anyhow!(
+                        "cannot reserve {} constant vector chunks: {error}",
+                        chunks.len()
+                    ))
+                })?;
+                for chunk in chunks {
+                    let serde_json::Value::Array(values) = chunk else {
+                        return Ok(Ok(None));
+                    };
+                    let Some(vector) = values
+                        .into_iter()
+                        .map(|value| value.as_f64())
+                        .collect::<Option<Vec<_>>>()
+                        .and_then(finite_f32_vector)
+                    else {
+                        return Ok(Ok(None));
+                    };
+                    typed.push(vector);
+                }
+                Some(typed)
+            }
+            _ => return Ok(Ok(None)),
+        };
+        return repeat_constant_rows_controlled(row, num_docs, column_index, checkpoint)
+            .map(|result| result.map(Some));
     }
     match column.codec {
         ColCodec::RawJson => {
@@ -1364,7 +1383,9 @@ fn parse_typed_chunk_reader<R: std::io::Read>(
         where
             A: serde::de::SeqAccess<'de>,
         {
-            let mut out = Vec::with_capacity(self.rows);
+            let mut out = Vec::new();
+            out.try_reserve_exact(self.rows)
+                .map_err(serde::de::Error::custom)?;
             let mut supported = true;
             for row in 0..self.rows {
                 let Some(value) = seq.next_element::<serde_json::Value>()? else {
@@ -1399,7 +1420,7 @@ fn parse_typed_chunk_reader<R: std::io::Read>(
                 };
                 out.push(typed);
                 let processed = row + 1;
-                if processed % STORED_DECODE_CHECK_INTERVAL == 0
+                if processed.is_multiple_of(STORED_DECODE_CHECK_INTERVAL)
                     && (self.checkpoint)(StoredDecodeCheckpoint {
                         phase: StoredDecodePhase::Rows,
                         column_index: self.column,
@@ -2027,7 +2048,7 @@ fn encode_dict_bitpack(entries: &[serde_json::Value], ids: &[u32]) -> Vec<u8> {
     // Dict entries as zstd(json array).
     let dict_json = serde_json::to_vec(entries).unwrap_or_default();
     let dict_zstd =
-        zstd::bulk::compress(&dict_json, STORED_ZSTD_LEVEL).unwrap_or(dict_json.clone());
+        zstd::encode_all(Cursor::new(&dict_json), STORED_ZSTD_LEVEL).unwrap_or(dict_json.clone());
     out.write_u32::<LittleEndian>(dict_zstd.len() as u32)
         .unwrap();
     out.extend_from_slice(&dict_zstd);
@@ -2036,7 +2057,8 @@ fn encode_dict_bitpack(entries: &[serde_json::Value], ids: &[u32]) -> Vec<u8> {
     let packed = bitpack_u32(ids, bit_width);
     // zstd over the bit-packed stream — gives another 20-40 % on log
     // data because repeated ids cluster.
-    let packed_zstd = zstd::bulk::compress(&packed, STORED_ZSTD_LEVEL).unwrap_or(packed.clone());
+    let packed_zstd =
+        zstd::encode_all(Cursor::new(&packed), STORED_ZSTD_LEVEL).unwrap_or(packed.clone());
     out.write_u32::<LittleEndian>(ids.len() as u32).unwrap();
     out.write_u32::<LittleEndian>(packed_zstd.len() as u32)
         .unwrap();
@@ -2514,6 +2536,26 @@ mod tests {
         lz4_flex::compress_prepend_size(&serde_json::to_vec(value).unwrap())
     }
 
+    fn dict_bitpack_with_content_sizes(entries: &[serde_json::Value], ids: &[u32]) -> Vec<u8> {
+        let bit_width = if entries.is_empty() {
+            1
+        } else {
+            32 - (entries.len() as u32).leading_zeros() as u8
+        };
+        let dict =
+            zstd::bulk::compress(&serde_json::to_vec(entries).unwrap(), STORED_ZSTD_LEVEL).unwrap();
+        let packed = zstd::bulk::compress(&bitpack_u32(ids, bit_width), STORED_ZSTD_LEVEL).unwrap();
+        let mut out = Vec::new();
+        out.write_u32::<LittleEndian>(entries.len() as u32).unwrap();
+        out.push(bit_width);
+        out.write_u32::<LittleEndian>(dict.len() as u32).unwrap();
+        out.extend_from_slice(&dict);
+        out.write_u32::<LittleEndian>(ids.len() as u32).unwrap();
+        out.write_u32::<LittleEndian>(packed.len() as u32).unwrap();
+        out.extend_from_slice(&packed);
+        out
+    }
+
     fn typed_fixture_with_columns(
         num_docs: usize,
         vector_codec: ColCodec,
@@ -2546,7 +2588,8 @@ mod tests {
         let raw_payload =
             zstd::bulk::compress(&serde_json::to_vec(&raw_values).unwrap(), STORED_ZSTD_LEVEL)
                 .unwrap();
-        let dict_payload = encode_dict_bitpack(&[json!("east"), json!("west")], &[0, 1, 0, 1]);
+        let dict_payload =
+            dict_bitpack_with_content_sizes(&[json!("east"), json!("west")], &[0, 1, 0, 1]);
         let encoded = handcrafted_v2(
             num_docs as u32,
             &[
@@ -2852,6 +2895,135 @@ mod tests {
                 "without cancellation {bad_column} must consume bad row 129"
             );
         }
+    }
+
+    #[test]
+    fn controlled_vector_decode_checkpoints_after_invalid_row_for_raw_and_lz4() {
+        let values: Vec<_> = (0..256)
+            .map(|row| {
+                if row == 0 {
+                    json!([1.0, "invalid"])
+                } else {
+                    json!([1.0, 0.0])
+                }
+            })
+            .collect();
+        let json = serde_json::to_vec(&values).unwrap();
+        let payloads = [
+            (
+                ColCodec::RawJson,
+                zstd::encode_all(Cursor::new(&json), STORED_ZSTD_LEVEL).unwrap(),
+            ),
+            (ColCodec::Lz4Json, lz4_flex::compress_prepend_size(&json)),
+        ];
+        for (codec, embedding) in payloads {
+            let encoded = handcrafted_v2(
+                256,
+                &[
+                    (
+                        "__id",
+                        ColCodec::Constant as u8,
+                        serde_json::to_vec(&json!("id")).unwrap(),
+                    ),
+                    (
+                        "__seq_no",
+                        ColCodec::Constant as u8,
+                        serde_json::to_vec(&json!(1)).unwrap(),
+                    ),
+                    ("embedding", codec as u8, embedding),
+                ],
+            );
+            assert_eq!(
+                decode_stored_v2_knn_projection_controlled(&encoded, "embedding", None, |point| {
+                    if point.column_index == 2
+                        && point.phase == StoredDecodePhase::Rows
+                        && point.rows_processed == 128
+                    {
+                        std::ops::ControlFlow::Break(())
+                    } else {
+                        std::ops::ControlFlow::Continue(())
+                    }
+                })
+                .unwrap(),
+                StoredDecodeRun::Cancelled,
+                "{codec:?} must checkpoint even after an invalid first row"
+            );
+        }
+    }
+
+    #[test]
+    fn controlled_constant_vector_and_chunk_decode_cancel_at_row_checkpoint() {
+        for cancel_column in [2, 3] {
+            let non_constant_embedding = zstd::encode_all(
+                Cursor::new(serde_json::to_vec(&vec![json!([1.0, 0.0]); 256]).unwrap()),
+                STORED_ZSTD_LEVEL,
+            )
+            .unwrap();
+            let encoded = handcrafted_v2(
+                256,
+                &[
+                    (
+                        "__id",
+                        ColCodec::Constant as u8,
+                        serde_json::to_vec(&json!("id")).unwrap(),
+                    ),
+                    (
+                        "__seq_no",
+                        ColCodec::Constant as u8,
+                        serde_json::to_vec(&json!(1)).unwrap(),
+                    ),
+                    (
+                        "embedding",
+                        if cancel_column == 2 {
+                            ColCodec::Constant as u8
+                        } else {
+                            ColCodec::RawJson as u8
+                        },
+                        if cancel_column == 2 {
+                            serde_json::to_vec(&json!([1.0, 0.0])).unwrap()
+                        } else {
+                            non_constant_embedding
+                        },
+                    ),
+                    (
+                        "embedding_chunks",
+                        ColCodec::Constant as u8,
+                        serde_json::to_vec(&json!([[1.0, 0.0], [0.0, 1.0]])).unwrap(),
+                    ),
+                ],
+            );
+            assert_eq!(
+                decode_stored_v2_knn_projection_controlled(
+                    &encoded,
+                    "embedding",
+                    Some("embedding_chunks"),
+                    |point| {
+                        if point.column_index == cancel_column
+                            && point.phase == StoredDecodePhase::Rows
+                            && point.rows_processed == 128
+                        {
+                            std::ops::ControlFlow::Break(())
+                        } else {
+                            std::ops::ControlFlow::Continue(())
+                        }
+                    }
+                )
+                .unwrap(),
+                StoredDecodeRun::Cancelled
+            );
+        }
+    }
+
+    #[test]
+    fn v2_directory_rejects_impossible_column_count_before_allocation() {
+        let mut body = Vec::new();
+        body.extend_from_slice(&0_u32.to_le_bytes());
+        body.extend_from_slice(&u32::MAX.to_le_bytes());
+        let error = match parse_v2_directory(&body) {
+            Ok(_) => panic!("impossible column count must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("exceeds the remaining directory framing"));
     }
 
     #[test]

--- a/engine/crates/xerj-storage/src/stored_codec.rs
+++ b/engine/crates/xerj-storage/src/stored_codec.rs
@@ -55,12 +55,13 @@
 use crate::{Result, StorageError};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;
-use std::io::{Cursor, Write};
+use std::io::{Cursor, Read, Write};
 
 mod row_hydration;
 pub use row_hydration::{
-    decode_stored_v2_rows, decode_stored_v2_rows_controlled, StoredV2HydratedRow,
-    StoredV2RowHydrationResult, StoredV2RowHydrationStats,
+    decode_stored_v2_rows, decode_stored_v2_rows_controlled, decode_stored_v2_rows_projected,
+    decode_stored_v2_rows_projected_controlled, StoredV2HydratedRow, StoredV2RowHydrationResult,
+    StoredV2RowHydrationStats,
 };
 
 pub const STORED_DECODE_CHECK_INTERVAL: usize = 128;
@@ -511,8 +512,12 @@ fn encode_v2_columns(
         }
         // Fallback: zstd over JSON-array of the column's values.
         let col_json = serde_json::to_vec(col).unwrap_or_default();
-        let zstd_payload = zstd::encode_all(Cursor::new(&col_json), STORED_ZSTD_LEVEL)
-            .unwrap_or_else(|_| col_json.clone());
+        // `bulk::compress` records the source size in the frame header.
+        // Publish-time cache admission can therefore bound expansion before
+        // decoding; historical stream frames without a content size safely
+        // skip warming.
+        let zstd_payload =
+            zstd::bulk::compress(&col_json, STORED_ZSTD_LEVEL).unwrap_or_else(|_| col_json.clone());
         // Choose RAW_JSON vs LZ4_JSON by size.
         let lz4_payload = lz4_flex::compress_prepend_size(&col_json);
         if lz4_payload.len() + 1 < zstd_payload.len() {
@@ -578,6 +583,230 @@ pub fn decode_stored(bytes: &[u8]) -> Result<Vec<u8>> {
             .map_err(|e| StorageError::Other(anyhow::anyhow!("LZ4 decompress failed: {e}")));
     }
     Ok(bytes.to_vec())
+}
+
+/// Conservative retained-size bound for the canonical stored bytes plus the
+/// `(start, end)` row-offset table used by the engine's `StoredSlices`.
+///
+/// This reads only framing metadata. It never decompresses a column or
+/// materialises a `serde_json::Value`, so publish-time cache admission can
+/// fail closed *before* paying the full ZBS2 expansion. `Ok(None)` means a
+/// zstd frame omitted its content-size field and therefore has no trustworthy
+/// finite bound in the current format.
+pub fn stored_slices_retained_upper_bound(bytes: &[u8], expected_docs: u64) -> Result<Option<u64>> {
+    const STORED_SLICES_STRUCT_OVERHEAD: u64 = 64;
+    const OFFSET_BYTES: u64 = 8;
+
+    let expected_offsets = expected_docs
+        .checked_mul(OFFSET_BYTES)
+        .and_then(|size| size.checked_add(STORED_SLICES_STRUCT_OVERHEAD))
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("stored retained bound overflow")))?;
+
+    let (decoded_bound, offsets_bound) = if bytes.len() >= 4 && &bytes[..4] == STORED_LZ4_MAGIC {
+        let payload = bytes
+            .get(4..8)
+            .ok_or_else(|| StorageError::Other(anyhow::anyhow!("LZ4 stored size truncated")))?;
+        let decoded = u32::from_le_bytes(payload.try_into().unwrap()) as u64;
+        let offsets = decoded
+            .checked_mul(OFFSET_BYTES)
+            .and_then(|size| size.checked_add(STORED_SLICES_STRUCT_OVERHEAD))
+            .ok_or_else(|| {
+                StorageError::Other(anyhow::anyhow!("LZ4 stored offset bound overflow"))
+            })?;
+        (decoded, offsets)
+    } else if bytes.len() >= 4 && &bytes[..4] == STORED_V2_MAGIC {
+        let directory = parse_v2_directory(&bytes[4..])?;
+        if directory.num_docs as u64 != expected_docs {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "v2 num_docs {} != expected {expected_docs}",
+                directory.num_docs
+            )));
+        }
+        let rows = expected_docs;
+        // Canonical wrapper punctuation, `_id`, `_seq_no`, `_source`, commas,
+        // colons and braces fit well below 64 bytes per row. This deliberately
+        // over-counts empty/null fields.
+        let mut bound = rows
+            .checked_mul(64)
+            .and_then(|size| size.checked_add(2))
+            .ok_or_else(|| {
+                StorageError::Other(anyhow::anyhow!("v2 decoded-size bound overflow"))
+            })?;
+        for column in &directory.columns {
+            let value_bound = match column.codec {
+                ColCodec::RawJson => {
+                    let Some(size) = zstd_frame_content_size(column.payload, "raw json")? else {
+                        return Ok(None);
+                    };
+                    size
+                }
+                ColCodec::Lz4Json => lz4_uncompressed_size(column.payload, "lz4 json")?,
+                ColCodec::Constant => {
+                    (column.payload.len() as u64)
+                        .checked_mul(rows)
+                        .ok_or_else(|| {
+                            StorageError::Other(anyhow::anyhow!(
+                                "constant decoded-size bound overflow"
+                            ))
+                        })?
+                }
+                ColCodec::DictBitpack => {
+                    let Some(dictionary_bytes) =
+                        dict_json_content_size(column.payload, directory.num_docs)?
+                    else {
+                        return Ok(None);
+                    };
+                    // Every row is either null (4 bytes) or one dictionary
+                    // entry. No entry can be longer than the complete
+                    // dictionary JSON payload.
+                    dictionary_bytes.max(4).checked_mul(rows).ok_or_else(|| {
+                        StorageError::Other(anyhow::anyhow!("dict decoded-size bound overflow"))
+                    })?
+                }
+                // CROSS_DEP materialises only JSON i64 or null cells. The
+                // longest i64 decimal representation is 20 bytes.
+                ColCodec::CrossDep => rows.checked_mul(20).ok_or_else(|| {
+                    StorageError::Other(anyhow::anyhow!("cross-dep decoded-size bound overflow"))
+                })?,
+            };
+            bound = bound.checked_add(value_bound).ok_or_else(|| {
+                StorageError::Other(anyhow::anyhow!("v2 decoded-size bound overflow"))
+            })?;
+            if column.name != "__id" && column.name != "__seq_no" {
+                let encoded_name_len = serde_json::to_vec(column.name)
+                    .map_err(|error| {
+                        StorageError::Other(anyhow::anyhow!(
+                            "v2 column-name size estimate: {error}"
+                        ))
+                    })?
+                    .len() as u64;
+                let key_overhead = rows
+                    .checked_mul(encoded_name_len.saturating_add(2))
+                    .ok_or_else(|| {
+                        StorageError::Other(anyhow::anyhow!("v2 key-size bound overflow"))
+                    })?;
+                bound = bound.checked_add(key_overhead).ok_or_else(|| {
+                    StorageError::Other(anyhow::anyhow!("v2 decoded-size bound overflow"))
+                })?;
+            }
+        }
+        (bound, expected_offsets)
+    } else {
+        let decoded = bytes.len() as u64;
+        let offsets = decoded
+            .checked_mul(OFFSET_BYTES)
+            .and_then(|size| size.checked_add(STORED_SLICES_STRUCT_OVERHEAD))
+            .ok_or_else(|| {
+                StorageError::Other(anyhow::anyhow!("plain stored offset bound overflow"))
+            })?;
+        (decoded, offsets)
+    };
+    decoded_bound
+        .checked_add(offsets_bound)
+        .map(Some)
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("stored retained bound overflow")))
+}
+
+fn zstd_frame_content_size(payload: &[u8], context: &str) -> Result<Option<u64>> {
+    let frame_size = zstd::zstd_safe::find_frame_compressed_size(payload).map_err(|_| {
+        StorageError::Other(anyhow::anyhow!("{context} zstd frame header is invalid"))
+    })?;
+    if frame_size != payload.len() {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "{context} contains concatenated/trailing zstd data"
+        )));
+    }
+    zstd::zstd_safe::get_frame_content_size(payload)
+        .map_err(|_| StorageError::Other(anyhow::anyhow!("{context} zstd frame header is invalid")))
+}
+
+fn decode_zstd_exact(payload: &[u8], expected: usize, context: &str) -> Result<Vec<u8>> {
+    if zstd_frame_content_size(payload, context)?.is_some_and(|size| size != expected as u64) {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "{context} content size does not match expected length"
+        )));
+    }
+    let decoder = zstd::stream::read::Decoder::new(payload)
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("{context}: {error}")))?;
+    let mut bounded = decoder.take(expected as u64 + 1);
+    let mut decoded = Vec::with_capacity(expected);
+    bounded
+        .read_to_end(&mut decoded)
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("{context}: {error}")))?;
+    if decoded.len() != expected {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "{context} decoded length {} != expected {expected}",
+            decoded.len()
+        )));
+    }
+    Ok(decoded)
+}
+
+fn lz4_uncompressed_size(payload: &[u8], context: &str) -> Result<u64> {
+    let size = payload
+        .get(..4)
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("{context} size is truncated")))?;
+    Ok(u32::from_le_bytes(size.try_into().unwrap()) as u64)
+}
+
+fn dict_json_content_size(payload: &[u8], num_docs: usize) -> Result<Option<u64>> {
+    let mut cursor = Cursor::new(payload);
+    let _dict_count = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("dict_count: {error}")))?;
+    let bit_width = cursor
+        .read_u8()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("bit_width: {error}")))?;
+    if !(1..=32).contains(&bit_width) {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict invalid bit_width {bit_width}"
+        )));
+    }
+    let dict_len = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("dict_zstd_len: {error}")))?
+        as usize;
+    let dict_start = cursor.position() as usize;
+    let dict_end = dict_start
+        .checked_add(dict_len)
+        .filter(|end| *end <= payload.len())
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict payload truncated")))?;
+    let content_size = zstd_frame_content_size(&payload[dict_start..dict_end], "dict json")?;
+    cursor.set_position(dict_end as u64);
+    let ids_len = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("ids_len: {error}")))?
+        as usize;
+    if ids_len != num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict ids_len {ids_len} != num_docs {num_docs}"
+        )));
+    }
+    let packed_len = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("packed_zstd_len: {error}")))?
+        as usize;
+    let packed_start = cursor.position() as usize;
+    let packed_end = packed_start
+        .checked_add(packed_len)
+        .filter(|end| *end == payload.len())
+        .ok_or_else(|| {
+            StorageError::Other(anyhow::anyhow!("dict packed payload truncated/trailing"))
+        })?;
+    let packed_size = zstd_frame_content_size(&payload[packed_start..packed_end], "dict ids")?;
+    let expected_packed_size = num_docs
+        .checked_mul(bit_width as usize)
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict packed-size overflow")))?
+        .div_ceil(8) as u64;
+    if packed_size.is_some_and(|size| size != expected_packed_size) {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict packed content size does not match ids_len"
+        )));
+    }
+    if packed_size.is_none() {
+        return Ok(None);
+    }
+    Ok(content_size)
 }
 
 /// Values decoded from a requested subset of a ZBS2 stored section.
@@ -738,14 +967,44 @@ pub fn decode_stored_v2_projection(
     }))
 }
 
-fn decode_cross_dep_body(payload: &[u8]) -> Result<Vec<u8>> {
+fn decode_cross_dep_body(payload: &[u8], num_docs: usize) -> Result<Vec<u8>> {
     if payload.is_empty() {
         return Err(StorageError::Other(anyhow::anyhow!("cross_dep empty")));
     }
+    // A source dictionary cannot contain more entries than source rows.
+    // Each mode costs 8 bytes and each row contributes at most one
+    // (u32-delta, i64-zigzag) exception of at most 15 bytes.
+    let max_body = num_docs
+        .checked_mul(23)
+        .and_then(|row_bytes| 12usize.checked_add(row_bytes))
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("cross_dep size overflow")))?;
     let body = if payload[0] == 1 {
-        zstd::decode_all(&payload[1..])
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep zstd decode: {e}")))?
+        if zstd_frame_content_size(&payload[1..], "cross_dep")?
+            .is_some_and(|size| size > max_body as u64)
+        {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "cross_dep frame exceeds maximum decoded size"
+            )));
+        }
+        let decoder = zstd::stream::read::Decoder::new(&payload[1..])
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep zstd decode: {e}")))?;
+        let mut bounded = decoder.take(max_body as u64 + 1);
+        let mut body = Vec::new();
+        bounded
+            .read_to_end(&mut body)
+            .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep zstd decode: {e}")))?;
+        if body.len() > max_body {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "cross_dep decoded body exceeds limit"
+            )));
+        }
+        body
     } else if payload[0] == 0 {
+        if payload.len() - 1 > max_body {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "cross_dep raw body exceeds limit"
+            )));
+        }
         payload[1..].to_vec()
     } else {
         Err(StorageError::Other(anyhow::anyhow!(
@@ -756,8 +1015,8 @@ fn decode_cross_dep_body(payload: &[u8]) -> Result<Vec<u8>> {
     Ok(body)
 }
 
-fn cross_dep_source_index(payload: &[u8]) -> Result<usize> {
-    let body = decode_cross_dep_body(payload)?;
+fn cross_dep_source_index(payload: &[u8], num_docs: usize) -> Result<usize> {
+    let body = decode_cross_dep_body(payload, num_docs)?;
     Cursor::new(body)
         .read_u32::<LittleEndian>()
         .map(|value| value as usize)
@@ -798,7 +1057,7 @@ fn decode_projected_column<'a>(
         ColCodec::Constant => decode_constant(column.payload, directory.num_docs)?,
         ColCodec::DictBitpack => decode_dict_bitpack(column.payload, directory.num_docs)?,
         ColCodec::CrossDep => {
-            let source_index = cross_dep_source_index(column.payload)?;
+            let source_index = cross_dep_source_index(column.payload, directory.num_docs)?;
             let source =
                 decode_projected_column(source_index, directory, decoded, visiting, depth + 1)?
                     .clone();
@@ -1768,7 +2027,7 @@ fn encode_dict_bitpack(entries: &[serde_json::Value], ids: &[u32]) -> Vec<u8> {
     // Dict entries as zstd(json array).
     let dict_json = serde_json::to_vec(entries).unwrap_or_default();
     let dict_zstd =
-        zstd::encode_all(Cursor::new(&dict_json), STORED_ZSTD_LEVEL).unwrap_or(dict_json.clone());
+        zstd::bulk::compress(&dict_json, STORED_ZSTD_LEVEL).unwrap_or(dict_json.clone());
     out.write_u32::<LittleEndian>(dict_zstd.len() as u32)
         .unwrap();
     out.extend_from_slice(&dict_zstd);
@@ -1777,8 +2036,7 @@ fn encode_dict_bitpack(entries: &[serde_json::Value], ids: &[u32]) -> Vec<u8> {
     let packed = bitpack_u32(ids, bit_width);
     // zstd over the bit-packed stream — gives another 20-40 % on log
     // data because repeated ids cluster.
-    let packed_zstd =
-        zstd::encode_all(Cursor::new(&packed), STORED_ZSTD_LEVEL).unwrap_or(packed.clone());
+    let packed_zstd = zstd::bulk::compress(&packed, STORED_ZSTD_LEVEL).unwrap_or(packed.clone());
     out.write_u32::<LittleEndian>(ids.len() as u32).unwrap();
     out.write_u32::<LittleEndian>(packed_zstd.len() as u32)
         .unwrap();
@@ -1791,9 +2049,19 @@ fn decode_dict_bitpack(payload: &[u8], num_docs: usize) -> Result<Vec<serde_json
     let dict_count =
         cur.read_u32::<LittleEndian>()
             .map_err(|e| StorageError::Other(anyhow::anyhow!("dict_count: {e}")))? as usize;
+    if dict_count > num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict_count {dict_count} exceeds num_docs {num_docs}"
+        )));
+    }
     let bit_width = cur
         .read_u8()
         .map_err(|e| StorageError::Other(anyhow::anyhow!("bit_width: {e}")))?;
+    if !(1..=32).contains(&bit_width) {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict invalid bit_width {bit_width}"
+        )));
+    }
 
     let dict_zstd_len = cur
         .read_u32::<LittleEndian>()
@@ -1826,13 +2094,21 @@ fn decode_dict_bitpack(payload: &[u8], num_docs: usize) -> Result<Vec<serde_json
         .map_err(|e| StorageError::Other(anyhow::anyhow!("packed_zstd_len: {e}")))?
         as usize;
     let pos = cur.position() as usize;
-    if payload.len() < pos + packed_zstd_len {
-        return Err(StorageError::Other(anyhow::anyhow!(
-            "dict bitpack packed truncated"
-        )));
-    }
-    let packed = zstd::decode_all(&payload[pos..pos + packed_zstd_len])
-        .map_err(|e| StorageError::Other(anyhow::anyhow!("packed zstd decode: {e}")))?;
+    let packed_end = pos
+        .checked_add(packed_zstd_len)
+        .filter(|end| *end == payload.len())
+        .ok_or_else(|| {
+            StorageError::Other(anyhow::anyhow!("dict bitpack packed truncated/trailing"))
+        })?;
+    let expected_packed_len = num_docs
+        .checked_mul(bit_width as usize)
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict packed length overflow")))?
+        .div_ceil(8);
+    let packed = decode_zstd_exact(
+        &payload[pos..packed_end],
+        expected_packed_len,
+        "packed zstd decode",
+    )?;
 
     let ids = bitunpack_u32(&packed, bit_width, num_docs);
     let null_id = dict_count as u32;
@@ -1953,13 +2229,7 @@ fn decode_cross_dep(
     if payload.is_empty() {
         return Err(StorageError::Other(anyhow::anyhow!("cross_dep empty")));
     }
-    let flag = payload[0];
-    let body = if flag == 1 {
-        zstd::decode_all(&payload[1..])
-            .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep zstd decode: {e}")))?
-    } else {
-        payload[1..].to_vec()
-    };
+    let body = decode_cross_dep_body(payload, num_docs)?;
     let mut cur = Cursor::new(&body[..]);
     let src_ix = cur
         .read_u32::<LittleEndian>()
@@ -1970,6 +2240,11 @@ fn decode_cross_dep(
         .read_u32::<LittleEndian>()
         .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep dict_count: {e}")))?
         as usize;
+    if dict_count > num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep dict_count {dict_count} exceeds num_docs {num_docs}"
+        )));
+    }
     let mut mode_values: Vec<i64> = Vec::with_capacity(dict_count);
     for _ in 0..dict_count {
         mode_values.push(
@@ -1981,6 +2256,11 @@ fn decode_cross_dep(
         .read_u32::<LittleEndian>()
         .map_err(|e| StorageError::Other(anyhow::anyhow!("cross_dep exc_count: {e}")))?
         as usize;
+    if exc_count > num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep exc_count {exc_count} exceeds num_docs {num_docs}"
+        )));
+    }
 
     // Rebuild the source column's dict ids by re-running `dict_encode_column`
     // on the already-decoded source column.
@@ -2000,11 +2280,24 @@ fn decode_cross_dep(
     let mut pos = cur.position() as usize;
     let mut prev_ord = 0u32;
     for _ in 0..exc_count {
-        let delta = read_varint(&body, &mut pos) as u32;
-        let val = read_zigzag_i64(&body, &mut pos);
-        let ord = prev_ord.wrapping_add(delta);
+        let delta = u32::try_from(read_varint(&body, &mut pos)?)
+            .map_err(|_| StorageError::Other(anyhow::anyhow!("cross_dep ordinal overflow")))?;
+        let val = read_zigzag_i64(&body, &mut pos)?;
+        let ord = prev_ord
+            .checked_add(delta)
+            .ok_or_else(|| StorageError::Other(anyhow::anyhow!("cross_dep ordinal overflow")))?;
+        if ord as usize >= num_docs || (!exc.is_empty() && ord <= prev_ord) {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "cross_dep invalid exception ordinal {ord}"
+            )));
+        }
         exc.push((ord, val));
         prev_ord = ord;
+    }
+    if pos != body.len() {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep trailing exception bytes"
+        )));
     }
 
     // Materialise.
@@ -2112,19 +2405,24 @@ fn write_varint(out: &mut Vec<u8>, mut v: u64) {
     }
 }
 
-fn read_varint(data: &[u8], pos: &mut usize) -> u64 {
+fn read_varint(data: &[u8], pos: &mut usize) -> Result<u64> {
     let mut v = 0u64;
     let mut shift = 0u32;
-    while *pos < data.len() {
+    while *pos < data.len() && shift < 64 {
         let b = data[*pos];
         *pos += 1;
+        if shift == 63 && b & 0x7e != 0 {
+            return Err(StorageError::Other(anyhow::anyhow!("varint overflow")));
+        }
         v |= ((b & 0x7F) as u64) << shift;
         if b & 0x80 == 0 {
-            return v;
+            return Ok(v);
         }
         shift += 7;
     }
-    v
+    Err(StorageError::Other(anyhow::anyhow!(
+        "truncated or overlong varint"
+    )))
 }
 
 fn write_zigzag_i64(out: &mut Vec<u8>, v: i64) {
@@ -2132,9 +2430,9 @@ fn write_zigzag_i64(out: &mut Vec<u8>, v: i64) {
     write_varint(out, z);
 }
 
-fn read_zigzag_i64(data: &[u8], pos: &mut usize) -> i64 {
-    let z = read_varint(data, pos);
-    ((z >> 1) as i64) ^ -((z & 1) as i64)
+fn read_zigzag_i64(data: &[u8], pos: &mut usize) -> Result<i64> {
+    let z = read_varint(data, pos)?;
+    Ok(((z >> 1) as i64) ^ -((z & 1) as i64))
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -2233,6 +2531,101 @@ mod tests {
             columns.push(("embedding_chunks", codec as u8, payload));
         }
         handcrafted_v2(num_docs as u32, &columns)
+    }
+
+    #[test]
+    fn retained_upper_bound_covers_real_decode_and_all_v2_codecs() {
+        let num_docs = 4usize;
+        let ids = json!(["a", "b", "a", "b"]);
+        let raw_values = json!([
+            {"nested": [1, 2]},
+            null,
+            {"nested": [3]},
+            {"text": "longer"}
+        ]);
+        let raw_payload =
+            zstd::bulk::compress(&serde_json::to_vec(&raw_values).unwrap(), STORED_ZSTD_LEVEL)
+                .unwrap();
+        let dict_payload = encode_dict_bitpack(&[json!("east"), json!("west")], &[0, 1, 0, 1]);
+        let encoded = handcrafted_v2(
+            num_docs as u32,
+            &[
+                ("__id", ColCodec::Lz4Json as u8, lz4_json(&ids)),
+                (
+                    "__seq_no",
+                    ColCodec::Constant as u8,
+                    serde_json::to_vec(&json!(7)).unwrap(),
+                ),
+                ("raw", ColCodec::RawJson as u8, raw_payload),
+                ("region", ColCodec::DictBitpack as u8, dict_payload),
+                (
+                    "amount",
+                    ColCodec::CrossDep as u8,
+                    valid_cross_dep(3, i64::MIN),
+                ),
+            ],
+        );
+        let decoded = decode_stored(&encoded).unwrap();
+        let bound = stored_slices_retained_upper_bound(&encoded, num_docs as u64)
+            .unwrap()
+            .unwrap();
+        let actual_retained = decoded.len() as u64 + num_docs as u64 * 8 + 64;
+        assert!(
+            bound >= actual_retained,
+            "bound {bound} < actual retained {actual_retained}"
+        );
+
+        let legacy = encode_stored_lz4(&decoded);
+        assert!(
+            stored_slices_retained_upper_bound(&legacy, num_docs as u64)
+                .unwrap()
+                .unwrap()
+                >= actual_retained
+        );
+        assert!(stored_slices_retained_upper_bound(&encoded, 5).is_err());
+    }
+
+    #[test]
+    fn retained_upper_bound_fails_closed_for_unknown_zstd_content_size() {
+        let values = serde_json::to_vec(&json!(["a", "b"])).unwrap();
+        let mut encoder = zstd::stream::Encoder::new(Vec::new(), STORED_ZSTD_LEVEL).unwrap();
+        encoder.include_contentsize(false).unwrap();
+        encoder.write_all(&values).unwrap();
+        let payload = encoder.finish().unwrap();
+        assert_eq!(
+            zstd::zstd_safe::get_frame_content_size(&payload).unwrap(),
+            None
+        );
+        let encoded = handcrafted_v2(
+            2,
+            &[
+                ("__id", ColCodec::RawJson as u8, payload),
+                (
+                    "__seq_no",
+                    ColCodec::Constant as u8,
+                    serde_json::to_vec(&json!(1)).unwrap(),
+                ),
+            ],
+        );
+        assert_eq!(
+            stored_slices_retained_upper_bound(&encoded, 2).unwrap(),
+            None
+        );
+
+        let first = zstd::bulk::compress(&values, STORED_ZSTD_LEVEL).unwrap();
+        let second = zstd::bulk::compress(b"[]", STORED_ZSTD_LEVEL).unwrap();
+        let concatenated = handcrafted_v2(
+            2,
+            &[
+                ("__id", ColCodec::RawJson as u8, [first, second].concat()),
+                (
+                    "__seq_no",
+                    ColCodec::Constant as u8,
+                    serde_json::to_vec(&json!(1)).unwrap(),
+                ),
+            ],
+        );
+        assert!(stored_slices_retained_upper_bound(&concatenated, 2).is_err());
     }
 
     #[test]
@@ -2596,6 +2989,30 @@ mod tests {
         let mut trailing = valid_cross_dep(1, 7);
         trailing.push(0);
         assert!(decode_cross_dep(&trailing, 4, &dependencies, &HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn malformed_cardinality_and_cross_dep_expansion_are_bounded() {
+        let oversized_dict = ((DICT_MAX_CARDINALITY + 1) as u32).to_le_bytes().to_vec();
+        assert!(decode_dict_bitpack(&oversized_dict, 1).is_err());
+
+        let dependencies = vec![vec![json!("key")]];
+        let mut oversized_cross = vec![0];
+        oversized_cross.extend_from_slice(&0u32.to_le_bytes());
+        oversized_cross.extend_from_slice(&((DICT_MAX_CARDINALITY + 1) as u32).to_le_bytes());
+        assert!(decode_cross_dep(&oversized_cross, 1, &dependencies, &HashMap::new()).is_err());
+
+        let mut too_many_exceptions = valid_cross_dep(0, 7);
+        let count_offset = 1 + 4 + 4 + 8;
+        too_many_exceptions[count_offset..count_offset + 4].copy_from_slice(&2u32.to_le_bytes());
+        assert!(decode_cross_dep(&too_many_exceptions, 1, &dependencies, &HashMap::new()).is_err());
+
+        let decoded_limit = 12 + 23;
+        let compressed =
+            zstd::bulk::compress(&vec![0; decoded_limit + 1], STORED_ZSTD_LEVEL).unwrap();
+        let mut bomb = vec![1];
+        bomb.extend_from_slice(&compressed);
+        assert!(decode_cross_dep(&bomb, 1, &dependencies, &HashMap::new()).is_err());
     }
 
     #[test]

--- a/engine/crates/xerj-storage/src/stored_codec.rs
+++ b/engine/crates/xerj-storage/src/stored_codec.rs
@@ -57,6 +57,12 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;
 use std::io::{Cursor, Write};
 
+mod row_hydration;
+pub use row_hydration::{
+    decode_stored_v2_rows, StoredV2HydratedRow, StoredV2RowHydrationResult,
+    StoredV2RowHydrationStats,
+};
+
 // ── V1: flat LZ4 over JSON (legacy) ───────────────────────────────────────
 
 /// Magic prefix for LZ4-compressed stored sections (v1, pre-columnar).

--- a/engine/crates/xerj-storage/src/stored_codec.rs
+++ b/engine/crates/xerj-storage/src/stored_codec.rs
@@ -1758,7 +1758,12 @@ fn decode_stored_v2(body: &[u8]) -> Result<Vec<u8>> {
     let id_col_ix = col_name_to_ix.get("__id").copied().unwrap_or(0);
     let seq_col_ix = col_name_to_ix.get("__seq_no").copied().unwrap_or(1);
 
-    let mut out_docs: Vec<serde_json::Value> = Vec::with_capacity(num_docs);
+    let mut out_docs: Vec<serde_json::Value> = Vec::new();
+    out_docs.try_reserve_exact(num_docs).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "cannot reserve {num_docs} decoded stored rows: {error}"
+        ))
+    })?;
     for d in 0..num_docs {
         let mut source_map = serde_json::Map::new();
         for (cix, name) in col_names.iter().enumerate() {
@@ -2026,7 +2031,14 @@ fn try_encode_constant<B: std::borrow::Borrow<serde_json::Value>>(col: &[B]) -> 
 fn decode_constant(payload: &[u8], num_docs: usize) -> Result<Vec<serde_json::Value>> {
     let v: serde_json::Value = serde_json::from_slice(payload)
         .map_err(|e| StorageError::Other(anyhow::anyhow!("constant decode: {e}")))?;
-    Ok(vec![v; num_docs])
+    let mut values = Vec::new();
+    values.try_reserve_exact(num_docs).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "cannot reserve {num_docs} constant stored rows: {error}"
+        ))
+    })?;
+    values.resize(num_docs, v);
+    Ok(values)
 }
 
 fn encode_dict_bitpack(entries: &[serde_json::Value], ids: &[u32]) -> Vec<u8> {
@@ -2298,7 +2310,12 @@ fn decode_cross_dep(
         .ok_or_else(|| StorageError::Other(anyhow::anyhow!("cross_dep re-dict src failed")))?;
 
     // Exceptions.
-    let mut exc: Vec<(u32, i64)> = Vec::with_capacity(exc_count);
+    let mut exc: Vec<(u32, i64)> = Vec::new();
+    exc.try_reserve_exact(exc_count).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "cannot reserve {exc_count} cross-dependency exceptions: {error}"
+        ))
+    })?;
     let mut pos = cur.position() as usize;
     let mut prev_ord = 0u32;
     for _ in 0..exc_count {
@@ -2323,7 +2340,12 @@ fn decode_cross_dep(
     }
 
     // Materialise.
-    let mut result: Vec<serde_json::Value> = Vec::with_capacity(num_docs);
+    let mut result: Vec<serde_json::Value> = Vec::new();
+    result.try_reserve_exact(num_docs).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "cannot reserve {num_docs} cross-dependency rows: {error}"
+        ))
+    })?;
     let mut exc_ix = 0;
     for row in 0..num_docs {
         if exc_ix < exc.len() && exc[exc_ix].0 as usize == row {

--- a/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
+++ b/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
@@ -1,5 +1,6 @@
 use super::*;
 use serde::de::Deserializer as _;
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 
 /// Logical work performed by row-selective hydration.
@@ -38,9 +39,74 @@ pub enum StoredV2RowHydrationResult {
     },
 }
 
+type IdentityColumns = (usize, Vec<serde_json::Value>, Vec<serde_json::Value>);
+
+pub(super) fn decode_v2_identity_columns_controlled(
+    bytes: &[u8],
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<StoredDecodeRun<Option<IdentityColumns>>> {
+    let directory = parse_v2_directory(&bytes[4..])?;
+    let id_index = directory
+        .columns
+        .iter()
+        .position(|column| column.name == "__id")
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 missing __id column")))?;
+    let seq_index = directory
+        .columns
+        .iter()
+        .position(|column| column.name == "__seq_no")
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 missing __seq_no column")))?;
+    let selected: Vec<usize> = (0..directory.num_docs).collect();
+    let mut stats = StoredV2RowHydrationStats::default();
+    let mut dict_ids = HashMap::new();
+    let mut decode =
+        |index| -> Result<std::result::Result<Vec<serde_json::Value>, Option<String>>> {
+            if decode_cancelled(checkpoint, StoredDecodePhase::BeforeColumn, index, 0) {
+                return Ok(Err(None));
+            }
+            let result = select_column_rows(
+                index,
+                &directory,
+                &selected,
+                &mut stats,
+                &mut dict_ids,
+                checkpoint,
+            )?;
+            if result.is_ok()
+                && decode_cancelled(
+                    checkpoint,
+                    StoredDecodePhase::AfterColumn,
+                    index,
+                    directory.num_docs,
+                )
+            {
+                return Ok(Err(None));
+            }
+            Ok(result)
+        };
+    let ids = match decode(id_index)? {
+        Ok(values) => values,
+        Err(None) => return Ok(StoredDecodeRun::Cancelled),
+        Err(Some(_)) => return Ok(StoredDecodeRun::Complete(None)),
+    };
+    let seq_nos = match decode(seq_index)? {
+        Ok(values) => values,
+        Err(None) => return Ok(StoredDecodeRun::Cancelled),
+        Err(Some(_)) => return Ok(StoredDecodeRun::Complete(None)),
+    };
+    Ok(StoredDecodeRun::Complete(Some((
+        directory.num_docs,
+        ids,
+        seq_nos,
+    ))))
+}
+
 struct SelectedRowsVisitor<'a> {
     selected: &'a [usize],
     expected_rows: usize,
+    column_index: usize,
+    checkpoint: &'a mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+    cancelled: &'a Cell<bool>,
 }
 
 impl<'de> serde::de::Visitor<'de> for SelectedRowsVisitor<'_> {
@@ -69,6 +135,18 @@ impl<'de> serde::de::Visitor<'de> for SelectedRowsVisitor<'_> {
                     .next_element::<serde::de::IgnoredAny>()?
                     .ok_or_else(|| serde::de::Error::custom("stored column ended early"))?;
             }
+            let processed = row + 1;
+            if processed % STORED_DECODE_CHECK_INTERVAL == 0
+                && (self.checkpoint)(StoredDecodeCheckpoint {
+                    phase: StoredDecodePhase::Rows,
+                    column_index: self.column_index,
+                    rows_processed: processed,
+                })
+                .is_break()
+            {
+                self.cancelled.set(true);
+                return Err(serde::de::Error::custom("stored decode cancelled"));
+            }
         }
         if sequence.next_element::<serde::de::IgnoredAny>()?.is_some() {
             return Err(serde::de::Error::custom(
@@ -84,18 +162,28 @@ fn select_json_rows<R: std::io::Read>(
     selected: &[usize],
     expected_rows: usize,
     context: &str,
-) -> Result<Vec<serde_json::Value>> {
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Vec<serde_json::Value>, ()>> {
+    let cancelled = Cell::new(false);
     let mut deserializer = serde_json::Deserializer::from_reader(reader);
-    let values = deserializer
-        .deserialize_seq(SelectedRowsVisitor {
-            selected,
-            expected_rows,
-        })
-        .map_err(|error| StorageError::Other(anyhow::anyhow!("{context}: {error}")))?;
+    let values = match deserializer.deserialize_seq(SelectedRowsVisitor {
+        selected,
+        expected_rows,
+        column_index,
+        checkpoint,
+        cancelled: &cancelled,
+    }) {
+        Ok(values) => values,
+        Err(_) if cancelled.get() => return Ok(Err(())),
+        Err(error) => {
+            return Err(StorageError::Other(anyhow::anyhow!("{context}: {error}")));
+        }
+    };
     deserializer
         .end()
         .map_err(|error| StorageError::Other(anyhow::anyhow!("{context}: {error}")))?;
-    Ok(values)
+    Ok(Ok(values))
 }
 
 fn unpack_id(packed: &[u8], bit_width: u8, ordinal: usize) -> Option<u32> {
@@ -122,7 +210,13 @@ struct SelectedDict {
     decompressed_bytes: usize,
 }
 
-fn decode_dict_rows(payload: &[u8], selected: &[usize], num_docs: usize) -> Result<SelectedDict> {
+fn decode_dict_rows(
+    payload: &[u8],
+    selected: &[usize],
+    num_docs: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<SelectedDict, ()>> {
     let mut cursor = Cursor::new(payload);
     let dict_count = cursor
         .read_u32::<LittleEndian>()
@@ -196,6 +290,16 @@ fn decode_dict_rows(payload: &[u8], selected: &[usize], num_docs: usize) -> Resu
                 "dict id {id} outside dictionary"
             )));
         }
+        if (ordinal + 1) % STORED_DECODE_CHECK_INTERVAL == 0
+            && checkpoint(StoredDecodeCheckpoint {
+                phase: StoredDecodePhase::Rows,
+                column_index,
+                rows_processed: ordinal + 1,
+            })
+            .is_break()
+        {
+            return Ok(Err(()));
+        }
     }
     let ids: Vec<u32> = selected
         .iter()
@@ -214,7 +318,17 @@ fn decode_dict_rows(payload: &[u8], selected: &[usize], num_docs: usize) -> Resu
     needed.dedup();
     let decoder = zstd::stream::read::Decoder::new(&payload[dict_start..dict_end])
         .map_err(|error| StorageError::Other(anyhow::anyhow!("dict zstd: {error}")))?;
-    let entries = select_json_rows(decoder, &needed, dict_count, "dict json")?;
+    let entries = match select_json_rows(
+        decoder,
+        &needed,
+        dict_count,
+        "dict json",
+        column_index,
+        checkpoint,
+    )? {
+        Ok(entries) => entries,
+        Err(()) => return Ok(Err(())),
+    };
     let entries: HashMap<usize, serde_json::Value> = needed.iter().copied().zip(entries).collect();
     let values = ids
         .iter()
@@ -228,12 +342,12 @@ fn decode_dict_rows(payload: &[u8], selected: &[usize], num_docs: usize) -> Resu
             }
         })
         .collect::<Result<_>>()?;
-    Ok(SelectedDict {
+    Ok(Ok(SelectedDict {
         values,
         ids,
         selected_entries: needed.len(),
         decompressed_bytes: packed.len(),
-    })
+    }))
 }
 
 fn decode_cross_dep_rows(
@@ -242,7 +356,9 @@ fn decode_cross_dep_rows(
     source_ids: &[u32],
     num_docs: usize,
     stats: &mut StoredV2RowHydrationStats,
-) -> Result<Vec<serde_json::Value>> {
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Vec<serde_json::Value>, ()>> {
     let body = decode_cross_dep_body(column.payload)?;
     stats.decompressed_buffer_bytes += body.len();
     let mut cursor = Cursor::new(body.as_slice());
@@ -285,13 +401,23 @@ fn decode_cross_dep_rows(
             exceptions.insert(ordinal, value);
         }
         previous = ordinal;
+        if (exception_index + 1) % STORED_DECODE_CHECK_INTERVAL == 0
+            && checkpoint(StoredDecodeCheckpoint {
+                phase: StoredDecodePhase::Rows,
+                column_index,
+                rows_processed: exception_index + 1,
+            })
+            .is_break()
+        {
+            return Ok(Err(()));
+        }
     }
     if position != body.len() {
         return Err(StorageError::Other(anyhow::anyhow!(
             "cross_dep trailing exception bytes"
         )));
     }
-    Ok(selected
+    Ok(Ok(selected
         .iter()
         .zip(source_ids)
         .map(|(ordinal, source_id)| {
@@ -310,7 +436,7 @@ fn decode_cross_dep_rows(
                 }
             }
         })
-        .collect())
+        .collect()))
 }
 
 fn select_column_rows(
@@ -319,21 +445,42 @@ fn select_column_rows(
     selected: &[usize],
     stats: &mut StoredV2RowHydrationStats,
     dict_ids: &mut HashMap<usize, Vec<u32>>,
-) -> Result<std::result::Result<Vec<serde_json::Value>, String>> {
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Vec<serde_json::Value>, Option<String>>> {
     let column = &directory.columns[column_index];
     let values = match column.codec {
         ColCodec::RawJson => {
             stats.encoded_rows_visited += directory.num_docs;
             let decoder = zstd::stream::read::Decoder::new(column.payload)
                 .map_err(|error| StorageError::Other(anyhow::anyhow!("raw zstd: {error}")))?;
-            select_json_rows(decoder, selected, directory.num_docs, "raw json")?
+            match select_json_rows(
+                decoder,
+                selected,
+                directory.num_docs,
+                "raw json",
+                column_index,
+                checkpoint,
+            )? {
+                Ok(values) => values,
+                Err(()) => return Ok(Err(None)),
+            }
         }
         ColCodec::Lz4Json => {
             let raw = lz4_flex::decompress_size_prepended(column.payload)
                 .map_err(|error| StorageError::Other(anyhow::anyhow!("lz4 decode: {error}")))?;
             stats.decompressed_buffer_bytes += raw.len();
             stats.encoded_rows_visited += directory.num_docs;
-            select_json_rows(raw.as_slice(), selected, directory.num_docs, "lz4 json")?
+            match select_json_rows(
+                raw.as_slice(),
+                selected,
+                directory.num_docs,
+                "lz4 json",
+                column_index,
+                checkpoint,
+            )? {
+                Ok(values) => values,
+                Err(()) => return Ok(Err(None)),
+            }
         }
         ColCodec::Constant => {
             let value: serde_json::Value = serde_json::from_slice(column.payload)
@@ -341,7 +488,16 @@ fn select_column_rows(
             vec![value; selected.len()]
         }
         ColCodec::DictBitpack => {
-            let decoded = decode_dict_rows(column.payload, selected, directory.num_docs)?;
+            let decoded = match decode_dict_rows(
+                column.payload,
+                selected,
+                directory.num_docs,
+                column_index,
+                checkpoint,
+            )? {
+                Ok(decoded) => decoded,
+                Err(()) => return Ok(Err(None)),
+            };
             stats.selected_dictionary_entries += decoded.selected_entries;
             stats.decompressed_buffer_bytes += decoded.decompressed_bytes;
             dict_ids.insert(column_index, decoded.ids);
@@ -361,28 +517,47 @@ fn select_column_rows(
                 // validate this column's complete body and exception stream
                 // before asking the caller to use the compatibility path.
                 let placeholder_source_ids = vec![0; selected.len()];
-                decode_cross_dep_rows(
+                match decode_cross_dep_rows(
                     column,
                     selected,
                     &placeholder_source_ids,
                     directory.num_docs,
                     stats,
-                )?;
-                return Ok(Err(column.name.to_string()));
+                    column_index,
+                    checkpoint,
+                )? {
+                    Ok(_) => {}
+                    Err(()) => return Ok(Err(None)),
+                }
+                return Ok(Err(Some(column.name.to_string())));
             }
             if let std::collections::hash_map::Entry::Vacant(entry) = dict_ids.entry(source_index) {
-                let decoded = decode_dict_rows(source.payload, selected, directory.num_docs)?;
+                let decoded = match decode_dict_rows(
+                    source.payload,
+                    selected,
+                    directory.num_docs,
+                    source_index,
+                    checkpoint,
+                )? {
+                    Ok(decoded) => decoded,
+                    Err(()) => return Ok(Err(None)),
+                };
                 stats.selected_dictionary_entries += decoded.selected_entries;
                 stats.decompressed_buffer_bytes += decoded.decompressed_bytes;
                 entry.insert(decoded.ids);
             }
-            decode_cross_dep_rows(
+            match decode_cross_dep_rows(
                 column,
                 selected,
                 &dict_ids[&source_index],
                 directory.num_docs,
                 stats,
-            )?
+                column_index,
+                checkpoint,
+            )? {
+                Ok(values) => values,
+                Err(()) => return Ok(Err(None)),
+            }
         }
     };
     stats.selected_json_values += values.len();
@@ -394,8 +569,26 @@ pub fn decode_stored_v2_rows(
     bytes: &[u8],
     ordinals: &[usize],
 ) -> Result<StoredV2RowHydrationResult> {
+    match decode_stored_v2_rows_controlled(
+        bytes,
+        ordinals,
+        |_| std::ops::ControlFlow::Continue(()),
+    )? {
+        StoredDecodeRun::Complete(result) => Ok(result),
+        StoredDecodeRun::Cancelled => unreachable!("non-cancelling compatibility wrapper"),
+    }
+}
+
+pub fn decode_stored_v2_rows_controlled<F>(
+    bytes: &[u8],
+    ordinals: &[usize],
+    mut checkpoint: F,
+) -> Result<StoredDecodeRun<StoredV2RowHydrationResult>>
+where
+    F: FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+{
     if bytes.len() < 4 || &bytes[..4] != STORED_V2_MAGIC {
-        return Ok(StoredV2RowHydrationResult::NotV2);
+        return Ok(StoredDecodeRun::Complete(StoredV2RowHydrationResult::NotV2));
     }
     let directory = parse_v2_directory(&bytes[4..])?;
     let id_index = directory
@@ -420,20 +613,43 @@ pub fn decode_stored_v2_rows(
         )));
     }
     if selected.is_empty() {
-        return Ok(StoredV2RowHydrationResult::Hydrated {
-            rows: Vec::new(),
-            stats: StoredV2RowHydrationStats::default(),
-        });
+        return Ok(StoredDecodeRun::Complete(
+            StoredV2RowHydrationResult::Hydrated {
+                rows: Vec::new(),
+                stats: StoredV2RowHydrationStats::default(),
+            },
+        ));
     }
     let mut stats = StoredV2RowHydrationStats::default();
     let mut columns = Vec::with_capacity(directory.columns.len());
     let mut dict_ids = HashMap::new();
     for index in 0..directory.columns.len() {
-        match select_column_rows(index, &directory, &selected, &mut stats, &mut dict_ids)? {
+        if decode_cancelled(&mut checkpoint, StoredDecodePhase::BeforeColumn, index, 0) {
+            return Ok(StoredDecodeRun::Cancelled);
+        }
+        match select_column_rows(
+            index,
+            &directory,
+            &selected,
+            &mut stats,
+            &mut dict_ids,
+            &mut checkpoint,
+        )? {
             Ok(values) => columns.push(values),
-            Err(column) => {
-                return Ok(StoredV2RowHydrationResult::UnsupportedDependencyShape { column });
+            Err(Some(column)) => {
+                return Ok(StoredDecodeRun::Complete(
+                    StoredV2RowHydrationResult::UnsupportedDependencyShape { column },
+                ));
             }
+            Err(None) => return Ok(StoredDecodeRun::Cancelled),
+        }
+        if decode_cancelled(
+            &mut checkpoint,
+            StoredDecodePhase::AfterColumn,
+            index,
+            directory.num_docs,
+        ) {
+            return Ok(StoredDecodeRun::Cancelled);
         }
     }
     let mut rows = Vec::with_capacity(selected.len());
@@ -457,7 +673,9 @@ pub fn decode_stored_v2_rows(
             source,
         });
     }
-    Ok(StoredV2RowHydrationResult::Hydrated { rows, stats })
+    Ok(StoredDecodeRun::Complete(
+        StoredV2RowHydrationResult::Hydrated { rows, stats },
+    ))
 }
 
 #[cfg(test)]
@@ -663,6 +881,123 @@ mod tests {
             _ => panic!("expected hydration"),
         };
         assert_eq!(selected(small), selected(large));
+    }
+
+    #[test]
+    fn controlled_hydration_has_deterministic_order_and_distinct_cancellation() {
+        let encoded = fixture(256, ColCodec::RawJson);
+        let mut observed = Vec::new();
+        let run = decode_stored_v2_rows_controlled(&encoded, &[0, 7], |point| {
+            observed.push(point);
+            if point.phase == StoredDecodePhase::Rows && point.rows_processed == 128 {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        })
+        .unwrap();
+        assert_eq!(run, StoredDecodeRun::Cancelled);
+        assert_eq!(
+            observed[0],
+            StoredDecodeCheckpoint {
+                phase: StoredDecodePhase::BeforeColumn,
+                column_index: 0,
+                rows_processed: 0,
+            }
+        );
+        assert_eq!(
+            observed[1],
+            StoredDecodeCheckpoint {
+                phase: StoredDecodePhase::Rows,
+                column_index: 0,
+                rows_processed: 128,
+            }
+        );
+
+        let complete = decode_stored_v2_rows_controlled(&encoded, &[0, 7], |_| {
+            std::ops::ControlFlow::Continue(())
+        })
+        .unwrap();
+        assert_eq!(
+            complete,
+            StoredDecodeRun::Complete(decode_stored_v2_rows(&encoded, &[0, 7]).unwrap())
+        );
+    }
+
+    #[test]
+    fn controlled_hydration_cancellation_precedes_unvisited_corruption() {
+        let mut encoded = fixture(256, ColCodec::RawJson);
+        let (offset, payload_len) = {
+            let directory = parse_v2_directory(&encoded[4..]).unwrap();
+            let last = directory.columns.last().unwrap();
+            (
+                last.payload.as_ptr() as usize - encoded.as_ptr() as usize,
+                last.payload.len(),
+            )
+        };
+        encoded[offset + payload_len / 2] ^= 0xff;
+
+        assert_eq!(
+            decode_stored_v2_rows_controlled(&encoded, &[0], |_| {
+                std::ops::ControlFlow::Break(())
+            })
+            .unwrap(),
+            StoredDecodeRun::Cancelled
+        );
+        assert!(decode_stored_v2_rows_controlled(&encoded, &[0], |_| {
+            std::ops::ControlFlow::Continue(())
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn controlled_hydration_stops_before_malformed_row_129() {
+        let mut json = String::from("[");
+        for row in 0..128 {
+            if row != 0 {
+                json.push(',');
+            }
+            json.push_str(&row.to_string());
+        }
+        json.push_str(",row_129_is_invalid]");
+        let malformed = zstd::encode_all(Cursor::new(json.as_bytes()), STORED_ZSTD_LEVEL).unwrap();
+        let encoded = assemble(
+            256,
+            &[
+                (
+                    "__id",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!("id")).unwrap(),
+                ),
+                (
+                    "__seq_no",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!(1)).unwrap(),
+                ),
+                ("bad", ColCodec::RawJson, malformed),
+            ],
+        );
+        assert_eq!(
+            decode_stored_v2_rows_controlled(&encoded, &[0], |point| {
+                if point.column_index == 2
+                    && point.phase == StoredDecodePhase::Rows
+                    && point.rows_processed == 128
+                {
+                    std::ops::ControlFlow::Break(())
+                } else {
+                    std::ops::ControlFlow::Continue(())
+                }
+            })
+            .unwrap(),
+            StoredDecodeRun::Cancelled
+        );
+        assert!(
+            decode_stored_v2_rows_controlled(&encoded, &[0], |_| {
+                std::ops::ControlFlow::Continue(())
+            })
+            .is_err(),
+            "without cancellation the parser must consume malformed row 129"
+        );
     }
 
     #[test]

--- a/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
+++ b/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
@@ -56,7 +56,16 @@ pub(super) fn decode_v2_identity_columns_controlled(
         .iter()
         .position(|column| column.name == "__seq_no")
         .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 missing __seq_no column")))?;
-    let selected: Vec<usize> = (0..directory.num_docs).collect();
+    let mut selected = Vec::new();
+    selected
+        .try_reserve_exact(directory.num_docs)
+        .map_err(|error| {
+            StorageError::Other(anyhow::anyhow!(
+                "cannot reserve {} identity row ordinals: {error}",
+                directory.num_docs
+            ))
+        })?;
+    selected.extend(0..directory.num_docs);
     let mut stats = StoredV2RowHydrationStats::default();
     let mut dict_ids = HashMap::new();
     let mut decode =
@@ -136,7 +145,7 @@ impl<'de> serde::de::Visitor<'de> for SelectedRowsVisitor<'_> {
                     .ok_or_else(|| serde::de::Error::custom("stored column ended early"))?;
             }
             let processed = row + 1;
-            if processed % STORED_DECODE_CHECK_INTERVAL == 0
+            if processed.is_multiple_of(STORED_DECODE_CHECK_INTERVAL)
                 && (self.checkpoint)(StoredDecodeCheckpoint {
                     phase: StoredDecodePhase::Rows,
                     column_index: self.column_index,
@@ -292,7 +301,7 @@ fn decode_dict_rows(
                 "dict id {id} outside dictionary"
             )));
         }
-        if (ordinal + 1) % STORED_DECODE_CHECK_INTERVAL == 0
+        if (ordinal + 1).is_multiple_of(STORED_DECODE_CHECK_INTERVAL)
             && checkpoint(StoredDecodeCheckpoint {
                 phase: StoredDecodePhase::Rows,
                 column_index,
@@ -413,7 +422,7 @@ fn decode_cross_dep_rows(
             exceptions.insert(ordinal, value);
         }
         previous = ordinal;
-        if (exception_index + 1) % STORED_DECODE_CHECK_INTERVAL == 0
+        if (exception_index + 1).is_multiple_of(STORED_DECODE_CHECK_INTERVAL)
             && checkpoint(StoredDecodeCheckpoint {
                 phase: StoredDecodePhase::Rows,
                 column_index,

--- a/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
+++ b/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
@@ -222,6 +222,11 @@ fn decode_dict_rows(
         .read_u32::<LittleEndian>()
         .map_err(|error| StorageError::Other(anyhow::anyhow!("dict_count: {error}")))?
         as usize;
+    if dict_count > num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict_count {dict_count} exceeds num_docs {num_docs}"
+        )));
+    }
     let bit_width = cursor
         .read_u8()
         .map_err(|error| StorageError::Other(anyhow::anyhow!("bit_width: {error}")))?;
@@ -258,18 +263,15 @@ fn decode_dict_rows(
         .checked_add(packed_len)
         .filter(|end| *end == payload.len())
         .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict packed truncated/trailing")))?;
-    let packed = zstd::decode_all(&payload[packed_start..packed_end])
-        .map_err(|error| StorageError::Other(anyhow::anyhow!("packed zstd: {error}")))?;
     let expected_packed_len = num_docs
         .checked_mul(bit_width as usize)
         .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict packed length overflow")))?
         .div_ceil(8);
-    if packed.len() != expected_packed_len {
-        return Err(StorageError::Other(anyhow::anyhow!(
-            "dict packed length {} != expected {expected_packed_len}",
-            packed.len()
-        )));
-    }
+    let packed = decode_zstd_exact(
+        &payload[packed_start..packed_end],
+        expected_packed_len,
+        "packed zstd",
+    )?;
     let used_bits = num_docs * bit_width as usize;
     if !used_bits.is_multiple_of(8) {
         let used_in_last = used_bits % 8;
@@ -359,7 +361,7 @@ fn decode_cross_dep_rows(
     column_index: usize,
     checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
 ) -> Result<std::result::Result<Vec<serde_json::Value>, ()>> {
-    let body = decode_cross_dep_body(column.payload)?;
+    let body = decode_cross_dep_body(column.payload, num_docs)?;
     stats.decompressed_buffer_bytes += body.len();
     let mut cursor = Cursor::new(body.as_slice());
     let _source_index = cursor
@@ -369,6 +371,11 @@ fn decode_cross_dep_rows(
         .read_u32::<LittleEndian>()
         .map_err(|error| StorageError::Other(anyhow::anyhow!("cross_dep dict_count: {error}")))?
         as usize;
+    if dict_count > num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep dict_count {dict_count} exceeds num_docs {num_docs}"
+        )));
+    }
     let mut modes = Vec::with_capacity(dict_count);
     for _ in 0..dict_count {
         modes.push(
@@ -381,6 +388,11 @@ fn decode_cross_dep_rows(
         .read_u32::<LittleEndian>()
         .map_err(|error| StorageError::Other(anyhow::anyhow!("cross_dep exc_count: {error}")))?
         as usize;
+    if exception_count > num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep exc_count {exception_count} exceeds num_docs {num_docs}"
+        )));
+    }
     let wanted: HashSet<u32> = selected.iter().map(|ordinal| *ordinal as u32).collect();
     let mut exceptions = HashMap::with_capacity(wanted.len().min(exception_count));
     let mut position = cursor.position() as usize;
@@ -504,7 +516,7 @@ fn select_column_rows(
             decoded.values
         }
         ColCodec::CrossDep => {
-            let source_index = cross_dep_source_index(column.payload)?;
+            let source_index = cross_dep_source_index(column.payload, directory.num_docs)?;
             let Some(source) = directory.columns.get(source_index) else {
                 return Err(StorageError::Other(anyhow::anyhow!(
                     "cross_dep source index {source_index} out of range"
@@ -569,11 +581,27 @@ pub fn decode_stored_v2_rows(
     bytes: &[u8],
     ordinals: &[usize],
 ) -> Result<StoredV2RowHydrationResult> {
-    match decode_stored_v2_rows_controlled(
-        bytes,
-        ordinals,
-        |_| std::ops::ControlFlow::Continue(()),
-    )? {
+    match decode_stored_v2_rows_projected_controlled(bytes, ordinals, None, |_| {
+        std::ops::ControlFlow::Continue(())
+    })? {
+        StoredDecodeRun::Complete(result) => Ok(result),
+        StoredDecodeRun::Cancelled => unreachable!("non-cancelling compatibility wrapper"),
+    }
+}
+
+/// Reconstruct selected ZBS2 rows and only the requested top-level `_source`
+/// fields. Identity and sequence metadata are always returned.
+///
+/// Missing requested fields remain absent, matching `_source` object
+/// semantics. An empty projection returns identity-only rows.
+pub fn decode_stored_v2_rows_projected(
+    bytes: &[u8],
+    ordinals: &[usize],
+    source_fields: &[&str],
+) -> Result<StoredV2RowHydrationResult> {
+    match decode_stored_v2_rows_projected_controlled(bytes, ordinals, Some(source_fields), |_| {
+        std::ops::ControlFlow::Continue(())
+    })? {
         StoredDecodeRun::Complete(result) => Ok(result),
         StoredDecodeRun::Cancelled => unreachable!("non-cancelling compatibility wrapper"),
     }
@@ -582,6 +610,18 @@ pub fn decode_stored_v2_rows(
 pub fn decode_stored_v2_rows_controlled<F>(
     bytes: &[u8],
     ordinals: &[usize],
+    checkpoint: F,
+) -> Result<StoredDecodeRun<StoredV2RowHydrationResult>>
+where
+    F: FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+{
+    decode_stored_v2_rows_projected_controlled(bytes, ordinals, None, checkpoint)
+}
+
+pub fn decode_stored_v2_rows_projected_controlled<F>(
+    bytes: &[u8],
+    ordinals: &[usize],
+    source_fields: Option<&[&str]>,
     mut checkpoint: F,
 ) -> Result<StoredDecodeRun<StoredV2RowHydrationResult>>
 where
@@ -621,9 +661,21 @@ where
         ));
     }
     let mut stats = StoredV2RowHydrationStats::default();
-    let mut columns = Vec::with_capacity(directory.columns.len());
+    let requested: Option<HashSet<&str>> =
+        source_fields.map(|fields| fields.iter().copied().collect());
+    let mut columns: Vec<Option<Vec<serde_json::Value>>> =
+        (0..directory.columns.len()).map(|_| None).collect();
     let mut dict_ids = HashMap::new();
     for index in 0..directory.columns.len() {
+        let column = &directory.columns[index];
+        let wanted = index == id_index
+            || index == seq_index
+            || requested
+                .as_ref()
+                .is_none_or(|fields| fields.contains(column.name));
+        if !wanted {
+            continue;
+        }
         if decode_cancelled(&mut checkpoint, StoredDecodePhase::BeforeColumn, index, 0) {
             return Ok(StoredDecodeRun::Cancelled);
         }
@@ -635,7 +687,7 @@ where
             &mut dict_ids,
             &mut checkpoint,
         )? {
-            Ok(values) => columns.push(values),
+            Ok(values) => columns[index] = Some(values),
             Err(Some(column)) => {
                 return Ok(StoredDecodeRun::Complete(
                     StoredV2RowHydrationResult::UnsupportedDependencyShape { column },
@@ -659,7 +711,10 @@ where
             if column_index == id_index || column_index == seq_index {
                 continue;
             }
-            let value = columns[column_index][selected_index].clone();
+            let Some(values) = columns[column_index].as_ref() else {
+                continue;
+            };
+            let value = values[selected_index].clone();
             if !value.is_null() {
                 source.insert(column.name.to_string(), value);
                 stats.output_values_cloned += 1;
@@ -668,8 +723,8 @@ where
         stats.output_values_cloned += 2;
         rows.push(StoredV2HydratedRow {
             ordinal,
-            id: columns[id_index][selected_index].clone(),
-            seq_no: columns[seq_index][selected_index].clone(),
+            id: columns[id_index].as_ref().unwrap()[selected_index].clone(),
+            seq_no: columns[seq_index].as_ref().unwrap()[selected_index].clone(),
             source,
         });
     }
@@ -1115,5 +1170,58 @@ mod tests {
                 full[ordinal]["_source"]
             );
         }
+    }
+
+    #[test]
+    fn row_projection_preserves_sparse_parity_and_skips_unrequested_payloads() {
+        let count = 128usize;
+        let ids: Vec<_> = (0..count).map(|row| json!(format!("id-{row}"))).collect();
+        let seqs: Vec<_> = (0..count).map(|row| json!(row)).collect();
+        let wanted: Vec<_> = (0..count)
+            .map(|row| {
+                if row % 3 == 0 {
+                    json!(format!("quarter-{row}"))
+                } else {
+                    serde_json::Value::Null
+                }
+            })
+            .collect();
+        let encoded = assemble(
+            count,
+            &[
+                ("__id", ColCodec::RawJson, raw(&ids)),
+                ("__seq_no", ColCodec::RawJson, raw(&seqs)),
+                ("wanted", ColCodec::RawJson, raw(&wanted)),
+                // Valid framing, deliberately corrupt payload. A projected
+                // read must not touch an unrelated column.
+                ("unrelated", ColCodec::RawJson, b"not-zstd".to_vec()),
+            ],
+        );
+        let selected = [0, 1, 42, 127];
+        let StoredV2RowHydrationResult::Hydrated { rows, stats } =
+            decode_stored_v2_rows_projected(&encoded, &selected, &["wanted"]).unwrap()
+        else {
+            panic!("expected projected hydration")
+        };
+        assert_eq!(rows.len(), selected.len());
+        for (row, ordinal) in rows.iter().zip(selected) {
+            assert_eq!(row.id, ids[ordinal]);
+            assert_eq!(row.seq_no, seqs[ordinal]);
+            if wanted[ordinal].is_null() {
+                assert!(!row.source.contains_key("wanted"));
+            } else {
+                assert_eq!(row.source["wanted"], wanted[ordinal]);
+            }
+            assert!(!row.source.contains_key("unrelated"));
+        }
+        assert_eq!(stats.selected_json_values, selected.len() * 3);
+        assert!(decode_stored_v2_rows(&encoded, &selected).is_err());
+
+        let StoredV2RowHydrationResult::Hydrated { rows, .. } =
+            decode_stored_v2_rows_projected(&encoded, &[7], &[]).unwrap()
+        else {
+            panic!("expected identity-only hydration")
+        };
+        assert!(rows[0].source.is_empty());
     }
 }

--- a/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
+++ b/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
@@ -460,6 +460,35 @@ fn decode_cross_dep_rows(
         .collect()))
 }
 
+fn repeat_constant_rows_controlled(
+    value: serde_json::Value,
+    output_count: usize,
+    column_index: usize,
+    checkpoint: &mut dyn FnMut(StoredDecodeCheckpoint) -> std::ops::ControlFlow<()>,
+) -> Result<std::result::Result<Vec<serde_json::Value>, ()>> {
+    let mut values = Vec::new();
+    values.try_reserve_exact(output_count).map_err(|error| {
+        StorageError::Other(anyhow::anyhow!(
+            "cannot reserve {output_count} selected constant values: {error}"
+        ))
+    })?;
+    for output_index in 0..output_count {
+        values.push(value.clone());
+        let processed = output_index + 1;
+        if processed.is_multiple_of(STORED_DECODE_CHECK_INTERVAL)
+            && checkpoint(StoredDecodeCheckpoint {
+                phase: StoredDecodePhase::Rows,
+                column_index,
+                rows_processed: processed,
+            })
+            .is_break()
+        {
+            return Ok(Err(()));
+        }
+    }
+    Ok(Ok(values))
+}
+
 fn select_column_rows(
     column_index: usize,
     directory: &V2Directory<'_>,
@@ -506,7 +535,11 @@ fn select_column_rows(
         ColCodec::Constant => {
             let value: serde_json::Value = serde_json::from_slice(column.payload)
                 .map_err(|error| StorageError::Other(anyhow::anyhow!("constant: {error}")))?;
-            vec![value; selected.len()]
+            match repeat_constant_rows_controlled(value, selected.len(), column_index, checkpoint)?
+            {
+                Ok(values) => values,
+                Err(()) => return Ok(Err(None)),
+            }
         }
         ColCodec::DictBitpack => {
             let decoded = match decode_dict_rows(
@@ -985,6 +1018,81 @@ mod tests {
         assert_eq!(
             complete,
             StoredDecodeRun::Complete(decode_stored_v2_rows(&encoded, &[0, 7]).unwrap())
+        );
+    }
+
+    #[test]
+    fn controlled_constant_hydration_is_fallible_cancellable_and_preserves_parity() {
+        let encoded = assemble(
+            256,
+            &[
+                (
+                    "__id",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!("same-id")).unwrap(),
+                ),
+                (
+                    "__seq_no",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!(7)).unwrap(),
+                ),
+                (
+                    "body",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!({"kind": "constant"})).unwrap(),
+                ),
+            ],
+        );
+        let selected: Vec<_> = (0..256).collect();
+        let mut observed = Vec::new();
+        let cancelled = decode_stored_v2_rows_controlled(&encoded, &selected, |point| {
+            observed.push(point);
+            if point.phase == StoredDecodePhase::Rows && point.rows_processed == 128 {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        })
+        .unwrap();
+        assert_eq!(cancelled, StoredDecodeRun::Cancelled);
+        assert_eq!(
+            observed[1],
+            StoredDecodeCheckpoint {
+                phase: StoredDecodePhase::Rows,
+                column_index: 0,
+                rows_processed: 128,
+            }
+        );
+
+        let complete = decode_stored_v2_rows_controlled(&encoded, &[255, 0, 7, 7], |_| {
+            std::ops::ControlFlow::Continue(())
+        })
+        .unwrap();
+        assert_eq!(
+            complete,
+            StoredDecodeRun::Complete(decode_stored_v2_rows(&encoded, &[255, 0, 7, 7]).unwrap())
+        );
+        let StoredDecodeRun::Complete(StoredV2RowHydrationResult::Hydrated { rows, .. }) = complete
+        else {
+            panic!("expected completed constant hydration")
+        };
+        assert_eq!(
+            rows.iter().map(|row| row.ordinal).collect::<Vec<_>>(),
+            [0, 7, 255]
+        );
+        assert!(rows
+            .iter()
+            .all(|row| row.source["body"] == json!({"kind": "constant"})));
+
+        let reserve_error =
+            repeat_constant_rows_controlled(json!(null), usize::MAX, 0, &mut |_| {
+                std::ops::ControlFlow::Continue(())
+            })
+            .unwrap_err();
+        let expected = format!("cannot reserve {} selected constant values", usize::MAX);
+        assert!(
+            reserve_error.to_string().contains(&expected),
+            "allocation failure must identify the requested output count: {reserve_error}"
         );
     }
 

--- a/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
+++ b/engine/crates/xerj-storage/src/stored_codec/row_hydration.rs
@@ -1,0 +1,784 @@
+use super::*;
+use serde::de::Deserializer as _;
+use std::collections::{HashMap, HashSet};
+
+/// Logical work performed by row-selective hydration.
+///
+/// These fields are not allocator or RSS measurements. In particular,
+/// decompressed buffers are counted by byte length while JSON values are
+/// counted as objects, so the fields must never be summed into "memory used".
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct StoredV2RowHydrationStats {
+    pub encoded_rows_visited: usize,
+    pub selected_json_values: usize,
+    pub selected_dictionary_entries: usize,
+    pub decompressed_buffer_bytes: usize,
+    pub output_values_cloned: usize,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct StoredV2HydratedRow {
+    pub ordinal: usize,
+    pub id: serde_json::Value,
+    pub seq_no: serde_json::Value,
+    pub source: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum StoredV2RowHydrationResult {
+    NotV2,
+    Hydrated {
+        rows: Vec<StoredV2HydratedRow>,
+        stats: StoredV2RowHydrationStats,
+    },
+    /// Valid storage whose dependency shape cannot be hydrated selectively.
+    /// The caller must use the compatibility path for the whole request.
+    UnsupportedDependencyShape {
+        column: String,
+    },
+}
+
+struct SelectedRowsVisitor<'a> {
+    selected: &'a [usize],
+    expected_rows: usize,
+}
+
+impl<'de> serde::de::Visitor<'de> for SelectedRowsVisitor<'_> {
+    type Value = Vec<serde_json::Value>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a JSON array matching the declared stored row count")
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut selected_index = 0usize;
+        let mut values = Vec::with_capacity(self.selected.len());
+        for row in 0..self.expected_rows {
+            if self.selected.get(selected_index).copied() == Some(row) {
+                values.push(
+                    sequence
+                        .next_element::<serde_json::Value>()?
+                        .ok_or_else(|| serde::de::Error::custom("stored column ended early"))?,
+                );
+                selected_index += 1;
+            } else {
+                sequence
+                    .next_element::<serde::de::IgnoredAny>()?
+                    .ok_or_else(|| serde::de::Error::custom("stored column ended early"))?;
+            }
+        }
+        if sequence.next_element::<serde::de::IgnoredAny>()?.is_some() {
+            return Err(serde::de::Error::custom(
+                "stored column exceeds declared row count",
+            ));
+        }
+        Ok(values)
+    }
+}
+
+fn select_json_rows<R: std::io::Read>(
+    reader: R,
+    selected: &[usize],
+    expected_rows: usize,
+    context: &str,
+) -> Result<Vec<serde_json::Value>> {
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    let values = deserializer
+        .deserialize_seq(SelectedRowsVisitor {
+            selected,
+            expected_rows,
+        })
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("{context}: {error}")))?;
+    deserializer
+        .end()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("{context}: {error}")))?;
+    Ok(values)
+}
+
+fn unpack_id(packed: &[u8], bit_width: u8, ordinal: usize) -> Option<u32> {
+    let width = bit_width as usize;
+    if !(1..=32).contains(&width) {
+        return None;
+    }
+    let bit_position = ordinal.checked_mul(width)?;
+    let byte_position = bit_position / 8;
+    let shift = bit_position % 8;
+    let needed = (width + shift).div_ceil(8);
+    let bytes = packed.get(byte_position..byte_position.checked_add(needed)?)?;
+    let mut word = 0u64;
+    for (offset, byte) in bytes.iter().enumerate() {
+        word |= (*byte as u64) << (offset * 8);
+    }
+    Some(((word >> shift) & ((1u64 << width) - 1)) as u32)
+}
+
+struct SelectedDict {
+    values: Vec<serde_json::Value>,
+    ids: Vec<u32>,
+    selected_entries: usize,
+    decompressed_bytes: usize,
+}
+
+fn decode_dict_rows(payload: &[u8], selected: &[usize], num_docs: usize) -> Result<SelectedDict> {
+    let mut cursor = Cursor::new(payload);
+    let dict_count = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("dict_count: {error}")))?
+        as usize;
+    let bit_width = cursor
+        .read_u8()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("bit_width: {error}")))?;
+    if !(1..=32).contains(&bit_width) {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict invalid bit_width {bit_width}"
+        )));
+    }
+    let dict_len = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("dict_zstd_len: {error}")))?
+        as usize;
+    let dict_start = cursor.position() as usize;
+    let dict_end = dict_start
+        .checked_add(dict_len)
+        .filter(|end| *end <= payload.len())
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict payload truncated")))?;
+    cursor.set_position(dict_end as u64);
+    let ids_len = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("ids_len: {error}")))?
+        as usize;
+    if ids_len != num_docs {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict ids_len {ids_len} != num_docs {num_docs}"
+        )));
+    }
+    let packed_len = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("packed_zstd_len: {error}")))?
+        as usize;
+    let packed_start = cursor.position() as usize;
+    let packed_end = packed_start
+        .checked_add(packed_len)
+        .filter(|end| *end == payload.len())
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict packed truncated/trailing")))?;
+    let packed = zstd::decode_all(&payload[packed_start..packed_end])
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("packed zstd: {error}")))?;
+    let expected_packed_len = num_docs
+        .checked_mul(bit_width as usize)
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict packed length overflow")))?
+        .div_ceil(8);
+    if packed.len() != expected_packed_len {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "dict packed length {} != expected {expected_packed_len}",
+            packed.len()
+        )));
+    }
+    let used_bits = num_docs * bit_width as usize;
+    if !used_bits.is_multiple_of(8) {
+        let used_in_last = used_bits % 8;
+        let padding_mask = !((1u8 << used_in_last) - 1);
+        if packed.last().is_some_and(|byte| byte & padding_mask != 0) {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "dict non-zero packed padding"
+            )));
+        }
+    }
+    let null_id = dict_count as u32;
+    // Validate every encoded id without constructing per-row Values.
+    for ordinal in 0..num_docs {
+        let id = unpack_id(&packed, bit_width, ordinal)
+            .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict id truncated")))?;
+        if id > null_id {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "dict id {id} outside dictionary"
+            )));
+        }
+    }
+    let ids: Vec<u32> = selected
+        .iter()
+        .map(|ordinal| {
+            unpack_id(&packed, bit_width, *ordinal)
+                .ok_or_else(|| StorageError::Other(anyhow::anyhow!("dict selected id truncated")))
+        })
+        .collect::<Result<_>>()?;
+    let mut needed: Vec<usize> = ids
+        .iter()
+        .copied()
+        .filter(|id| *id != null_id)
+        .map(|id| id as usize)
+        .collect();
+    needed.sort_unstable();
+    needed.dedup();
+    let decoder = zstd::stream::read::Decoder::new(&payload[dict_start..dict_end])
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("dict zstd: {error}")))?;
+    let entries = select_json_rows(decoder, &needed, dict_count, "dict json")?;
+    let entries: HashMap<usize, serde_json::Value> = needed.iter().copied().zip(entries).collect();
+    let values = ids
+        .iter()
+        .map(|id| {
+            if *id == null_id {
+                Ok(serde_json::Value::Null)
+            } else {
+                entries.get(&(*id as usize)).cloned().ok_or_else(|| {
+                    StorageError::Other(anyhow::anyhow!("selected dict entry missing"))
+                })
+            }
+        })
+        .collect::<Result<_>>()?;
+    Ok(SelectedDict {
+        values,
+        ids,
+        selected_entries: needed.len(),
+        decompressed_bytes: packed.len(),
+    })
+}
+
+fn decode_cross_dep_rows(
+    column: &V2ColumnRef<'_>,
+    selected: &[usize],
+    source_ids: &[u32],
+    num_docs: usize,
+    stats: &mut StoredV2RowHydrationStats,
+) -> Result<Vec<serde_json::Value>> {
+    let body = decode_cross_dep_body(column.payload)?;
+    stats.decompressed_buffer_bytes += body.len();
+    let mut cursor = Cursor::new(body.as_slice());
+    let _source_index = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("cross_dep src_ix: {error}")))?;
+    let dict_count = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("cross_dep dict_count: {error}")))?
+        as usize;
+    let mut modes = Vec::with_capacity(dict_count);
+    for _ in 0..dict_count {
+        modes.push(
+            cursor
+                .read_i64::<LittleEndian>()
+                .map_err(|error| StorageError::Other(anyhow::anyhow!("cross_dep mode: {error}")))?,
+        );
+    }
+    let exception_count = cursor
+        .read_u32::<LittleEndian>()
+        .map_err(|error| StorageError::Other(anyhow::anyhow!("cross_dep exc_count: {error}")))?
+        as usize;
+    let wanted: HashSet<u32> = selected.iter().map(|ordinal| *ordinal as u32).collect();
+    let mut exceptions = HashMap::with_capacity(wanted.len().min(exception_count));
+    let mut position = cursor.position() as usize;
+    let mut previous = 0u32;
+    for exception_index in 0..exception_count {
+        let delta = u32::try_from(read_varint(&body, &mut position)?)
+            .map_err(|_| StorageError::Other(anyhow::anyhow!("cross_dep ordinal overflow")))?;
+        let value = read_zigzag_i64(&body, &mut position)?;
+        let ordinal = previous
+            .checked_add(delta)
+            .ok_or_else(|| StorageError::Other(anyhow::anyhow!("cross_dep ordinal overflow")))?;
+        if ordinal as usize >= num_docs || (exception_index > 0 && ordinal <= previous) {
+            return Err(StorageError::Other(anyhow::anyhow!(
+                "cross_dep invalid exception ordinal {ordinal}"
+            )));
+        }
+        if wanted.contains(&ordinal) {
+            exceptions.insert(ordinal, value);
+        }
+        previous = ordinal;
+    }
+    if position != body.len() {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "cross_dep trailing exception bytes"
+        )));
+    }
+    Ok(selected
+        .iter()
+        .zip(source_ids)
+        .map(|(ordinal, source_id)| {
+            if let Some(value) = exceptions.get(&(*ordinal as u32)).copied() {
+                if value == i64::MIN + 1 {
+                    serde_json::Value::Null
+                } else {
+                    serde_json::Value::Number(value.into())
+                }
+            } else {
+                let value = modes.get(*source_id as usize).copied().unwrap_or(i64::MIN);
+                if value == i64::MIN {
+                    serde_json::Value::Null
+                } else {
+                    serde_json::Value::Number(value.into())
+                }
+            }
+        })
+        .collect())
+}
+
+fn select_column_rows(
+    column_index: usize,
+    directory: &V2Directory<'_>,
+    selected: &[usize],
+    stats: &mut StoredV2RowHydrationStats,
+    dict_ids: &mut HashMap<usize, Vec<u32>>,
+) -> Result<std::result::Result<Vec<serde_json::Value>, String>> {
+    let column = &directory.columns[column_index];
+    let values = match column.codec {
+        ColCodec::RawJson => {
+            stats.encoded_rows_visited += directory.num_docs;
+            let decoder = zstd::stream::read::Decoder::new(column.payload)
+                .map_err(|error| StorageError::Other(anyhow::anyhow!("raw zstd: {error}")))?;
+            select_json_rows(decoder, selected, directory.num_docs, "raw json")?
+        }
+        ColCodec::Lz4Json => {
+            let raw = lz4_flex::decompress_size_prepended(column.payload)
+                .map_err(|error| StorageError::Other(anyhow::anyhow!("lz4 decode: {error}")))?;
+            stats.decompressed_buffer_bytes += raw.len();
+            stats.encoded_rows_visited += directory.num_docs;
+            select_json_rows(raw.as_slice(), selected, directory.num_docs, "lz4 json")?
+        }
+        ColCodec::Constant => {
+            let value: serde_json::Value = serde_json::from_slice(column.payload)
+                .map_err(|error| StorageError::Other(anyhow::anyhow!("constant: {error}")))?;
+            vec![value; selected.len()]
+        }
+        ColCodec::DictBitpack => {
+            let decoded = decode_dict_rows(column.payload, selected, directory.num_docs)?;
+            stats.selected_dictionary_entries += decoded.selected_entries;
+            stats.decompressed_buffer_bytes += decoded.decompressed_bytes;
+            dict_ids.insert(column_index, decoded.ids);
+            decoded.values
+        }
+        ColCodec::CrossDep => {
+            let source_index = cross_dep_source_index(column.payload)?;
+            let Some(source) = directory.columns.get(source_index) else {
+                return Err(StorageError::Other(anyhow::anyhow!(
+                    "cross_dep source index {source_index} out of range"
+                )));
+            };
+            // Current encoder guarantees CROSS_DEP sources remain DICT. Valid
+            // historical/handcrafted chains use the compatibility decoder.
+            if source.codec != ColCodec::DictBitpack {
+                // Unsupported is not an escape hatch for malformed storage:
+                // validate this column's complete body and exception stream
+                // before asking the caller to use the compatibility path.
+                let placeholder_source_ids = vec![0; selected.len()];
+                decode_cross_dep_rows(
+                    column,
+                    selected,
+                    &placeholder_source_ids,
+                    directory.num_docs,
+                    stats,
+                )?;
+                return Ok(Err(column.name.to_string()));
+            }
+            if let std::collections::hash_map::Entry::Vacant(entry) = dict_ids.entry(source_index) {
+                let decoded = decode_dict_rows(source.payload, selected, directory.num_docs)?;
+                stats.selected_dictionary_entries += decoded.selected_entries;
+                stats.decompressed_buffer_bytes += decoded.decompressed_bytes;
+                entry.insert(decoded.ids);
+            }
+            decode_cross_dep_rows(
+                column,
+                selected,
+                &dict_ids[&source_index],
+                directory.num_docs,
+                stats,
+            )?
+        }
+    };
+    stats.selected_json_values += values.len();
+    Ok(Ok(values))
+}
+
+/// Reconstruct only selected ZBS2 documents without the canonical full decode.
+pub fn decode_stored_v2_rows(
+    bytes: &[u8],
+    ordinals: &[usize],
+) -> Result<StoredV2RowHydrationResult> {
+    if bytes.len() < 4 || &bytes[..4] != STORED_V2_MAGIC {
+        return Ok(StoredV2RowHydrationResult::NotV2);
+    }
+    let directory = parse_v2_directory(&bytes[4..])?;
+    let id_index = directory
+        .columns
+        .iter()
+        .position(|column| column.name == "__id")
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 missing __id column")))?;
+    let seq_index = directory
+        .columns
+        .iter()
+        .position(|column| column.name == "__seq_no")
+        .ok_or_else(|| StorageError::Other(anyhow::anyhow!("v2 missing __seq_no column")))?;
+    let mut selected = ordinals.to_vec();
+    selected.sort_unstable();
+    selected.dedup();
+    if selected
+        .iter()
+        .any(|ordinal| *ordinal >= directory.num_docs)
+    {
+        return Err(StorageError::Other(anyhow::anyhow!(
+            "selected row outside stored section"
+        )));
+    }
+    if selected.is_empty() {
+        return Ok(StoredV2RowHydrationResult::Hydrated {
+            rows: Vec::new(),
+            stats: StoredV2RowHydrationStats::default(),
+        });
+    }
+    let mut stats = StoredV2RowHydrationStats::default();
+    let mut columns = Vec::with_capacity(directory.columns.len());
+    let mut dict_ids = HashMap::new();
+    for index in 0..directory.columns.len() {
+        match select_column_rows(index, &directory, &selected, &mut stats, &mut dict_ids)? {
+            Ok(values) => columns.push(values),
+            Err(column) => {
+                return Ok(StoredV2RowHydrationResult::UnsupportedDependencyShape { column });
+            }
+        }
+    }
+    let mut rows = Vec::with_capacity(selected.len());
+    for (selected_index, ordinal) in selected.into_iter().enumerate() {
+        let mut source = serde_json::Map::new();
+        for (column_index, column) in directory.columns.iter().enumerate() {
+            if column_index == id_index || column_index == seq_index {
+                continue;
+            }
+            let value = columns[column_index][selected_index].clone();
+            if !value.is_null() {
+                source.insert(column.name.to_string(), value);
+                stats.output_values_cloned += 1;
+            }
+        }
+        stats.output_values_cloned += 2;
+        rows.push(StoredV2HydratedRow {
+            ordinal,
+            id: columns[id_index][selected_index].clone(),
+            seq_no: columns[seq_index][selected_index].clone(),
+            source,
+        });
+    }
+    Ok(StoredV2RowHydrationResult::Hydrated { rows, stats })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn assemble(num_docs: usize, columns: &[(&str, ColCodec, Vec<u8>)]) -> Vec<u8> {
+        let mut out = STORED_V2_MAGIC.to_vec();
+        out.write_u32::<LittleEndian>(num_docs as u32).unwrap();
+        out.write_u32::<LittleEndian>(columns.len() as u32).unwrap();
+        for (name, codec, payload) in columns {
+            out.write_u16::<LittleEndian>(name.len() as u16).unwrap();
+            out.extend_from_slice(name.as_bytes());
+            out.push(*codec as u8);
+            out.write_u32::<LittleEndian>(payload.len() as u32).unwrap();
+            out.extend_from_slice(payload);
+        }
+        out
+    }
+
+    fn raw(values: &[serde_json::Value]) -> Vec<u8> {
+        zstd::encode_all(
+            Cursor::new(serde_json::to_vec(values).unwrap()),
+            STORED_ZSTD_LEVEL,
+        )
+        .unwrap()
+    }
+
+    fn fixture(n: usize, body_codec: ColCodec) -> Vec<u8> {
+        let ids: Vec<_> = (0..n).map(|i| json!(format!("doc-{i}"))).collect();
+        let seq: Vec<_> = (0..n).map(|i| json!(i)).collect();
+        let body: Vec<_> = (0..n)
+            .map(|i| json!({"row": i, "text": format!("payload-{i}")}))
+            .collect();
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+        let body_payload = match body_codec {
+            ColCodec::RawJson => zstd::encode_all(Cursor::new(body_bytes), 3).unwrap(),
+            ColCodec::Lz4Json => lz4_flex::compress_prepend_size(&body_bytes),
+            _ => unreachable!(),
+        };
+        assemble(
+            n,
+            &[
+                ("__id", ColCodec::RawJson, raw(&ids)),
+                ("__seq_no", ColCodec::RawJson, raw(&seq)),
+                ("body", body_codec, body_payload),
+            ],
+        )
+    }
+
+    #[test]
+    fn raw_and_lz4_select_rows_and_reject_trailing_json() {
+        for codec in [ColCodec::RawJson, ColCodec::Lz4Json] {
+            let encoded = fixture(128, codec);
+            let StoredV2RowHydrationResult::Hydrated { rows, stats } =
+                decode_stored_v2_rows(&encoded, &[127, 0, 7, 7]).unwrap()
+            else {
+                panic!("expected hydration")
+            };
+            assert_eq!(
+                rows.iter().map(|row| row.ordinal).collect::<Vec<_>>(),
+                [0, 7, 127]
+            );
+            assert_eq!(rows[1].source["body"]["row"], 7);
+            assert_eq!(stats.output_values_cloned, 9);
+            if codec == ColCodec::Lz4Json {
+                assert!(stats.decompressed_buffer_bytes > 0);
+            }
+        }
+
+        let mut bad_values = serde_json::to_vec(&vec![json!("x"); 4]).unwrap();
+        bad_values.extend_from_slice(b"[]");
+        let bad = assemble(
+            4,
+            &[
+                ("__id", ColCodec::RawJson, raw(&vec![json!("x"); 4])),
+                ("__seq_no", ColCodec::RawJson, raw(&vec![json!(0); 4])),
+                (
+                    "bad",
+                    ColCodec::Lz4Json,
+                    lz4_flex::compress_prepend_size(&bad_values),
+                ),
+            ],
+        );
+        assert!(decode_stored_v2_rows(&bad, &[0]).is_err());
+    }
+
+    #[test]
+    fn dictionary_nulls_boundaries_and_corruption_are_validated() {
+        let values = vec![json!("a"), json!("b"), json!("c")];
+        let ids = vec![0, 1, 3, 2, 0, 3, 1, 2];
+        let encoded = assemble(
+            ids.len(),
+            &[
+                (
+                    "__id",
+                    ColCodec::DictBitpack,
+                    encode_dict_bitpack(&values, &ids),
+                ),
+                (
+                    "__seq_no",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!(9)).unwrap(),
+                ),
+            ],
+        );
+        let StoredV2RowHydrationResult::Hydrated { rows, stats } =
+            decode_stored_v2_rows(&encoded, &[0, 2, 7]).unwrap()
+        else {
+            panic!("expected hydration")
+        };
+        assert_eq!(rows[0].id, "a");
+        assert!(rows[1].id.is_null());
+        assert_eq!(rows[2].id, "c");
+        assert_eq!(stats.selected_dictionary_entries, 2);
+
+        for width in 1..=32 {
+            let max = if width == 32 {
+                u32::MAX
+            } else {
+                (1u32 << width) - 1
+            };
+            let packed = bitpack_u32(&[0, max, max / 2], width);
+            assert_eq!(unpack_id(&packed, width, 1), Some(max));
+            assert_eq!(unpack_id(&packed, width, 2), Some(max / 2));
+            assert_eq!(unpack_id(&packed[..packed.len() - 1], width, 2), None);
+        }
+
+        let mut corrupt = encode_dict_bitpack(&[json!("only")], &[0, 0, 0]);
+        // Rebuild the packed stream with id=3, which is outside {entry,null}.
+        let dict_len = u32::from_le_bytes(corrupt[5..9].try_into().unwrap()) as usize;
+        let packed_offset = 9 + dict_len + 8;
+        let bad_packed = zstd::encode_all(Cursor::new(bitpack_u32(&[0, 3, 0], 2)), 3).unwrap();
+        corrupt.truncate(packed_offset);
+        corrupt.extend_from_slice(&bad_packed);
+        corrupt[4] = 2;
+        let length_offset = 9 + dict_len + 4;
+        corrupt[length_offset..length_offset + 4]
+            .copy_from_slice(&(bad_packed.len() as u32).to_le_bytes());
+        let bad = assemble(
+            3,
+            &[
+                ("__id", ColCodec::DictBitpack, corrupt),
+                (
+                    "__seq_no",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!(0)).unwrap(),
+                ),
+            ],
+        );
+        assert!(decode_stored_v2_rows(&bad, &[0]).is_err());
+
+        let mut padding = encode_dict_bitpack(&[json!("only")], &[0, 0, 0]);
+        let dict_len = u32::from_le_bytes(padding[5..9].try_into().unwrap()) as usize;
+        let packed_length_offset = 9 + dict_len + 4;
+        let packed_offset = packed_length_offset + 4;
+        let mut unpacked = zstd::decode_all(&padding[packed_offset..]).unwrap();
+        unpacked[0] |= 0b1000_0000;
+        let repacked = zstd::encode_all(Cursor::new(unpacked), 3).unwrap();
+        padding.truncate(packed_offset);
+        padding.extend_from_slice(&repacked);
+        padding[packed_length_offset..packed_offset]
+            .copy_from_slice(&(repacked.len() as u32).to_le_bytes());
+        let bad_padding = assemble(
+            3,
+            &[
+                ("__id", ColCodec::DictBitpack, padding),
+                (
+                    "__seq_no",
+                    ColCodec::Constant,
+                    serde_json::to_vec(&json!(0)).unwrap(),
+                ),
+            ],
+        );
+        assert!(decode_stored_v2_rows(&bad_padding, &[0]).is_err());
+    }
+
+    #[test]
+    fn selection_validation_empty_fast_path_and_fixed_r_work() {
+        assert!(matches!(
+            decode_stored_v2_rows(b"plain", &[0]).unwrap(),
+            StoredV2RowHydrationResult::NotV2
+        ));
+        let encoded = fixture(128, ColCodec::RawJson);
+        assert!(decode_stored_v2_rows(&encoded, &[128]).is_err());
+        let StoredV2RowHydrationResult::Hydrated { rows, stats } =
+            decode_stored_v2_rows(&encoded, &[]).unwrap()
+        else {
+            panic!("expected hydration")
+        };
+        assert!(rows.is_empty());
+        assert_eq!(stats, StoredV2RowHydrationStats::default());
+
+        let small = decode_stored_v2_rows(&fixture(128, ColCodec::RawJson), &[1, 9, 17]).unwrap();
+        let large = decode_stored_v2_rows(&fixture(1024, ColCodec::RawJson), &[1, 9, 17]).unwrap();
+        let selected = |result| match result {
+            StoredV2RowHydrationResult::Hydrated { rows, stats } => (
+                rows.len(),
+                stats.selected_json_values,
+                stats.output_values_cloned,
+            ),
+            _ => panic!("expected hydration"),
+        };
+        assert_eq!(selected(small), selected(large));
+    }
+
+    #[test]
+    fn malformed_framing_and_unsupported_dependency_are_explicit() {
+        let encoded = fixture(4, ColCodec::RawJson);
+        assert!(decode_stored_v2_rows(&encoded[..encoded.len() - 1], &[0]).is_err());
+
+        let valid_cross_dep = |source_index: u32| {
+            let mut bytes = vec![0];
+            bytes.extend_from_slice(&source_index.to_le_bytes());
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes.extend_from_slice(&0u32.to_le_bytes());
+            bytes
+        };
+        let unsupported = assemble(
+            1,
+            &[
+                ("__id", ColCodec::RawJson, raw(&[json!("a")])),
+                ("__seq_no", ColCodec::RawJson, raw(&[json!(0)])),
+                ("dep", ColCodec::CrossDep, valid_cross_dep(0)),
+            ],
+        );
+        assert!(matches!(
+            decode_stored_v2_rows(&unsupported, &[0]).unwrap(),
+            StoredV2RowHydrationResult::UnsupportedDependencyShape { .. }
+        ));
+
+        let malformed = assemble(
+            1,
+            &[
+                ("__id", ColCodec::RawJson, raw(&[json!("a")])),
+                ("__seq_no", ColCodec::RawJson, raw(&[json!(0)])),
+                ("dep", ColCodec::CrossDep, vec![0, 0, 0, 0, 0]),
+            ],
+        );
+        assert!(decode_stored_v2_rows(&malformed, &[0]).is_err());
+    }
+
+    #[test]
+    fn selected_cross_dep_exceptions_and_nulls_match_full_semantics() {
+        let mut dependent = vec![0];
+        dependent.extend_from_slice(&0u32.to_le_bytes()); // source column
+        dependent.extend_from_slice(&2u32.to_le_bytes());
+        dependent.extend_from_slice(&10i64.to_le_bytes());
+        dependent.extend_from_slice(&20i64.to_le_bytes());
+        dependent.extend_from_slice(&2u32.to_le_bytes());
+        write_varint(&mut dependent, 1);
+        write_zigzag_i64(&mut dependent, i64::MIN + 1);
+        write_varint(&mut dependent, 2);
+        write_zigzag_i64(&mut dependent, 99);
+        let encoded = assemble(
+            4,
+            &[
+                (
+                    "__id",
+                    ColCodec::DictBitpack,
+                    encode_dict_bitpack(&[json!("a"), json!("b")], &[0, 1, 0, 1]),
+                ),
+                ("__seq_no", ColCodec::CrossDep, dependent),
+            ],
+        );
+        let StoredV2RowHydrationResult::Hydrated { rows, .. } =
+            decode_stored_v2_rows(&encoded, &[0, 1, 2, 3]).unwrap()
+        else {
+            panic!("expected hydration")
+        };
+        let canonical: Vec<serde_json::Value> =
+            serde_json::from_slice(&decode_stored(&encoded).unwrap()).unwrap();
+        for (row, full) in rows.iter().zip(&canonical) {
+            assert_eq!(row.id, full["_id"]);
+            assert_eq!(row.seq_no, full["_seq_no"]);
+            assert_eq!(
+                serde_json::Value::Object(row.source.clone()),
+                full["_source"]
+            );
+        }
+        assert_eq!(rows[0].seq_no, 10);
+        assert!(rows[1].seq_no.is_null());
+        assert_eq!(rows[2].seq_no, 10);
+        assert_eq!(rows[3].seq_no, 99);
+    }
+
+    #[test]
+    fn adaptive_encoder_rows_match_canonical_decode_across_source_shapes() {
+        let sources: Vec<_> = (0..256)
+            .map(|i| {
+                json!({
+                    "company": if i % 3 == 0 { "Acme" } else { "Globex" },
+                    "quarter": (i % 4) + 1,
+                    "constant": true,
+                    "nested": {"amount": i as f64 / 7.0, "tags": ["finance", i]},
+                    "nullable": if i % 11 == 0 { serde_json::Value::Null } else { json!(i % 5) }
+                })
+            })
+            .collect();
+        let ids: Vec<_> = (0..256).map(|i| format!("doc-{i}")).collect();
+        let docs: Vec<_> = (0..256)
+            .map(|i| (ids[i].as_str(), i as u64, &sources[i]))
+            .collect();
+        let encoded = encode_stored_v2_from_values_nojson(&docs);
+        assert_eq!(&encoded[..4], STORED_V2_MAGIC);
+        let full: Vec<serde_json::Value> =
+            serde_json::from_slice(&decode_stored(&encoded).unwrap()).unwrap();
+        let selected = [0, 7, 42, 128, 255];
+        let StoredV2RowHydrationResult::Hydrated { rows, .. } =
+            decode_stored_v2_rows(&encoded, &selected).unwrap()
+        else {
+            panic!("current encoder must have a selectively supported dependency shape")
+        };
+        for (row, ordinal) in rows.iter().zip(selected) {
+            assert_eq!(row.id, full[ordinal]["_id"]);
+            assert_eq!(row.seq_no, full[ordinal]["_seq_no"]);
+            assert_eq!(
+                serde_json::Value::Object(row.source.clone()),
+                full[ordinal]["_source"]
+            );
+        }
+    }
+}

--- a/engine/reports/2026-07-27_bounded_stored_projection.md
+++ b/engine/reports/2026-07-27_bounded_stored_projection.md
@@ -6,7 +6,7 @@ This report measures the storage primitive only. It does not claim an
 end-to-end engine speedup or cache-memory reduction because no engine consumer
 is included in this branch.
 
-- Source commit: `b3776019cf9d100c66c9dfde6ee005651822ebee`
+- Source commit: `c7c4cfedcc5dafaa048996951400f02b46eaf99c`
 - Upstream base: `c2020229e70c2041c6d0b199c79a3c76ffb5e04f`
 - Probe source SHA-256:
   `86326cab5a4e2f7f2fb141d081855ac8ba790a3403f9103a973732a19c109953`

--- a/engine/reports/2026-07-27_bounded_stored_projection.md
+++ b/engine/reports/2026-07-27_bounded_stored_projection.md
@@ -6,7 +6,7 @@ This report measures the storage primitive only. It does not claim an
 end-to-end engine speedup or cache-memory reduction because no engine consumer
 is included in this branch.
 
-- Source commit: `0d28f07453e206516c7390c019c1dec45c7d52be`
+- Source commit: `031e9cc9286d8e8970704438acebef93f5ab72a8`
 - Upstream base: `16d6df0`
 - Probe source SHA-256:
   `86326cab5a4e2f7f2fb141d081855ac8ba790a3403f9103a973732a19c109953`
@@ -108,7 +108,7 @@ measured.
 
 ```text
 cargo test -p xerj-storage --lib
-121 passed; 0 failed; 0 ignored
+122 passed; 0 failed; 0 ignored
 
 cargo clippy -p xerj-storage --all-targets -- -D warnings
 passed

--- a/engine/reports/2026-07-27_bounded_stored_projection.md
+++ b/engine/reports/2026-07-27_bounded_stored_projection.md
@@ -6,8 +6,8 @@ This report measures the storage primitive only. It does not claim an
 end-to-end engine speedup or cache-memory reduction because no engine consumer
 is included in this branch.
 
-- Source commit: `c7c4cfedcc5dafaa048996951400f02b46eaf99c`
-- Upstream base: `c2020229e70c2041c6d0b199c79a3c76ffb5e04f`
+- Source commit: `0d28f07453e206516c7390c019c1dec45c7d52be`
+- Upstream base: `16d6df0`
 - Probe source SHA-256:
   `86326cab5a4e2f7f2fb141d081855ac8ba790a3403f9103a973732a19c109953`
 - Probe: `crates/xerj-storage/examples/stored_projection_probe.rs`

--- a/engine/reports/2026-07-27_bounded_stored_projection.md
+++ b/engine/reports/2026-07-27_bounded_stored_projection.md
@@ -1,0 +1,118 @@
+# Bounded stored projection probe — 2026-07-27
+
+## Scope and source
+
+This report measures the storage primitive only. It does not claim an
+end-to-end engine speedup or cache-memory reduction because no engine consumer
+is included in this branch.
+
+- Source commit: `b3776019cf9d100c66c9dfde6ee005651822ebee`
+- Upstream base: `c2020229e70c2041c6d0b199c79a3c76ffb5e04f`
+- Probe source SHA-256:
+  `86326cab5a4e2f7f2fb141d081855ac8ba790a3403f9103a973732a19c109953`
+- Probe: `crates/xerj-storage/examples/stored_projection_probe.rs`
+- Rust: `rustc 1.97.1 (8bab26f4f 2026-07-14)`, LLVM 22.1.6
+- Host: x86-64 Linux 6.12.95, 62.8 GiB RAM, no swap
+- Build: release profile; no workspace-wide build and no `cargo clean`
+
+Exact commands, from `engine/`:
+
+```sh
+cargo build --release -j 32 -p xerj-storage --example stored_projection_probe
+probe=target/release/examples/stored_projection_probe
+fixture=/workspace/.tmp/stored-decode-probe/finance-stream-final.zbs2
+"$probe" generate "$fixture" 20000
+sha256sum "$fixture"
+for mode in full row projected; do
+  for run in 1 2 3; do
+    "$probe" "$mode" "$fixture" "/workspace/.tmp/stored-decode-probe/${mode}-stream-final-${run}.json"
+  done
+  sha256sum /workspace/.tmp/stored-decode-probe/${mode}-stream-final-*.json
+done
+for run in 1 2 3; do
+  "$probe" zstd-compare 20
+done
+```
+
+The deterministic fixture contains 20,000 finance-like rows and 86,834,777
+bytes of input JSON. Its encoded size is **137,876 bytes** and its SHA-256 is
+`71aef08c71077cec61a2482a3d8089571007f5167e7fa6a0b1d89b6b6f25e76d`.
+This supersedes the earlier 139,062/139,064-byte scratch fixtures; neither is
+evidence for this source commit.
+
+## Decode results
+
+All nine canonical output files have the same 4,225-byte content and SHA-256:
+`d505b2317c26eec30cf7ff40604d37a5b54986b652bb7348730c5d7ce5d2b35d`.
+This is the equality check between full decode, selective row hydration, and
+selective row-plus-field projection.
+
+| Mode | Wall µs, run 1 | Run 2 | Run 3 | Median | Peak RSS range |
+|---|---:|---:|---:|---:|---:|
+| Full | 352,653 | 327,372 | 336,715 | 336,715 | 334,647,296–337,702,912 |
+| One row | 1,350,147 | 1,454,028 | 1,392,531 | 1,392,531 | 5,636,096–5,742,592 |
+| One row, `body` only | 1,410,533 | 1,360,279 | 1,356,389 | 1,360,279 | 5,500,928–5,644,288 |
+
+Raw probe output:
+
+```text
+mode=full rows=20000 decoded_bytes=86832275 output_bytes=4225 wall_us=352653 cpu_ticks=35 peak_rss_bytes=336138240
+mode=full rows=20000 decoded_bytes=86832275 output_bytes=4225 wall_us=327372 cpu_ticks=32 peak_rss_bytes=334647296
+mode=full rows=20000 decoded_bytes=86832275 output_bytes=4225 wall_us=336715 cpu_ticks=33 peak_rss_bytes=337702912
+mode=row rows=1 output_bytes=4225 visited=80000 selected_values=8 decompressed_bytes=47264 wall_us=1350147 cpu_ticks=135 peak_rss_bytes=5636096
+mode=row rows=1 output_bytes=4225 visited=80000 selected_values=8 decompressed_bytes=47264 wall_us=1454028 cpu_ticks=144 peak_rss_bytes=5689344
+mode=row rows=1 output_bytes=4225 visited=80000 selected_values=8 decompressed_bytes=47264 wall_us=1392531 cpu_ticks=139 peak_rss_bytes=5742592
+mode=projected rows=1 output_bytes=4225 visited=60000 selected_values=3 decompressed_bytes=0 wall_us=1410533 cpu_ticks=140 peak_rss_bytes=5517312
+mode=projected rows=1 output_bytes=4225 visited=60000 selected_values=3 decompressed_bytes=0 wall_us=1360279 cpu_ticks=136 peak_rss_bytes=5500928
+mode=projected rows=1 output_bytes=4225 visited=60000 selected_values=3 decompressed_bytes=0 wall_us=1356389 cpu_ticks=135 peak_rss_bytes=5644288
+```
+
+Raw logical-work counters:
+
+- One row: 80,000 encoded rows visited, 8 selected JSON values, 47,264
+  decompressed buffer bytes.
+- One row plus field projection: 60,000 encoded rows visited, 3 selected JSON
+  values, zero whole-column decompressed-buffer bytes.
+
+Interpretation: selective hydration cuts peak RSS by roughly 59x, but is about
+4x slower in this RAW-column fixture because streaming JSON still visits O(N)
+rows. That is a useful bounded-memory primitive, not a latency win. LZ4 columns
+still require whole-column decompression before row selection. A single giant
+selected cell is not globally budgeted by this API.
+
+`VmHWM` comes from `/proc/self/status`; CPU is reported by the probe as Linux
+process ticks. Fresh processes are used for each measurement.
+
+## Stream `encode_all` versus bulk zstd
+
+Each cell below is one process timing 20 compression/decompression iterations.
+The three raw wall-time runs are retained, rather than presenting only a
+favorable aggregate.
+
+| Shape | Input bytes | Stream bytes | Bulk bytes | Stream wall µs (3 runs) | Bulk wall µs (3 runs) |
+|---|---:|---:|---:|---|---|
+| Repeated text | 4,160,000 | 413 | 417 | 53,707 / 55,046 / 55,614 | 86,177 / 82,769 / 91,054 |
+| JSON numbers | 945,611 | 8,507 | 8,510 | 6,671 / 6,920 / 6,876 | 5,216 / 6,251 / 5,290 |
+| Packed IDs | 2,000,000 | 1,335,160 | 1,335,163 | 63,980 / 73,980 / 69,865 | 60,947 / 65,366 / 66,119 |
+
+Bulk frames are 3–4 bytes larger. They are modestly faster for two shapes but
+materially slower for repeated text. Therefore this branch does **not** change
+the production encoder from `zstd::encode_all` to `zstd::bulk::compress`.
+Current stream frames commonly omit a content-size field, so
+`stored_slices_retained_upper_bound` deliberately returns `Ok(None)` and cache
+admission must skip warming. Emitting content-size frames should be evaluated
+with the future cache-resident integration, where its end-to-end benefit can be
+measured.
+
+## Verification
+
+```text
+cargo test -p xerj-storage --lib
+121 passed; 0 failed; 0 ignored
+
+cargo clippy -p xerj-storage --all-targets -- -D warnings
+passed
+
+cargo fmt --all --check
+passed
+```


### PR DESCRIPTION
## Summary

This change adds a storage-level API that hydrates selected document ordinals and selected top-level `_source` fields directly from the existing ZBS2 stored format without reconstructing the full canonical JSON array.

It is a bounded-memory primitive for late materialization. It preserves exact selected bytes and supports every current ZBS2 codec, sparse fields, nested values, cross-column dependencies, malformed-input errors, cancellation, V1 compatibility fallback, and checked allocation behavior.

This branch does not connect the primitive to an engine search route and does not claim an end-to-end speedup. A dependent engine change integrates point GET and publish-time admission through the shared segment-hydration budget.

## Why this is needed

The existing `decode_stored_v2` path decodes every column into `Vec<Value>` and reconstructs the complete canonical stored JSON array even when a caller needs one document or a few fields.

On the deterministic 20,000-row probe, the canonical decoded representation is 86,832,275 bytes while the encoded section is 137,876 bytes. Full decode reached roughly 335–338 MB peak RSS. Hydrating one exact row used roughly 5.6–5.7 MB RSS.

The large reduction comes from retaining only selected values. RAW/zstd selection still streams through all rows, so this is a memory win rather than a latency win.

## What changes

### Selected row hydration

The new decoder accepts selected document ordinals, normalizes their ordering, removes duplicate ordinals, and returns exact selected stored documents without building the full stored corpus.

### Top-level field projection

Callers may request selected top-level `_source` fields. Identity and sequence metadata remain available for exact document reconstruction and provenance.

### Codec coverage

The implementation handles:

- raw JSON columns;
- LZ4 JSON columns;
- constants;
- dictionary plus bit-packed IDs;
- cross-column dependencies;
- typed vector and chunk representations;
- V1/plain and full-decode compatibility fallback.

### Controlled cancellation

Long row paths check cancellation every 128 consumed or produced rows. This includes invalid/nonfinite vector rows and repeated constant vectors/chunks.

Constant selected-row hydration uses fallible incremental allocation instead of eager `vec![value; selected.len()]`. Tests prove cancellation at output 128, normal parity, ordinal normalization, duplicate handling, and deterministic capacity failure.

### Checked malformed-input behavior

Directory column counts are validated against minimum remaining framing before allocation. Header-sized vectors, sets, row outputs, constant expansion, dependency structures, dictionary entries, packed IDs, and exception lists use checked arithmetic and fallible reservation.

Unknown-size historical zstd frames remain readable through the compatibility path, but the retained-size upper-bound API returns `None` so a cache can skip predecode admission rather than guessing.

### Conservative retained upper bound

`stored_slices_retained_upper_bound` inspects framing without performing full decode and returns a conservative bound when the encoded representation provides enough information. Callers can reserve or refuse before materializing a complete stored-slice cache entry.

## Measured result

The committed release probe uses a deterministic 20,000-row finance-like fixture.

- Fixture encoded size: `137,876` bytes.
- Fixture SHA-256: `71aef08c71077cec61a2482a3d8089571007f5167e7fa6a0b1d89b6b6f25e76d`.
- All nine full, selected-row, and field-projected outputs have SHA-256 `d505b2317c26eec30cf7ff40604d37a5b54986b652bb7348730c5d7ce5d2b35d`.

| Mode | Median wall time | Peak RSS range |
|---|---:|---:|
| Full decode | 336.715 ms | 334,647,296–337,702,912 bytes |
| One exact row | 1,392.531 ms | 5,636,096–5,742,592 bytes |
| One row, `body` only | 1,360.279 ms | 5,500,928–5,644,288 bytes |

Selected hydration used roughly 59 times less peak RSS on this fixture but was roughly four times slower because RAW/zstd decoding still visits O(rows). The PR intentionally describes this as a bounded-memory fallback, not a query-latency improvement.

## Why production zstd encoding is unchanged

The probe compared the existing streaming encoder with bulk zstd across repeated text, JSON numbers, and packed IDs.

- Bulk output was 3–4 bytes larger in every measured shape.
- Bulk was modestly faster on two shapes.
- Bulk was materially slower on repeated text.

There was no universal win, so this branch retains `zstd::encode_all`. Current streaming frames may omit content size; the bound API fails closed for those frames.

## Reproduction

From `engine/`:

```bash
cargo build --release -j 32 -p xerj-storage --example stored_projection_probe
probe=target/release/examples/stored_projection_probe
fixture=/workspace/.tmp/stored-decode-probe/finance-stream-final.zbs2
"$probe" generate "$fixture" 20000
sha256sum "$fixture"
for mode in full row projected; do
  for run in 1 2 3; do
    "$probe" "$mode" "$fixture" "/workspace/.tmp/stored-decode-probe/${mode}-stream-final-${run}.json"
  done
  sha256sum /workspace/.tmp/stored-decode-probe/${mode}-stream-final-*.json
done
for run in 1 2 3; do
  "$probe" zstd-compare 20
done
```

The raw outputs, environment, source identity, commands, and all hashes are committed in `engine/reports/2026-07-27_bounded_stored_projection.md`.

## Verification

- `cargo test -p xerj-storage --lib`: `122 passed / 0 failed`;
- `cargo clippy -p xerj-storage --all-targets -- -D warnings`: passed;
- `cargo fmt --all --check`: passed;
- diff check: passed;
- current-main ancestry: passed;
- independent Grok review of the final cancellation delta: approved.

## Tradeoffs and non-claims

- RAW/zstd selected reads still perform O(rows) work.
- LZ4 selected reads decompress the complete column buffer before selection.
- Cancellation cannot interrupt a single giant JSON cell or one decompressor call.
- A selected giant value is not governed by a process-wide byte reservation in this storage-only API.
- Current stream-zstd frames often provide no conservative predecode bound, so cache warming must skip rather than guess.
- This branch does not change an engine route, server RSS, autoindex timing, retrieval quality, or FinanceBench results.

The dependent engine contribution routes exact point GET and publish-time predecode refusal through the shared process-wide cache budget. Semantic winner hydration and the 10K/FinanceBench end-to-end gates follow separately.