### PR TITLE
# feat(search): return the winning semantic passage

### DIFF
--- a/docs/recipes/passage-retrieval.md
+++ b/docs/recipes/passage-retrieval.md
@@ -54,6 +54,24 @@ curl -sX POST "$XERJ_URL/docs/_search" -H 'content-type: application/json' -d '{
 }'
 ```
 
+Ask for the winning passage through the standard `fields` mechanism:
+
+```bash
+curl -sX POST "$XERJ_URL/docs/_search" -H 'content-type: application/json' -d '{
+  "fields": ["_passage"],
+  "_source": {"includes": ["file", "page"]},
+  "query": { "semantic": { "field": "body",
+                           "query": "how does chlorophyll drive photosynthesis",
+                           "k": 10 } }
+}'
+```
+
+Each hit then carries `fields._passage[0]` with the original semantic field,
+zero-based passage ordinal, UTF-8 byte offsets, winning text, and numeric PDF
+`page` when the source has one. `_passage` is opt-in: ordinary responses are
+unchanged. XERJ stores only compact offsets alongside the derived vectors; it
+does not store a second copy of the passage text.
+
 The document is retrieved on the strength of the one passage that matches —
 even if the rest of it is about something else entirely.
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -2087,7 +2087,8 @@ pub async fn get_doc(
     };
 
     match idx.get_document(&id).await {
-        Ok(Some(source)) => {
+        Ok(Some(mut source)) => {
+            xerj_query::executor::strip_internal_passage_metadata(&mut source);
             // Apply _source filtering based on query params.
             let filtered = apply_get_doc_source_filter(source, &params);
             // Real per-doc metadata (was hardcoded `_version: 1` /
@@ -8620,6 +8621,9 @@ pub async fn search(
                     obj.remove("__xy_collapse_group__");
                     obj.remove("__xy_collapse_spec__");
                     obj.remove("_matched_queries");
+                    obj.retain(|name, _| {
+                        !name.starts_with(xerj_query::executor::PASSAGE_METADATA_PREFIX)
+                    });
                 }
                 // Non-synthetic mode: strip the internal copy-to
                 // tracking marker; keep the copied values in the source
@@ -10169,6 +10173,17 @@ pub async fn search(
                                 other => Value::Array(vec![other]),
                             };
                             fmap.insert(fname.clone(), arr);
+                        }
+                    }
+                }
+                // XERJ's opt-in semantic provenance pseudo-field. Keeping it
+                // under the standard ES `fields` envelope preserves the
+                // default hit wire shape and lets ES clients request it
+                // without a separate response dialect.
+                if field_specs.iter().any(|(name, _, _)| name == "_passage") {
+                    if let Some(passage) = &h.passage {
+                        if let Ok(value) = serde_json::to_value(passage) {
+                            fmap.insert("_passage".to_string(), Value::Array(vec![value]));
                         }
                     }
                 }

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -29,6 +29,15 @@ use crate::{
     state::AppState,
 };
 
+fn passage_fields(hit: &xerj_query::executor::Hit) -> Option<HashMap<String, Value>> {
+    let passage = hit.passage.as_ref()?;
+    let value = serde_json::to_value(passage).ok()?;
+    Some(HashMap::from([(
+        xerj_query::executor::PASSAGE_RESPONSE_FIELD.to_string(),
+        Value::Array(vec![value]),
+    )]))
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // GET / — cluster info
 // ─────────────────────────────────────────────────────────────────────────────
@@ -4633,6 +4642,12 @@ fn build_search_request(
     if let Some(ref tth) = body.track_total_hits {
         query_body["track_total_hits"] = tth.clone();
     }
+    // Preserve every accepted ES `fields` wire shape. The query parser
+    // normalizes scalar, string-array, and `{field: ...}` entries into names
+    // used by engine-owned pseudo-fields such as `_passage`.
+    if let Some(ref fields) = body.fields {
+        query_body["fields"] = fields.clone();
+    }
 
     let mut req = parse_request(&query_body)
         .map_err(|e| xerj_common::XerjError::invalid_query(e.to_string()))?;
@@ -4738,22 +4753,6 @@ fn build_search_request(
     // script is evaluated per hit against the hit's source in the search
     // handler's fields-building closure and merged into the hit's `fields`.
     req.script_fields = body.script_fields.clone();
-
-    // Forward fields request.
-    if let Some(fields_val) = &body.fields {
-        match fields_val {
-            Value::Array(arr) => {
-                req.fields = arr
-                    .iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect();
-            }
-            Value::String(s) => {
-                req.fields = vec![s.clone()];
-            }
-            _ => {}
-        }
-    }
 
     // track_total_hits is already forwarded via the JSON blob above.
 
@@ -15036,7 +15035,7 @@ pub async fn search_with_scroll(
                 } else {
                     Some(h.source.clone())
                 },
-                fields: None,
+                fields: passage_fields(h),
                 sort: if h.sort.is_empty() {
                     None
                 } else {
@@ -15090,12 +15089,18 @@ pub async fn search_with_scroll(
             "hits": {
                 "total": { "value": total_count, "relation": "eq" },
                 "max_score": first_page.first().and_then(|h| h.score),
-                "hits": first_page.iter().map(|h| json!({
-                    "_index": h.index,
-                    "_id": h.id,
-                    "_score": h.score,
-                    "_source": h.source,
-                })).collect::<Vec<_>>()
+                "hits": first_page.iter().map(|h| {
+                    let mut hit = json!({
+                        "_index": h.index,
+                        "_id": h.id,
+                        "_score": h.score,
+                        "_source": h.source,
+                    });
+                    if let Some(fields) = &h.fields {
+                        hit["fields"] = serde_json::to_value(fields).unwrap_or(Value::Null);
+                    }
+                    hit
+                }).collect::<Vec<_>>()
             }
         });
         return Json(resp).into_response();
@@ -15120,7 +15125,7 @@ pub async fn search_with_scroll(
             } else {
                 Some(h.source.clone())
             },
-            fields: None,
+            fields: passage_fields(h),
             sort: if h.sort.is_empty() {
                 None
             } else {
@@ -15257,7 +15262,7 @@ pub async fn next_scroll(
                     } else {
                         Some(h.source.clone())
                     },
-                    fields: None,
+                    fields: passage_fields(h),
                     sort: if h.sort.is_empty() {
                         None
                     } else {
@@ -15311,6 +15316,12 @@ pub async fn next_scroll(
                         if let Some(sort) = &h.sort {
                             o.insert("sort".to_string(), Value::Array(sort.clone()));
                         }
+                        if let Some(fields) = &h.fields {
+                            o.insert(
+                                "fields".to_string(),
+                                serde_json::to_value(fields).unwrap_or(Value::Null),
+                            );
+                        }
                         Value::Object(o)
                     }).collect::<Vec<_>>()
                 }
@@ -15323,6 +15334,153 @@ pub async fn next_scroll(
             Json(resp).into_response()
         }
         None => search_context_missing(&scroll_id),
+    }
+}
+
+#[cfg(test)]
+mod passage_scroll_tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use std::time::{Duration, Instant};
+    use tower::ServiceExt;
+    use xerj_query::executor::{Hit, PassageMatch};
+
+    fn test_state() -> AppState {
+        let dir = tempfile::tempdir().expect("tempdir").keep();
+        let mut config = xerj_common::config::Config::default();
+        config.server.data_dir = dir.to_string_lossy().into_owned();
+        config.storage.wal_sync = xerj_common::config::WalSync::Async;
+        let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+        let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+        AppState::new(config, engine, metrics)
+    }
+
+    fn passage_hit(id: &str, ordinal: u32) -> Hit {
+        Hit {
+            id: id.to_string(),
+            score: 1.0,
+            source: json!({"company": "ACME"}),
+            sort: Vec::new(),
+            explain: None,
+            highlight: None,
+            matched_queries: Vec::new(),
+            passage: Some(PassageMatch {
+                field: "content".into(),
+                ordinal,
+                start_offset: 0,
+                end_offset: 8,
+                text: "evidence".into(),
+                page: Some(u64::from(ordinal) + 1),
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn scroll_continuation_preserves_opted_in_passage_fields() {
+        let state = test_state();
+        let scroll_id = Uuid::new_v4().to_string();
+        let now = Instant::now();
+        state.engine.scrolls.insert(
+            scroll_id.clone(),
+            xerj_engine::engine::ScrollContext {
+                index: "reports".into(),
+                hits: vec![passage_hit("page-1", 0), passage_hit("page-2", 1)],
+                position: 1,
+                page_size: 1,
+                created: now,
+                keep_alive: Duration::from_secs(60),
+                expires_at: now + Duration::from_secs(60),
+            },
+        );
+        let app = crate::router::build_es_compat_router(state);
+        let response = app
+            .oneshot(
+                Request::post("/_search/scroll")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"scroll_id": scroll_id}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["hits"]["hits"][0]["_id"], "page-2");
+        assert_eq!(
+            body["hits"]["hits"][0]["fields"]["_passage"][0]["ordinal"],
+            1
+        );
+        assert_eq!(body["hits"]["hits"][0]["fields"]["_passage"][0]["page"], 2);
+    }
+
+    #[tokio::test]
+    async fn passage_field_scalar_array_and_object_forms_reach_the_engine() {
+        let state = test_state();
+        let mut schema = Schema::empty();
+        let mut content = FieldConfig::new("content", FieldType::Text);
+        content.options.dimensions = Some(32);
+        content.embedding = Some(xerj_common::types::EmbeddingConfig {
+            endpoint: None,
+            model: None,
+            target_field: Some("embedding".into()),
+        });
+        schema.fields.push(content);
+        state.engine.create_index("passage-fields", schema).unwrap();
+        let index = state.engine.get_index("passage-fields").unwrap();
+        index
+            .index_document(
+                Some("report-page".into()),
+                json!({
+                    "content": format!(
+                        "{} quarterly zephyr liquidity evidence {}",
+                        "operating narrative ".repeat(50),
+                        "tax footnote ".repeat(50)
+                    ),
+                    "page": 7
+                }),
+            )
+            .await
+            .unwrap();
+        index.refresh().await.unwrap();
+        let app = crate::router::build_es_compat_router(state);
+
+        for fields in [
+            json!("_passage"),
+            json!(["_passage"]),
+            json!([{"field": "_passage"}]),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::post("/passage-fields/_search")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            json!({
+                                "fields": fields,
+                                "query": {"semantic": {
+                                    "field": "content",
+                                    "query": "quarterly zephyr liquidity evidence",
+                                    "k": 1
+                                }}
+                            })
+                            .to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(
+                body["hits"]["hits"][0]["fields"]["_passage"][0]["page"], 7,
+                "fields form {fields} did not propagate: {body}"
+            );
+        }
     }
 }
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -15482,6 +15482,109 @@ mod passage_scroll_tests {
             );
         }
     }
+
+    async fn assert_ambiguous_passage_query_is_actionable_400(app: &axum::Router, body: Value) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/passage-composition/_search")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "ambiguous passage ownership must be a caller-fixable 400, not a 500"
+        );
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["status"], 400, "{body}");
+        let reason = body["error"]["reason"].as_str().unwrap_or_default();
+        assert!(
+            reason.contains("one unambiguous winning passage"),
+            "error must explain why provenance is ambiguous: {body}"
+        );
+        assert!(
+            reason.contains("request `_passage` only with a single semantic/kNN clause")
+                && reason.contains("omit `_passage` for fusion"),
+            "error must tell the caller how to fix the request: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ambiguous_multi_knn_passage_requests_are_http_400_in_both_orders() {
+        let state = test_state();
+        state
+            .engine
+            .create_index("passage-composition", Schema::empty())
+            .unwrap();
+        let app = crate::router::build_es_compat_router(state);
+        let knn_a = json!({
+            "field": "embedding_a",
+            "query_vector": [1.0, 0.0],
+            "k": 10
+        });
+        let knn_b = json!({
+            "field": "embedding_b",
+            "query_vector": [0.0, 1.0],
+            "k": 10
+        });
+
+        for knn in [
+            json!([knn_a.clone(), knn_b.clone()]),
+            json!([knn_b.clone(), knn_a.clone()]),
+        ] {
+            assert_ambiguous_passage_query_is_actionable_400(
+                &app,
+                json!({"fields": ["_passage"], "knn": knn}),
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn ambiguous_hybrid_passage_requests_are_http_400_in_both_orders() {
+        let state = test_state();
+        state
+            .engine
+            .create_index("passage-composition", Schema::empty())
+            .unwrap();
+        let app = crate::router::build_es_compat_router(state);
+        let semantic = json!({
+            "query": {
+                "semantic": {
+                    "field": "content",
+                    "query": "quarterly evidence",
+                    "k": 10
+                }
+            }
+        });
+        let lexical = json!({"query": {"match_all": {}}});
+
+        for queries in [
+            json!([semantic.clone(), lexical.clone()]),
+            json!([lexical.clone(), semantic.clone()]),
+        ] {
+            assert_ambiguous_passage_query_is_actionable_400(
+                &app,
+                json!({
+                    "fields": ["_passage"],
+                    "query": {
+                        "hybrid": {
+                            "queries": queries,
+                            "fusion": "rrf"
+                        }
+                    }
+                }),
+            )
+            .await;
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/engine/crates/xerj-api/src/native.rs
+++ b/engine/crates/xerj-api/src/native.rs
@@ -67,6 +67,72 @@ fn default_size() -> usize {
     10
 }
 
+fn native_fields_supported(fields: Option<&[String]>) -> bool {
+    fields.is_none_or(|fields| {
+        fields
+            .iter()
+            .all(|field| field == xerj_query::executor::PASSAGE_RESPONSE_FIELD)
+    })
+}
+
+fn native_hit_value(hit: &xerj_query::executor::Hit) -> Value {
+    let mut value = serde_json::json!({
+        "_id": hit.id,
+        "_score": hit.score,
+        "_source": hit.source,
+    });
+    if let Some(passage) = &hit.passage {
+        value["_passage"] = serde_json::to_value(passage).unwrap_or(Value::Null);
+    }
+    value
+}
+
+#[cfg(test)]
+mod passage_wire_tests {
+    use super::*;
+    use xerj_query::executor::{Hit, PassageMatch};
+
+    fn hit(passage: Option<PassageMatch>) -> Hit {
+        Hit {
+            id: "report-page".to_string(),
+            score: 0.91,
+            source: serde_json::json!({"company": "ACME"}),
+            sort: Vec::new(),
+            explain: None,
+            highlight: None,
+            matched_queries: Vec::new(),
+            passage,
+        }
+    }
+
+    #[test]
+    fn native_fields_accept_only_passage_pseudo_field() {
+        assert!(native_fields_supported(None));
+        assert!(native_fields_supported(Some(&[])));
+        assert!(native_fields_supported(Some(&["_passage".to_string()])));
+        assert!(!native_fields_supported(Some(&["company".to_string()])));
+    }
+
+    #[test]
+    fn native_passage_wire_is_opt_in_and_structured() {
+        let ordinary = native_hit_value(&hit(None));
+        assert!(ordinary.get("_passage").is_none());
+
+        let passage = PassageMatch {
+            field: "content".to_string(),
+            ordinal: 2,
+            start_offset: 320,
+            end_offset: 704,
+            text: "quarterly evidence".to_string(),
+            page: Some(17),
+        };
+        let enriched = native_hit_value(&hit(Some(passage)));
+        assert_eq!(enriched["_passage"]["ordinal"], 2);
+        assert_eq!(enriched["_passage"]["page"], 17);
+        assert_eq!(enriched["_source"], serde_json::json!({"company": "ACME"}));
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct EvolveSchemaRequest {
     pub fields: Vec<FieldConfig>,
@@ -424,8 +490,22 @@ pub async fn search(
     // recorded once at completion via `record_query`.
     let _search_guard = state.metrics.active_search_guard();
 
+    if !native_fields_supported(req.fields.as_deref()) {
+        let error = xerj_common::XerjError::invalid_query(
+            "native search only supports the `_passage` pseudo-field; remove `fields` and read \
+             values from `_source`, request only `_passage`, or use the \
+             Elasticsearch-compatible `_search` endpoint",
+        );
+        return native_error(
+            error,
+            Some(&request_id),
+            started.elapsed().as_millis() as u64,
+        )
+        .into_response();
+    }
+
     // Build a query body for the parser.
-    let query_body = if let Some(q_str) = &req.q {
+    let mut query_body = if let Some(q_str) = &req.q {
         serde_json::json!({
             "query": {
                 "multi_match": {
@@ -449,6 +529,9 @@ pub async fn search(
             "size": req.size
         })
     };
+    if let Some(fields) = &req.fields {
+        query_body["fields"] = serde_json::json!(fields);
+    }
 
     let search_req = match parse_request(&query_body) {
         Ok(r) => r,
@@ -490,17 +573,7 @@ pub async fn search(
                     .unwrap_or_default(),
             );
 
-            let hits: Vec<Value> = result
-                .hits
-                .iter()
-                .map(|h| {
-                    serde_json::json!({
-                        "_id": h.id,
-                        "_score": h.score,
-                        "_source": h.source,
-                    })
-                })
-                .collect();
+            let hits: Vec<Value> = result.hits.iter().map(native_hit_value).collect();
 
             let resp = NativeResponse::new(
                 serde_json::json!({

--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -2265,6 +2265,9 @@ pub(crate) fn run_pipeline_agg(agg_type: &str, params: &Value) -> Value {
 /// Extract all scalar string representations of a field value from a document.
 /// Arrays are flattened — each element becomes a separate bucket key.
 pub(crate) fn extract_field_values(doc: &Value, field: &str) -> Vec<String> {
+    if field.starts_with(xerj_query::executor::PASSAGE_METADATA_PREFIX) {
+        return Vec::new();
+    }
     let val = get_nested_field(doc, field);
     let mut out = flatten_to_strings(val);
     if out.is_empty() {
@@ -12110,6 +12113,17 @@ fn run_ip_range(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn passage_metadata_is_not_an_aggregation_field() {
+        let doc = json!({
+            "content": "visible",
+            "__xerj_passage_meta__embedding": {"field": "content", "chunks": [[0, 7]]}
+        });
+        assert_eq!(extract_field_values(&doc, "content"), vec!["visible"]);
+        assert!(extract_field_values(&doc, "__xerj_passage_meta__embedding").is_empty());
+        assert!(extract_field_values(&doc, "__xerj_passage_meta__embedding.field").is_empty());
+    }
 
     // Regression: a deeply nested scripted-metric script must not overflow the
     // recursive-descent parser (which would abort the whole server). The guard

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -25,7 +25,10 @@ use xerj_query::ast::{
     RandomScore, RescoreQuery, ScoreFunction, ScoreMode, SearchRequest, SourceFilter,
     TrackTotalHits,
 };
-use xerj_query::executor::{Hit, SearchResult, TotalHits, TotalHitsRelation};
+use xerj_query::executor::{
+    strip_internal_passage_metadata, Hit, PassageMatch, SearchResult, TotalHits, TotalHitsRelation,
+    PASSAGE_METADATA_PREFIX, PASSAGE_RESPONSE_FIELD,
+};
 use xerj_storage::index_store::{IndexStore, IndexStoreConfig};
 use xerj_storage::segment::SectionType;
 use xerj_storage::wal::{SyncMode, WalEntry};
@@ -6097,7 +6100,7 @@ impl Index {
         // fetch consults the version map first and returns None for
         // tombstoned ids.
         let chunk_field = format!("{field}_chunks");
-        let mut scored: Vec<(String, f32, Value)> = Vec::with_capacity(doc_ids.len());
+        let mut scored: Vec<(String, f32, Value, Option<u32>)> = Vec::with_capacity(doc_ids.len());
         for doc_id in doc_ids {
             let src = match self.get_document_uncounted(&doc_id).await {
                 Ok(Some(s)) => s,
@@ -6119,7 +6122,7 @@ impl Index {
                 return None;
             }
             let score = compute_vector_similarity(similarity, query_vec, &doc_vec);
-            scored.push((doc_id, score, src));
+            scored.push((doc_id, score, src, None));
         }
 
         // Item 8: this line is only reached when the coverage gate admitted
@@ -6134,7 +6137,7 @@ impl Index {
             candidates = scored.len(),
             "knn served via HNSW (coverage gate passed)"
         );
-        Some(knn_result_from_scored(request, scored, k, started))
+        Some(knn_result_from_scored(request, field, scored, k, started))
     }
 
     /// Brute-force exact KNN against every doc's stored source.
@@ -6332,7 +6335,8 @@ impl Index {
         };
 
         // ── Score each candidate against the query vector ─────────────
-        let mut scored: Vec<(String, f32, Value)> = Vec::with_capacity(candidates.len());
+        let mut scored: Vec<(String, f32, Value, Option<u32>)> =
+            Vec::with_capacity(candidates.len());
         if use_sq8 {
             // Cosine fields are L2-normalised before quantising so SQ8 fits
             // over bounded [-1,1] per-dim ranges (much better recall); cosine
@@ -6426,7 +6430,7 @@ impl Index {
                     };
                     store.params.decode_into(codes, &mut decoded);
                     let score = compute_vector_similarity(similarity, query_vec, &decoded);
-                    scored.push((id, score, src));
+                    scored.push((id, score, src, None));
                 }
             }
         } else {
@@ -6454,52 +6458,58 @@ impl Index {
                         continue;
                     }
                 }
-                let score = if let Some(Value::Array(chunks)) = get_field_value(&src, &chunk_field)
-                {
-                    // Best-matching passage over the stored chunk vectors.
-                    let mut best: Option<f32> = None;
-                    for (chunk_position, cv) in chunks.iter().enumerate() {
-                        if chunk_position & 31 == 0
-                            && self.exact_scan_checkpoint(chunk_position, deadline).await
-                        {
-                            timed_out = true;
-                            break;
+                let (score, passage_ordinal) =
+                    if let Some(Value::Array(chunks)) = get_field_value(&src, &chunk_field) {
+                        // Best-matching passage over the stored chunk vectors.
+                        let mut best: Option<(f32, u32)> = None;
+                        for (chunk_position, cv) in chunks.iter().enumerate() {
+                            if chunk_position & 31 == 0
+                                && self.exact_scan_checkpoint(chunk_position, deadline).await
+                            {
+                                timed_out = true;
+                                break;
+                            }
+                            let dv: Vec<f32> = match cv {
+                                Value::Array(a) => a
+                                    .iter()
+                                    .filter_map(|v| v.as_f64().map(|f| f as f32))
+                                    .collect(),
+                                _ => continue,
+                            };
+                            if dv.len() != query_vec.len() {
+                                continue;
+                            }
+                            let s = compute_vector_similarity(similarity, query_vec, &dv);
+                            let Some(ordinal) = u32::try_from(chunk_position).ok() else {
+                                continue;
+                            };
+                            choose_passage_winner(&mut best, s, ordinal);
                         }
-                        let dv: Vec<f32> = match cv {
-                            Value::Array(a) => a
+                        match best {
+                            Some((score, ordinal)) => (score, Some(ordinal)),
+                            None => continue,
+                        }
+                    } else {
+                        let vec_val = match get_field_value(&src, field) {
+                            Some(v) => v,
+                            None => continue,
+                        };
+                        let doc_vec: Vec<f32> = match &vec_val {
+                            Value::Array(arr) => arr
                                 .iter()
                                 .filter_map(|v| v.as_f64().map(|f| f as f32))
                                 .collect(),
                             _ => continue,
                         };
-                        if dv.len() != query_vec.len() {
+                        if doc_vec.len() != query_vec.len() {
                             continue;
                         }
-                        let s = compute_vector_similarity(similarity, query_vec, &dv);
-                        best = Some(best.map_or(s, |b| b.max(s)));
-                    }
-                    match best {
-                        Some(s) => s,
-                        None => continue,
-                    }
-                } else {
-                    let vec_val = match get_field_value(&src, field) {
-                        Some(v) => v,
-                        None => continue,
+                        (
+                            compute_vector_similarity(similarity, query_vec, &doc_vec),
+                            Some(0),
+                        )
                     };
-                    let doc_vec: Vec<f32> = match &vec_val {
-                        Value::Array(arr) => arr
-                            .iter()
-                            .filter_map(|v| v.as_f64().map(|f| f as f32))
-                            .collect(),
-                        _ => continue,
-                    };
-                    if doc_vec.len() != query_vec.len() {
-                        continue;
-                    }
-                    compute_vector_similarity(similarity, query_vec, &doc_vec)
-                };
-                scored.push((id, score, src));
+                scored.push((id, score, src, passage_ordinal));
             }
         }
         if trace_phases {
@@ -6515,15 +6525,15 @@ impl Index {
         // total (live-verified 2026-07-12).
         if let Some(raw) = min_similarity {
             let cut = raw_similarity_to_score(similarity, raw);
-            scored.retain(|(_, s, _)| *s >= cut);
+            scored.retain(|(_, score, _, _)| *score >= cut);
         }
         // ES applies `boost` to the final `_score` AFTER the similarity
         // cutoff (a boosted sub-threshold doc stays excluded; a boosted
         // passing doc scores `transform(sim) * boost`).
         if let Some(b) = boost {
             if (b - 1.0).abs() > f32::EPSILON {
-                for (_, s, _) in scored.iter_mut() {
-                    *s *= b;
+                for (_, score, _, _) in scored.iter_mut() {
+                    *score *= b;
                 }
             }
         }
@@ -6531,7 +6541,7 @@ impl Index {
         // ── Rank, cap the candidate pool at k, then paginate ──────────
         // (shared with the HNSW path so hits format / total semantics
         // cannot drift between the exact and approximate executors)
-        let mut result = knn_result_from_scored(request, scored, k, started);
+        let mut result = knn_result_from_scored(request, field, scored, k, started);
         result.timed_out = timed_out;
         if timed_out {
             result.total.relation = TotalHitsRelation::Gte;
@@ -6557,7 +6567,7 @@ impl Index {
         clauses: Vec<PeeledKnn>,
     ) -> Result<SearchResult> {
         let started = std::time::Instant::now();
-        let mut merged: Vec<(String, f32, Value)> = Vec::new();
+        let mut merged: Vec<(String, f32, Value, Option<u32>)> = Vec::new();
         let mut slot_by_id: HashMap<String, usize> = HashMap::new();
         let mut k_sum: usize = 0;
         let mut any_timed_out = false;
@@ -6597,7 +6607,12 @@ impl Index {
                     Some(&i) => merged[i].1 += hit.score,
                     None => {
                         slot_by_id.insert(hit.id.clone(), merged.len());
-                        merged.push((hit.id, hit.score, hit.source));
+                        merged.push((
+                            hit.id,
+                            hit.score,
+                            hit.source,
+                            hit.passage.map(|passage| passage.ordinal),
+                        ));
                     }
                 }
             }
@@ -6605,7 +6620,11 @@ impl Index {
                 break;
             }
         }
-        let mut result = knn_result_from_scored(request, merged, k_sum, started);
+        // Multi-field KNN has no single vector field with which to resolve
+        // passage metadata. Child clauses retain ordinary ranking semantics;
+        // provenance is intentionally omitted until per-clause ownership is
+        // represented in the merged winner.
+        let mut result = knn_result_from_scored(request, "", merged, k_sum, started);
         result.timed_out = any_timed_out;
         if any_timed_out {
             result.total.relation = TotalHitsRelation::Gte;
@@ -6836,15 +6855,37 @@ impl Index {
             dims: usize,
             original_text: String,
             texts: Vec<String>,
+            offsets: Vec<(usize, usize)>,
         }
 
         let mut jobs = Vec::<EmbedJob>::new();
         let mut pre_failures: Vec<Option<String>> = (0..sources.len()).map(|_| None).collect();
+        let allowed_metadata_fields: HashSet<String> = specs
+            .iter()
+            .map(|(_, target, _)| passage_metadata_field(target))
+            .collect();
+        for (source_idx, source) in sources.iter().enumerate() {
+            let Some(object) = source.as_object() else {
+                continue;
+            };
+            if let Some(name) = object.keys().find(|name| {
+                name.starts_with(PASSAGE_METADATA_PREFIX)
+                    && !allowed_metadata_fields.contains(*name)
+            }) {
+                pre_failures[source_idx] = Some(format!(
+                    "field [{name}] uses XERJ's reserved passage-metadata prefix; \
+                     remove it or rename the user field"
+                ));
+            }
+        }
         let onnx_pinned = self
             .embedding_config
             .mode
             .eq_ignore_ascii_case("onnx-experimental");
         for (source_idx, source) in sources.iter().enumerate() {
+            if pre_failures[source_idx].is_some() {
+                continue;
+            }
             #[cfg(test)]
             if crate::bulk::semantic_lifecycle_hook(
                 self.name.as_str(),
@@ -6864,6 +6905,15 @@ impl Index {
                     .get(&format!("{target}_chunks"))
                     .map(|v| !v.is_null())
                     .unwrap_or(false);
+                let supplied_metadata = obj.contains_key(&passage_metadata_field(target));
+                if supplied_metadata {
+                    pre_failures[source_idx] = Some(format!(
+                        "field [{}] is engine-owned passage metadata; submit semantic text \
+                         without derived vectors or reserved metadata",
+                        passage_metadata_field(target)
+                    ));
+                    continue;
+                }
                 if onnx_pinned && (supplied_vector || supplied_chunks) {
                     pre_failures[source_idx] = Some(format!(
                         "field [{field}]: caller-supplied derived vectors are not accepted for \
@@ -6879,10 +6929,16 @@ impl Index {
                     continue;
                 };
                 let chunks = semantic_chunker().chunk(text, None);
-                let texts = if chunks.len() <= 1 {
-                    vec![text.to_string()]
+                let (texts, offsets) = if chunks.len() <= 1 {
+                    (vec![text.to_string()], vec![(0, text.len())])
                 } else {
-                    chunks.iter().map(|c| c.text.clone()).collect()
+                    (
+                        chunks.iter().map(|c| c.text.clone()).collect(),
+                        chunks
+                            .iter()
+                            .map(|c| (c.start_offset, c.end_offset))
+                            .collect(),
+                    )
                 };
                 jobs.push(EmbedJob {
                     source_idx,
@@ -6891,6 +6947,7 @@ impl Index {
                     dims: *dims,
                     original_text: text.to_string(),
                     texts,
+                    offsets,
                 });
             }
         }
@@ -7005,11 +7062,16 @@ impl Index {
             if failures[job.source_idx].is_some() {
                 continue;
             }
-            let chunk_vecs: Vec<Vec<f32>> = outputs[job_idx]
+            let chunk_vecs_and_offsets: Vec<(Vec<f32>, (usize, usize))> = outputs[job_idx]
                 .take()
                 .unwrap_or_default()
                 .into_iter()
-                .filter(|v| !v.is_empty())
+                .zip(job.offsets.iter().copied())
+                .filter(|(vector, _)| !vector.is_empty())
+                .collect();
+            let chunk_vecs: Vec<Vec<f32>> = chunk_vecs_and_offsets
+                .iter()
+                .map(|(vector, _)| vector.clone())
                 .collect();
             let Some(obj) = sources[job.source_idx].as_object_mut() else {
                 continue;
@@ -7026,6 +7088,24 @@ impl Index {
             };
             let arr: Vec<Value> = pooled.into_iter().map(|f| Value::from(f as f64)).collect();
             obj.insert(job.target.clone(), Value::Array(arr));
+            // Compact, durable passage provenance. Text is deliberately NOT
+            // duplicated: the response reconstructs only the winning page
+            // slice from the original semantic field using these UTF-8 byte
+            // offsets. The field name is stored once per document/target and
+            // ordinals are implicit in array order.
+            let offsets_json: Vec<Value> = chunk_vecs_and_offsets
+                .iter()
+                .map(|(_, (start, end))| {
+                    Value::Array(vec![Value::from(*start as u64), Value::from(*end as u64)])
+                })
+                .collect();
+            obj.insert(
+                passage_metadata_field(&job.target),
+                serde_json::json!({
+                    "field": job.field,
+                    "chunks": offsets_json,
+                }),
+            );
             // Per-chunk passage vectors — persisted ONLY when the document
             // actually spans more than one chunk, under `<target>_chunks` as an
             // array of vectors. Semantic search prefers these and scores by the
@@ -7426,6 +7506,7 @@ impl Index {
                 explain: None,
                 highlight: None,
                 matched_queries: Vec::new(),
+                passage: None,
             })
             .collect();
 
@@ -7701,7 +7782,10 @@ impl Index {
     pub async fn get_document(&self, id: &str) -> Result<Option<Value>> {
         let get_started = std::time::Instant::now();
         self.metric_get_count.fetch_add(1, Ordering::Relaxed);
-        let res = self.get_document_uncounted(id).await;
+        let mut res = self.get_document_uncounted(id).await;
+        if let Ok(Some(source)) = &mut res {
+            strip_internal_passage_metadata(source);
+        }
         match &res {
             Ok(Some(_)) => {
                 self.metric_get_exists_count.fetch_add(1, Ordering::Relaxed);
@@ -9199,6 +9283,7 @@ impl Index {
                                         explain: None,
                                         highlight: None,
                                         matched_queries: Vec::new(),
+                                        passage: None,
                                     },
                                     seq,
                                 );
@@ -9216,6 +9301,7 @@ impl Index {
                                 explain: None,
                                 highlight: None,
                                 matched_queries: Vec::new(),
+                                passage: None,
                             });
                         }
                     }
@@ -9604,6 +9690,7 @@ impl Index {
                         explain: None,
                         highlight: None,
                         matched_queries: Vec::new(),
+                        passage: None,
                     });
                 }
                 // Beyond-cap remainder still counts toward hits.total
@@ -9706,6 +9793,7 @@ impl Index {
                                 explain: None,
                                 highlight: None,
                                 matched_queries: Vec::new(),
+                                passage: None,
                             });
                         } else {
                             total_count += 1;
@@ -10497,6 +10585,7 @@ impl Index {
                                                 explain: None,
                                                 highlight: None,
                                                 matched_queries: Vec::new(),
+                                                passage: None,
                                             };
                                             if let Some(topk) = sort_topk.as_mut() {
                                                 let seq =
@@ -12587,6 +12676,9 @@ impl Index {
                     continue;
                 };
                 for (key, val) in obj {
+                    if key.starts_with(PASSAGE_METADATA_PREFIX) {
+                        continue;
+                    }
                     if !schema.schema.has_field(key) && !out.iter().any(|(k, _)| k == key) {
                         let ft = infer_field_type(val, date_detection);
                         out.push((key.clone(), FieldConfig::new(key.clone(), ft)));
@@ -12636,7 +12728,9 @@ impl Index {
             }
             let date_detection = self.date_detection_enabled();
             obj.iter()
-                .filter(|(key, _)| !schema.schema.has_field(key))
+                .filter(|(key, _)| {
+                    !key.starts_with(PASSAGE_METADATA_PREFIX) && !schema.schema.has_field(key)
+                })
                 .map(|(key, val)| {
                     let ft = infer_field_type(val, date_detection);
                     (key.clone(), FieldConfig::new(key.clone(), ft))
@@ -14187,6 +14281,7 @@ impl Index {
                         explain: None,
                         highlight: None,
                         matched_queries: Vec::new(),
+                        passage: None,
                     });
                 }
                 Cand::Seg(si, row) => {
@@ -14215,6 +14310,7 @@ impl Index {
                         explain: None,
                         highlight: None,
                         matched_queries: Vec::new(),
+                        passage: None,
                     });
                 }
             }
@@ -15661,6 +15757,7 @@ impl Index {
                 explain: None,
                 highlight: None,
                 matched_queries: Vec::new(),
+                passage: None,
             });
         }
         Some((hits, total, from_applied))
@@ -16875,6 +16972,7 @@ impl Index {
                     explain: None,
                     highlight: None,
                     matched_queries: Vec::new(),
+                    passage: None,
                 },
                 seq,
             );
@@ -17005,6 +17103,7 @@ impl Index {
                 explain: None,
                 highlight: None,
                 matched_queries: Vec::new(),
+                passage: None,
             });
         }
     }
@@ -17512,6 +17611,7 @@ impl Index {
                         explain: None,
                         highlight: None,
                         matched_queries: Vec::new(),
+                        passage: None,
                     },
                     seq,
                 );
@@ -17556,6 +17656,7 @@ impl Index {
                 explain: None,
                 highlight: None,
                 matched_queries: Vec::new(),
+                passage: None,
             });
         }
     }
@@ -18243,6 +18344,13 @@ fn es_format_to_epoch_ms(s: &str, fmt: &str) -> Option<i64> {
 }
 
 fn apply_source_filter(hits: Vec<Hit>, filter: &SourceFilter) -> Vec<Hit> {
+    let hits: Vec<Hit> = hits
+        .into_iter()
+        .map(|mut hit| {
+            strip_internal_passage_metadata(&mut hit.source);
+            hit
+        })
+        .collect();
     match filter {
         SourceFilter::Enabled(true) => hits,
         // `_source: false`: keep the raw source so the response layer can
@@ -19820,13 +19928,74 @@ const HNSW_MIN_DOCS: u64 = 1024;
 /// ~1.1 ms. A user-supplied num_candidates above the floor is honored.
 const HNSW_EF_FLOOR: usize = 800;
 
+fn passage_metadata_field(target: &str) -> String {
+    format!("{PASSAGE_METADATA_PREFIX}{target}")
+}
+
+fn choose_passage_winner(best: &mut Option<(f32, u32)>, score: f32, ordinal: u32) {
+    // Strictly greater preserves the lowest ordinal on an exact score tie.
+    if best.is_none_or(|(current, _)| score > current) {
+        *best = Some((score, ordinal));
+    }
+}
+
+fn passage_requested(request: &SearchRequest) -> bool {
+    request
+        .fields
+        .iter()
+        .any(|field| field == PASSAGE_RESPONSE_FIELD)
+}
+
+fn passage_match_from_source(
+    source: &Value,
+    vector_field: &str,
+    ordinal: Option<u32>,
+) -> Option<PassageMatch> {
+    let metadata = source
+        .get(passage_metadata_field(vector_field))?
+        .as_object()?;
+    let field = metadata.get("field")?.as_str()?;
+    let chunks = metadata.get("chunks")?.as_array()?;
+    let ordinal = ordinal.or_else(|| (chunks.len() == 1).then_some(0))?;
+    let offsets = chunks.get(ordinal as usize)?.as_array()?;
+    if offsets.len() != 2 {
+        return None;
+    }
+    let start = offsets[0].as_u64()?;
+    let end = offsets[1].as_u64()?;
+    let text_value = get_field_value(source, field)?;
+    let text = text_value.as_str()?;
+    let start_usize = usize::try_from(start).ok()?;
+    let end_usize = usize::try_from(end).ok()?;
+    if start_usize > end_usize
+        || end_usize > text.len()
+        || !text.is_char_boundary(start_usize)
+        || !text.is_char_boundary(end_usize)
+    {
+        return None;
+    }
+    let page = get_field_value(source, "page")
+        .or_else(|| get_field_value(source, "page_number"))
+        .or_else(|| get_field_value(source, "metadata.page"))
+        .and_then(|value| value.as_u64());
+    Some(PassageMatch {
+        field: field.to_string(),
+        ordinal,
+        start_offset: start,
+        end_offset: end,
+        text: text[start_usize..end_usize].to_string(),
+        page,
+    })
+}
+
 /// Shared tail of every top-level kNN executor (brute force and HNSW):
 /// rank by score desc, cap the candidate pool at `k`, window with
 /// `from`/`size`, and shape the response. Centralised so the exact and
 /// approximate paths cannot drift on hits format or total semantics.
 fn knn_result_from_scored(
     request: &SearchRequest,
-    mut scored: Vec<(String, f32, Value)>,
+    vector_field: &str,
+    mut scored: Vec<(String, f32, Value, Option<u32>)>,
     k: usize,
     started: std::time::Instant,
 ) -> SearchResult {
@@ -19854,7 +20023,10 @@ fn knn_result_from_scored(
     // sources (not the paginated page). Every knn executor (HNSW,
     // brute-force, multi-knn) funnels through here, so all of them gain it.
     let aggs = request.aggs.as_ref().map(|aggs_def| {
-        let sources: Vec<Value> = scored.iter().map(|(_, _, s)| s.clone()).collect();
+        let sources: Vec<Value> = scored
+            .iter()
+            .map(|(_, _, source, _)| source.clone())
+            .collect();
         crate::aggs::run_aggs(aggs_def, &sources)
     });
 
@@ -19868,16 +20040,24 @@ fn knn_result_from_scored(
             .collect::<Vec<_>>()
     }
     .into_iter()
-    .map(|(id, score, source)| Hit {
-        id,
-        score,
-        source,
-        sort: Vec::new(),
-        explain: None,
-        highlight: None,
-        matched_queries: Vec::new(),
+    .map(|(id, score, mut source, ordinal)| {
+        let passage = passage_requested(request)
+            .then(|| passage_match_from_source(&source, vector_field, ordinal))
+            .flatten();
+        strip_internal_passage_metadata(&mut source);
+        Hit {
+            id,
+            score,
+            source,
+            sort: Vec::new(),
+            explain: None,
+            highlight: None,
+            matched_queries: Vec::new(),
+            passage,
+        }
     })
     .collect();
+    let hits = apply_source_filter(hits, &request.source);
 
     SearchResult {
         hits,
@@ -29257,6 +29437,170 @@ mod chunk_embed_tests {
         assert!(
             max_sim > pooled_score,
             "best-passage max-sim ({max_sim}) should beat pooled ({pooled_score})"
+        );
+    }
+
+    #[test]
+    fn passage_scoring_ties_choose_lowest_ordinal() {
+        let mut best = None;
+        choose_passage_winner(&mut best, 1.0, 0);
+        choose_passage_winner(&mut best, 1.0, 1);
+        assert_eq!(best, Some((1.0, 0)));
+    }
+
+    #[test]
+    fn passage_metadata_roundtrip_uses_valid_utf8_byte_boundaries() {
+        let text = "Préface αβ. Résumé 📄 quarterly evidence. 終了";
+        let start = text.find("Résumé").unwrap();
+        let end = text.find("終了").unwrap();
+        let source = serde_json::json!({
+            "content": text,
+            "page": 42,
+            "__xerj_passage_meta__embedding": {
+                "field": "content",
+                "chunks": [[0, start], [start, end], [end, text.len()]]
+            }
+        });
+        let roundtrip: Value =
+            serde_json::from_slice(&serde_json::to_vec(&source).unwrap()).unwrap();
+        let passage = passage_match_from_source(&roundtrip, "embedding", Some(1)).unwrap();
+        assert_eq!(passage.ordinal, 1);
+        assert_eq!(passage.page, Some(42));
+        assert_eq!(
+            passage.text,
+            &text[passage.start_offset as usize..passage.end_offset as usize]
+        );
+        assert!(text.is_char_boundary(passage.start_offset as usize));
+        assert!(text.is_char_boundary(passage.end_offset as usize));
+
+        let malformed = serde_json::json!({
+            "content": text,
+            "__xerj_passage_meta__embedding": {
+                "field": "content",
+                "chunks": [[3, text.len()]]
+            }
+        });
+        assert!(
+            passage_match_from_source(&malformed, "embedding", Some(0)).is_none(),
+            "offset inside the multibyte 'P/é' sequence must be refused"
+        );
+    }
+
+    #[test]
+    fn passage_metadata_has_bounded_stored_overhead_without_text_duplication() {
+        let content = "quarterly finance evidence with stable page-local wording. ".repeat(24);
+        let plain: Vec<Value> = (0..256)
+            .map(|id| {
+                serde_json::json!({
+                    "_id": id.to_string(),
+                    "_seq_no": id,
+                    "_source": {"content": content.as_str(), "page": id % 32}
+                })
+            })
+            .collect();
+        let with_metadata: Vec<Value> = plain
+            .iter()
+            .cloned()
+            .map(|mut doc| {
+                doc["_source"]["__xerj_passage_meta__embedding"] = serde_json::json!({
+                    "field": "content",
+                    "chunks": [[0, 384], [320, 704], [640, 1024], [960, content.len()]]
+                });
+                doc
+            })
+            .collect();
+        let plain_json = serde_json::to_vec(&plain).unwrap();
+        let metadata_json = serde_json::to_vec(&with_metadata).unwrap();
+        let plain_stored = xerj_storage::stored_codec::encode_stored_v2(&plain_json);
+        let metadata_stored = xerj_storage::stored_codec::encode_stored_v2(&metadata_json);
+        let delta = metadata_stored.len().saturating_sub(plain_stored.len());
+        assert!(
+            delta < 64 * plain.len(),
+            "compact offsets added {delta} bytes ({:.2} bytes/doc)",
+            delta as f64 / plain.len() as f64
+        );
+        assert_eq!(
+            metadata_json
+                .windows(content.len())
+                .filter(|window| *window == content.as_bytes())
+                .count(),
+            plain.len(),
+            "metadata must not duplicate passage text"
+        );
+        eprintln!(
+            "controlled passage metadata stored delta: {delta} bytes / {} docs = {:.2} bytes/doc",
+            plain.len(),
+            delta as f64 / plain.len() as f64
+        );
+    }
+
+    #[test]
+    fn varied_passage_metadata_reports_raw_and_stored_overhead() {
+        let mut plain = Vec::with_capacity(256);
+        let mut with_metadata = Vec::with_capacity(256);
+        let mut authoritative_texts = Vec::with_capacity(256);
+        for id in 0..256 {
+            let content = format!(
+                "Résumé 📄 page {id}. {} 終了 {}",
+                "finance covenant narrative. ".repeat(3 + id % 29),
+                "auditor footnote. ".repeat(1 + (id * 7) % 17)
+            );
+            let offsets: Vec<Value> = {
+                let chunks = semantic_chunker().chunk(&content, None);
+                if chunks.len() <= 1 {
+                    vec![serde_json::json!([0, content.len()])]
+                } else {
+                    chunks
+                        .iter()
+                        .map(|chunk| serde_json::json!([chunk.start_offset, chunk.end_offset]))
+                        .collect()
+                }
+            };
+            let doc = serde_json::json!({
+                "_id": format!("report-{id:04}"),
+                "_seq_no": id,
+                "_source": {
+                    "content": content,
+                    "page": 1 + id % 97,
+                    "company": format!("company-{}", id % 23)
+                }
+            });
+            let mut enriched = doc.clone();
+            enriched["_source"]["__xerj_passage_meta__embedding"] = serde_json::json!({
+                "field": "content",
+                "chunks": offsets
+            });
+            authoritative_texts.push(
+                doc["_source"]["content"]
+                    .as_str()
+                    .expect("fixture content")
+                    .to_string(),
+            );
+            plain.push(doc);
+            with_metadata.push(enriched);
+        }
+        let plain_json = serde_json::to_vec(&plain).unwrap();
+        let metadata_json = serde_json::to_vec(&with_metadata).unwrap();
+        let raw_delta = metadata_json.len() - plain_json.len();
+        let plain_stored = xerj_storage::stored_codec::encode_stored_v2(&plain_json);
+        let metadata_stored = xerj_storage::stored_codec::encode_stored_v2(&metadata_json);
+        let stored_delta = metadata_stored.len().saturating_sub(plain_stored.len());
+        for text in &authoritative_texts {
+            assert_eq!(
+                metadata_json
+                    .windows(text.len())
+                    .filter(|window| *window == text.as_bytes())
+                    .count(),
+                1,
+                "metadata must not duplicate authoritative content"
+            );
+        }
+        assert!(stored_delta < raw_delta);
+        eprintln!(
+            "varied passage metadata delta: raw={raw_delta} bytes ({:.2}/doc), \
+             stored={stored_delta} bytes ({:.2}/doc)",
+            raw_delta as f64 / plain.len() as f64,
+            stored_delta as f64 / plain.len() as f64
         );
     }
 }

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -8725,6 +8725,16 @@ impl Index {
         // exact brute-force scan below. Filtered knn stays exact brute
         // force with a pre-filter, where `num_candidates` (the ANN fan-out)
         // has no effect.
+        if passage_requested(request)
+            && (peel_multi_knn_query(query).is_some() || peel_hybrid_query(query).is_some())
+        {
+            return Err(EngineError::Common(xerj_common::XerjError::invalid_query(
+                "`fields: [\"_passage\"]` requires one semantic or kNN clause; \
+                     multi-kNN and hybrid queries combine independent score contributions, \
+                     so they do not have one unambiguous winning passage; request `_passage` \
+                     only with a single semantic/kNN clause, or omit `_passage` for fusion",
+            )));
+        }
         if let Some(peeled) = peel_knn_query(query) {
             let PeeledKnn {
                 field,

--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -3427,6 +3427,11 @@ pub fn semantic_derived_vector_fields(schema: &Schema) -> std::collections::Hash
             .unwrap_or_else(|| format!("{}_vector", field.name));
         excluded.insert(target.clone());
         excluded.insert(format!("{target}_chunks"));
+        excluded.insert(format!(
+            "{}{}",
+            xerj_query::executor::PASSAGE_METADATA_PREFIX,
+            target
+        ));
     }
     excluded
 }
@@ -3468,8 +3473,10 @@ mod semantic_derived_vector_exclusion_tests {
             std::collections::HashSet::from([
                 "body_vector".to_string(),
                 "body_vector_chunks".to_string(),
+                "__xerj_passage_meta__body_vector".to_string(),
                 "summary_model_output".to_string(),
                 "summary_model_output_chunks".to_string(),
+                "__xerj_passage_meta__summary_model_output".to_string(),
             ])
         );
 
@@ -3480,8 +3487,13 @@ mod semantic_derived_vector_exclusion_tests {
             "body_vector_backup": [3.0, 4.0],
             "body_vector": [0.1, 0.2],
             "body_vector_chunks": [[0.1, 0.2], [0.3, 0.4]],
+            "__xerj_passage_meta__body_vector": {"field": "body", "chunks": [[0, 20]]},
             "summary_model_output": [0.5, 0.6],
-            "summary_model_output_chunks": [[0.5, 0.6], [0.7, 0.8]]
+            "summary_model_output_chunks": [[0.5, 0.6], [0.7, 0.8]],
+            "__xerj_passage_meta__summary_model_output": {
+                "field": "summary",
+                "chunks": [[0, 7]]
+            }
         });
         let fields = extract_text_fields_from_excluding(&source, &excluded);
         assert_eq!(fields.get("page").map(String::as_str), Some("7"));

--- a/engine/crates/xerj-engine/src/painless.rs
+++ b/engine/crates/xerj-engine/src/painless.rs
@@ -1080,7 +1080,9 @@ fn eval_access_chain(
                 (Some("params"), Step::Index(index)) => {
                     let key = access_key(eval_expr(index, ctx, env)?)?;
                     value = Some(if key == "_source" {
-                        PainlessValue::from_json(ctx.doc)
+                        let mut source = ctx.doc.clone();
+                        xerj_query::executor::strip_internal_passage_metadata(&mut source);
+                        PainlessValue::from_json(&source)
                     } else {
                         PainlessValue::from_json(
                             &ctx.params.get(&key).cloned().unwrap_or(Value::Null),
@@ -1393,6 +1395,9 @@ fn date_component(ms: i64, member: &str) -> Result<PainlessValue, String> {
 }
 
 fn get_doc_value(doc: &Value, field: &str) -> Value {
+    if field.starts_with(xerj_query::executor::PASSAGE_METADATA_PREFIX) {
+        return Value::Null;
+    }
     let parts: Vec<&str> = field.split('.').collect();
     let mut cur = doc.clone();
     for part in &parts {
@@ -1613,6 +1618,28 @@ mod tests {
         )
         .unwrap();
         assert!((v.as_f64().unwrap() - 1500.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn passage_metadata_is_hidden_from_doc_and_source_scripts() {
+        let doc = json!({
+            "content": "visible",
+            "__xerj_passage_meta__embedding": {"field": "content", "chunks": [[0, 7]]}
+        });
+        let params = json!({});
+        let size = eval_painless(
+            "doc['__xerj_passage_meta__embedding'].size()",
+            &ctx(&doc, &params, 0.0),
+        )
+        .unwrap();
+        assert_eq!(size.as_f64(), Some(0.0));
+        let rendered =
+            eval_painless("params['_source'].toString()", &ctx(&doc, &params, 0.0)).unwrap();
+        let PainlessValue::String(rendered) = rendered else {
+            panic!("expected rendered source string");
+        };
+        assert!(rendered.contains("content=visible"));
+        assert!(!rendered.contains("__xerj_passage_meta__"));
     }
 
     #[test]

--- a/engine/crates/xerj-engine/tests/integration.rs
+++ b/engine/crates/xerj-engine/tests/integration.rs
@@ -43,6 +43,12 @@ async fn test_semantic_vectors_stay_stored_but_not_fts_indexed_after_merge_and_r
         assert!(semantic.hits.iter().all(|hit| {
             hit.source.get("custom_embedding").is_some()
                 && hit.source.get("custom_embedding_chunks").is_some()
+                && hit.passage.is_none()
+                && hit.source.as_object().is_some_and(|source| {
+                    source
+                        .keys()
+                        .all(|name| !name.starts_with("__xerj_passage_meta__"))
+                })
         }));
 
         let lexical = idx
@@ -109,10 +115,210 @@ async fn test_semantic_vectors_stay_stored_but_not_fts_indexed_after_merge_and_r
     assert!(!names
         .iter()
         .any(|name| name.ends_with(".custom_embedding_chunks.fst")));
+    assert!(!names
+        .iter()
+        .any(|name| name.contains("__xerj_passage_meta__")));
 
     let reopened = make_engine(&dir);
     let idx = reopened.get_index("sem-fts-exclusion").unwrap();
     assert_queries(&idx).await;
+}
+
+#[tokio::test]
+async fn semantic_passage_provenance_survives_update_merge_restart_and_source_filter() {
+    let dir = TempDir::new().unwrap();
+    let mut schema = Schema::empty();
+    let mut content = FieldConfig::new("content", FieldType::Text);
+    content.options.dimensions = Some(64);
+    content.options.similarity = Some("cosine".to_string());
+    content.embedding = Some(xerj_common::types::EmbeddingConfig {
+        endpoint: None,
+        model: None,
+        target_field: Some("custom_embedding".to_string()),
+    });
+    schema.fields.push(content);
+    schema
+        .fields
+        .push(FieldConfig::new("page", FieldType::Long));
+
+    let initial = format!(
+        "{} Résumé 📄 quarterly zephyr liquidity evidence. {}",
+        "unrelated operating narrative. ".repeat(40),
+        "unrelated tax footnote. ".repeat(40)
+    );
+    {
+        let engine = make_engine(&dir);
+        engine.create_index("passage-provenance", schema).unwrap();
+        let idx = engine.get_index("passage-provenance").unwrap();
+        idx.index_document(
+            Some("report-page".into()),
+            json!({"content": initial, "page": 17, "company": "ACME"}),
+        )
+        .await
+        .unwrap();
+        idx.refresh().await.unwrap();
+        idx.force_merge(1).await.unwrap();
+
+        let request = parse_request(&json!({
+            "query": {"semantic": {
+                "field": "content",
+                "query": "Résumé 📄 quarterly zephyr liquidity evidence",
+                "k": 10
+            }},
+            "fields": ["_passage"],
+            "_source": {"includes": ["company"]},
+            "size": 1
+        }))
+        .unwrap();
+        let result = idx.search(&request).await.unwrap();
+        let hit = &result.hits[0];
+        assert_eq!(hit.source, json!({"company": "ACME"}));
+        let passage = hit.passage.as_ref().expect("opt-in passage");
+        assert_eq!(passage.field, "content");
+        assert_eq!(passage.page, Some(17));
+        assert!(passage.text.contains("Résumé 📄 quarterly zephyr"));
+        assert!(initial.is_char_boundary(passage.start_offset as usize));
+        assert!(initial.is_char_boundary(passage.end_offset as usize));
+        assert_eq!(
+            &initial[passage.start_offset as usize..passage.end_offset as usize],
+            passage.text
+        );
+
+        let ordinary = idx
+            .search(
+                &parse_request(&json!({
+                    "query": {"semantic": {
+                        "field": "content",
+                        "query": "quarterly zephyr liquidity",
+                        "k": 10
+                    }},
+                    "size": 1
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(ordinary.hits[0].passage.is_none());
+        assert!(ordinary.hits[0]
+            .source
+            .as_object()
+            .unwrap()
+            .keys()
+            .all(|name| !name.starts_with("__xerj_passage_meta__")));
+
+        // Re-indexing regenerates offsets from the new authoritative text.
+        let updated = format!(
+            "{} deferred tax aurora covenant disclosure. {}",
+            "replacement narrative. ".repeat(36),
+            "replacement appendix. ".repeat(36)
+        );
+        idx.index_document(
+            Some("report-page".into()),
+            json!({"content": updated, "page": 18, "company": "ACME"}),
+        )
+        .await
+        .unwrap();
+        idx.refresh().await.unwrap();
+        idx.force_merge(1).await.unwrap();
+        let updated_result = idx
+            .search(
+                &parse_request(&json!({
+                    "query": {"semantic": {
+                        "field": "content",
+                        "query": "deferred tax aurora covenant disclosure",
+                        "k": 10
+                    }},
+                    "fields": ["_passage"],
+                    "size": 1
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let updated_passage = updated_result.hits[0].passage.as_ref().unwrap();
+        assert_eq!(updated_passage.page, Some(18));
+        assert!(updated_passage.text.contains("aurora covenant"));
+        assert_eq!(
+            &updated[updated_passage.start_offset as usize..updated_passage.end_offset as usize],
+            updated_passage.text
+        );
+    }
+
+    let reopened = make_engine(&dir);
+    let idx = reopened.get_index("passage-provenance").unwrap();
+    let reopened_result = idx
+        .search(
+            &parse_request(&json!({
+                "query": {"semantic": {
+                    "field": "content",
+                    "query": "deferred tax aurora covenant disclosure",
+                    "k": 10
+                }},
+                "fields": ["_passage"],
+                "size": 1
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(reopened_result.hits[0]
+        .passage
+        .as_ref()
+        .unwrap()
+        .text
+        .contains("aurora covenant"));
+
+    idx.delete_document("report-page").await.unwrap();
+    let after_delete = idx
+        .search(
+            &parse_request(&json!({
+                "query": {"semantic": {
+                    "field": "content",
+                    "query": "deferred tax aurora covenant disclosure",
+                    "k": 10
+                }},
+                "fields": ["_passage"]
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(after_delete.hits.is_empty());
+}
+
+#[tokio::test]
+async fn reserved_passage_metadata_input_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let mut schema = Schema::empty();
+    let mut content = FieldConfig::new("content", FieldType::Text);
+    content.options.dimensions = Some(16);
+    content.embedding = Some(xerj_common::types::EmbeddingConfig {
+        endpoint: None,
+        model: None,
+        target_field: Some("custom_embedding".to_string()),
+    });
+    schema.fields.push(content);
+    engine
+        .create_index("reserved-passage-field", schema)
+        .unwrap();
+    let idx = engine.get_index("reserved-passage-field").unwrap();
+    let error = idx
+        .index_document(
+            Some("spoof".into()),
+            json!({
+                "content": "user text",
+                "__xerj_passage_meta__custom_embedding": {
+                    "field": "content",
+                    "chunks": [[0, 9]]
+                }
+            }),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("engine-owned passage metadata"), "{error}");
+    assert!(idx.get_document("spoof").await.unwrap().is_none());
 }
 
 fn make_search(query_json: Value) -> SearchRequest {

--- a/engine/crates/xerj-engine/tests/integration.rs
+++ b/engine/crates/xerj-engine/tests/integration.rs
@@ -321,6 +321,82 @@ async fn reserved_passage_metadata_input_is_rejected() {
     assert!(idx.get_document("spoof").await.unwrap().is_none());
 }
 
+#[tokio::test]
+async fn passage_provenance_rejects_ambiguous_multi_vector_composition_in_any_order() {
+    use xerj_query::ast::{FusionStrategy, WeightedQuery};
+
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine
+        .create_index("passage-composition", Schema::empty())
+        .unwrap();
+    let idx = engine.get_index("passage-composition").unwrap();
+
+    let knn_a = QueryNode::Knn {
+        field: "embedding_a".into(),
+        vector: vec![1.0, 0.0],
+        k: 10,
+        num_candidates: None,
+        filter: None,
+        boost: None,
+        similarity: None,
+    };
+    let knn_b = QueryNode::Knn {
+        field: "embedding_b".into(),
+        vector: vec![0.0, 1.0],
+        k: 10,
+        num_candidates: None,
+        filter: None,
+        boost: None,
+        similarity: None,
+    };
+
+    for should in [
+        vec![knn_a.clone(), knn_b.clone()],
+        vec![knn_b.clone(), knn_a.clone()],
+    ] {
+        let request = SearchRequest {
+            query: QueryNode::Bool {
+                must: Vec::new(),
+                should,
+                filter: Vec::new(),
+                must_not: Vec::new(),
+                minimum_should_match: None,
+            },
+            fields: vec!["_passage".into()],
+            ..SearchRequest::default()
+        };
+        let error = idx.search(&request).await.unwrap_err().to_string();
+        assert!(error.contains("one unambiguous winning passage"), "{error}");
+    }
+
+    let semantic = QueryNode::SemanticSearch {
+        field: "content".into(),
+        text: "quarterly evidence".into(),
+        k: 10,
+        filter: None,
+        boost: None,
+    };
+    for queries in [
+        vec![semantic.clone(), QueryNode::MatchAll],
+        vec![QueryNode::MatchAll, semantic.clone()],
+    ] {
+        let request = SearchRequest {
+            query: QueryNode::Hybrid {
+                queries: queries
+                    .into_iter()
+                    .map(|query| WeightedQuery { query, weight: 1.0 })
+                    .collect(),
+                fusion: FusionStrategy::Rrf { k: 60 },
+            },
+            fields: vec!["_passage".into()],
+            ..SearchRequest::default()
+        };
+        let error = idx.search(&request).await.unwrap_err().to_string();
+        assert!(error.contains("one unambiguous winning passage"), "{error}");
+    }
+}
+
 fn make_search(query_json: Value) -> SearchRequest {
     parse_request(&json!({ "query": query_json, "size": 100 })).expect("parse_request")
 }

--- a/engine/crates/xerj-query/src/executor.rs
+++ b/engine/crates/xerj-query/src/executor.rs
@@ -25,6 +25,17 @@ use crate::error::Result;
 use crate::planner::ExecutionPlan;
 use crate::sort::{compare_sort_keys, SortField};
 
+pub const PASSAGE_METADATA_PREFIX: &str = "__xerj_passage_meta__";
+pub const PASSAGE_RESPONSE_FIELD: &str = "_passage";
+
+/// Remove engine-owned passage-offset companions before `_source` reaches a
+/// client. The metadata remains in stored source for restart/merge correctness.
+pub fn strip_internal_passage_metadata(source: &mut serde_json::Value) {
+    if let Some(object) = source.as_object_mut() {
+        object.retain(|name, _| !name.starts_with(PASSAGE_METADATA_PREFIX));
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Result types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -51,6 +62,30 @@ pub struct Hit {
     /// Names of named queries that matched this document (only present when `_name` was used).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub matched_queries: Vec<String>,
+    /// Winning semantic passage, populated only when the caller explicitly
+    /// requests the `_passage` pseudo-field.
+    ///
+    /// This is derived from compact ingest-time byte offsets. It is not
+    /// persisted as a second text copy and is absent from ordinary responses.
+    #[serde(rename = "_passage", skip_serializing_if = "Option::is_none", default)]
+    pub passage: Option<PassageMatch>,
+}
+
+/// Provenance for the passage that supplied a semantic hit's max score.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PassageMatch {
+    /// Original `semantic_text` field, rather than its derived vector field.
+    pub field: String,
+    /// Zero-based ordinal in the deterministic ingest-time chunk sequence.
+    pub ordinal: u32,
+    /// UTF-8 byte offsets into `field`.
+    pub start_offset: u64,
+    pub end_offset: u64,
+    /// Winning text slice materialized only for the returned page.
+    pub text: String,
+    /// Autoindex PDF page identity when the source carries a numeric `page`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<u64>,
 }
 
 /// Total hits information (mirrors ES semantics exactly).
@@ -351,6 +386,7 @@ mod tests {
             explain: None,
             highlight: None,
             matched_queries: vec![],
+            passage: None,
         }
     }
 

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -210,12 +210,19 @@ pub fn parse_request(body: &Value) -> Result<SearchRequest> {
     let script_fields = obj.get("script_fields").cloned();
 
     // fields — stored/doc-value fields to return alongside _source.
+    let parse_field = |value: &Value| {
+        value.as_str().map(String::from).or_else(|| {
+            value
+                .as_object()
+                .and_then(|object| object.get("field"))
+                .and_then(Value::as_str)
+                .map(String::from)
+        })
+    };
     let fields: Vec<String> = match obj.get("fields") {
-        Some(Value::Array(arr)) => arr
-            .iter()
-            .filter_map(|v| v.as_str().map(String::from))
-            .collect(),
-        _ => Vec::new(),
+        Some(Value::Array(arr)) => arr.iter().filter_map(parse_field).collect(),
+        Some(value) => parse_field(value).into_iter().collect(),
+        None => Vec::new(),
     };
 
     // profile — include timing breakdown
@@ -5049,5 +5056,22 @@ mod tests {
             "rank_feature": { "field": "pr", "log": {} }
         }))
         .is_err());
+    }
+
+    #[test]
+    fn fields_accept_scalar_array_and_object_forms() {
+        for (body, expected) in [
+            (json!({"fields": "_passage"}), vec!["_passage"]),
+            (
+                json!({"fields": ["company", "_passage"]}),
+                vec!["company", "_passage"],
+            ),
+            (
+                json!({"fields": [{"field": "_passage", "format": "ignored"}]}),
+                vec!["_passage"],
+            ),
+        ] {
+            assert_eq!(parse_request(&body).unwrap().fields, expected);
+        }
     }
 }


### PR DESCRIPTION
## Why

XERJ already scores a long `semantic_text` document by its best matching generated chunk, but the search response does not tell the caller which chunk produced the score. An agent must therefore receive or re-read the complete source document to recover the evidence behind a hit. This is especially costly for page-oriented PDF indices, where the desired response is usually the relevant passage plus the document and page identity.

## What changes

This change records compact provenance for generated semantic chunks and exposes the winning passage only when the caller requests the `_passage` pseudo-field.

- Ingest persists the original semantic field name and UTF-8 byte-offset pairs beside its derived chunk vectors.
- Exact chunk scoring retains the winning zero-based chunk ordinal and uses a deterministic lowest-ordinal tie-break.
- Response assembly slices the winning text from the authoritative source only for returned hits, so passage text is not stored twice.
- Elasticsearch-compatible search returns the result as `fields._passage[0]`.
- Native search accepts `fields: ["_passage"]` and returns the result as hit-level `_passage`.
- A numeric source `page` is copied into the passage result, preserving page-local PDF provenance.
- Scalar, array, and Elasticsearch object forms of `fields` are normalized consistently.
- Scroll continuations preserve opted-in passage provenance.
- Engine-owned metadata is rejected in caller writes and hidden from `_source`, GET, field discovery, full-text indexing, aggregations, and Painless scripts.
- Update, delete, flush, merge, restart, and source-filtering paths retain correct provenance.

The response object contains:

```json
{
  "field": "body",
  "ordinal": 2,
  "start_offset": 896,
  "end_offset": 1408,
  "text": "The covenant remains in effect through the fourth quarter...",
  "page": 17
}
```

Offsets are UTF-8 byte offsets into the original semantic field. `page` is omitted when the source does not contain a numeric `page`.

## Usage

No mapping change is required beyond the existing `semantic_text` field:

```bash
curl -sS -X PUT "$XERJ_URL/reports" -H 'content-type: application/json' -d '{
  "mappings": {
    "properties": {
      "body": {"type": "semantic_text"},
      "file": {"type": "keyword"},
      "page": {"type": "integer"}
    }
  }
}'
```

Index normally, then opt in through `fields`:

```bash
BODY="$(printf 'Routine quarterly operating context. %.0s' {1..80})The covenant remains in effect through the fourth quarter."

curl -sS -X PUT "$XERJ_URL/reports/_doc/q4?refresh=true" -H 'content-type: application/json' -d "$(jq -n --arg body "$BODY" '{
  body: $body,
  file: "acme-2025-q4.pdf",
  page: 17
}')"

curl -sS -X POST "$XERJ_URL/reports/_search" -H 'content-type: application/json' -d '{
  "fields": ["_passage"],
  "_source": {"includes": ["file", "page"]},
  "query": {
    "semantic": {
      "field": "body",
      "query": "What covenant applies in the fourth quarter?",
      "k": 10
    }
  }
}'
```

The same request may use `"fields": "_passage"` or `"fields": [{"field": "_passage"}]`. Ordinary searches that omit `_passage` preserve their previous response shape and do not materialize passage text.

For native search, add `"fields": ["_passage"]` to the request. Native hits contain `_passage` directly instead of the Elasticsearch-compatible `fields._passage` array.

## Honest scope and limitations

- This PR exposes provenance for the existing exact per-chunk max-sim scoring path; it does not introduce passage-node HNSW or make passage scoring approximate.
- `_passage` is valid when one semantic clause owns the score, or when one kNN clause targets a generated semantic chunk-vector field. An arbitrary dense-vector kNN field has no generated passage metadata, so `_passage` may be absent. Multi-kNN and hybrid fusion combine independent contributions and do not have one honest winning passage, so those requests return an actionable HTTP 400 telling the caller to use one eligible semantic/kNN clause or omit `_passage`.
- The built-in default embedder remains lexical feature hashing. Neural semantics still require explicitly enabling the neural embedding mode or configuring an embedding endpoint.
- This adds provenance metadata, not another copy of the passage text. The original source and existing generated vectors remain the authoritative data.
- Short single-passage values continue to use their existing single-vector behavior.

## Storage measurement

The committed deterministic measurement uses 256 varied Unicode documents with variable passage counts. It compares identical stored-source batches with and without the field-name/offset metadata and also verifies that each authoritative text occurs exactly once.

| Metric | Total | Per document |
|---|---:|---:|
| Raw JSON metadata delta | 20,547 bytes | 80.26 bytes |
| ZBS2 stored metadata delta | 1,019 bytes | 3.98 bytes |

Command:

```bash
cd engine
cargo test -p xerj-engine index::chunk_embed_tests::varied_passage_metadata_reports_raw_and_stored_overhead -- --exact --nocapture
```

Observed output:

```text
varied passage metadata delta: raw=20547 bytes (80.26/doc), stored=1019 bytes (3.98/doc)
```

This is a controlled metadata-overhead measurement, not an end-to-end index-size claim.

## Manual reproduction

1. Start XERJ against a throwaway data directory and create an index with a long `semantic_text` field plus numeric `page`.
2. Index a value longer than one chunk with a distinctive phrase in a later passage and use `refresh=true`.
3. Search for that phrase with `"fields": ["_passage"]`.
4. Confirm that `fields._passage[0].text` is the exact source slice bounded by `start_offset` and `end_offset`, `ordinal` identifies the winning generated passage, `field` names the original semantic field, and `page` matches the source.
5. Repeat the search without `fields` and confirm `_passage` is absent.
6. Flush, restart XERJ on the same data directory, repeat the opted-in search, and confirm the same passage is returned.
7. Update the document with a new distinctive phrase and page number, search again, and confirm the old passage is no longer returned.
8. Request `_passage` from a hybrid or multi-kNN query and confirm HTTP 400 includes the concrete alternatives: use one semantic/kNN clause or omit `_passage` for fusion.

The repository integration test performs the update, flush/merge, restart, source-filter, Unicode-offset, and response-hiding sequence deterministically:

```bash
cd engine
cargo test -p xerj-engine semantic_passage_provenance_survives_update_merge_restart_and_source_filter -- --exact --nocapture
```

The router tests exercise all accepted `fields` forms, scroll continuation, both multi-kNN clause orders, and both hybrid child orders:

```bash
cd engine
cargo test -p xerj-api passage_
```

## Validation

Current branch base and fetched upstream main are both `761b47dfcb5f8fcc57bc929385c422bcffbe130b`; no rebase changed production code.

- `cargo test -p xerj-query`: 125 passed, 0 failed; 1 doc-test ignored
- `cargo test -p xerj-engine passage_ -- --test-threads=1`: 10 passage tests passed across unit and integration suites, 0 failed
- `cargo test -p xerj-api passage_`: 6 passed, 0 failed
- `cargo clippy -p xerj-query -p xerj-engine -p xerj-api --all-targets -- -D warnings`: passed
- `cargo fmt --all --check`: passed
- `git diff --check`: passed
- Release ES-YAML hard gate on this exact branch/base: 1360 passed, 0 failed, 3 skipped

The earlier full package runs on this exact branch/base also passed: 227 engine unit tests, 10 chaos tests, 65 ES integration tests, 101 engine integration tests with 1 ignored, and 61 API tests.