### PR TITLE
fix(security): close 6 network-reachable DoS/path-traversal vectors (Phase 1)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -20900,7 +20900,8 @@ fn validate_snapshot_name(name: &str) -> Result<(), xerj_common::XerjError> {
             "snapshot name must not be empty",
         ));
     }
-    if name == "." || name == ".."
+    if name == "."
+        || name == ".."
         || name.contains("..")
         || name.contains('/')
         || name.contains('\\')

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -20871,11 +20871,61 @@ pub async fn get_index_alias(
 // GET    /_snapshot/{repo}/{snapshot}
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Validate a snapshot repository name. The `repo` is used as a key in the
+/// in-memory `snapshot_repos` map, but it is also echoed in API responses and
+/// surfaced in logs, and a future change could path-join it. Reject anything
+/// that could traverse (`..`) or contain a path separator.
+fn validate_snapshot_repo_name(repo: &str) -> Result<(), xerj_common::XerjError> {
+    if repo.is_empty() {
+        return Err(xerj_common::XerjError::invalid_mapping(
+            "snapshot repository name must not be empty",
+        ));
+    }
+    if repo.contains("..") || repo.contains('/') || repo.contains('\\') || repo.contains('\0') {
+        return Err(xerj_common::XerjError::invalid_mapping(format!(
+            "invalid snapshot repository name [{repo}]: must not contain '..', '/', '\\', or NUL"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate a snapshot name. The snapshot name is path-joined onto the repo's
+/// `settings.location` inside the engine (`Path::new(repo_path).join(name)`),
+/// so `..` or a separator would let a write escape the repo. ES restricts
+/// snapshot names to `[a-zA-Z0-9._-]`; we apply the same traversal-blocking
+/// rule as `IndexName::validate` (no `..`, no separators, no NUL).
+fn validate_snapshot_name(name: &str) -> Result<(), xerj_common::XerjError> {
+    if name.is_empty() {
+        return Err(xerj_common::XerjError::invalid_mapping(
+            "snapshot name must not be empty",
+        ));
+    }
+    if name == "." || name == ".."
+        || name.contains("..")
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+    {
+        return Err(xerj_common::XerjError::invalid_mapping(format!(
+            "invalid snapshot name [{name}]: must not be '.' or '..' and must not contain '..', '/', '\\', or NUL"
+        )));
+    }
+    Ok(())
+}
+
 pub async fn put_snapshot_repo(
     State(state): State<AppState>,
     Path(repo): Path<String>,
     Json(body): Json<Value>,
 ) -> impl IntoResponse {
+    // Reject repository names that would let a later create/restore escape
+    // the configured filesystem location via `..` or separators. The snapshot
+    // name is path-joined onto `repo_path` inside the engine; a `repo` of
+    // `..` is a path-traversal vector even before the repo's `settings.location`
+    // is consulted.
+    if let Err(e) = validate_snapshot_repo_name(&repo) {
+        return ApiError::new(e).into_response();
+    }
     state.engine.snapshot_repos.insert(repo, body);
     Json(json!({ "acknowledged": true })).into_response()
 }
@@ -20917,6 +20967,15 @@ pub async fn create_snapshot(
     Path((repo, snapshot)): Path<(String, String)>,
     body: OptionalJson<Value>,
 ) -> impl IntoResponse {
+    // Validate both path params before any lookup. The snapshot name is
+    // path-joined onto the repo's `settings.location`; a name containing `..`
+    // or a separator would let the engine write outside the repo.
+    if let Err(e) = validate_snapshot_repo_name(&repo) {
+        return ApiError::new(e).into_response();
+    }
+    if let Err(e) = validate_snapshot_name(&snapshot) {
+        return ApiError::new(e).into_response();
+    }
     // Look up the repository config to get the filesystem location.
     let repo_config = match state.engine.snapshot_repos.get(&repo) {
         Some(cfg) => cfg.clone(),
@@ -20986,6 +21045,12 @@ pub async fn restore_snapshot(
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     body: Option<Json<Value>>,
 ) -> impl IntoResponse {
+    if let Err(e) = validate_snapshot_repo_name(&repo) {
+        return ApiError::new(e).into_response();
+    }
+    if let Err(e) = validate_snapshot_name(&snapshot) {
+        return ApiError::new(e).into_response();
+    }
     let repo_config = match state.engine.snapshot_repos.get(&repo) {
         Some(cfg) => cfg.clone(),
         None => {

--- a/engine/crates/xerj-common/src/config.rs
+++ b/engine/crates/xerj-common/src/config.rs
@@ -889,6 +889,14 @@ pub struct LimitsConfig {
     ///
     /// Elasticsearch's mapping explosion protection. Keep this low.
     pub max_fields_per_index: u32,
+    /// Maximum number of actions in a single `_bulk` request (default:
+    /// `50_000`). Each action materializes several intermediate Vecs
+    /// (line pairs, parse outcomes, parsed actions) totalling ~300 B/entry,
+    /// so an unbounded bulk body of one-byte lines can amplify to ~7.5 GiB
+    /// of heap before any memtable admission check fires. This cap rejects
+    /// oversized bulks at the top of the parse phase with a 413-style per-item
+    /// error instead of letting jemalloc abort the process on OOM.
+    pub max_actions_per_bulk: usize,
     /// Maximum HTTP request body size in bytes (default: `100 * 1024 * 1024`,
     /// i.e. 100 MiB). Caps NDJSON bulk payloads, large mget bodies, etc.
     /// Raise this only if your client routinely sends bigger requests; the
@@ -954,6 +962,7 @@ impl Default for LimitsConfig {
             max_query_memory_mb: 512,
             max_concurrent_searches: 64,
             max_fields_per_index: 500,
+            max_actions_per_bulk: 50_000,
             max_body_bytes: 100 * 1024 * 1024,
             max_result_window: 10_000,
             max_mget_docs: 10_000,

--- a/engine/crates/xerj-common/src/types.rs
+++ b/engine/crates/xerj-common/src/types.rs
@@ -106,6 +106,21 @@ impl IndexName {
         let Some(first) = name.chars().next() else {
             return Err(XerjError::invalid_mapping("index name cannot be empty"));
         };
+        // Reject the literal names "." and ".." and any name containing a
+        // path separator. Previously a leading '.' was carved out for system
+        // indices (`.kibana`) and '.' was allowed in the body of the name,
+        // which let `..` through — `IndexName::new("..")` succeeded and
+        // `data_dir.join("..")` traversed out of the data directory.
+        if name == "." || name == ".." {
+            return Err(XerjError::invalid_mapping(format!(
+                "index name must not be '.' or '..' (got '{name}')"
+            )));
+        }
+        if name.contains('/') || name.contains('\\') || name.contains('\0') {
+            return Err(XerjError::invalid_mapping(format!(
+                "index name must not contain a path separator (got '{name}')"
+            )));
+        }
         // Allow leading '.' for system indices like .kibana, .security-* etc.
         if !first.is_ascii_lowercase() && first != '.' {
             return Err(XerjError::invalid_mapping(format!(
@@ -121,6 +136,14 @@ impl IndexName {
                      (only lowercase letters, digits, '-', '_', '.' allowed)"
                 )));
             }
+        }
+        // A leading dot is permitted (system indices), but a doubled ".."
+        // anywhere in the name is a path-traversal vector — reject it the
+        // same way the /_memory/{ns} validator does.
+        if name.contains("..") {
+            return Err(XerjError::invalid_mapping(format!(
+                "index name must not contain '..' (got '{name}')"
+            )));
         }
         Ok(())
     }
@@ -525,6 +548,16 @@ mod tests {
         assert!(IndexName::new("_private").is_err()); // starts with _
         assert!(IndexName::new("bad name").is_err()); // space
         assert!(IndexName::new("1bad").is_err()); // starts with digit
+        // Path-traversal vectors (regression: leading-dot carve-out plus '.'
+        // in the body previously let "."/".."/"a/../b" through).
+        assert!(IndexName::new(".").is_err()); // literal dot
+        assert!(IndexName::new("..").is_err()); // literal double-dot
+        assert!(IndexName::new("...").is_err()); // triple
+        assert!(IndexName::new("a..b").is_err()); // embedded ..
+        assert!(IndexName::new(".kibana..").is_err()); // trailing .. on system index
+        assert!(IndexName::new("a/b").is_err()); // forward slash
+        assert!(IndexName::new("a\\b").is_err()); // backslash
+        assert!(IndexName::new("a\0b").is_err()); // NUL
     }
 
     #[test]

--- a/engine/crates/xerj-common/src/types.rs
+++ b/engine/crates/xerj-common/src/types.rs
@@ -548,8 +548,8 @@ mod tests {
         assert!(IndexName::new("_private").is_err()); // starts with _
         assert!(IndexName::new("bad name").is_err()); // space
         assert!(IndexName::new("1bad").is_err()); // starts with digit
-        // Path-traversal vectors (regression: leading-dot carve-out plus '.'
-        // in the body previously let "."/".."/"a/../b" through).
+                                                  // Path-traversal vectors (regression: leading-dot carve-out plus '.'
+                                                  // in the body previously let "."/".."/"a/../b" through).
         assert!(IndexName::new(".").is_err()); // literal dot
         assert!(IndexName::new("..").is_err()); // literal double-dot
         assert!(IndexName::new("...").is_err()); // triple

--- a/engine/crates/xerj-engine/src/bulk.rs
+++ b/engine/crates/xerj-engine/src/bulk.rs
@@ -263,6 +263,41 @@ pub async fn process_bulk_with_opts(
     use rayon::prelude::*;
 
     let started = std::time::Instant::now();
+
+    // ── F8: bulk DoS protections ──────────────────────────────────────────
+    //
+    // 1. Acquire a global bulk-concurrency permit. Caps the number of
+    //    concurrent `_bulk` requests in the parse phase to
+    //    `max_concurrent_bulks` (default 8), preventing N concurrent bulks
+    //    from each materializing ~300 B/action of parse-phase heap before the
+    //    memtable admission check fires.
+    // 2. Enforce `max_actions_per_bulk` (default 50 000). An unbounded bulk
+    //    body of one-byte lines produces ~50 M lines → ~25 M action pairs ×
+    //    ~300 B ≈ 7.5 GiB of heap per request. The cap rejects oversized
+    //    bulks with a single 413-style error item before allocating the
+    //    parse-phase Vecs.
+    let _bulk_permit = match crate::governor::global() {
+        Some(g) => match g.acquire_bulk().await {
+            Ok(p) => Some(p),
+            Err(e) => {
+                return BulkResult {
+                    took_ms: started.elapsed().as_millis() as u64,
+                    errors: true,
+                    items: vec![BulkItemResult {
+                        action: "bulk".to_string(),
+                        index: default_index.unwrap_or("").to_string(),
+                        id: String::new(),
+                        status: 503,
+                        result: None,
+                        error: Some(e.to_string()),
+                        get_source: None,
+                    }],
+                };
+            }
+        },
+        None => None,
+    };
+
     let t_lines = std::time::Instant::now();
     let lines: Vec<&str> = body.lines().filter(|l| !l.trim().is_empty()).collect();
     let lines_ms = t_lines.elapsed().as_millis() as u64;
@@ -270,6 +305,32 @@ pub async fn process_bulk_with_opts(
     // Pre-allocate output slots — filled in after execution.
     let mut items: Vec<Option<BulkItemResult>> = Vec::new();
     let mut errors = false;
+
+    // F8: enforce `max_actions_per_bulk`. Each action is an action+doc line
+    // pair (or a single delete line), so the action count is at most
+    // `lines.len()`. Reject before building `pairs` / `parse_results` /
+    // `parsed` (the ~300 B/action amplifiers).
+    let max_actions = engine.config().limits.max_actions_per_bulk;
+    if max_actions > 0 && lines.len() > max_actions * 2 {
+        return BulkResult {
+            took_ms: started.elapsed().as_millis() as u64,
+            errors: true,
+            items: vec![BulkItemResult {
+                action: "bulk".to_string(),
+                index: default_index.unwrap_or("").to_string(),
+                id: String::new(),
+                status: 413,
+                result: None,
+                error: Some(format!(
+                    "bulk request contains {} lines (~{} actions); exceeds max_actions_per_bulk of {}",
+                    lines.len(),
+                    lines.len() / 2,
+                    max_actions,
+                )),
+                get_source: None,
+            }],
+        };
+    }
 
     // M5.3 — PARALLEL NDJSON PARSE.
     //

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -1560,6 +1560,7 @@ impl Engine {
         indices: Option<Vec<String>>,
     ) -> Result<Value> {
         let snap_dir = std::path::Path::new(repo_path).join(name);
+        let snap_dir = validate_snapshot_path(repo_path, name, &snap_dir)?;
         std::fs::create_dir_all(&snap_dir).map_err(EngineError::Io)?;
 
         // Wall-clock start, captured BEFORE the flush+copy work so
@@ -1651,6 +1652,7 @@ impl Engine {
         indices: Option<Vec<String>>,
     ) -> Result<Vec<String>> {
         let snap_dir = std::path::Path::new(repo_path).join(name);
+        let snap_dir = validate_snapshot_path(repo_path, name, &snap_dir)?;
         let manifest_path = snap_dir.join("manifest.json");
 
         let manifest_bytes = std::fs::read(&manifest_path).map_err(EngineError::Io)?;
@@ -1716,7 +1718,30 @@ impl Engine {
             selected
         };
 
+        // Canonicalize the data_dir once for the per-index containment check
+        // below. `self.data_dir` always exists at this point (the engine opens
+        // indices under it), but canonicalize defensively in case a test mounts
+        // a relative path that hasn't been created yet.
+        let data_dir_canon = self
+            .data_dir
+            .canonicalize()
+            .unwrap_or_else(|_| self.data_dir.clone());
+
         for idx_name in &index_names {
+            // Validate the index name BEFORE any filesystem op. Previously the
+            // `IndexName::new` check ran AFTER `remove_dir_all`, so a manifest
+            // carrying `..` as an index name deleted the parent of `data_dir`.
+            // `IndexName::validate` now rejects `.`/`..`/separators/`..`
+            // substrings, so this is belt-and-suspenders against a future
+            // regression in the validator.
+            let index_name = match IndexName::new(idx_name) {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!(index = idx_name, error = %e, "skipping restore of invalid index name");
+                    continue;
+                }
+            };
+
             let src_dir = snap_dir.join(idx_name.as_str());
             if !src_dir.exists() {
                 warn!(index = idx_name, "snapshot directory missing, skipping");
@@ -1724,6 +1749,19 @@ impl Engine {
             }
 
             let dst_dir = self.data_dir.join(idx_name);
+
+            // Containment: lexical check BEFORE any filesystem op. `IndexName`
+            // validation already rejects `.`/`..`/separators/`..` substrings,
+            // so this is a cheap belt-and-suspenders guard against a future
+            // regression in the validator that would let `dst_dir` escape the
+            // data_dir.
+            if !dst_dir.starts_with(&self.data_dir) {
+                return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+                    format!(
+                        "refusing to restore index [{idx_name}] outside data_dir"
+                    ),
+                )));
+            }
 
             // Remove existing index data (if any) and close it.
             if self.indices.contains_key(idx_name.as_str()) {
@@ -1734,12 +1772,24 @@ impl Engine {
             }
             std::fs::create_dir_all(&dst_dir).map_err(EngineError::Io)?;
 
+            // After create_dir_all, re-verify the canonicalized path is still
+            // inside the canonicalized data_dir (catches symlink-based escapes
+            // that the lexical check misses).
+            if let Ok(dst_canon) = dst_dir.canonicalize() {
+                if !dst_canon.starts_with(&data_dir_canon) {
+                    return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+                        format!(
+                            "refusing to restore index [{idx_name}] outside data_dir (canonical)"
+                        ),
+                    )));
+                }
+            }
+
             // Copy snapshot files back.
             let mut _files: Vec<String> = Vec::new();
             copy_dir_recursive(&src_dir, &dst_dir, &mut _files).map_err(EngineError::Io)?;
 
             // Reopen the index.
-            let index_name = IndexName::new(idx_name).map_err(EngineError::Common)?;
             match Index::open(index_name, &self.config, &self.data_dir) {
                 Ok(idx) => {
                     // Snapshot dirs carry es_mapping.json — reload it so the
@@ -1783,6 +1833,74 @@ fn now_millis() -> i64 {
 /// we do the same for ours so `_snapshot`/`_restore` operate on user data.
 pub(crate) fn is_system_index(name: &str) -> bool {
     name.starts_with(".xerj_")
+}
+
+/// Validate a snapshot repo path and snapshot name before any filesystem op.
+///
+/// Returns the canonicalized `snap_dir` (creating it is the caller's job) or
+/// an error. This is the chokepoint for the snapshot path-traversal surface:
+///   - the snapshot `name` must not contain `..`, `/`, `\`, or NUL, so
+///     `Path::new(repo).join(name)` cannot escape the repo;
+///   - the canonicalized `snap_dir` must remain inside the canonicalized
+///     `repo_path`, so a `repo_path` like `/tmp/repo/../..` is rejected;
+///   - the `repo_path` itself must not be empty (defensive).
+///
+/// Pre-fix, `PUT /_snapshot/evil` with `location: "/etc"` plus a snapshot
+/// `name = ".."` made `snap_dir = "/etc/.."`, so `create_dir_all` and
+/// `manifest.json` landed in the parent of `/etc`. The snapshot name was
+/// otherwise unvalidated.
+fn validate_snapshot_path(
+    repo_path: &str,
+    name: &str,
+    snap_dir: &std::path::Path,
+) -> Result<std::path::PathBuf> {
+    if repo_path.is_empty() {
+        return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+            "snapshot repository location must not be empty",
+        )));
+    }
+    if name.is_empty()
+        || name.contains("..")
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+    {
+        return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+            format!("invalid snapshot name [{name}]: must not be empty or contain '..', '/', '\\', or NUL"),
+        )));
+    }
+    // Canonicalize repo_path. The repo may not yet exist (create_snapshot
+    // creates it on the next line), so fall back to the lexically-cleaned
+    // path. `Path::canonicalize` requires the path to exist.
+    let repo_canon = std::path::Path::new(repo_path)
+        .canonicalize()
+        .unwrap_or_else(|_| std::path::PathBuf::from(repo_path));
+    // If snap_dir already exists, canonicalize it and verify containment;
+    // if it does not yet exist (the create_snapshot case), verify lexically
+    // that it starts with the repo.
+    if let Ok(snap_canon) = snap_dir.canonicalize() {
+        if !snap_canon.starts_with(&repo_canon) {
+            return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+                format!(
+                    "snapshot [{name}] resolves outside its repository; refusing"
+                ),
+            )));
+        }
+        Ok(snap_canon)
+    } else {
+        // Not yet on disk: lexical containment check. This catches `..` in
+        // repo_path that canonicalize couldn't resolve because the parent
+        // exists but the repo dir does not.
+        let snap_lex = snap_dir.to_path_buf();
+        if !snap_lex.starts_with(&repo_canon) {
+            return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+                format!(
+                    "snapshot [{name}] resolves outside its repository; refusing"
+                ),
+            )));
+        }
+        Ok(snap_lex)
+    }
 }
 
 /// Recursively copy all files from `src` to `dst`, recording relative paths in `files`.

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -1756,11 +1756,11 @@ impl Engine {
             // regression in the validator that would let `dst_dir` escape the
             // data_dir.
             if !dst_dir.starts_with(&self.data_dir) {
-                return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
-                    format!(
+                return Err(EngineError::Common(
+                    xerj_common::XerjError::invalid_mapping(format!(
                         "refusing to restore index [{idx_name}] outside data_dir"
-                    ),
-                )));
+                    )),
+                ));
             }
 
             // Remove existing index data (if any) and close it.
@@ -1777,11 +1777,11 @@ impl Engine {
             // that the lexical check misses).
             if let Ok(dst_canon) = dst_dir.canonicalize() {
                 if !dst_canon.starts_with(&data_dir_canon) {
-                    return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
-                        format!(
+                    return Err(EngineError::Common(
+                        xerj_common::XerjError::invalid_mapping(format!(
                             "refusing to restore index [{idx_name}] outside data_dir (canonical)"
-                        ),
-                    )));
+                        )),
+                    ));
                 }
             }
 
@@ -1855,9 +1855,11 @@ fn validate_snapshot_path(
     snap_dir: &std::path::Path,
 ) -> Result<std::path::PathBuf> {
     if repo_path.is_empty() {
-        return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
-            "snapshot repository location must not be empty",
-        )));
+        return Err(EngineError::Common(
+            xerj_common::XerjError::invalid_mapping(
+                "snapshot repository location must not be empty",
+            ),
+        ));
     }
     if name.is_empty()
         || name.contains("..")
@@ -1880,11 +1882,11 @@ fn validate_snapshot_path(
     // that it starts with the repo.
     if let Ok(snap_canon) = snap_dir.canonicalize() {
         if !snap_canon.starts_with(&repo_canon) {
-            return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
-                format!(
+            return Err(EngineError::Common(
+                xerj_common::XerjError::invalid_mapping(format!(
                     "snapshot [{name}] resolves outside its repository; refusing"
-                ),
-            )));
+                )),
+            ));
         }
         Ok(snap_canon)
     } else {
@@ -1893,11 +1895,11 @@ fn validate_snapshot_path(
         // exists but the repo dir does not.
         let snap_lex = snap_dir.to_path_buf();
         if !snap_lex.starts_with(&repo_canon) {
-            return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
-                format!(
+            return Err(EngineError::Common(
+                xerj_common::XerjError::invalid_mapping(format!(
                     "snapshot [{name}] resolves outside its repository; refusing"
-                ),
-            )));
+                )),
+            ));
         }
         Ok(snap_lex)
     }

--- a/engine/crates/xerj-engine/src/governor.rs
+++ b/engine/crates/xerj-engine/src/governor.rs
@@ -82,6 +82,15 @@ pub struct ResourceGovernor {
     /// High-water mark of concurrent searches observed (proof of the cap).
     search_inflight_peak: Arc<AtomicU64>,
 
+    // ── item 2b: global bulk pool (concurrent bulk parse cap) ─────────
+    /// Global bulk-concurrency permits. Caps the number of concurrent
+    /// `_bulk` requests in the parse phase, preventing memory amplification
+    /// from N concurrent bulks each materializing ~300 B/action before the
+    /// memtable admission check fires.
+    bulk_pool: Arc<Semaphore>,
+    /// Configured bulk permit count (for observability / stats).
+    max_concurrent_bulks: usize,
+
     // ── item 3: disk flood-stage write block ────────────────────────────
     /// Used-percentage watermark that engages the write block. `0` = off.
     disk_flood_pct: u8,
@@ -199,6 +208,25 @@ impl ResourceGovernor {
         self.max_concurrent_searches
     }
 
+    // ── item 2b: global bulk pool ──────────────────────────────────────
+
+    /// Acquire one global bulk permit. Bounds process-wide bulk-parse
+    /// concurrency to `max_concurrent_bulks` (default 8), preventing N
+    /// concurrent bulks from each materializing ~300 B/action of parse-phase
+    /// heap before the memtable admission check fires.
+    pub async fn acquire_bulk(&self) -> Result<tokio::sync::OwnedSemaphorePermit, XerjError> {
+        self.bulk_pool
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| XerjError::internal("global bulk pool closed — shutting down"))
+    }
+
+    /// Configured global bulk-concurrency cap.
+    pub fn max_concurrent_bulks(&self) -> usize {
+        self.max_concurrent_bulks
+    }
+
     // ── Sampler surface (called by the background task) ─────────────────
 
     /// Refresh every sampled atomic in one call (memtable, RSS, disk).
@@ -308,6 +336,7 @@ impl ResourceGovernor {
             max_concurrent_searches: self.max_concurrent_searches,
             search_inflight: self.search_inflight.load(Ordering::Relaxed),
             search_inflight_peak: self.search_inflight_peak.load(Ordering::Relaxed),
+            max_concurrent_bulks: self.max_concurrent_bulks,
         }
     }
 
@@ -347,6 +376,7 @@ pub struct GovernorSnapshot {
     pub max_concurrent_searches: usize,
     pub search_inflight: u64,
     pub search_inflight_peak: u64,
+    pub max_concurrent_bulks: usize,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -482,6 +512,12 @@ fn build(config: &Config) -> ResourceGovernor {
 
     let max_concurrent_searches = (limits.max_concurrent_searches.max(1)) as usize;
 
+    // Bulk concurrency cap: default 8. Bounds the number of concurrent
+    // `_bulk` requests in the parse phase. Each bulk materializes ~300 B
+    // per action before the memtable admission check fires, so N concurrent
+    // 50 k-action bulks would allocate ~N × 15 MiB of parse-phase heap.
+    let max_concurrent_bulks = 8usize;
+
     tracing::info!(
         memtable_budget_mb = memtable_budget_bytes / (1024 * 1024),
         memory_limit_mb = memory_limit_bytes / (1024 * 1024),
@@ -489,6 +525,7 @@ fn build(config: &Config) -> ResourceGovernor {
         memory_watermark_pct = limits.memory_watermark_percent,
         max_query_memory_mb = limits.max_query_memory_mb,
         max_concurrent_searches,
+        max_concurrent_bulks,
         disk_flood_pct = limits.disk_flood_stage_percent,
         segment_hydration_cache_mb = resolved_segment_hydration.bytes / (1024 * 1024),
         segment_hydration_cache_source = ?resolved_segment_hydration.source,
@@ -510,6 +547,8 @@ fn build(config: &Config) -> ResourceGovernor {
         max_concurrent_searches,
         search_inflight: Arc::new(AtomicU64::new(0)),
         search_inflight_peak: Arc::new(AtomicU64::new(0)),
+        bulk_pool: Arc::new(Semaphore::new(max_concurrent_bulks)),
+        max_concurrent_bulks,
         disk_flood_pct: limits.disk_flood_stage_percent.min(100),
         disk_blocked: AtomicBool::new(false),
         disk_used_pct: AtomicU64::new(0),

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1757,6 +1757,13 @@ pub struct Index {
     /// same embedding identity before its first document is accepted.
     embedding_config: xerj_common::config::EmbeddingConfig,
 
+    /// Snapshot of `config.limits.max_fields_per_index`, enforced on the
+    /// dynamic-mapping ingest path (`evolve_schema_from_doc(s)`) to prevent
+    /// mapping-explosion DoS. Mirrors `ManagedSchema::apply_document`'s check
+    /// but on the production path the engine uses `evolve_schema_from_doc(s)`
+    /// directly, which previously bypassed the limit.
+    max_fields_per_index: u32,
+
     /// Embedding backend for `semantic` / `semantic_text` (v0.7-P2).
     /// One of lexical (built-in, default), an external proxy, the built-in
     /// Candle neural BERT embedder, or the experimental ONNX Runtime backend
@@ -2070,6 +2077,13 @@ impl Index {
         data_dir: &Path,
     ) -> Result<Arc<Self>> {
         let index_dir = data_dir.join(name.as_str());
+        // Defense-in-depth: IndexName::validate rejects '.', '..', separators,
+        // and '..' substrings, so join cannot escape data_dir. The debug_assert
+        // catches a regression in the validator during development.
+        debug_assert!(
+            index_dir.starts_with(data_dir),
+            "IndexName validation regression: {index_dir:?} escaped {data_dir:?}"
+        );
         std::fs::create_dir_all(&index_dir)?;
 
         let store_config = store_config_from(config);
@@ -2209,6 +2223,7 @@ impl Index {
             merge_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             merge_config: config.merge.clone(),
             embedding_config: config.embedding.clone(),
+            max_fields_per_index: config.limits.max_fields_per_index,
             embedder: Arc::new(RwLock::new(effective_embedder)),
             dv_cache: Arc::new(dashmap::DashMap::new()),
             sort_shadow_cache: Arc::new(dashmap::DashMap::new()),
@@ -2489,6 +2504,7 @@ impl Index {
             merge_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             merge_config: config.merge.clone(),
             embedding_config: config.embedding.clone(),
+            max_fields_per_index: config.limits.max_fields_per_index,
             embedder: Arc::new(RwLock::new(effective_embedder)),
             dv_cache: Arc::new(dashmap::DashMap::new()),
             sort_shadow_cache: Arc::new(dashmap::DashMap::new()),
@@ -12702,13 +12718,45 @@ impl Index {
             return;
         }
 
+        // Mapping-explosion guard: enforce `max_fields_per_index` on the
+        // production ingest path. `ManagedSchema::apply_document` checks the
+        // same limit, but the engine's dynamic-mapping path calls
+        // `Schema::add_field` directly, which previously bypassed the cap.
+        // An authenticated client could ingest documents with arbitrarily many
+        // distinct field names, bloating the schema unbounded.
+        {
+            let schema = self.schema.read().await;
+            let current = schema.schema.field_count() as u32;
+            let projected = current.saturating_add(new_fields.len() as u32);
+            if projected > self.max_fields_per_index {
+                tracing::warn!(
+                    current_fields = current,
+                    new_fields = new_fields.len(),
+                    limit = self.max_fields_per_index,
+                    "rejecting schema evolution: field limit exceeded"
+                );
+                return;
+            }
+        }
+
         let mut schema = self.schema.write().await;
         if !matches!(schema.dynamic, xerj_common::schema::DynamicMapping::Dynamic) {
             return;
         }
+        // Re-check under the write lock: another concurrent ingest may have
+        // already added fields up to the limit between the read-lock check
+        // above and this write lock.
         let mut schema_changed = false;
         for (_, fc) in new_fields {
             if !schema.schema.has_field(&fc.name) {
+                if schema.schema.field_count() as u32 >= self.max_fields_per_index {
+                    tracing::warn!(
+                        field = %fc.name,
+                        limit = self.max_fields_per_index,
+                        "rejecting new field: field limit reached"
+                    );
+                    break;
+                }
                 if matches!(fc.field_type, FieldType::Date) {
                     self.has_date_fields.store(true, Ordering::Relaxed);
                 }
@@ -12753,6 +12801,22 @@ impl Index {
             return;
         }
 
+        // Mapping-explosion guard (see evolve_schema_from_docs for rationale).
+        {
+            let schema = self.schema.read().await;
+            let current = schema.schema.field_count() as u32;
+            let projected = current.saturating_add(new_fields.len() as u32);
+            if projected > self.max_fields_per_index {
+                tracing::warn!(
+                    current_fields = current,
+                    new_fields = new_fields.len(),
+                    limit = self.max_fields_per_index,
+                    "rejecting schema evolution: field limit exceeded"
+                );
+                return;
+            }
+        }
+
         // Slow path: at least one new field found.  Upgrade to write lock and
         // persist the updated schema.
         let mut schema = self.schema.write().await;
@@ -12762,6 +12826,14 @@ impl Index {
         let mut schema_changed = false;
         for (_, fc) in new_fields {
             if !schema.schema.has_field(&fc.name) {
+                if schema.schema.field_count() as u32 >= self.max_fields_per_index {
+                    tracing::warn!(
+                        field = %fc.name,
+                        limit = self.max_fields_per_index,
+                        "rejecting new field: field limit reached"
+                    );
+                    break;
+                }
                 if matches!(fc.field_type, FieldType::Date) {
                     self.has_date_fields.store(true, Ordering::Relaxed);
                 }

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -1099,6 +1099,20 @@ fn parse_query_string(params: &Value) -> Result<QueryNode> {
         .ok_or_else(|| qerr("`query_string` must be an object"))?;
 
     let query = string_field(obj, "query")?;
+    // Defense-in-depth: bound the raw query string length before tokenizing.
+    // The depth guard in `parse_qs_unary`'s `LParen` arm caps paren nesting to
+    // `MAX_QUERY_DEPTH`, but a pathological non-paren query (e.g. millions of
+    // juxtaposed terms) can still blow up the token stream. 64 KiB is far
+    // above any realistic Lucene query string (ES effectively limits this too)
+    // and well within the 100 MiB request body cap.
+    const MAX_QUERY_STRING_LEN: usize = 65_536;
+    if query.len() > MAX_QUERY_STRING_LEN {
+        return Err(qerr(format!(
+            "query_string.query length {} exceeds max of {} characters",
+            query.len(),
+            MAX_QUERY_STRING_LEN
+        )));
+    }
     let default_field = obj
         .get("default_field")
         .and_then(|v| v.as_str())
@@ -1631,6 +1645,17 @@ fn parse_qs_unary(
     match toks[*pos].clone() {
         QsTok::LParen => {
             *pos += 1;
+            // Bound paren-nesting depth. The shared thread-local `QUERY_DEPTH`
+            // is already at 1 from the outer `parse_query` call that dispatched
+            // to `parse_query_string` → `try_lower_query_string`. Each `LParen`
+            // recurses `parse_qs_or → parse_qs_and → parse_qs_unary`, so without
+            // this guard a ~100 k-paren query string overflows the tokio worker
+            // stack (default 2 MiB) and aborts the process with SIGSEGV — not
+            // catchable by `catch_unwind`. On overflow we return `None`, which
+            // `try_lower_query_string` turns into a graceful fallback to the
+            // opaque `QueryNode::QueryString` path (iterative tokenizer, no
+            // recursion). The guard decrements on drop when this arm returns.
+            let _depth_guard = DepthGuard::enter().ok()?;
             let n = parse_qs_or(toks, pos, default_field, None)?;
             if *pos >= toks.len() || !matches!(toks[*pos], QsTok::RParen) {
                 return None;
@@ -3040,7 +3065,40 @@ fn parse_more_like_this(params: &Value) -> Result<QueryNode> {
     // build the disjunction, so we fall back to the legacy MoreLikeThis node
     // (which scans all string fields on the brute path).
     if !fields.is_empty() {
-        let mut should: Vec<QueryNode> = Vec::with_capacity(fields.len() * like.len());
+        // Bound the cross-product. `fields.len() × like.len()` QueryNode entries
+        // are pre-allocated below; without a cap a ~200 KB body with 10 000
+        // fields × 10 000 like-texts forces a 10^8-entry Vec (~10 GiB) and
+        // aborts the process on OOM. ES effectively bounds MLT `fields` to a
+        // handful; we enforce hard limits and reject oversized requests
+        // with a 400-style parse error instead of allocating.
+        const MAX_MLT_FIELDS: usize = 64;
+        const MAX_MLT_LIKE: usize = 1_024;
+        const MAX_MLT_CROSS_PRODUCT: usize = 4_096;
+        if fields.len() > MAX_MLT_FIELDS {
+            return invalid(format!(
+                "`more_like_this.fields` has {} entries; max is {}",
+                fields.len(),
+                MAX_MLT_FIELDS
+            ));
+        }
+        if like.len() > MAX_MLT_LIKE {
+            return invalid(format!(
+                "`more_like_this.like` has {} entries; max is {}",
+                like.len(),
+                MAX_MLT_LIKE
+            ));
+        }
+        let cross = fields.len().saturating_mul(like.len());
+        if cross > MAX_MLT_CROSS_PRODUCT {
+            return invalid(format!(
+                "`more_like_this` cross-product ({} fields × {} like = {}) exceeds max of {}",
+                fields.len(),
+                like.len(),
+                cross,
+                MAX_MLT_CROSS_PRODUCT
+            ));
+        }
+        let mut should: Vec<QueryNode> = Vec::with_capacity(cross);
         for field in &fields {
             for text in &like {
                 should.push(QueryNode::Match {
@@ -5073,5 +5131,99 @@ mod tests {
         ] {
             assert_eq!(parse_request(&body).unwrap().fields, expected);
         }
+    }
+
+    // ── Security regression tests ───────────────────────────────────────────
+
+    /// F1: deeply nested parens in `query_string` must not overflow the stack.
+    /// Pre-fix, ~100 k nested `(` caused a SIGSEGV process abort. The depth
+    /// guard in `parse_qs_unary`'s `LParen` arm caps nesting to
+    /// `MAX_QUERY_DEPTH` (64) and falls back to the opaque `QueryString` path.
+    #[test]
+    fn test_query_string_deep_paren_nesting_does_not_overflow() {
+        // 5000 nested parens is well above the 64-depth cap but well below
+        // the stack-overflow threshold (~100 k). Pre-fix this would have
+        // recursed 5000 deep; post-fix the depth guard trips at 64 and the
+        // parser falls back to QueryString without crashing.
+        let deep = "(".repeat(5000) + "a" + &")".repeat(5000);
+        let node = q(json!({"query_string": {"query": &deep}}));
+        // The fallback is opaque QueryString (the depth guard returns None
+        // from parse_qs_unary, try_lower_query_string returns Ok(None), and
+        // parse_query_string wraps the raw query in QueryNode::QueryString).
+        // It must NOT panic / abort.
+        match &node {
+            QueryNode::QueryString { query, .. } => assert_eq!(query, &deep),
+            other => panic!("expected QueryString fallback, got {other:?}"),
+        }
+    }
+
+    /// F1: a `query_string.query` longer than 64 KiB is rejected with a parse
+    /// error (defense-in-depth before tokenizing).
+    #[test]
+    fn test_query_string_over_length_cap_rejected() {
+        let too_long = "a ".repeat(40_000); // 80_000 chars > 65_536
+        let res = parse_query(&json!({
+            "query_string": { "query": too_long }
+        }));
+        assert!(res.is_err(), "oversized query_string should be rejected");
+    }
+
+    /// F1: a legitimate moderately-nested query still lowers into a Bool tree.
+    /// Ensures the depth guard doesn't trip on reasonable nesting (10 levels).
+    #[test]
+    fn test_query_string_moderate_paren_nesting_still_parses() {
+        let mut qs = String::new();
+        for _ in 0..10 {
+            qs.push_str("(title:foo OR ");
+        }
+        qs.push_str("title:bar");
+        for _ in 0..10 {
+            qs.push(')');
+        }
+        let node = q(json!({"query_string": {"query": &qs}}));
+        // 10 levels of nesting is well within the 64-depth cap, so it should
+        // lower into a Bool tree (not fall back to opaque QueryString).
+        assert!(
+            matches!(node, QueryNode::Bool { .. }),
+            "moderate nesting should parse to Bool, got {node:?}"
+        );
+    }
+
+    /// F6: `more_like_this` with an oversized `fields × like` cross-product
+    /// is rejected with a parse error instead of pre-allocating a huge Vec.
+    /// Pre-fix, 10 000 × 10 000 would try to allocate ~10 GiB and abort.
+    #[test]
+    fn test_more_like_this_cross_product_capped() {
+        let fields: Vec<String> = (0..200).map(|i| format!("f{i}")).collect();
+        let like: Vec<String> = (0..200).map(|i| format!("text{i}")).collect();
+        let res = parse_query(&json!({
+            "more_like_this": { "fields": fields, "like": like }
+        }));
+        assert!(
+            res.is_err(),
+            "200×200=40000 cross-product exceeds 4096 cap and must be rejected"
+        );
+    }
+
+    /// F6: `more_like_this` with too many fields is rejected.
+    #[test]
+    fn test_more_like_this_fields_cap() {
+        let fields: Vec<String> = (0..65).map(|i| format!("f{i}")).collect();
+        let res = parse_query(&json!({
+            "more_like_this": { "fields": fields, "like": ["text"] }
+        }));
+        assert!(res.is_err(), "65 fields exceeds the 64-field cap");
+    }
+
+    /// F6: `more_like_this` within the caps still parses successfully.
+    #[test]
+    fn test_more_like_this_within_caps_parses() {
+        let fields = vec!["title".to_string(), "body".to_string()];
+        let like = vec!["interesting text".to_string(), "more text".to_string()];
+        // 2 fields × 2 like = 4 cross-product, well within 4096.
+        let res = parse_query(&json!({
+            "more_like_this": { "fields": fields, "like": like }
+        }));
+        assert!(res.is_ok(), "2×2 cross-product should parse fine");
     }
 }

--- a/engine/xerj.default.toml
+++ b/engine/xerj.default.toml
@@ -306,6 +306,13 @@ max_concurrent_searches = 64
 # Elasticsearch uses 1000 as its default; 500 is intentionally stricter.
 max_fields_per_index = 500
 
+# Maximum number of actions in a single _bulk request (DoS protection).
+# Each action materializes ~300 B of parse-phase heap; an unbounded bulk
+# can amplify a 100 MiB body to ~7.5 GiB of heap before admission checks
+# fire. 50 000 actions × ~300 B ≈ 15 MiB — well bounded. Set to 0 to
+# disable the cap (not recommended in production).
+max_actions_per_bulk = 50000
+
 # Process-wide retained-payload budget for the seven immutable segment
 # hydration caches (MiB). 0 derives 20% of the effective cgroup/system memory
 # limit with no minimum floor. This is not an RSS limit: query-owned results,


### PR DESCRIPTION
## Summary

Phase 1 of a security remediation plan: closes **6 Critical/High, network-reachable** findings from a security review of the engine's network-facing surface. All were single-request, network-reachable, and previously bypassed every other defense (process abort or arbitrary directory deletion before any query/ingest admission check fired).

**No config defaults or TLS/binding posture changed** — those stay for a Phase 2 PR.

## Findings fixed

| ID | Severity | One-liner |
|---|---|---|
| F1 | **Critical** | `query_string` unbounded paren recursion → stack-overflow process abort |
| F2 | **Critical** | `IndexName` accepts `.`/`..` → snapshot-restore `remove_dir_all`s parent of `data_dir` |
| F6 | High | `more_like_this` `fields × like` cross-product → unbounded alloc → OOM abort |
| F7 | High | `max_fields_per_index` (500) NOT enforced on ingest path — mapping explosion |
| F8 | High | Bulk NDJSON parse-phase memory amplification (~8–15× body) before admission |
| F9 | High | Snapshot `repo_path`/`name` unvalidated → writes outside the repo |

## Changes by file

**`engine/crates/xerj-common/src/types.rs`** — F2
- `IndexName::validate` now rejects `.`, `..`, path separators (`/`, `\`, NUL), and any `..` substring. The leading-dot carve-out for `.kibana` system indices is preserved, but a doubled `..` anywhere is blocked (mirrors the `/_memory/{ns}` validator).
- 8 new regression tests for path-traversal vectors.

**`engine/crates/xerj-query/src/parser.rs`** — F1, F6
- F1: `parse_qs_unary`'s `LParen` arm now enters `DepthGuard::enter()` before recursing into `parse_qs_or`. On overflow it returns `None`, which `try_lower_query_string` turns into a graceful fallback to the opaque `QueryNode::QueryString` path (iterative tokenizer, no recursion). Also caps `query_string.query` length at 64 KiB as defense-in-depth.
- F6: `parse_more_like_this` caps `fields` at 64, `like` at 1024, cross-product at 4096; rejects oversized with a 400-style parse error before allocating.
- 6 new regression tests (deep-paren no-overflow, length cap, moderate nesting still parses, MLT cross-product cap, MLT fields cap, MLT within caps).

**`engine/crates/xerj-engine/src/index.rs`** — F2, F7
- F2: `Index::create_with_settings` gets a `debug_assert!` containment guard.
- F7: New per-Index `max_fields_per_index` snapshot (from `config.limits`). Both `evolve_schema_from_doc` and `evolve_schema_from_docs` now check `field_count() + new_fields.len()` against the limit before adding fields, with a re-check under the write lock for concurrency.

**`engine/crates/xerj-engine/src/engine.rs`** — F2, F9
- F2: `restore_snapshot` now validates `idx_name` with `IndexName::new` **before** any `remove_dir_all`, adds a lexical containment check on `dst_dir` before the delete, and a canonicalize-and-contain check after `create_dir_all` (catches symlink escapes).
- F9: New `validate_snapshot_path` helper rejects `..`/separators/NUL in the snapshot `name`, and verifies the canonicalized `snap_dir` stays inside the canonicalized `repo_path`. Called by both `create_snapshot` and `restore_snapshot`.

**`engine/crates/xerj-api/src/es_compat.rs`** — F9
- New `validate_snapshot_repo_name` / `validate_snapshot_name` helpers applied to `put_snapshot_repo`, `create_snapshot`, and `restore_snapshot` handlers (reject `..`/separators/NUL at the API boundary).

**`engine/crates/xerj-engine/src/bulk.rs`** — F8
- Acquires a global bulk-concurrency permit at the top of `process_bulk_with_opts` (caps concurrent bulks in the parse phase).
- Enforces `max_actions_per_bulk` (default 50 000) — rejects oversized bulks with a 413-style error item before allocating the parse-phase Vecs.

**`engine/crates/xerj-engine/src/governor.rs`** — F8
- New `bulk_pool` semaphore (default 8 concurrent bulks) on `ResourceGovernor`, with `acquire_bulk()` / `max_concurrent_bulks()` accessors and a `max_concurrent_bulks` field on `GovernorSnapshot`.

**`engine/crates/xerj-common/src/config.rs`** — F8
- New `limits.max_actions_per_bulk` setting (default 50 000; 0 disables).

**`engine/xerj.default.toml`** — F8
- Documents the new `max_actions_per_bulk` setting.

## Verification

- **Builds**: `cargo build --release -p xerj-common`, `-p xerj-query`, `-p xerj-engine`, `-p xerj-api` — all clean (scoped, never workspace-wide, no `cargo clean`).
- **Unit tests**: xerj-common 31/31, xerj-query 137/137 (6 new regression tests), xerj-engine 226/226, xerj-api 65/65 — all pass.
- **Hard gate**: ES-YAML conformance **1360 passed / 0 failed / 3 skipped** — unchanged from baseline.

## Test plan

- [x] `cargo test --release -p xerj-common --lib` — 31 passed
- [x] `cargo test --release -p xerj-query --lib` — 137 passed (6 new)
- [x] `cargo test --release -p xerj-engine --lib` — 226 passed
- [x] `cargo test --release -p xerj-api --lib` — 65 passed
- [x] ES-YAML conformance suite (199 files) — 1360/0/3
- [ ] Reviewer: spot-check that `.kibana` and `.security-*` system indices still pass `IndexName::validate` (covered by existing `index_name_valid` test)
- [ ] Reviewer: confirm no existing ES-YAML suite sends a bulk > 50 000 actions (conformance run confirms none do)

## Out of scope (Phase 2)

The remaining Medium/High findings from the review (default-secure TLS/binding posture, plaintext gRPC, plaintext minted-key at-rest storage, role_descriptors not enforced, cluster Raft auth, console cookie/WebAuthn hardening, symlink escape in autoindex, neural model integrity check, dashboard security headers) are deferred to a Phase 2 PR per the agreed scope.