### PR TITLE
fix(console): show only the surfaces the engine has data for (brain-only launch)

### DIFF
--- a/xerj-ux/src/app.js
+++ b/xerj-ux/src/app.js
@@ -24,6 +24,7 @@ import {
   defaultClusterId, setDefaultCluster,
 } from './data/data-sources.js';
 import { sbBrainsPresent } from './data/brains-probe.js';
+import { dataFeaturesPresent, emptyDataFeatures } from './data/data-probe.js';
 import { activeBackendId, backendBaseUrl } from './data/backends/index.js';
 
 // ---------- state -----------------------------------------
@@ -94,7 +95,7 @@ const state = {
   // `requiresLive: '<key>'` only appears in the NAV once the matching
   // key here is true (fed by a probe against the live engine). Routes
   // and MANAGE are never filtered — a deep link must always resolve.
-  liveFeatures: { brains: false },
+  liveFeatures: { brains: false, ...emptyDataFeatures() },
 };
 // Merge any URL-seeded filters into the current dashboard's filter set.
 if (_urlState.filters) {
@@ -284,9 +285,21 @@ async function probeLiveFeatures() {
   if (_probingLive) return;
   _probingLive = true;
   try {
-    const brains = await sbBrainsPresent(backendBaseUrl(activeBackendId()));
-    if (brains !== state.liveFeatures.brains) {
-      state.liveFeatures.brains = brains;
+    const base = backendBaseUrl(activeBackendId());
+    // Two cheap probes: brains (.xerj-memory-*-edges) + the data-plane classes
+    // (chat-events, vector-ops, agent-memory, anomalies, logs-*). Each dashboard
+    // gates its nav entry on its own key so a fresh / brain-only engine never
+    // advertises a mock-filled telemetry dashboard.
+    const [brains, dataFeat] = await Promise.all([
+      sbBrainsPresent(base),
+      dataFeaturesPresent(base),
+    ]);
+    const next = { brains, ...dataFeat };
+    let changed = false;
+    for (const k of Object.keys(next)) {
+      if (next[k] !== state.liveFeatures[k]) { state.liveFeatures[k] = next[k]; changed = true; }
+    }
+    if (changed) {
       // Same guards as the store/panel re-render hooks: never nuke an
       // in-flight drag gesture or steal focus from a form field.
       const ae = document.activeElement;
@@ -900,17 +913,35 @@ async function render() {
   // the user metadata store. User-cloned dashboards inherit their
   // render from their clonedFrom template.
   const allDash = mergedDashboards(defaults, { includeHidden: true });
-  const dash = allDash.find((d) => d.id === state.route)
-    || dashboardsInSection(state.section, allDash)[0]
-    || registry['ai-overview'];
-  // NAV list only: hide live-gated dashboards until their probe says
-  // the engine has data for them (e.g. Second Brain before any
-  // `xerj brain` run). `allDash` above is deliberately NOT filtered —
-  // the deep link a fresh `xerj brain` prints must resolve instantly;
-  // the nav catches up on the next probe tick.
+  // NAV list only: hide live-gated dashboards until their probe says the engine
+  // holds their data (Second Brain before any `xerj brain`; the telemetry
+  // dashboards before anything is ingested). `allDash` stays unfiltered so a
+  // deep link resolves instantly; the nav catches up on the next probe tick.
   const navDash = mergedDashboards(defaults)
     .filter((d) => !d.requiresLive || state.liveFeatures[d.requiresLive]);
   const dashboardsForSection = dashboardsInSection('dashboards', navDash);
+  // Secondary nav: drop dashboard GROUPS that have no visible members, so an
+  // empty "Logs" group doesn't linger on a brain-only engine.
+  const activeGroups = DASHBOARD_GROUPS.filter((g) => dashboardsForSection.some((d) => d.group === g.id));
+
+  // Which dashboard to RENDER. An explicit deep link (`#/dashboards/<id>`)
+  // resolves even if that id is currently gated — a fresh `xerj brain` prints
+  // exactly such a link and it must open before the probe confirms the brain.
+  // But the DEFAULT landing must never open a gated, mock-filled dashboard: fall
+  // through to the first VISIBLE one (Second Brain on a brain-only engine, or
+  // System — always-on — on a truly empty engine).
+  const explicitDeepLink = /#\/dashboards\/[a-z0-9._-]+/i
+    .test((typeof location !== 'undefined' && location.hash) || '');
+  const routed = allDash.find((d) => d.id === state.route);
+  const routedGated = routed && routed.requiresLive && !state.liveFeatures[routed.requiresLive];
+  // Deliberately NOT synced back to state.route: keeping the (gated) default
+  // route means the fallthrough re-resolves to the first VISIBLE dashboard on
+  // every render, so the landing follows the probe — System on an empty engine,
+  // then Second Brain the moment a `xerj brain` run registers a brain. An
+  // explicit deep link sets state.route itself and takes the first branch.
+  const dash = (routed && (explicitDeepLink || !routedGated))
+    ? routed
+    : (dashboardsInSection(state.section, navDash)[0] || navDash[0] || registry['system']);
 
   // For the SEARCH dashboard, eagerly run the search so panels see hits.
   if (dash.id === 'search-discover' && !state.search.result) {
@@ -964,7 +995,7 @@ async function render() {
     }
     if (fetchErr) {
       app.innerHTML = `
-        ${Nav({ sections: SECTIONS, activeSection: state.section, dashboards: dashboardsForSection, groups: DASHBOARD_GROUPS, activeDash: dash.id, theme: state.theme, edit: state.edit, status: navStatus() })}
+        ${Nav({ sections: SECTIONS, activeSection: state.section, dashboards: dashboardsForSection, groups: activeGroups, activeDash: dash.id, theme: state.theme, edit: state.edit, status: navStatus() })}
         <div class="scene"><div class="key" style="margin-bottom:12px;">ERROR</div><h1 class="h-scene">CANNOT LOAD</h1></div>
         <pre class="mono faint" style="white-space:pre-wrap; font-size:var(--fs-13);">${esc((fetchErr && fetchErr.stack) || fetchErr)}</pre>
         <div style="margin-top:var(--sp-6);"><button type="button" data-retry class="text-btn">RETRY</button></div>`;
@@ -1053,7 +1084,7 @@ async function render() {
       sections: SECTIONS,
       activeSection: state.section,
       dashboards: dashboardsForSection,
-      groups: DASHBOARD_GROUPS,
+      groups: activeGroups,
       activeDash: dash.id,
       theme: state.theme,
       edit: state.edit,

--- a/xerj-ux/src/dashboards/registry.js
+++ b/xerj-ux/src/dashboards/registry.js
@@ -56,6 +56,19 @@ for (const d of [aiOverview, ragQuality, vectorIndex, agentMemory, secondBrain, 
 // Routing, MANAGE, and deep links (`#/dashboards/second-brain?...`)
 // always resolve; only nav presence is gated.
 secondBrain.requiresLive = 'brains';
+// Same gate for the data-plane dashboards: each falls back to full MOCK data
+// when its backing index is empty (data/backends/xerj.js → mock.js), so a fresh
+// or brain-only engine that showed them would advertise fabricated numbers. Each
+// earns a nav entry only once its own data-class index exists (fed by
+// data/data-probe.js → state.liveFeatures). Deep links still resolve; only nav
+// presence is gated. 'system' stays always-on (cluster stats always exist).
+aiOverview.requiresLive     = 'chat-events';
+ragQuality.requiresLive     = 'chat-events';
+vectorIndex.requiresLive    = 'vector-ops';
+agentMemory.requiresLive    = 'agent-memory';
+anomalyDetect.requiresLive  = 'anomalies';
+ingestPipeline.requiresLive = 'logs-ingest-events';
+logsOverview.requiresLive   = 'logs';
 // Search-discover gets tagged as the DISCOVER section (promoted out of the dashboards list).
 searchDiscover.section = 'discover';
 

--- a/xerj-ux/src/data/data-probe.js
+++ b/xerj-ux/src/data/data-probe.js
@@ -1,0 +1,97 @@
+// ============================================================
+// XERJ Console — "which data classes does this engine hold?" probe
+//
+// Sibling to brains-probe.js. The AI / logs / vector / memory dashboards each
+// fall back to FULL MOCK data when their backing index has zero rows (see
+// data/backends/xerj.js: `if (!total) return null` → query.js → mock.js). So a
+// fresh or brain-only engine that advertised those dashboards would be showing
+// fabricated numbers behind a real-looking UI. This probe answers, per data
+// class, "does the engine actually hold this?" so app.js can hide the nav entry
+// until it does — exactly the pattern secondBrain already uses via brains-probe.
+//
+// One cheap `_cat/indices` call, classified client-side by the index-name
+// literals the dashboards query (data/backends/xerj.js). Fail-CLOSED: absent on
+// any transport failure or non-OK status, so we never CLAIM data we can't prove.
+//
+// Cached per baseUrl with a short TTL (same as brains-probe) so the boot probe
+// and periodic re-probes don't hammer `_cat`, and a backend switch re-probes.
+// ============================================================
+
+const TTL_MS = 30_000;
+
+/** baseUrl → { at: epoch-ms, value: features } */
+const cache = new Map();
+
+/** The data-class feature keys, all false. Also the shape app.js merges into
+ *  state.liveFeatures, and the safe answer on any failure. */
+export function emptyDataFeatures() {
+  return {
+    'chat-events': false,
+    'vector-ops': false,
+    'agent-memory': false,
+    'anomalies': false,
+    'logs-ingest-events': false,
+    'logs': false,
+  };
+}
+
+/** Classify a list of index names into data-class presence flags. The literals
+ *  mirror the hardcoded `/<index>/_search` targets in data/backends/xerj.js. */
+export function classifyIndices(names) {
+  const has = (n) => names.includes(n);
+  const anyPrefix = (p) => names.some((n) => n.startsWith(p));
+  return {
+    'chat-events':        has('chat-events'),        // ai-overview, rag-quality
+    'vector-ops':         has('vector-ops'),          // vector-index
+    'agent-memory':       has('agent-memory'),        // agent-memory
+    'anomalies':          has('anomalies'),           // anomaly-detect
+    'logs-ingest-events': has('logs-ingest-events'),  // ingest-pipeline
+    'logs':               anyPrefix('logs-'),         // logs-overview (logs-*)
+  };
+}
+
+/**
+ * Return which data classes the engine at `baseUrl` holds. Never throws;
+ * returns all-false on transport failure, non-OK status, or empty baseUrl.
+ */
+export async function dataFeaturesPresent(baseUrl, signal) {
+  const base = (baseUrl || '').replace(/\/+$/, '');
+  if (!base) return emptyDataFeatures();
+
+  const hit = cache.get(base);
+  if (hit && Date.now() - hit.at < TTL_MS) return hit.value;
+
+  let value = emptyDataFeatures();
+  try {
+    // The data-class indices (chat-events, vector-ops, …) are non-dot, so the
+    // default `_cat/indices` lists them; no expand_wildcards needed.
+    const r = await fetch(`${base}/_cat/indices`, {
+      signal,
+      headers: { accept: 'text/plain, application/json' },
+    });
+    if (r.ok) {
+      value = classifyIndices(parseIndexNames(await r.text()));
+    }
+  } catch {
+    value = emptyDataFeatures(); // engine down / CORS / abort — no claim
+  }
+
+  cache.set(base, { at: Date.now(), value });
+  return value;
+}
+
+/**
+ * Parse a `_cat/indices` body into index names. This engine emits plain text
+ * lines (`health status NAME uuid …`); tolerate a JSON array in case a later
+ * build adds `?format=json`. Exported for the node self-test.
+ */
+export function parseIndexNames(text) {
+  const trimmed = (text || '').trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith('[')) {
+    try { return JSON.parse(trimmed).map((i) => i.index).filter(Boolean); } catch { return []; }
+  }
+  return trimmed.split('\n')
+    .map((l) => l.trim().split(/\s+/)[2])
+    .filter(Boolean);
+}


### PR DESCRIPTION
## Problem

Launching XERJ with no data — or with only a brain indexed — greeted the user with the full row of AI / RAG / Vector / Agent-Memory / Logs dashboards. Worse than empty: each of those falls back to **full mock data** when its backing index has zero rows (`data/backends/xerj.js` → `mock.js`), so the console was advertising **fabricated telemetry** behind a real-looking UI, with only a small "MOCK FALLBACK" pill as the tell.

## Fix

Extend the existing `requiresLive` nav gate — today wired only for Second Brain via `brains-probe` — to the data-plane dashboards.

- **`data/data-probe.js`** (new): one cheap `_cat/indices` call classifies which data-class indices exist (`chat-events`, `vector-ops`, `agent-memory`, `anomalies`, `logs-*`), fail-closed, mirroring `brains-probe`. Pure parse/classify logic unit-tested (14 cases).
- **`dashboards/registry.js`**: `ai-overview`/`rag-quality` gate on `chat-events`, `vector-index` on `vector-ops`, `agent-memory` on `agent-memory`, `anomaly-detect` on `anomalies`, `ingest-pipeline` on `logs-ingest-events`, `logs-overview` on `logs-*`.
- **`app.js`**: `probeLiveFeatures()` now also runs the data probe; the **default landing** resolves to the first *visible* dashboard (deep links still resolve gated ids, so a fresh `xerj brain` link opens instantly); empty dashboard **groups collapse**.

Always-on: **System** (cluster stats always exist), **Data / Settings / Users** (management surfaces).

## Verified against a freshly-built binary

| Launch state | Console now |
|---|---|
| Empty engine | Lands on **System**; dashboard groups = `[Infra]` only; **no mock** |
| Brain-only (`xerj brain`) | Lands on **Second Brain**; groups = `[AI, Infra]`, AI group = *just* Second Brain; **no mock** |
| Has telemetry | Dashboards return as their data appears |

## Follow-up (not in this PR)

A *deep link* to a gated dashboard still shows mock data (each adapter does `null → mock`). The honest fix is a real empty state per adapter (like `second-brain.js` already has) — a larger, separate change.