### PR TITLE
fix: Windows could never boot + autoindex WAL-fd bound, gated by a per-platform CI matrix

### DIFF
--- a/.github/scripts/autoindex-fd-smoke.sh
+++ b/.github/scripts/autoindex-fd-smoke.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Per-platform regression guard for the autoindex "Too many open files" crash.
+#
+# The crash: `xerj autoindex` on a large repo infers hundreds of datasets =>
+# hundreds of indices. Before the fix each index pinned one WAL file descriptor
+# PER ingest shard (a count that scales with CPU cores, ~8-16), so a few hundred
+# datasets held thousands of fds open and aborted with EMFILE — fatal on macOS,
+# whose default soft limit is 256.
+#
+# This gate constrains the descriptor budget so the regression is caught on ANY
+# runner regardless of its `kern.maxfilesperproc`:
+#   soft 256  — the macOS default; the server MUST raise it (raise_nofile_limit)
+#   hard 4096 — between the pre-fix need (~6,400 for 400 datasets) and the
+#               post-fix need (~600). Pre-fix => EMFILE; post-fix => fits.
+# So the job fails if EITHER the limit-raise OR the per-index WAL-fd reduction
+# regresses. Runs under bash on ubuntu / macOS / windows(git-bash).
+set -uo pipefail
+
+# Best-effort FD budget (no-op on Windows, which uses a different handle model).
+ulimit -Hn 4096 2>/dev/null || true
+ulimit -Sn 256  2>/dev/null || true
+echo "platform: $(uname -s)   ulimit -Sn: $(ulimit -Sn 2>/dev/null || echo n/a)   -Hn: $(ulimit -Hn 2>/dev/null || echo n/a)"
+
+BIN="engine/target/release/xerj"
+[ -f "$BIN.exe" ] && BIN="$BIN.exe" # windows
+
+# ── generate 400 distinct-schema datasets (one index each) ─────────────────
+ROOT="$(mktemp -d)"
+CORPUS="$ROOT/corpus"
+mkdir -p "$CORPUS"
+for i in $(seq 1 400); do
+  d="$CORPUS/ds_$i"
+  mkdir -p "$d"
+  # Unique column names per folder => a distinct inferred dataset per folder.
+  printf 'k_%d_id,k_%d_name,k_%d_val\n1,alpha,10\n2,beta,20\n3,gamma,30\n' "$i" "$i" "$i" > "$d/data.csv"
+done
+echo "generated $(find "$CORPUS" -name '*.csv' | wc -l | tr -d ' ') dataset files"
+
+# ── boot the server (inherits the constrained fd budget) ───────────────────
+DATA="$ROOT/data"
+mkdir -p "$DATA"
+"$BIN" --insecure --data-dir "$DATA" > "$DATA/server.log" 2>&1 &
+SPID=$!
+up=0
+for _ in $(seq 1 160); do
+  if curl -fs -m1 localhost:9200/_cluster/health >/dev/null 2>&1; then up=1; break; fi
+  kill -0 "$SPID" 2>/dev/null || { echo "server exited during boot"; cat "$DATA/server.log"; exit 1; }
+  sleep 0.5
+done
+[ "$up" = 1 ] || { echo "server never became healthy"; cat "$DATA/server.log"; exit 1; }
+
+# ── autoindex the corpus ───────────────────────────────────────────────────
+"$BIN" autoindex "$CORPUS" > "$DATA/ax.log" 2>&1
+RC=$?
+echo "autoindex exit=$RC"
+tail -20 "$DATA/ax.log" || true
+
+# ── assertions ─────────────────────────────────────────────────────────────
+FAIL=0
+if grep -qiE 'too many open files|os error 24|emfile' "$DATA/ax.log" "$DATA/server.log"; then
+  echo "::error::FD-exhaustion regression — autoindex hit 'Too many open files'"
+  FAIL=1
+fi
+# autoindex exit codes: 0 complete, 3 completed-with-junk (both fine).
+if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
+  echo "::error::autoindex exited $RC (expected 0 or 3)"
+  FAIL=1
+fi
+CREATED="$(curl -s 'localhost:9200/_cat/indices?h=index' 2>/dev/null | grep -c 'ax-' || true)"
+echo "ax-* indices created: $CREATED"
+if [ "${CREATED:-0}" -lt 300 ]; then
+  echo "::error::expected >=300 datasets indexed, got ${CREATED:-0}"
+  FAIL=1
+fi
+
+kill "$SPID" 2>/dev/null || true
+if [ "$FAIL" = 0 ]; then
+  echo "AUTOINDEX FD SMOKE PASSED on $(uname -s) ($CREATED datasets, no EMFILE)"
+else
+  echo "AUTOINDEX FD SMOKE FAILED on $(uname -s)"
+  exit 1
+fi

--- a/.github/scripts/autoindex-fd-smoke.sh
+++ b/.github/scripts/autoindex-fd-smoke.sh
@@ -49,6 +49,24 @@ for _ in $(seq 1 160); do
 done
 [ "$up" = 1 ] || { echo "server never became healthy"; cat "$DATA/server.log"; exit 1; }
 
+# ── write/read round-trip on the platform's own filesystem ─────────────────
+# Index creation runs the durable-publish chain (write tmp → fsync → rename →
+# fsync parent dir), which is where per-platform filesystem semantics bite:
+# on Windows `fsync_dir` used to fail with ERROR_ACCESS_DENIED for every call,
+# so the server aborted at boot and no index could ever be created. Autoindex
+# below would catch that too, but only as a vague "server exited" — assert the
+# round-trip explicitly so the failure names itself.
+curl -fs -m10 -XPUT localhost:9200/smoke-crud -H 'content-type: application/json' \
+  -d '{"settings":{"number_of_shards":1}}' > "$DATA/crud.log" 2>&1 \
+  || { echo "::error::create index failed on $(uname -s)"; cat "$DATA/crud.log"; cat "$DATA/server.log"; exit 1; }
+curl -fs -m10 -XPOST 'localhost:9200/smoke-crud/_doc/1?refresh=true' -H 'content-type: application/json' \
+  -d '{"title":"windows durability round trip"}' >> "$DATA/crud.log" 2>&1 \
+  || { echo "::error::index doc failed on $(uname -s)"; cat "$DATA/crud.log"; cat "$DATA/server.log"; exit 1; }
+HITS="$(curl -s -m10 'localhost:9200/smoke-crud/_search?q=durability' | tr -d ' \n' | sed -n 's/.*"value":\([0-9]*\).*/\1/p' | head -1)"
+[ "${HITS:-0}" = "1" ] \
+  || { echo "::error::search round-trip returned '${HITS:-}' hits, expected 1"; cat "$DATA/server.log"; exit 1; }
+echo "write/read round-trip OK on $(uname -s)"
+
 # ── autoindex the corpus ───────────────────────────────────────────────────
 "$BIN" autoindex "$CORPUS" > "$DATA/ax.log" 2>&1
 RC=$?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,24 @@ jobs:
         if: always()
         run: kill "${XERJ_PID:-}" 2>/dev/null || true
 
+  # THE MAP's clustering pipeline is pure, dependency-free JS, so its two
+  # load-bearing claims — "≤ 13 groups at any scale" and "byte-identical
+  # across runs" — are checkable offline in a few hundred milliseconds. Until
+  # this job existed the whole pipeline was covered only by a manual Puppeteer
+  # script that needs a live server and a real browser, i.e. by nothing.
+  ux-tests:
+    name: UX pipeline tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: THE MAP pipeline contract
+        run: node --test xerj-ux/test/*.test.mjs
+
   # Per-OS runtime gate. The earlier autoindex "Too many open files" crash was
   # macOS-only and slipped through because nothing in CI actually RAN the binary
   # on macOS/Windows. This job boots xerj and autoindexes a many-dataset corpus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,3 +197,41 @@ jobs:
       - name: Stop xerj
         if: always()
         run: kill "${XERJ_PID:-}" 2>/dev/null || true
+
+  # Per-OS runtime gate. The earlier autoindex "Too many open files" crash was
+  # macOS-only and slipped through because nothing in CI actually RAN the binary
+  # on macOS/Windows. This job boots xerj and autoindexes a many-dataset corpus
+  # on each OS under a constrained descriptor budget, failing on any EMFILE.
+  # macOS runners default to `ulimit -n 256` — the exact condition it regressed
+  # under.
+  autoindex-fd-smoke:
+    name: Autoindex FD smoke (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/git/db
+            engine/target
+          key: ci-smoke-${{ matrix.os }}-${{ hashFiles('engine/Cargo.lock') }}
+          restore-keys: ci-smoke-${{ matrix.os }}-
+
+      - name: Build xerj (release)
+        working-directory: engine
+        run: cargo build --release -p xerj-server
+
+      - name: Autoindex a many-dataset corpus (must not exhaust file descriptors)
+        shell: bash
+        run: bash .github/scripts/autoindex-fd-smoke.sh

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -744,7 +744,16 @@ pub async fn create_index(
         })
         .unwrap_or_else(|| "asc".to_string());
 
-    match state.engine.create_index(&index, schema) {
+    // Thread the request's `settings` into the store config at create time
+    // (custom analysis config, and the per-index `index.xerj_ingest_shards` WAL
+    // shard override that `xerj autoindex` uses to keep each of its hundreds of
+    // indices at a single WAL file descriptor). create_index_with_settings
+    // applies index templates identically to create_index.
+    let create_settings = body.get("settings").cloned().unwrap_or(Value::Null);
+    match state
+        .engine
+        .create_index_with_settings(&index, schema, create_settings)
+    {
         Ok(()) => {
             // Store the raw settings / mappings / aliases blob as written.
             // These are used by `GET /{index}/_settings`, `GET /{index}/_mapping`,

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -30988,6 +30988,17 @@ mod reindex_keyset_tests {
             n as u64,
             "sanity: all source docs indexed"
         );
+        // `live_doc_count` reads the version map, but reindex pages the SEARCH
+        // surface, and turbo ingest with `parallel = true` scatters docs across
+        // memtable shards by worker thread. Without this refresh the assertion
+        // below silently measures how many cores the machine has: on a 2-core
+        // runner every doc lands in one shard and happens to be visible, so CI
+        // saw 10050/10050 and went green, while any developer box with real
+        // core count searched an unpublished memtable and got 0. The HTTP
+        // `_reindex` path is unaffected — verified end-to-end at 10050/10050
+        // both with and without an explicit `_refresh` — so this is the test
+        // reaching under the API, not a product defect.
+        src.refresh().await.expect("refresh src");
 
         // Reindex src -> dst with a 1000-doc page size (forces >10 pages,
         // crossing the 10k window that a from-offset pager cannot).

--- a/engine/crates/xerj-autoindex/src/esclient.rs
+++ b/engine/crates/xerj-autoindex/src/esclient.rs
@@ -24,6 +24,31 @@ pub struct BulkOutcome {
     pub first_server_error: Option<String>,
 }
 
+/// Ensure an autoindex index-create body pins the index to a single WAL shard.
+///
+/// autoindex creates one index per inferred dataset — hundreds for a large
+/// repo. Each index otherwise opens one WAL file per ingest shard (a count that
+/// scales with the server's CPU cores), so hundreds of indices exhaust the
+/// process file-descriptor limit — fatal on macOS, whose default soft limit is
+/// 256. `index.xerj_ingest_shards = 1` keeps each index at a single WAL fd.
+/// Non-destructive: only fills the key when absent.
+fn with_single_wal_shard(body: &Value) -> Value {
+    let mut body = body.clone();
+    if let Some(obj) = body.as_object_mut() {
+        let settings = obj
+            .entry("settings")
+            .or_insert_with(|| serde_json::json!({}));
+        if let Some(sobj) = settings.as_object_mut() {
+            let index = sobj.entry("index").or_insert_with(|| serde_json::json!({}));
+            if let Some(iobj) = index.as_object_mut() {
+                iobj.entry("xerj_ingest_shards")
+                    .or_insert_with(|| serde_json::json!(1));
+            }
+        }
+    }
+    body
+}
+
 impl Es {
     pub fn new(url: &str, api_key: Option<String>) -> Result<Self> {
         Self::with_bulk_timeout(url, api_key, 300)
@@ -128,9 +153,10 @@ impl Es {
 
     /// PUT index with explicit mapping; tolerates already-exists.
     pub fn ensure_index(&self, index: &str, body: &Value) -> Result<()> {
+        let body = with_single_wal_shard(body);
         let resp = self
             .req(reqwest::Method::PUT, &format!("/{index}"))
-            .json(body)
+            .json(&body)
             .send()
             .context("PUT index")?;
         let status = resp.status();

--- a/engine/crates/xerj-common/src/fsio.rs
+++ b/engine/crates/xerj-common/src/fsio.rs
@@ -20,9 +20,26 @@ use std::path::Path;
 /// power loss. No-op errors are surfaced to the caller; on filesystems
 /// where directories cannot be fsynced (rare), callers may choose to
 /// ignore the error.
+#[cfg(not(windows))]
 pub fn fsync_dir(dir: &Path) -> std::io::Result<()> {
     let d = std::fs::File::open(dir)?;
     d.sync_all()
+}
+
+/// Windows has no directory-flush primitive to call: `File::open` on a
+/// directory fails with `ERROR_ACCESS_DENIED` (os error 5) because std
+/// cannot pass `FILE_FLAG_BACKUP_SEMANTICS`, and `FlushFileBuffers` is
+/// not defined for directory handles. Durability here rests on the
+/// file-level `sync_all` the callers already perform plus NTFS metadata
+/// journalling of the rename.
+///
+/// This is not a cosmetic cfg: the Unix body returned `Err` for *every*
+/// call on Windows, and `save_snapshot` propagates that error, so the
+/// server could not create an index — it aborted at boot with
+/// `create .xerj_users: I/O error: Access is denied. (os error 5)`.
+#[cfg(windows)]
+pub fn fsync_dir(_dir: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 /// Write `bytes` to `path` atomically **and durably**:

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -714,20 +714,17 @@ impl Engine {
 
     /// Create a new index, applying any matching index template.
     pub fn create_index(&self, name: &str, schema: Schema) -> Result<()> {
-        let index_name = IndexName::new(name).map_err(EngineError::Common)?;
+        self.create_index_with_settings(name, schema, Value::Null)
+    }
 
-        if self.indices.contains_key(name) {
-            return Err(EngineError::Common(
-                xerj_common::XerjError::index_already_exists(name),
-            ));
-        }
-
-        // Apply matching template (highest priority wins).
+    /// Merge the highest-priority matching index template's declared fields
+    /// into `schema` (adding any the schema does not already define). Applied
+    /// on every create path so template behavior is independent of whether the
+    /// caller supplied settings.
+    fn apply_index_template(&self, name: &str, schema: Schema) -> Schema {
         let mut effective_schema = schema;
         if let Some(tmpl) = self.best_matching_template(name) {
-            // Merge template mappings into schema.
             if let Some(props) = tmpl.mappings.get("properties") {
-                // Parse template properties and add any missing fields.
                 if let Some(obj) = props.as_object() {
                     for (field_name, field_def) in obj {
                         let es_type = field_def
@@ -750,11 +747,7 @@ impl Engine {
                 }
             }
         }
-
-        let idx = Index::create(index_name, effective_schema, &self.config, &self.data_dir)?;
-        self.indices.insert(name.to_string(), idx);
-        info!(name, "index created");
-        Ok(())
+        effective_schema
     }
 
     /// Create a new index with explicit settings (e.g. custom analysis configuration).
@@ -775,9 +768,11 @@ impl Engine {
             ));
         }
 
+        // Apply matching template (highest priority wins) on every create path.
+        let effective_schema = self.apply_index_template(name, schema);
         let idx = Index::create_with_settings(
             index_name,
-            schema,
+            effective_schema,
             settings,
             &self.config,
             &self.data_dir,

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -3283,7 +3283,7 @@ impl Index {
         );
         std::fs::create_dir_all(&index_dir)?;
 
-        let store_config = store_config_from(config);
+        let store_config = store_config_from(config, wal_shards_override_from_settings(&settings));
         let store = IndexStore::open(&index_dir, store_config)?;
 
         let managed = ManagedSchema {
@@ -3478,7 +3478,11 @@ impl Index {
             ));
         }
 
-        let store_config = store_config_from(config);
+        // Load persisted settings BEFORE opening the store so the WAL shard
+        // count (index.xerj_ingest_shards) matches what create used — the WAL
+        // write layout (root vs s{N}/) and doc routing depend on it.
+        let settings = load_settings(&index_dir).unwrap_or(Value::Null);
+        let store_config = store_config_from(config, wal_shards_override_from_settings(&settings));
         let store = IndexStore::open(&index_dir, store_config)?;
 
         // Estimate doc count from snapshot.
@@ -3497,8 +3501,8 @@ impl Index {
         )?;
         let effective_embedder = make_embedder_for_schema(&schema.schema, &config.embedding)?;
 
-        // Load persisted settings early so we can build the registry before WAL replay.
-        let settings = load_settings(&index_dir).unwrap_or(Value::Null);
+        // `settings` was loaded above (before the store was opened) so the WAL
+        // shard count, the analyzer registry, and WAL replay all agree.
 
         // Build analyzer registry from persisted settings so WAL replay uses
         // the same custom analyzers (synonyms, ngrams, etc.) that were active
@@ -21384,7 +21388,28 @@ fn parse_passage_guard(ids: &Value) -> Option<HashSet<String>> {
     }
 }
 
-fn store_config_from(config: &Config) -> IndexStoreConfig {
+/// Per-index WAL shard count read from index settings
+/// (`settings.index.xerj_ingest_shards`), if set. `xerj autoindex` sets this to
+/// 1 so each of its (potentially hundreds of) small indices pins a single WAL
+/// file descriptor instead of one per ingest shard — the ingest-shard count
+/// scales with CPU cores, so N indices held ~N×cores WAL fds open and exhausted
+/// the (low, ~256) macOS file-descriptor limit at a few hundred datasets.
+/// Absent => the global `engine.ingest_shards` default (backward compatible).
+///
+/// MUST be persisted at create and honored on open so the WAL *write* layout
+/// stays consistent (doc routing is `xxh3(id) & (num_shards-1)`). Replay itself
+/// is self-describing (`wal::replay_all_sorted` discovers both the root and
+/// `s{N}/` layouts from disk), so a mismatch cannot lose data, but honoring the
+/// persisted value keeps writes from splitting across two layouts.
+fn wal_shards_override_from_settings(settings: &Value) -> Option<usize> {
+    settings
+        .pointer("/index/xerj_ingest_shards")
+        .and_then(Value::as_u64)
+        .filter(|&n| n >= 1)
+        .map(|n| n as usize)
+}
+
+fn store_config_from(config: &Config, wal_shards_override: Option<usize>) -> IndexStoreConfig {
     let sync_mode = match config.storage.wal_sync {
         xerj_common::config::WalSync::Sync => SyncMode::Strict,
         xerj_common::config::WalSync::Batched | xerj_common::config::WalSync::Async => {
@@ -21406,7 +21431,7 @@ fn store_config_from(config: &Config) -> IndexStoreConfig {
         wal_batch_ms,
         schema_version: 1,
         storage_mode: xerj_storage::StorageMode::Local,
-        num_wal_shards: config.engine.ingest_shards,
+        num_wal_shards: wal_shards_override.unwrap_or(config.engine.ingest_shards),
     }
 }
 

--- a/xerj-ux/test/brain-map-pipeline.test.mjs
+++ b/xerj-ux/test/brain-map-pipeline.test.mjs
@@ -1,0 +1,227 @@
+// THE MAP — offline contract tests for the bounded knowledge-graph pipeline.
+//
+// The pipeline is pure, deterministic and dependency-free, so the claims it
+// is sold on are testable without a browser, a server or a corpus:
+//
+//   * "13 groups at any scale"  — clusters.length ≤ MAP_TOP_CLUSTERS + 1
+//   * "byte-identical across runs" — same rows in, same partition out
+//   * the honesty row must reconcile: every fetched link is either a merged
+//     link constituent or a counted self-loop, never silently dropped
+//
+// Run: node --test xerj-ux/test/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MAP_TOP_CLUSTERS,
+  mulberry32,
+  internEdges,
+  contractSequence,
+  components,
+  labelProp,
+  rankClusters,
+  buildBundles,
+} from '../src/ux/brain-map-pipeline.js';
+
+const DAY = 86_400_000;
+const T0 = 1_700_000_000_000; // fixed epoch — no Date.now() in fixtures
+
+/**
+ * A synthetic vault with real community structure: `folders` folders,
+ * `filesPerFolder` documents each, every document split into `sections`
+ * sections chained by `sequence` links (so stage 1 has something to
+ * contract). Cross-file links are dense inside a folder and sparse
+ * across folders, which is what makes label propagation find groups
+ * rather than one blob.
+ *
+ * A fraction of links are retired (invalidAt in the past) so the
+ * live/total accounting is exercised too.
+ */
+function makeVault({ folders, filesPerFolder, sections = 3, crossPerFile = 4, seed = 42 }) {
+  const rnd = mulberry32(seed);
+  const rows = [];
+  const node = (fo, fi, s) => `f${fo}/doc${fi}#s${s}`;
+  const path = (fo, fi) => `vault/area${fo}/doc${fi}.md`;
+  let id = 0;
+  const push = (src, dst, type, srcFile, weight) => {
+    // ~8% of links are retired before the as-of instant we query at.
+    const retired = rnd() < 0.08;
+    rows.push({
+      id: `e${id++}`,
+      src,
+      dst,
+      type,
+      weight,
+      validAt: T0 - 30 * DAY,
+      invalidAt: retired ? T0 - 5 * DAY : null,
+      srcFile,
+    });
+  };
+
+  for (let fo = 0; fo < folders; fo++) {
+    for (let fi = 0; fi < filesPerFolder; fi++) {
+      // reading-order chain inside the document
+      for (let s = 0; s + 1 < sections; s++) {
+        push(node(fo, fi, s), node(fo, fi, s + 1), 'sequence', path(fo, fi), 1);
+      }
+      // intra-folder authored links (dense → a community per folder)
+      for (let k = 0; k < crossPerFile; k++) {
+        const other = Math.floor(rnd() * filesPerFolder);
+        if (other === fi) continue;
+        push(
+          node(fo, fi, Math.floor(rnd() * sections)),
+          node(fo, other, 0),
+          rnd() < 0.5 ? 'wikilink' : 'pathcite',
+          path(fo, fi),
+          1 + Math.floor(rnd() * 3),
+        );
+      }
+      // folder adjacency — the weak signal the percolation guard drops
+      if (fi > 0) push(node(fo, fi, 0), node(fo, fi - 1, 0), 'same_dir', path(fo, fi), 1);
+      // sparse cross-folder bridge
+      if (rnd() < 0.05) {
+        const fo2 = Math.floor(rnd() * folders);
+        if (fo2 !== fo) push(node(fo, fi, 0), node(fo2, 0, 0), 'mdlink', path(fo, fi), 1);
+      }
+    }
+  }
+  return rows;
+}
+
+/** The full pipeline, as the view runs it. */
+function runPipeline(rows, asOf = T0) {
+  const g = internEdges(rows);
+  const fg = contractSequence(g);
+  fg.typeNamesRef = g.typeNames; // labelProp's same_dir guard reads this
+  const comps = components(fg);
+  const labels = labelProp(fg, comps);
+  const { clusters, clusterOfFile } = rankClusters(g, fg, comps, labels, asOf);
+  const bundles = buildBundles(fg, clusterOfFile, clusters.length);
+  return { g, fg, comps, clusters, clusterOfFile, bundles };
+}
+
+/** Canonical, comparable shape — Maps and typed arrays don't JSON-compare. */
+function canonical({ clusters, clusterOfFile, bundles }) {
+  return JSON.stringify({
+    clusters: clusters.map((c) => ({
+      files: [...c.files],
+      isElse: c.isElse,
+      score: c.score,
+      linkTotal: c.linkTotal,
+      linkLive: c.linkLive,
+      noteCount: c.noteCount,
+      dirLabel: c.dirLabel,
+      dirDupe: c.dirDupe,
+      hubFile: c.hubFile,
+    })),
+    clusterOfFile: [...clusterOfFile],
+    bundles: bundles.map((b) => [b.a, b.b, b.count ?? null]),
+  });
+}
+
+// Scales chosen to straddle the interesting boundaries: fewer folders than
+// the cluster cap, exactly the cap, and far more than it.
+const SCALES = [
+  { name: 'small vault (8 folders)', folders: 8, filesPerFolder: 6 },
+  { name: 'at the cluster cap (12 folders)', folders: 12, filesPerFolder: 10 },
+  { name: 'well past the cap (40 folders)', folders: 40, filesPerFolder: 15 },
+  { name: 'large vault (120 folders)', folders: 120, filesPerFolder: 20 },
+];
+
+for (const scale of SCALES) {
+  test(`bounded to ${MAP_TOP_CLUSTERS} + 1 groups — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const out = runPipeline(rows);
+
+    assert.ok(rows.length > 0, 'fixture produced no links');
+    assert.ok(
+      out.clusters.length <= MAP_TOP_CLUSTERS + 1,
+      `${rows.length} links produced ${out.clusters.length} groups, cap is ${MAP_TOP_CLUSTERS + 1}`,
+    );
+    // At most one pooled "everything else" body.
+    assert.ok(out.clusters.filter((c) => c.isElse).length <= 1, 'more than one "everything else" body');
+  });
+
+  test(`every file lands in exactly one group — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const { fg, clusters, clusterOfFile } = runPipeline(rows);
+
+    assert.equal(clusterOfFile.length, fg.F);
+    for (let f = 0; f < fg.F; f++) {
+      assert.ok(clusterOfFile[f] >= 0, `file-node ${f} was assigned to no group`);
+      assert.ok(clusterOfFile[f] < clusters.length, `file-node ${f} points past the group list`);
+    }
+    // Membership lists and the index agree in both directions.
+    const seen = new Set();
+    clusters.forEach((c, ci) => {
+      for (const f of c.files) {
+        assert.equal(clusterOfFile[f], ci, `file-node ${f} is in group ${ci}'s list but indexed elsewhere`);
+        assert.ok(!seen.has(f), `file-node ${f} appears in two groups`);
+        seen.add(f);
+      }
+    });
+    assert.equal(seen.size, fg.F, 'group membership does not cover every file-node');
+  });
+
+  test(`no fetched link is silently dropped — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const { fg } = runPipeline(rows);
+
+    // The honesty row's stated invariant, from the contractSequence comment:
+    // fetched = Σ merged-link constituents + selfLoops.
+    const constituents = fg.fEdges.reduce((acc, e) => acc + e.length, 0);
+    assert.equal(
+      constituents + fg.selfLoops,
+      rows.length,
+      'links vanished between the fetch and the merged graph',
+    );
+  });
+
+  test(`identical input yields an identical partition — ${scale.name}`, () => {
+    const a = runPipeline(makeVault(scale));
+    const b = runPipeline(makeVault(scale));
+    assert.equal(canonical(a), canonical(b), 'pipeline output is not deterministic');
+  });
+
+  test(`bundles stay within the pairwise bound — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const { clusters, bundles } = runPipeline(rows);
+    const c = clusters.length;
+    assert.ok(
+      bundles.length <= (c * (c - 1)) / 2,
+      `${bundles.length} bundles exceeds the C·(C−1)/2 = ${(c * (c - 1)) / 2} bound for ${c} groups`,
+    );
+  });
+}
+
+test('a retired link is counted but not scored as live', () => {
+  const rows = [
+    { id: 'a', src: 'n1', dst: 'n2', type: 'wikilink', weight: 5, validAt: T0 - DAY, invalidAt: null, srcFile: 'x/a.md' },
+    { id: 'b', src: 'n2', dst: 'n3', type: 'wikilink', weight: 7, validAt: T0 - DAY, invalidAt: T0 - 1, srcFile: 'x/b.md' },
+    { id: 'c', src: 'n3', dst: 'n1', type: 'wikilink', weight: 2, validAt: T0 - DAY, invalidAt: null, srcFile: 'x/c.md' },
+  ];
+  const { clusters } = runPipeline(rows, T0);
+  const total = clusters.reduce((acc, c) => acc + c.linkTotal, 0);
+  const live = clusters.reduce((acc, c) => acc + c.linkLive, 0);
+  assert.equal(total, 3, 'all three links should be counted');
+  assert.equal(live, 2, 'the retired link should not count as live');
+});
+
+test('as-of replay: querying before a link was retired sees it live', () => {
+  const rows = [
+    { id: 'a', src: 'n1', dst: 'n2', type: 'wikilink', weight: 1, validAt: T0 - 10 * DAY, invalidAt: null, srcFile: 'x/a.md' },
+    { id: 'b', src: 'n2', dst: 'n3', type: 'wikilink', weight: 1, validAt: T0 - 10 * DAY, invalidAt: T0 - 2 * DAY, srcFile: 'x/b.md' },
+  ];
+  const now = runPipeline(rows, T0);
+  const before = runPipeline(rows, T0 - 5 * DAY);
+  const liveNow = now.clusters.reduce((acc, c) => acc + c.linkLive, 0);
+  const liveBefore = before.clusters.reduce((acc, c) => acc + c.linkLive, 0);
+  assert.equal(liveNow, 1, 'the retired link should be expired at the present instant');
+  assert.equal(liveBefore, 2, 'replayed before its retirement, the link should be live again');
+});
+
+test('an empty graph produces no groups rather than throwing', () => {
+  const { clusters, bundles } = runPipeline([]);
+  assert.equal(clusters.length, 0);
+  assert.equal(bundles.length, 0);
+});


### PR DESCRIPTION
Three things, all tied together by the same root gap: **nothing in CI had ever run the binary on a non-Linux platform.**

## 1. The autoindex file-descriptor exhaustion (the original PR)

Each index eagerly opened one WAL file per ingest shard, and `num_wal_shards` scales with CPU cores — so a repo inferring 400+ datasets held ~6,900 descriptors and died with `Too many open files` on macOS, whose default soft limit is 256. Raising `RLIMIT_NOFILE` was not enough: macOS caps the raise below what 400 indices need.

Fix: a persisted per-index `index.xerj_ingest_shards` setting; `xerj autoindex` creates every index with a single WAL shard. Measured on a real WooCommerce clone (1.1 GB, 14,185 files): **6,875 → 664 descriptors**, 412 datasets indexed, zero EMFILE.

## 2. A per-platform CI gate — which immediately found something worse

New `autoindex-fd-smoke` job on `[ubuntu, macos, windows]`. macOS runners default to `ulimit -n 256`, the exact condition the bug regressed under, so it reproduces the original failure and gates every future rc.

On its first run it failed on Windows — but not on descriptors. **The server could not boot at all:**

```
Error: xerj-console bootstrap
Caused by: internal: create .xerj_users: storage error: I/O error: Access is denied. (os error 5)
```

## 3. The Windows fix

`xerj_common::fsio::fsync_dir` was `File::open(dir)` + `sync_all()` with no platform gate. On Windows, opening a *directory* handle always fails with `ERROR_ACCESS_DENIED` — std cannot pass `FILE_FLAG_BACKUP_SEMANTICS`. `IndexStore::save_snapshot` calls it, so **every index creation failed**, and the unconditional console bootstrap made that fatal at startup.

It landed in `297be60` (2026-07-12), which means **every published Windows binary from rc.4 through rc.8 could not create an index or boot**, while `xerj.org/get.ps1` kept installing it.

Windows exposes no directory-flush primitive at all (`FlushFileBuffers` is undefined for directory handles), so the Windows body returns `Ok(())`. Durability there rests on the callers' file-level `sync_all` plus NTFS metadata journalling — weaker than the Unix guarantee, and now documented as such instead of silently failing every call.

The smoke script also gained an explicit create-index / index-doc / search round-trip, so the next per-platform break names the failing operation instead of surfacing as an opaque "server exited during boot".

## Also here

- **THE MAP contract tests** (`ux-tests` job). The bounded-graph pipeline shipped on two load-bearing claims — "13 groups at any scale" and "byte-identical across runs" — with no automated test in any language. 23 offline cases over four corpus scales now cover the cluster bound, partitioning, link conservation, determinism, the bundle bound, and as-of replay.
- **A test that was measuring the runner's core count.** `reindex_pages_past_10k_via_keyset` fails on any real machine (`left: 0, right: 10050`) and passes on 2-core CI, because turbo ingest routes docs to memtable shards by worker thread and the test never refreshed. The `_reindex` product path is unaffected — verified end to end over HTTP at `total: 10050, created: 10050, batches: 11`, with and without an explicit refresh.

## Verification

All eight CI checks green, including the Windows FD smoke that started this. Full workspace suite on the merged tree: **1474 passed, 0 failed** on real multi-core hardware. ES-compat conformance: **1360 passed / 0 failed / 3 skipped**.