### PR TITLE
release: cut v1.0.0-rc.9 — cross-platform correctness, plus the test coverage that found four more bugs

### DIFF
--- a/.github/scripts/installer-lint.sh
+++ b/.github/scripts/installer-lint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Syntax gate for the two install scripts served from xerj.org — `curl | sh`
+# and `irm | iex` are the first thing a new user runs, so a parse error there
+# is a broken front door that no other job would catch (neither file is Rust,
+# neither is executed by any test).
+#
+# Deliberately cheap and tool-optional: the parse checks below are the floor
+# and always run; shellcheck (POSIX sh) and pwsh (PowerShell AST) sharpen them
+# when the runner happens to have them, and are skipped — never failed — when
+# it does not.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+SH="$REPO/landing/get"
+PS="$REPO/landing/get.ps1"
+ERR="$(mktemp)"
+trap 'rm -f "$ERR"' EXIT
+
+FAIL=0
+note() { echo "  $*"; }
+bad()  { echo "::error::$*"; FAIL=1; }
+
+echo "── installer lint ──"
+
+for f in "$SH" "$PS"; do
+  [ -f "$f" ] || bad "installer missing: $f"
+done
+[ "$FAIL" = 0 ] || exit 1
+
+# ── landing/get — POSIX sh ────────────────────────────────────────────────
+if sh -n "$SH" 2>"$ERR"; then
+  note "PASS: sh -n landing/get"
+else
+  bad "landing/get is not valid POSIX sh"
+  sed 's/^/    /' "$ERR"
+fi
+
+# The script is piped into `sh`, so a bashism that a bash-as-sh runner happily
+# accepts still breaks users on dash/ash. Those are SC3xxx, reported at warning
+# severity — hence -S warning rather than errors-only. Style notes stay advisory.
+if command -v shellcheck >/dev/null 2>&1; then
+  if shellcheck -s sh -S warning "$SH"; then
+    note "PASS: shellcheck -s sh (warnings and up)"
+  else
+    bad "shellcheck reported errors in landing/get"
+  fi
+else
+  note "SKIP: shellcheck not installed"
+fi
+
+# ── landing/get.ps1 — PowerShell ──────────────────────────────────────────
+# The path travels in the environment: `pwsh -Command` appends trailing argv
+# to the command text rather than binding it to $args.
+if command -v pwsh >/dev/null 2>&1; then
+  if XERJ_PS_FILE="$PS" pwsh -NoProfile -NonInteractive -Command '
+      $errors = $null
+      [void][System.Management.Automation.Language.Parser]::ParseFile(
+        $env:XERJ_PS_FILE, [ref]$null, [ref]$errors)
+      if ($errors.Count -gt 0) { $errors | ForEach-Object { $_.ToString() }; exit 1 }
+      exit 0'; then
+    note "PASS: PowerShell parser accepts landing/get.ps1"
+  else
+    bad "landing/get.ps1 has PowerShell parse errors"
+  fi
+else
+  note "SKIP: pwsh not installed"
+fi
+
+echo "──"
+if [ "$FAIL" = 0 ]; then
+  echo "INSTALLER LINT PASSED"
+else
+  echo "INSTALLER LINT FAILED"
+  exit 1
+fi

--- a/.github/scripts/usecase-smoke.sh
+++ b/.github/scripts/usecase-smoke.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# CI gate for the use-case harnesses under demo/usecases/.
+#
+# Those harnesses are the only executable proof that the shipped use cases
+# still work — the brain HTTP surface, the MCP tool surface an agent sees, and
+# autoindex's zero-config discovery. Until this script existed every one of
+# them was run by hand, so a regression in any of the three was caught by
+# nothing.
+#
+# It drives the EXISTING harnesses rather than restating them: gen-corpus.sh →
+# boot-and-brain.sh → transcript.sh → mcp-smoke.sh, then run-eval.sh over a
+# small generated corpus plus a search round-trip. Everything they need is
+# passed as an env override, so this stays free of machine-specific paths.
+#
+# Deliberately self-contained: no browser, no model, no network, nothing
+# outside the repo — only the release binaries, curl and jq.
+#
+# Env overrides:
+#   XERJ_BIN                xerj binary        (default <repo>/engine/target/release/xerj)
+#   XERJ_MCP_BIN            xerj-mcp binary    (default <repo>/engine/target/release/xerj-mcp)
+#   XERJ_USECASE_ROOT       scratch root       (default a fresh mktemp -d)
+#   XERJ_BRAIN_DEMO_PORT    brain es-compat    (default 9331; also takes +1/+2)
+#   XERJ_AUTOINDEX_PORT     autoindex es-compat(default 9341; also takes +100/+101)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+SB="$REPO/demo/usecases/second-brain"
+
+XERJ_BIN="${XERJ_BIN:-$REPO/engine/target/release/xerj}"
+XERJ_MCP_BIN="${XERJ_MCP_BIN:-$REPO/engine/target/release/xerj-mcp}"
+[ -f "$XERJ_BIN.exe" ] && XERJ_BIN="$XERJ_BIN.exe"
+[ -f "$XERJ_MCP_BIN.exe" ] && XERJ_MCP_BIN="$XERJ_MCP_BIN.exe"
+
+ROOT="${XERJ_USECASE_ROOT:-$(mktemp -d)}"
+BRAIN_PORT="${XERJ_BRAIN_DEMO_PORT:-9331}"
+AX_PORT="${XERJ_AUTOINDEX_PORT:-9341}"
+BRAIN_ROOT="$ROOT/second-brain"
+AX_WORK="$ROOT/autoindex"
+AX_URL="http://localhost:$AX_PORT"
+mkdir -p "$BRAIN_ROOT" "$AX_WORK"
+
+FAILED=0
+phase() { echo; echo "════ $* ════"; }
+bad()   { echo "::error::$*"; FAILED=$((FAILED + 1)); }
+ok()    { echo "  PASS: $*"; }
+
+# The brain server is spawned detached by `xerj brain` and outlives that
+# command by design, so it must be stopped explicitly however we exit.
+cleanup() {
+  for pidfile in "$BRAIN_ROOT/data/server.pid" "$AX_WORK/server.pid"; do
+    [ -s "$pidfile" ] && kill "$(cat "$pidfile")" 2>/dev/null
+  done
+  return 0
+}
+trap cleanup EXIT
+
+# ── 0. preflight ──────────────────────────────────────────────────────────
+phase "0. preflight"
+for tool in curl jq; do
+  command -v "$tool" >/dev/null 2>&1 \
+    || { echo "::error::$tool is required by the use-case harnesses but is not installed"; exit 1; }
+done
+
+# Use the release binaries the job already built; build only the missing
+# package if this is being run from a bare checkout.
+build_if_missing() {
+  local bin="$1" pkg="$2"
+  [ -x "$bin" ] && return 0
+  echo "  $pkg not built at $bin — building it"
+  command -v cargo >/dev/null 2>&1 \
+    || { echo "::error::$bin is missing and cargo is not available to build $pkg"; exit 1; }
+  (cd "$REPO/engine" && cargo build --release -p "$pkg") \
+    || { echo "::error::failed to build $pkg"; exit 1; }
+}
+build_if_missing "$XERJ_BIN" xerj-server
+build_if_missing "$XERJ_MCP_BIN" xerj-mcp
+echo "  xerj:     $XERJ_BIN ($("$XERJ_BIN" --version 2>/dev/null | head -1))"
+echo "  xerj-mcp: $XERJ_MCP_BIN"
+echo "  scratch:  $ROOT"
+
+export XERJ_BIN XERJ_MCP_BIN
+
+# ── 1. second brain: pinned corpus → live brain → API transcript ──────────
+phase "1. second brain (corpus, boot, transcript)"
+export XERJ_BRAIN_DEMO_ROOT="$BRAIN_ROOT"
+export XERJ_BRAIN_DEMO_PORT="$BRAIN_PORT"
+
+if bash "$SB/boot-and-brain.sh"; then
+  ok "brain booted and indexed the pinned demo vault"
+else
+  bad "boot-and-brain.sh failed — no brain to assert against"
+  tail -40 "$BRAIN_ROOT/data/server.log" 2>/dev/null
+  echo "USE-CASE SMOKE FAILED"
+  exit 1
+fi
+
+# overview/ego/link/unlink/as_of replay + the normative 400/404s.
+if bash "$SB/transcript.sh"; then
+  ok "second-brain API transcript"
+else
+  bad "second-brain API transcript failed (see the FAIL lines above)"
+fi
+
+# ── 2. the agent surface: MCP tools listed and callable ───────────────────
+phase "2. MCP tool surface"
+if bash "$SB/mcp-smoke.sh"; then
+  ok "MCP tools listed and tools/call round-tripped"
+else
+  bad "MCP smoke failed (see the FAIL lines above)"
+fi
+
+# ── 3. autoindex: zero-config discovery, then find a value by search ──────
+phase "3. autoindex discovery + query"
+CORPUS="$AX_WORK/corpus"
+mkdir -p "$CORPUS/orders" "$CORPUS/logs" "$CORPUS/people"
+# Three shapes, three inferred datasets. The tokens are nonsense words so a
+# hit can only come from THIS corpus having been discovered, parsed and made
+# searchable — never from anything else on the runner.
+cat > "$CORPUS/orders/orders.csv" <<'EOF'
+order_id,customer,amount,placed_at
+1,zanzibarite,42.50,2026-01-04
+2,quovadium,17.25,2026-01-05
+3,zanzibarite,99.00,2026-01-06
+EOF
+cat > "$CORPUS/people/people.jsonl" <<'EOF'
+{"person_id":1,"name":"quovadium","city":"lisbon","role":"buyer"}
+{"person_id":2,"name":"zanzibarite","city":"porto","role":"buyer"}
+EOF
+cat > "$CORPUS/logs/app.log" <<'EOF'
+2026-01-04T10:00:00Z INFO  checkout completed for zanzibarite
+2026-01-04T10:00:01Z WARN  retry scheduled for quovadium
+2026-01-04T10:00:02Z ERROR payment declined for quovadium
+EOF
+
+export XERJ_AUTOINDEX_WORK="$AX_WORK" XERJ_AUTOINDEX_PORT="$AX_PORT"
+if bash "$REPO/demo/usecases/autoindex/run-eval.sh" "$CORPUS" "$XERJ_BIN"; then
+  ok "autoindex discovered the corpus and re-ran idempotently"
+else
+  bad "autoindex eval failed (discovery or idempotency)"
+  tail -40 "$AX_WORK/server-$AX_PORT.log" 2>/dev/null
+fi
+
+curl -s -o /dev/null -m 30 -XPOST "$AX_URL/ax-*/_refresh" || true
+
+# _cat/indices always emits the full `green open <name> …` row, so match the
+# name column rather than anchoring at the start of the line.
+DATASETS="$(curl -s -m 30 "$AX_URL/_cat/indices" | grep -cE '(^|[[:space:]])ax-' || true)"
+echo "  ax-* datasets: ${DATASETS:-0}"
+if [ "${DATASETS:-0}" -ge 3 ]; then
+  ok "each of the 3 source shapes became its own dataset"
+else
+  bad "expected >=3 ax-* datasets from the 3-shape corpus, got ${DATASETS:-0}"
+fi
+
+if curl -s -m 30 "$AX_URL/autoindex-catalog/_search?size=0" | jq -e '.hits' >/dev/null 2>&1; then
+  ok "autoindex-catalog is queryable"
+else
+  bad "autoindex-catalog index is missing or unqueryable"
+fi
+
+# The discovery claim in full: a value that existed only inside a CSV cell is
+# retrievable by search, with no schema and no mapping written by hand.
+HITS="$(curl -s -m 30 -G "$AX_URL/ax-*/_search" --data-urlencode 'q=zanzibarite' \
+        --data-urlencode 'size=0' | jq -r '.hits.total.value // .hits.total // 0')"
+echo "  hits for 'zanzibarite': ${HITS:-0}"
+if [ "${HITS:-0}" -ge 3 ]; then
+  ok "a CSV/JSONL/log value is searchable straight after discovery"
+else
+  bad "expected >=3 hits for 'zanzibarite' across the discovered datasets, got ${HITS:-0}"
+fi
+
+# ── summary ───────────────────────────────────────────────────────────────
+echo
+if [ "$FAILED" = 0 ]; then
+  echo "USE-CASE SMOKE PASSED (second brain · MCP · autoindex)"
+else
+  echo "USE-CASE SMOKE FAILED — $FAILED phase(s) broken"
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,45 @@ jobs:
       - name: THE MAP pipeline contract
         run: node --test xerj-ux/test/*.test.mjs
 
+  # The harnesses under demo/usecases/ are the only executable proof that the
+  # shipped use cases still work — the brain HTTP surface, the MCP tool surface
+  # an agent actually sees, and autoindex's zero-config discovery. Every one of
+  # them was manual until this job, so a regression in any was caught by
+  # nothing. The installer lint rides along: landing/get{,.ps1} had no
+  # verification of any kind and needs no toolchain, so it gates first and
+  # cheaply.
+  usecase-smoke:
+    name: Use-case harnesses (brain + MCP + autoindex)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installer script lint (landing/get, landing/get.ps1)
+        run: bash .github/scripts/installer-lint.sh
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/git/db
+            engine/target
+          key: ci-cargo-${{ hashFiles('engine/Cargo.lock') }}
+          restore-keys: ci-cargo-
+
+      - name: Build xerj + xerj-mcp (release)
+        working-directory: engine
+        run: cargo build --release -p xerj-server -p xerj-mcp
+
+      # Drives the demo/usecases scripts themselves, so the thing CI gates is
+      # the same thing a reader runs. No browser, no model, no network.
+      - name: Use-case smoke (brain transcript, MCP tools, autoindex discovery)
+        run: bash .github/scripts/usecase-smoke.sh
+
   # Per-OS runtime gate. The earlier autoindex "Too many open files" crash was
   # macOS-only and slipped through because nothing in CI actually RAN the binary
   # on macOS/Windows. This job boots xerj and autoindexes a many-dataset corpus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,24 @@ jobs:
         if: always()
         run: kill "${XERJ_PID:-}" 2>/dev/null || true
 
+  # THE MAP's clustering pipeline is pure, dependency-free JS, so its two
+  # load-bearing claims — "≤ 13 groups at any scale" and "byte-identical
+  # across runs" — are checkable offline in a few hundred milliseconds. Until
+  # this job existed the whole pipeline was covered only by a manual Puppeteer
+  # script that needs a live server and a real browser, i.e. by nothing.
+  ux-tests:
+    name: UX pipeline tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: THE MAP pipeline contract
+        run: node --test xerj-ux/test/*.test.mjs
+
   # Per-OS runtime gate. The earlier autoindex "Too many open files" crash was
   # macOS-only and slipped through because nothing in CI actually RAN the binary
   # on macOS/Windows. This job boots xerj and autoindexes a many-dataset corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,284 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.9] - 2026-07-31
+
+Ninth release candidate: the **cross-platform correctness release**.
+Headline for users, stated plainly because it is the most serious defect
+this project has shipped: **the Windows binaries published as rc.4
+through rc.8 could not start.** Every index creation returned
+`Access is denied. (os error 5)`, and because the console bootstrap
+creates a system index on first boot, the server aborted before it ever
+listened. `xerj.org/get.ps1` installed those binaries for three weeks.
+The cause was one unguarded Unix idiom in the durability path; the fix
+is four lines, and a Windows runner now boots the binary, writes a
+document, reads it back and indexes 400 datasets on every pull request.
+Nothing else caught this because, until this release, no CI job had ever
+*run* the binary anywhere except Ubuntu — `release.yml` built eight
+targets and executed none of them.
+
+The release also closes the self-contained half of the post-audit
+security backlog — a snapshot location that could still escape
+`data_dir`, index-name validation missing at the create boundary, a
+field limit that dynamic ingest enforced and explicit mapping updates
+did not, an unserialised magic-link redemption, and node identity leaking
+from an unauthenticated endpoint — and it carries the consequences of
+taking the Windows lesson seriously: a test pass over the surfaces that
+shipped untested, and the four real defects writing those tests exposed.
+A create-time file-descriptor exhaustion reachable from an index-create
+request, inline `<script>` contents indexed as prose, XML record election
+that changed shape between runs of the same file, and a core dump on
+`xerj … | head`. The Rust suite grows from 1,420 to 1,486 test
+functions; conformance is unchanged at 1360 passed / 0 failed / 3
+skipped. The only performance change is a memory regression fix in the
+ONNX embedding path; no speed measurement was taken and none is claimed.
+The `_reindex` keyset behaviour is untouched — a test around it was
+wrong, not the code, and that distinction is spelled out below because
+it is easy to misread as a data-loss bug.
+
+### Fixed
+
+- **The server can start on Windows.** `xerj_common::fsio::fsync_dir`
+  was `std::fs::File::open(dir)` followed by `sync_all()`, with no
+  platform gate. On Windows, obtaining a handle to a *directory* that
+  way always fails with `ERROR_ACCESS_DENIED (os error 5)`: the standard
+  library cannot pass `FILE_FLAG_BACKUP_SEMANTICS`, which that call
+  requires. `IndexStore::save_snapshot` fsyncs the parent directory
+  after publishing the segment manifest, so **every index creation
+  returned an I/O error**, and the unconditional `xerj-console`
+  bootstrap — which creates `.xerj_users` on first boot — turned that
+  into a fatal `xerj-console bootstrap` error at startup. Introduced in
+  `297be60` (2026-07-12) as part of the power-loss-ordered publish
+  chain, so it affected rc.4, rc.5, rc.6, rc.7 and rc.8. Windows now
+  takes a separate `fsync_dir` that returns `Ok(())`, because Windows
+  exposes no directory-flush primitive at all — `FlushFileBuffers` is
+  not defined for directory handles. **State the consequence honestly:
+  durability on Windows is weaker than on Unix.** The file contents are
+  still fsynced by the callers before the rename; what is not forced is
+  the rename itself, which relies on NTFS metadata journalling. That is
+  the best available behaviour on the platform, and it is now a
+  documented property rather than an error returned on every call.
+- **`xerj … | head` no longer aborts with a core dump.** The Rust
+  runtime installs `SIG_IGN` for `SIGPIPE` before `main`, so once the
+  reader closed the pipe the next write returned `EPIPE`, `println!`
+  panicked with `failed printing to stdout: Broken pipe`, and the
+  release profile's `panic = "abort"` turned that into a core dump —
+  which also swallowed the command's real exit status. The binary now
+  restores the default disposition before anything can write to stdout
+  (unix only), so the kernel terminates the process on the signal and
+  shells report the conventional 141. Found because `xerj autoindex map
+  | head -80` core-dumped on every run of a use-case harness. **Two
+  consequences worth knowing.** Client sockets are unaffected: the
+  standard library writes those with `MSG_NOSIGNAL` (`SO_NOSIGPIPE` on
+  macOS), so a client disconnecting mid-response still surfaces as
+  `EPIPE` and cannot signal the server. The server's own stdout does
+  change — previously tracing discarded write errors and a server
+  outlived a vanished stdout; now the next log line terminates it.
+  Supervised deployments redirect stdout to a file or `/dev/null` (the
+  `brain` boot path included), so in practice this reaches only
+  `xerj | reader-that-leaves`.
+- **Inline `<script>` and `<style>` contents are no longer indexed as
+  prose.** The HTML extractor's `skip_until` state suppressed the
+  *tags* inside those elements but the tokenizer's text branch appended
+  their contents to the buffer unconditionally, and the closing tag
+  continued without discarding it — so the buffered CSS and JavaScript
+  were flushed into the document body at the next tag boundary.
+  Minified stylesheets and scripts became indexed prose in every HTML
+  record: BM25 noise, and — the reason this is more than a quality bug
+  — inline configuration blocks carrying API keys, tokens and internal
+  endpoints were stored in `_source`. For the "point xerj at my project
+  folder" use case that is a real exposure. Text is now dropped at the
+  point it is read rather than at the closing tag, which also bounds an
+  unclosed `<script>`: the tail of the file is discarded instead of
+  buffered.
+- **XML record election is deterministic.** `elect_record_tag` chose the
+  repeating element with `max_by_key` over a `HashMap`, and `max_by_key`
+  settles ties by iteration order — which is seeded randomly per map.
+  When a wrapper element and one of its children were both structured
+  and equally frequent, repeated runs over the *same bytes* elected
+  different tags: 200 runs of one fixture split 89 / 111. The record
+  count and the locators held, so the documents kept their `_id`s, but
+  every one was rewritten with a completely different field set, and
+  field inference for that dataset never settled. The comparison is now
+  total — most occurrences, then the outermost tag, then the lowest name
+  — with the outermost tag as the principled key: when a wrapper repeats
+  as often as its child, the wrapper is the record and the child is one
+  of its fields.
+
+- **The ONNX embedding path no longer materialises every window upfront.**
+  `embed_semantic_jobs` built and cloned the passage text of every window
+  before embedding any of them, so peak memory scaled with the whole job
+  rather than with what was in flight. Windows now carry
+  `(start, end, passages)` and their texts are built lazily and moved
+  into `embed_batch`, with at most two batches in flight. This closes a
+  memory regression at default settings (#71); no throughput measurement
+  was taken and no speed claim is made.
+
+### Security
+
+Five items from the post-audit backlog, each with a regression test
+where the defect is testable, plus one found while writing this
+release's tests. The three that remain open are listed under Known
+limitations rather than quietly omitted.
+
+- **Snapshot repository locations could still escape `data_dir`
+  (#73, High).** The residual half of F-PATH-02: a `settings.location`
+  containing `..` that resolved to a *nonexistent* target slipped past
+  the guard, because canonicalisation fell back to a lexical path and
+  the containment check compared components of a path that had never
+  been resolved. `..` components are now rejected outright, before any
+  resolution. The regression test covers both the direct form and
+  laundering it through an explicit allowlist entry.
+- **Index-name validation is enforced at the create-index boundary
+  (#80).** `IndexName::validate` existed and was applied elsewhere;
+  the ES-compatible `create_index` handler did not call it. Wiring it up
+  is defense in depth against path traversal through index names — the
+  accepted set is unchanged, so no previously valid name is now
+  rejected.
+- **The field limit applies to explicit mapping updates (#76 S5-5).**
+  `max_fields_per_index` was enforced on dynamic ingest but not on the
+  explicit `add_fields` path, so `PUT _mapping` and schema evolution
+  could push an index past the ceiling that exists to bound mapping
+  explosion.
+- **Concurrent magic-link redemptions cannot both mint a session
+  (#76 S5-3).** The check-then-consume sequence in the redeem handler
+  was not serialised, so two requests carrying the same token could both
+  pass the used-check. Redemption is now serialised behind a gate.
+  Stated precisely, because it is easy to overclaim: in the shipped
+  engine the second session was already being blocked incidentally, by
+  the index's optimistic concurrency rejecting the colliding write — so
+  the observable pre-fix exposure was a 500 with internal detail instead
+  of a clean 401, plus a single-use guarantee that rested on what the
+  store happened to do with racing writes rather than on the handler.
+  The fix moves that guarantee into the handler where it belongs. This
+  is covered by 25 rounds of 6 concurrent redemptions.
+- **The unauthenticated `cluster/info` body no longer leaks the node
+  identifier or exact build version (#76 AUTHZ-2).** It now carries only
+  mode and uptime.
+- **A per-index setting could exhaust file descriptors at index-create
+  time.** `index.xerj_ingest_shards` — added in rc.8 to *reduce*
+  descriptor usage — was accepted with only a `>= 1` check, and the
+  ES-compatible create-index handler threads the request body's
+  `settings` through verbatim. `IndexStore::open` eagerly creates a
+  directory and opens a WAL file descriptor per shard, so
+  `{"settings":{"index":{"xerj_ingest_shards": 100000}}}` was a
+  single-request descriptor and inode exhaustion — precisely the failure
+  the setting exists to prevent. The override is now bounded to
+  `1..=256`, the same ceiling `EngineConfig::validate` already enforced
+  on the global `engine.ingest_shards`. Out-of-range values are
+  **refused, not clamped**, so a typo falls back to the engine default
+  rather than silently taking a different one. Found while writing the
+  tests that rc.8 shipped without.
+
+### Added
+
+- **CI runs the binary on macOS and Windows.** A new
+  `autoindex-fd-smoke` job on an `[ubuntu, macos, windows]` matrix boots
+  the server under a constrained descriptor budget (soft 256 / hard
+  4096 — between the pre-fix need of roughly 6,400 for 400 datasets and
+  the post-fix 600), asserts a create-index / index-document / search
+  round-trip, autoindexes a 400-dataset corpus and fails on any
+  `EMFILE`. macOS runners default to `ulimit -n 256`, the exact
+  condition the rc.8 descriptor bug regressed under, so the job
+  reproduces it rather than approximating it. The explicit round-trip
+  exists so that the next platform-specific break names the operation
+  that failed instead of surfacing as an opaque "server exited during
+  boot".
+- **The use-case harnesses run in CI.** A new `usecase-smoke.sh` gate
+  drives the second-brain transcript (overview counts and detector
+  families, ego evidence and `not_shown`, idempotent link, unlink
+  retiring rather than deleting, `as_of` replay, and the normative
+  `hops > 2` / self-edge 400s and unknown-brain 404), the MCP tool
+  surface (initialize handshake, the four `xerj_brain_*` tools listed
+  with their honesty strings, and a real `tools/call` round-trip), and
+  autoindex discovery with post-discovery search. These harnesses
+  already existed but were manual, so a regression in the brain API or
+  the MCP tool list was caught by nothing. Wiring them up immediately
+  found two assertions that could never have passed: the transcript
+  pinned detector versions at `@1` when five of them are at `@2`, and
+  the autoindex idempotency check compared whole `_cat/indices` rows
+  including on-disk size, which legitimately changes across a re-extract.
+- **THE MAP's bounded-graph claims are tested.** The knowledge-graph
+  pipeline shipped in rc.7 on two load-bearing claims — at most 13
+  groups at any scale, and byte-identical output across runs — with no
+  automated test in any language behind either; the only exercise was a
+  manual browser script needing a live server and a real Chrome. The
+  pipeline is pure dependency-free JavaScript, so 23 offline cases now
+  run in under a second over four corpus scales (8, 12, 40 and 120
+  folders, straddling the 12-cluster cap): the group bound with at most
+  one pooled "everything else" body, every file landing in exactly one
+  group with the membership lists and the index agreeing both ways, link
+  conservation against the honesty row the UI computes from,
+  run-to-run determinism, the pairwise bundle bound, and `as_of` replay
+  making a retired link live again.
+- **Regression cover for four surfaces that shipped without any.** The
+  DOCX decompression and paragraph caps from rc.7 (both verified by
+  removing each guard in turn and confirming the matching test fails);
+  the six autoindex extractors that had no direct tests at all — HTML,
+  CSV, JSON, JSONL, XML and SQLite, 49 cases; the magic-link redemption
+  race hardened in rc.9's Phase-2 work, driven with 25 rounds of 6
+  concurrent redemptions; and the per-index WAL shard override,
+  including a reopen test that pins a shard count, writes documents that
+  live only in the memtable and WAL, restarts, and asserts both the
+  layout and every document survive. An installer lint gate covers
+  `landing/get` and `landing/get.ps1`, which had no verification of any
+  kind despite being the only user-facing entry point.
+
+### Changed
+
+- **A test was measuring the CI runner's core count, not the code.**
+  `reindex_pages_past_10k_via_keyset` failed on any machine with real
+  core count (`left: 0, right: 10050`) and passed on CI's two-core
+  runners, so `cargo test --workspace` was red for every developer and
+  green for the project. Turbo ingest routes documents to memtable
+  shards by worker thread: on two cores they all land in one
+  incidentally-visible shard, on a real box they scatter into
+  unpublished shards that the search the reindex pages over cannot see.
+  The sanity assertion above it passed either way because
+  `live_doc_count` reads the version map rather than the search surface.
+  The test now refreshes the source. **The `_reindex` product path was
+  never affected** — driven end to end over HTTP, bulk-indexing 10,050
+  documents and reindexing with `size: 1000` reports
+  `total: 10050, created: 10050, batches: 11` and the destination counts
+  10,050, both with and without an explicit refresh. This was the test
+  reaching under the API, not a reindex defect, and it is recorded here
+  because a bare changelog line about "reindex returning 0 documents"
+  would badly misrepresent it.
+
+### Known limitations
+
+- **DOCX truncation at the decompression cap is silent.** When a
+  document's XML inflates past the 72 MiB cap the reader simply hits
+  end-of-file; because a truncated tag reads as a clean `Eof` rather
+  than an error, nothing increments the junk counter. A bomb-truncated
+  document is therefore indistinguishable from a legitimately short one
+  — the caller gets a well-formed record that is quietly missing
+  content. The memory bound itself holds and is tested; only the
+  *reporting* is missing. Making truncation observable would change the
+  statistics autoindex reports, so it is deliberately left for a
+  separate change.
+- **`index.xerj_ingest_shards` is only read in its nested spelling.**
+  `{"index": {"xerj_ingest_shards": 1}}` is honoured;
+  `{"index.xerj_ingest_shards": 1}` is not, unlike the neighbouring
+  `index.sort.*` settings which accept both. Nothing in the product
+  emits the flat form, so this is an inconsistency rather than a break.
+- **A brain is still not an authorization boundary.** Any authenticated
+  caller can read any brain's `overview` and `ego`; with a shared engine
+  that is a multi-tenant exposure. This needs an access model rather
+  than a patch and is tracked in #79, deliberately not rushed into a
+  release candidate. The concrete part of that issue — the walker
+  indexing `.env` and other dotfiles — was fixed in rc.7.
+- **Cluster transport control messages are still unauthenticated**
+  (#75). Reachable only with cluster mode enabled, which is off by
+  default.
+- **`x-forwarded-for` is still trusted for client identity** (#76 S5-4),
+  which means a caller can spoof the address the per-IP rate limiter
+  keys on. The fix needs `ConnectInfo` threaded through the shared
+  serve and TLS path and is deliberately not bundled with the smaller
+  items above.
+- **Windows durability is weaker than Unix durability**, as described
+  under Fixed. The platform provides no way to make it otherwise.
+
 ## [1.0.0-rc.8] - 2026-07-31
 
 Eighth release candidate: an **autoindex robustness + code-AST release**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,291 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.9] - 2026-07-31
+
+Ninth release candidate: the **cross-platform correctness release**.
+Headline for users, stated plainly because it is the most serious defect
+this project has shipped: **the Windows binaries published as rc.4
+through rc.8 could not start.** Every index creation returned
+`Access is denied. (os error 5)`, and because the console bootstrap
+creates a system index on first boot, the server aborted before it ever
+listened. `xerj.org/get.ps1` installed those binaries for three weeks.
+The cause was one unguarded Unix idiom in the durability path; the fix
+is four lines, and a Windows runner now boots the binary, writes a
+document, reads it back and indexes 400 datasets on every pull request.
+Nothing else caught this because, until this release, no CI job had ever
+*run* the binary anywhere except Ubuntu — `release.yml` built eight
+targets and executed none of them.
+
+The release also closes the self-contained half of the post-audit
+security backlog — a snapshot location that could still escape
+`data_dir`, index-name validation missing at the create boundary, a
+field limit that dynamic ingest enforced and explicit mapping updates
+did not, an unserialised magic-link redemption, and node identity leaking
+from an unauthenticated endpoint — and it carries the consequences of
+taking the Windows lesson seriously: a test pass over the surfaces that
+shipped untested, and the four real defects writing those tests exposed.
+A create-time file-descriptor exhaustion reachable from an index-create
+request, inline `<script>` contents indexed as prose, XML record election
+that changed shape between runs of the same file, and a core dump on
+`xerj … | head`. The Rust suite grows from 1,420 to 1,486 test
+functions; conformance is unchanged at 1360 passed / 0 failed / 3
+skipped. The only performance change is a memory regression fix in the
+ONNX embedding path; no speed measurement was taken and none is claimed.
+The `_reindex` keyset behaviour is untouched — a test around it was
+wrong, not the code, and that distinction is spelled out below because
+it is easy to misread as a data-loss bug.
+
+### Fixed
+
+- **The server can start on Windows.** `xerj_common::fsio::fsync_dir`
+  was `std::fs::File::open(dir)` followed by `sync_all()`, with no
+  platform gate. On Windows, obtaining a handle to a *directory* that
+  way always fails with `ERROR_ACCESS_DENIED (os error 5)`: the standard
+  library cannot pass `FILE_FLAG_BACKUP_SEMANTICS`, which that call
+  requires. `IndexStore::save_snapshot` fsyncs the parent directory
+  after publishing the segment manifest, so **every index creation
+  returned an I/O error**, and the unconditional `xerj-console`
+  bootstrap — which creates `.xerj_users` on first boot — turned that
+  into a fatal `xerj-console bootstrap` error at startup. Introduced in
+  `297be60` (2026-07-12) as part of the power-loss-ordered publish
+  chain, so it affected rc.4, rc.5, rc.6, rc.7 and rc.8. Windows now
+  takes a separate `fsync_dir` that returns `Ok(())`, because Windows
+  exposes no directory-flush primitive at all — `FlushFileBuffers` is
+  not defined for directory handles. **State the consequence honestly:
+  durability on Windows is weaker than on Unix.** The file contents are
+  still fsynced by the callers before the rename; what is not forced is
+  the rename itself, which relies on NTFS metadata journalling. That is
+  the best available behaviour on the platform, and it is now a
+  documented property rather than an error returned on every call.
+- **`xerj … | head` no longer aborts with a core dump.** The Rust
+  runtime installs `SIG_IGN` for `SIGPIPE` before `main`, so once the
+  reader closed the pipe the next write returned `EPIPE`, `println!`
+  panicked with `failed printing to stdout: Broken pipe`, and the
+  release profile's `panic = "abort"` turned that into a core dump —
+  which also swallowed the command's real exit status. The binary now
+  restores the default disposition before anything can write to stdout
+  (unix only), so the kernel terminates the process on the signal and
+  shells report the conventional 141. Found because `xerj autoindex map
+  | head -80` core-dumped on every run of a use-case harness. **Two
+  consequences worth knowing.** Client sockets are unaffected: the
+  standard library writes those with `MSG_NOSIGNAL` (`SO_NOSIGPIPE` on
+  macOS), so a client disconnecting mid-response still surfaces as
+  `EPIPE` and cannot signal the server. The server's own stdout does
+  change — previously tracing discarded write errors and a server
+  outlived a vanished stdout; now the next log line terminates it.
+  Supervised deployments redirect stdout to a file or `/dev/null` (the
+  `brain` boot path included), so in practice this reaches only
+  `xerj | reader-that-leaves`.
+- **Inline `<script>` and `<style>` contents are no longer indexed as
+  prose.** The HTML extractor's `skip_until` state suppressed the
+  *tags* inside those elements but the tokenizer's text branch appended
+  their contents to the buffer unconditionally, and the closing tag
+  continued without discarding it — so the buffered CSS and JavaScript
+  were flushed into the document body at the next tag boundary.
+  Minified stylesheets and scripts became indexed prose in every HTML
+  record: BM25 noise, and — the reason this is more than a quality bug
+  — inline configuration blocks carrying API keys, tokens and internal
+  endpoints were stored in `_source`. For the "point xerj at my project
+  folder" use case that is a real exposure. Text is now dropped at the
+  point it is read rather than at the closing tag, which also bounds an
+  unclosed `<script>`: the tail of the file is discarded instead of
+  buffered.
+- **XML record election is deterministic.** `elect_record_tag` chose the
+  repeating element with `max_by_key` over a `HashMap`, and `max_by_key`
+  settles ties by iteration order — which is seeded randomly per map.
+  When a wrapper element and one of its children were both structured
+  and equally frequent, elections over the *same bytes* chose different
+  tags: 200 in-process elections over one fixture split 89 / 111. The
+  record count and the locators held, so documents kept their `_id`s,
+  but each build gave them a completely different field set, and field
+  inference for that dataset never settled across builds. The comparison
+  is now total — most occurrences, then the outermost tag, then the
+  lowest name — with the outermost tag as the principled key: when a
+  wrapper repeats as often as its child, the wrapper is the record and
+  the child is one of its fields. **Two limits worth being precise
+  about.** This bites across *independent* builds — a `--fresh` run, a
+  new state directory, a second machine, a CI reproducibility check —
+  not across ordinary repeated runs, because the resume journal skips
+  files whose content digest has not changed. For the same reason an
+  index built before this fix does **not** heal itself: it keeps
+  whatever shape it rolled until the XML file's bytes change or the
+  index is rebuilt with `--fresh`.
+
+- **The ONNX embedding path no longer materialises every window upfront.**
+  `embed_semantic_jobs` built and cloned the passage text of every window
+  before embedding any of them, so peak memory scaled with the whole job
+  rather than with what was in flight. Windows now carry
+  `(start, end, passages)` and their texts are built lazily and moved
+  into `embed_batch`, with at most two batches in flight. This closes a
+  memory regression at default settings (#71); no throughput measurement
+  was taken and no speed claim is made.
+
+### Security
+
+Five items from the post-audit backlog, each with a regression test
+where the defect is testable, plus one found while writing this
+release's tests. The three that remain open are listed under Known
+limitations rather than quietly omitted.
+
+- **Snapshot repository locations could still escape `data_dir`
+  (#73, High).** The residual half of F-PATH-02: a `settings.location`
+  containing `..` that resolved to a *nonexistent* target slipped past
+  the guard, because canonicalisation fell back to a lexical path and
+  the containment check compared components of a path that had never
+  been resolved. `..` components are now rejected outright, before any
+  resolution. The regression test covers both the direct form and
+  laundering it through an explicit allowlist entry.
+- **Index-name validation is enforced at the create-index boundary
+  (#80).** `IndexName::validate` existed and was applied elsewhere;
+  the ES-compatible `create_index` handler did not call it. Wiring it up
+  is defense in depth against path traversal through index names — the
+  accepted set is unchanged, so no previously valid name is now
+  rejected.
+- **The field limit applies to explicit mapping updates (#76 S5-5).**
+  `max_fields_per_index` was enforced on dynamic ingest but not on the
+  explicit `add_fields` path, so `PUT _mapping` and schema evolution
+  could push an index past the ceiling that exists to bound mapping
+  explosion.
+- **Concurrent magic-link redemptions cannot both mint a session
+  (#76 S5-3).** The check-then-consume sequence in the redeem handler
+  was not serialised, so two requests carrying the same token could both
+  pass the used-check. Redemption is now serialised behind a gate.
+  Stated precisely, because it is easy to overclaim: in the shipped
+  engine the second session was already being blocked incidentally, by
+  the index's optimistic concurrency rejecting the colliding write — so
+  the observable pre-fix exposure was a 500 with internal detail instead
+  of a clean 401, plus a single-use guarantee that rested on what the
+  store happened to do with racing writes rather than on the handler.
+  The fix moves that guarantee into the handler where it belongs. This
+  is covered by 25 rounds of 6 concurrent redemptions.
+- **The unauthenticated `cluster/info` body no longer leaks the node
+  identifier or exact build version (#76 AUTHZ-2).** It now carries only
+  mode and uptime.
+- **A per-index setting could exhaust file descriptors at index-create
+  time.** `index.xerj_ingest_shards` — added in rc.8 to *reduce*
+  descriptor usage — was accepted with only a `>= 1` check, and the
+  ES-compatible create-index handler threads the request body's
+  `settings` through verbatim. `IndexStore::open` eagerly creates a
+  directory and opens a WAL file descriptor per shard, so
+  `{"settings":{"index":{"xerj_ingest_shards": 100000}}}` was a
+  single-request descriptor and inode exhaustion — precisely the failure
+  the setting exists to prevent. The override is now bounded to
+  `1..=256`, the same ceiling `EngineConfig::validate` already enforced
+  on the global `engine.ingest_shards`. Out-of-range values are
+  **refused, not clamped**, so a typo falls back to the engine default
+  rather than silently taking a different one. Found while writing the
+  tests that rc.8 shipped without.
+
+### Added
+
+- **CI runs the binary on macOS and Windows.** A new
+  `autoindex-fd-smoke` job on an `[ubuntu, macos, windows]` matrix boots
+  the server under a constrained descriptor budget (soft 256 / hard
+  4096 — between the pre-fix need of roughly 6,400 for 400 datasets and
+  the post-fix 600), asserts a create-index / index-document / search
+  round-trip, autoindexes a 400-dataset corpus and fails on any
+  `EMFILE`. macOS runners default to `ulimit -n 256`, the exact
+  condition the rc.8 descriptor bug regressed under, so the job
+  reproduces it rather than approximating it. The explicit round-trip
+  exists so that the next platform-specific break names the operation
+  that failed instead of surfacing as an opaque "server exited during
+  boot".
+- **The use-case harnesses run in CI.** A new `usecase-smoke.sh` gate
+  drives the second-brain transcript (overview counts and detector
+  families, ego evidence and `not_shown`, idempotent link, unlink
+  retiring rather than deleting, `as_of` replay, and the normative
+  `hops > 2` / self-edge 400s and unknown-brain 404), the MCP tool
+  surface (initialize handshake, the four `xerj_brain_*` tools listed
+  with their honesty strings, and a real `tools/call` round-trip), and
+  autoindex discovery with post-discovery search. These harnesses
+  already existed but were manual, so a regression in the brain API or
+  the MCP tool list was caught by nothing. Wiring them up immediately
+  found two assertions that could never have passed: the transcript
+  pinned detector versions at `@1` when five of them are at `@2`, and
+  the autoindex idempotency check compared whole `_cat/indices` rows
+  including on-disk size, which legitimately changes across a re-extract.
+- **THE MAP's bounded-graph claims are tested.** The knowledge-graph
+  pipeline shipped in rc.7 on two load-bearing claims — at most 13
+  groups at any scale, and byte-identical output across runs — with no
+  automated test in any language behind either; the only exercise was a
+  manual browser script needing a live server and a real Chrome. The
+  pipeline is pure dependency-free JavaScript, so 23 offline cases now
+  run in under a second over four corpus scales (8, 12, 40 and 120
+  folders, straddling the 12-cluster cap): the group bound with at most
+  one pooled "everything else" body, every file landing in exactly one
+  group with the membership lists and the index agreeing both ways, link
+  conservation against the honesty row the UI computes from,
+  run-to-run determinism, the pairwise bundle bound, and `as_of` replay
+  making a retired link live again.
+- **Regression cover for four surfaces that shipped without any.** The
+  DOCX decompression and paragraph caps from rc.7 (both verified by
+  removing each guard in turn and confirming the matching test fails);
+  the six autoindex extractors that had no direct tests at all — HTML,
+  CSV, JSON, JSONL, XML and SQLite, 49 cases; the magic-link redemption
+  race hardened in rc.9's Phase-2 work, driven with 25 rounds of 6
+  concurrent redemptions; and the per-index WAL shard override,
+  including a reopen test that pins a shard count, writes documents that
+  live only in the memtable and WAL, restarts, and asserts both the
+  layout and every document survive. An installer lint gate covers
+  `landing/get` and `landing/get.ps1`, which had no verification of any
+  kind despite being the only user-facing entry point.
+
+### Changed
+
+- **A test was measuring the CI runner's core count, not the code.**
+  `reindex_pages_past_10k_via_keyset` failed on any machine with real
+  core count (`left: 0, right: 10050`) and passed on CI's two-core
+  runners, so `cargo test --workspace` was red for every developer and
+  green for the project. Turbo ingest routes documents to memtable
+  shards by worker thread: on two cores they all land in one
+  incidentally-visible shard, on a real box they scatter into
+  unpublished shards that the search the reindex pages over cannot see.
+  The sanity assertion above it passed either way because
+  `live_doc_count` reads the version map rather than the search surface.
+  The test now refreshes the source. **The `_reindex` product path was
+  never affected** — driven end to end over HTTP, bulk-indexing 10,050
+  documents and reindexing with `size: 1000` reports
+  `total: 10050, created: 10050, batches: 11` and the destination counts
+  10,050, both with and without an explicit refresh. This was the test
+  reaching under the API, not a reindex defect, and it is recorded here
+  because a bare changelog line about "reindex returning 0 documents"
+  would badly misrepresent it.
+
+### Known limitations
+
+- **DOCX truncation at the decompression cap is silent.** When a
+  document's XML inflates past the 72 MiB cap the reader simply hits
+  end-of-file; because a truncated tag reads as a clean `Eof` rather
+  than an error, nothing increments the junk counter. A bomb-truncated
+  document is therefore indistinguishable from a legitimately short one
+  — the caller gets a well-formed record that is quietly missing
+  content. The memory bound itself holds and is tested; only the
+  *reporting* is missing. Making truncation observable would change the
+  statistics autoindex reports, so it is deliberately left for a
+  separate change.
+- **`index.xerj_ingest_shards` is only read in its nested spelling.**
+  `{"index": {"xerj_ingest_shards": 1}}` is honoured;
+  `{"index.xerj_ingest_shards": 1}` is not, unlike the neighbouring
+  `index.sort.*` settings which accept both. Nothing in the product
+  emits the flat form, so this is an inconsistency rather than a break.
+- **A brain is still not an authorization boundary.** Any authenticated
+  caller can read any brain's `overview` and `ego`; with a shared engine
+  that is a multi-tenant exposure. This needs an access model rather
+  than a patch and is tracked in #79, deliberately not rushed into a
+  release candidate. The concrete part of that issue — the walker
+  indexing `.env` and other dotfiles — was fixed in rc.7.
+- **Cluster transport control messages are still unauthenticated**
+  (#75). Reachable only with cluster mode enabled, which is off by
+  default.
+- **`x-forwarded-for` is still trusted for client identity** (#76 S5-4),
+  which means a caller can spoof the address the per-IP rate limiter
+  keys on. The fix needs `ConnectInfo` threaded through the shared
+  serve and TLS path and is deliberately not bundled with the smaller
+  items above.
+- **Windows durability is weaker than Unix durability**, as described
+  under Fixed. The platform provides no way to make it otherwise.
+
 ## [1.0.0-rc.8] - 2026-07-31
 
 Eighth release candidate: an **autoindex robustness + code-AST release**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,10 +93,20 @@ it is easy to misread as a data-loss bug.
   record: BM25 noise, and — the reason this is more than a quality bug
   — inline configuration blocks carrying API keys, tokens and internal
   endpoints were stored in `_source`. For the "point xerj at my project
-  folder" use case that is a real exposure. Text is now dropped at the
-  point it is read rather than at the closing tag, which also bounds an
-  unclosed `<script>`: the tail of the file is discarded instead of
-  buffered.
+  folder" use case that is a real exposure. Script and style elements
+  are now treated as the raw-text elements they are — the scanner jumps
+  to the literal end tag instead of tokenising inside them, which also
+  bounds an unclosed `<script>`: the tail of the file is discarded
+  rather than buffered and indexed. Two narrower ways the leak survived
+  a first attempt were caught in review and are closed here. A trailing
+  `/` inside an *unquoted* attribute value (`<script src=/cdn/lib/>`)
+  was read as a self-closing tag, so the element was never entered —
+  legal HTML5, since `script` is never a void element. And an end tag
+  whose name ran on into a non-alphanumeric character
+  (`</script-foo>`) was accepted as the terminator, ending raw text
+  early and indexing everything after it. The tag scanner now tracks
+  attribute state to decide self-closing, and the end-tag test follows
+  the spec's appropriate-end-tag rule: whitespace, `/`, or `>`.
 - **XML record election is deterministic.** `elect_record_tag` chose the
   repeating element with `max_by_key` over a `HashMap`, and `max_by_key`
   settles ties by iteration order — which is seeded randomly per map.
@@ -117,6 +127,22 @@ it is easy to misread as a data-loss bug.
   index built before this fix does **not** heal itself: it keeps
   whatever shape it rolled until the XML file's bytes change or the
   index is rebuilt with `--fresh`.
+- **Three further inference elections are deterministic.** Reviewing the
+  fix above found the same defect — `max_by_key` over a `HashMap`, ties
+  settled by a per-instance random hash seed — at three more decisions,
+  each with a wider blast radius than the XML one. Each now has a
+  tie-break argued from what the decision means rather than a copied
+  rule. The log extractor elects the template an *entire file* is parsed
+  with, and every line missing that template is demoted to a
+  continuation, so a flip changes the record count; ties now go to the
+  most specific template, in the order `parse_kind` already tries them
+  (app before clf before syslog), so an ambiguous file resolves the way
+  an ambiguous line does. Field inference elects the date encoding
+  written into the mapping, the catalog and the coercion plan; ties go
+  to the lowest `DateEnc` in declaration order, which is `parse_date_str`'s
+  own richest-first priority, so a field mixing `…T00:00:13` with
+  `… 00:00:13` names the encoding that concedes the least. The third
+  elects a field's entity type, keyword versus text.
 
 - **The ONNX embedding path no longer materialises every window upfront.**
   `embed_semantic_jobs` built and cloned the passage text of every window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-rc.9] - 2026-07-31
+## [1.0.0-rc.9] - 2026-08-01
 
 Ninth release candidate: the **cross-platform correctness release**.
 Headline for users, stated plainly because it is the most serious defect

--- a/demo/usecases/autoindex/run-eval.sh
+++ b/demo/usecases/autoindex/run-eval.sh
@@ -1,26 +1,47 @@
 #!/usr/bin/env bash
 # End-to-end eval of `xerj autoindex` against a corpus folder.
 #
-# Boots a dedicated worktree server on es_compat :9260 (rest 9360, grpc 9361),
-# runs autoindex over $CORPUS, exercises the 5 query classes + map, then
-# re-runs to prove idempotency (counts must not change).
+# Boots a dedicated server on es_compat $PORT (rest PORT+100, grpc PORT+101),
+# runs autoindex over $CORPUS, then re-runs twice to prove idempotency — the
+# resume path (all files done) and a full --fresh re-extract — and requires the
+# per-index doc counts to be byte-identical to run 1. Ends with the data map.
+#
+# Nothing here is bound to one machine: every path is an env override with a
+# default under the repo or $TMPDIR, so the same script gates CI and drives a
+# local eval over a large corpus.
 #
 # Usage: run-eval.sh [corpus-dir] [binary]
+#
+# Env overrides:
+#   XERJ_AUTOINDEX_CORPUS  corpus folder   (default ${TMPDIR:-/tmp}/xerj-discover/corpus)
+#   XERJ_BIN               xerj binary     (default <repo>/engine/target/release/xerj)
+#   XERJ_AUTOINDEX_PORT    es-compat port  (default 9260)
+#   XERJ_AUTOINDEX_WORK    work dir        (default ${TMPDIR:-/tmp}/xerj-autoindex)
+#
+# Exits non-zero if autoindex fails or idempotency breaks.
 set -uo pipefail
-CORPUS="${1:-/tmp/xerj-discover/corpus}"
-BIN="${2:-/home/claude/ai/xerj-autoindex-wt/engine/target/release/xerj}"
-PORT=9260
-DATA="/tmp/xerj-autoindex/data-build"
-CFG="/tmp/xerj-autoindex/server-9260.toml"
-LOG="/tmp/xerj-autoindex/server-9260.log"
-URL="http://localhost:$PORT"
-STATE="/tmp/xerj-autoindex/state"
 
-mkdir -p /tmp/xerj-autoindex
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+
+CORPUS="${1:-${XERJ_AUTOINDEX_CORPUS:-${TMPDIR:-/tmp}/xerj-discover/corpus}}"
+BIN="${2:-${XERJ_BIN:-$REPO/engine/target/release/xerj}}"
+PORT="${XERJ_AUTOINDEX_PORT:-9260}"
+WORK="${XERJ_AUTOINDEX_WORK:-${TMPDIR:-/tmp}/xerj-autoindex}"
+DATA="$WORK/data-build"
+CFG="$WORK/server-$PORT.toml"
+LOG="$WORK/server-$PORT.log"
+URL="http://localhost:$PORT"
+STATE="$WORK/state"
+
+[ -x "$BIN" ] || { echo "xerj binary not found at $BIN"; exit 1; }
+[ -d "$CORPUS" ] || { echo "corpus folder not found at $CORPUS"; exit 1; }
+
+mkdir -p "$WORK"
 cat >"$CFG" <<EOF
 [server]
-rest_port = 9360
-grpc_port = 9361
+rest_port = $((PORT + 100))
+grpc_port = $((PORT + 101))
 es_compat_port = $PORT
 bind_address = "127.0.0.1"
 data_dir = "$DATA"
@@ -32,21 +53,38 @@ EOF
 if ! curl -sf "$URL/" >/dev/null 2>&1; then
   mkdir -p "$DATA"
   "$BIN" --insecure --config "$CFG" --data-dir "$DATA" >"$LOG" 2>&1 &
+  # Recorded so a caller (CI) can stop the server it made us start.
+  echo $! > "$WORK/server.pid"
   echo "server pid $!"
-  for i in $(seq 1 60); do
+  for _ in $(seq 1 60); do
     curl -sf "$URL/" >/dev/null 2>&1 && break
     sleep 0.5
   done
 fi
 curl -sf "$URL/" >/dev/null || { echo "server failed to boot"; tail -20 "$LOG"; exit 1; }
 
+FAIL=0
+
 echo "=== autoindex run ($CORPUS) ==="
 time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --fresh
-echo "exit code: $?"
+RC=$?
+echo "exit code: $RC"
+# 0 complete, 3 completed-with-junk (unreadable files recorded, never fatal).
+if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
+  echo "autoindex exited $RC (expected 0 or 3)"
+  FAIL=1
+fi
+
+# Name + doc count only. The _cat row also carries on-disk size, which a
+# --fresh re-extract legitimately changes (segments are rewritten), and the
+# catalog is excluded outright because every run appends its own run record —
+# a growing catalog is the design, not drift. Columns of the _cat row:
+# green(1) open(2) name(3) uuid(4) pri(5) rep(6) docs(7).
+counts() { curl -s "$URL/_cat/indices" | awk '$3 ~ /^ax-/ {print $3, $7}' | sort; }
 
 echo "=== per-index counts (run 1) ==="
-curl -s "$URL/_cat/indices" | grep -E 'ax-|autoindex-catalog' | sort > /tmp/xerj-autoindex/counts-run1.txt
-cat /tmp/xerj-autoindex/counts-run1.txt
+curl -s "$URL/_cat/indices" | grep -E 'ax-|autoindex-catalog' | sort
+counts > "$WORK/counts-run1.txt"
 
 echo "=== idempotency: re-run (resume path — all files done) ==="
 time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE"
@@ -54,9 +92,27 @@ time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE"
 echo "=== idempotency: re-run with --fresh (full re-extract, idempotent ids) ==="
 time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --fresh
 
-curl -s "$URL/_cat/indices" | grep -E 'ax-|autoindex-catalog' | sort > /tmp/xerj-autoindex/counts-run3.txt
-echo "=== count diff run1 vs run3 (must be empty on doc counts) ==="
-diff /tmp/xerj-autoindex/counts-run1.txt /tmp/xerj-autoindex/counts-run3.txt && echo "IDENTICAL COUNTS ✓"
+counts > "$WORK/counts-run3.txt"
+echo "=== doc-count diff run1 vs run3 (must be empty) ==="
+cat "$WORK/counts-run3.txt"
+if diff "$WORK/counts-run1.txt" "$WORK/counts-run3.txt"; then
+  echo "IDENTICAL COUNTS ✓"
+else
+  echo "doc counts drifted across re-runs — autoindex is not idempotent"
+  FAIL=1
+fi
 
 echo "=== data map ==="
-"$BIN" autoindex map --url "$URL" | head -80
+# Captured, then headed — piping straight into `head` closes stdout under the
+# writer, and the map aborts on the resulting EPIPE (a core dump that hides
+# whether `map` itself worked).
+"$BIN" autoindex map --url "$URL" > "$WORK/map.md"
+MAP_RC=$?
+head -80 "$WORK/map.md"
+if [ "$MAP_RC" != "0" ]; then
+  echo "autoindex map exited $MAP_RC"
+  FAIL=1
+fi
+
+[ "$FAIL" = 0 ] && echo "RESULT: PASS" || echo "RESULT: FAIL"
+exit "$FAIL"

--- a/demo/usecases/second-brain/README.md
+++ b/demo/usecases/second-brain/README.md
@@ -43,6 +43,9 @@ port `9331` (override with `XERJ_BRAIN_DEMO_ROOT` / `XERJ_BRAIN_DEMO_PORT`),
 binaries from `engine/target/release/`. All scripts are idempotent; stop the
 booted server with `kill $(cat <root>/data/server.pid)`.
 
+These three are also what CI runs, via `.github/scripts/usecase-smoke.sh` — so
+the gate on every PR is this exact harness, not a separate copy of it.
+
 ## What the transcript proves
 
 1. **Overview** — brain exists, live/retired counts, all five detectors

--- a/demo/usecases/second-brain/transcript.sh
+++ b/demo/usecases/second-brain/transcript.sh
@@ -66,8 +66,12 @@ ck "contract xerj-second-brain/1"          J '.contract == "xerj-second-brain/1"
 ck "embedder honesty marker is lexical"    J '.embedder == "lexical-feature-hash"'
 ck "edges.total >= 1"                      J '.edges.total >= 1'
 ck "invalidated == total - live"           J '.edges.invalidated == .edges.total - .edges.live'
-for tag in wikilink@1 mdlink@1 href@1 sequence@1 samedir@1; do
-  ck "detector $tag has live edges"        J --arg t "$tag" '[.detectors[] | select(.detector == $t and .live > 0)] | length == 1'
+# Matched on the detector family, not the pinned `@N`: the contract is that
+# each of these five fires on the vault, while the version is *designed* to
+# move (detect/mod.rs mandates bumping @N on any behavior change), so pinning
+# it here would fail every deliberate bump instead of every real regression.
+for tag in wikilink mdlink href sequence samedir; do
+  ck "detector $tag has live edges"        J --arg t "$tag@" '[.detectors[] | select((.detector | startswith($t)) and .live > 0)] | length == 1'
 done
 ck "not_shown accounting present"          J '.not_shown | has("types_not_listed") and has("hubs_out_not_listed")'
 echo "  measured: $(jq -c '{edges, types: [.types[] | {(.type): .live}] | add}' "$WORK/resp.json")"

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-ai"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -6370,7 +6370,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-api"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-autoindex"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-cluster"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-common"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-compress"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "byteorder",
  "bytes",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-console-api"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6530,7 +6530,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-engine"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-fts"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "bitpacking",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-logs"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6613,7 +6613,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-mcp"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-query"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-server"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-storage"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-vector"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-wasm"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "anyhow",
  "bytes",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["xerj Contributors"]

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -30998,6 +30998,17 @@ mod reindex_keyset_tests {
             n as u64,
             "sanity: all source docs indexed"
         );
+        // `live_doc_count` reads the version map, but reindex pages the SEARCH
+        // surface, and turbo ingest with `parallel = true` scatters docs across
+        // memtable shards by worker thread. Without this refresh the assertion
+        // below silently measures how many cores the machine has: on a 2-core
+        // runner every doc lands in one shard and happens to be visible, so CI
+        // saw 10050/10050 and went green, while any developer box with real
+        // core count searched an unpublished memtable and got 0. The HTTP
+        // `_reindex` path is unaffected — verified end-to-end at 10050/10050
+        // both with and without an explicit `_refresh` — so this is the test
+        // reaching under the API, not a product defect.
+        src.refresh().await.expect("refresh src");
 
         // Reindex src -> dst with a 1000-doc page size (forces >10 pages,
         // crossing the 10k window that a from-offset pager cannot).

--- a/engine/crates/xerj-autoindex/src/extract/csv_x.rs
+++ b/engine/crates/xerj-autoindex/src/extract/csv_x.rs
@@ -79,3 +79,164 @@ pub fn extract(
     }
     Ok(stats)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sniff::{CsvDialect, Family};
+
+    fn sniffed(delim: u8, has_header: bool, decimal_comma: bool) -> Sniffed {
+        Sniffed {
+            family: Family::Csv,
+            gzip: false,
+            binary_kind: None,
+            csv: Some(CsvDialect {
+                delim,
+                has_header,
+                decimal_comma,
+            }),
+            encoding: "utf-8",
+        }
+    }
+
+    fn run(sn: &Sniffed, bytes: &[u8]) -> (Result<ExtractStats>, Vec<RawRecord>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.csv");
+        std::fs::write(&path, bytes).unwrap();
+        let mut recs = Vec::new();
+        let stats = extract(&path, sn, None, &mut |r| {
+            recs.push(r);
+            true
+        });
+        (stats, recs)
+    }
+
+    fn ok(sn: &Sniffed, bytes: &[u8]) -> (ExtractStats, Vec<RawRecord>) {
+        let (stats, recs) = run(sn, bytes);
+        (stats.unwrap(), recs)
+    }
+
+    #[test]
+    fn the_header_row_names_the_fields_and_every_data_row_becomes_one_record() {
+        let (stats, recs) = ok(
+            &sniffed(b',', true, false),
+            b"id,Full Name,amount\n1,Ann Lee,10.5\n2,Bob Ray,20\n",
+        );
+        assert_eq!(stats.records, 2);
+        assert_eq!(stats.junk, 0);
+        assert_eq!(recs[0].locator, "r0");
+        assert_eq!(recs[1].locator, "r1");
+        assert_eq!(recs[0].fields["id"], serde_json::json!("1"));
+        assert_eq!(
+            recs[0].fields["Full_Name"],
+            serde_json::json!("Ann Lee"),
+            "column names are sanitized, never guessed"
+        );
+        assert_eq!(recs[1].fields["amount"], serde_json::json!("20"));
+        assert!(
+            recs.iter().all(|r| r.group.is_none()),
+            "a CSV file is one dataset"
+        );
+    }
+
+    #[test]
+    fn a_headerless_dialect_names_every_column_by_position() {
+        let (stats, recs) = ok(&sniffed(b';', false, false), b"1;Ann;10\n2;Bob;20\n");
+        assert_eq!(stats.records, 2, "the first row is data, not a header");
+        assert_eq!(recs[0].fields["col_1"], serde_json::json!("1"));
+        assert_eq!(recs[0].fields["col_2"], serde_json::json!("Ann"));
+        assert_eq!(recs[0].fields["col_3"], serde_json::json!("10"));
+    }
+
+    #[test]
+    fn a_decimal_comma_dialect_rewrites_only_whole_numeric_fields() {
+        let (_, recs) = ok(
+            &sniffed(b';', true, true),
+            "id;amount;note\n1;10,5;Ann, Lee\n2;-3,25;a,b,c\n".as_bytes(),
+        );
+        assert_eq!(recs[0].fields["amount"], serde_json::json!("10.5"));
+        assert_eq!(recs[1].fields["amount"], serde_json::json!("-3.25"));
+        assert_eq!(
+            recs[0].fields["note"],
+            serde_json::json!("Ann, Lee"),
+            "text that merely contains a comma must be left alone"
+        );
+        assert_eq!(recs[1].fields["note"], serde_json::json!("a,b,c"));
+    }
+
+    #[test]
+    fn duplicate_header_names_are_disambiguated_instead_of_overwriting_each_other() {
+        let (_, recs) = ok(&sniffed(b',', true, false), b"id,id,amount\n1,2,3\n");
+        assert_eq!(recs[0].fields["id"], serde_json::json!("1"));
+        assert_eq!(recs[0].fields["id_2"], serde_json::json!("2"));
+        assert_eq!(recs[0].fields["amount"], serde_json::json!("3"));
+    }
+
+    #[test]
+    fn quoted_fields_keep_embedded_delimiters_and_newlines() {
+        let (stats, recs) = ok(
+            &sniffed(b',', true, false),
+            b"a,b\n\"x,y\",\"line1\nline2\"\n",
+        );
+        assert_eq!(stats.records, 1);
+        assert_eq!(recs[0].fields["a"], serde_json::json!("x,y"));
+        assert_eq!(recs[0].fields["b"], serde_json::json!("line1\nline2"));
+    }
+
+    #[test]
+    fn ragged_rows_keep_their_extra_columns_and_all_blank_rows_are_dropped() {
+        let (stats, recs) = ok(&sniffed(b',', true, false), b"a,b\n1,2,3,4\n,,\n5\n");
+        assert_eq!(stats.records, 2, "the all-empty row yields no record");
+        assert_eq!(stats.junk, 0, "a ragged row is not junk");
+        assert_eq!(recs[0].fields["col_3"], serde_json::json!("3"));
+        assert_eq!(recs[0].fields["col_4"], serde_json::json!("4"));
+        assert_eq!(recs[1].fields["a"], serde_json::json!("5"));
+        assert!(
+            recs[1].fields.get("b").is_none(),
+            "a short row omits the missing field rather than blanking it"
+        );
+        assert_eq!(
+            recs[1].locator, "r2",
+            "locators stay positional in the file, skipped rows included"
+        );
+    }
+
+    #[test]
+    fn an_undecodable_row_is_counted_as_junk_and_the_rest_of_the_file_still_extracts() {
+        let mut bytes = b"a,b\n1,ok\n".to_vec();
+        bytes.extend_from_slice(&[b'2', b',', 0xff, 0xfe, b'\n']);
+        bytes.extend_from_slice(b"3,fine\n");
+        let (stats, recs) = ok(&sniffed(b',', true, false), &bytes);
+        assert_eq!(stats.records, 2);
+        assert_eq!(stats.junk, 1);
+        assert_eq!(recs[1].fields["b"], serde_json::json!("fine"));
+    }
+
+    /// The asymmetry is deliberate to record, not to endorse: a bad DATA row is
+    /// junk-counted and skipped, but the header is read with `?`, so a header
+    /// that will not decode fails the whole file. The caller junk-files it.
+    #[test]
+    fn an_undecodable_header_row_fails_the_file_rather_than_skipping_a_row() {
+        let mut bytes = vec![b'a', b',', 0xff, 0xfe, b'\n'];
+        bytes.extend_from_slice(b"1,2\n");
+        let (stats, recs) = run(&sniffed(b',', true, false), &bytes);
+        assert!(stats.is_err());
+        assert!(recs.is_empty());
+    }
+
+    #[test]
+    fn a_file_sniffed_without_a_dialect_falls_back_to_comma_with_a_header() {
+        let mut sn = sniffed(b',', true, false);
+        sn.csv = None;
+        let (stats, recs) = ok(&sn, b"x,y\n1,2\n");
+        assert_eq!(stats.records, 1);
+        assert_eq!(recs[0].fields["x"], serde_json::json!("1"));
+    }
+
+    #[test]
+    fn a_header_only_file_yields_no_records_and_no_junk() {
+        let (stats, recs) = ok(&sniffed(b',', true, false), b"a,b\n");
+        assert_eq!((stats.records, stats.junk), (0, 0));
+        assert!(recs.is_empty());
+    }
+}

--- a/engine/crates/xerj-autoindex/src/extract/docx.rs
+++ b/engine/crates/xerj-autoindex/src/extract/docx.rs
@@ -9,7 +9,32 @@ use quick_xml::Reader;
 use std::io::BufReader;
 use std::path::Path;
 
+// SECURITY: bound the DECOMPRESSED read. `word/document.xml` inflates from
+// the zip at whatever ratio the author chose — a ~400 KB docx can expand to
+// hundreds of MB, and a single 400 MB `<w:t>` text run makes quick-xml
+// allocate that whole run for one event (measured 1.68 GB RSS from an 815 KB
+// file). Reading through a `Take` caps peak memory no matter the ratio; a
+// real document's document.xml is far below this. Past the cap the reader
+// hits EOF and the loop ends; quick-xml reports that as `Eof`, not an error,
+// so the paragraphs read so far are emitted and the remainder is dropped
+// silently — truncation is not counted as junk.
+const MAX_DECOMPRESSED_BYTES: u64 = 72 << 20;
+
+/// Extraction body cap (also bounds any single paragraph — see the Text arm).
+const MAX_BODY_BYTES: usize = 64 << 20;
+
 pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
+    extract_bounded(path, sink, MAX_DECOMPRESSED_BYTES, MAX_BODY_BYTES)
+}
+
+/// Both caps are parameters so the truncation boundaries can be exercised with
+/// kilobyte fixtures; production always passes the two constants above.
+fn extract_bounded(
+    path: &Path,
+    sink: Sink,
+    max_decompressed_bytes: u64,
+    max_body_bytes: usize,
+) -> Result<ExtractStats> {
     let mut stats = ExtractStats::default();
     let f = std::fs::File::open(path)?;
     let mut z = zip::ZipArchive::new(f).context("open docx container")?;
@@ -20,20 +45,10 @@ pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
             return Ok(stats);
         }
     };
-    // SECURITY: bound the DECOMPRESSED read. `word/document.xml` inflates from
-    // the zip at whatever ratio the author chose — a ~400 KB docx can expand to
-    // hundreds of MB, and a single 400 MB `<w:t>` text run makes quick-xml
-    // allocate that whole run for one event (measured 1.68 GB RSS from an 815 KB
-    // file). Reading through a `Take` caps peak memory no matter the ratio; a
-    // real document's document.xml is far below this. Past the cap the reader
-    // hits EOF and the loop ends (a truncated tag is handled as junk below).
-    const MAX_DECOMPRESSED_BYTES: u64 = 72 << 20;
-    let capped = std::io::Read::take(entry, MAX_DECOMPRESSED_BYTES);
+    let capped = std::io::Read::take(entry, max_decompressed_bytes);
     let mut reader = Reader::from_reader(BufReader::new(capped));
     reader.config_mut().trim_text(false);
 
-    // Extraction body cap (also bounds any single paragraph — see the Text arm).
-    const MAX_BODY_BYTES: usize = 64 << 20;
     let mut body = String::new();
     let mut headings: Vec<String> = Vec::new();
     let mut para = String::new();
@@ -67,7 +82,7 @@ pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
                 // without bound: measured 1.68 GB RSS from that 815 KB input.
                 // Stop appending once one paragraph reaches the body cap; the
                 // per-paragraph text a real document holds is far below it.
-                if para.len() < MAX_BODY_BYTES {
+                if para.len() < max_body_bytes {
                     para.push_str(&t.unescape().unwrap_or_default());
                 }
             }
@@ -93,7 +108,7 @@ pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
             }
         }
         buf.clear();
-        if body.len() > MAX_BODY_BYTES {
+        if body.len() > max_body_bytes {
             break;
         }
     }
@@ -114,4 +129,232 @@ pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
     });
     emit_document(&title, &headings, body, sink, &mut stats);
     Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_bounded, ExtractStats};
+    use std::io::Write;
+    use std::path::Path;
+
+    const XML_HEAD: &str = concat!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>"#,
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>"#
+    );
+    const XML_TAIL: &str = "</w:body></w:document>";
+
+    /// A docx is a zip; the extractor only ever looks at `word/document.xml`,
+    /// so fixtures name their members explicitly.
+    fn write_container(path: &Path, members: &[(&str, &str)]) {
+        let mut z = zip::ZipWriter::new(std::fs::File::create(path).unwrap());
+        let opts = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        for (name, content) in members {
+            z.start_file(*name, opts).unwrap();
+            z.write_all(content.as_bytes()).unwrap();
+        }
+        z.finish().unwrap();
+    }
+
+    fn write_docx(path: &Path, document_xml: &str) {
+        write_container(path, &[("word/document.xml", document_xml)]);
+    }
+
+    /// Section bodies in emission order, plus the stats the run reported.
+    fn extract_sections(
+        path: &Path,
+        max_decompressed_bytes: u64,
+        max_body_bytes: usize,
+    ) -> (Vec<String>, ExtractStats) {
+        let mut sections = Vec::new();
+        let stats = extract_bounded(
+            path,
+            &mut |r| {
+                sections.push(r.fields["body"].as_str().unwrap().to_string());
+                true
+            },
+            max_decompressed_bytes,
+            max_body_bytes,
+        )
+        .unwrap();
+        (sections, stats)
+    }
+
+    /// Every paragraph carries a distinct fixed-width marker, so "was this byte
+    /// range read?" is answerable exactly rather than by size heuristics.
+    fn marker(i: usize) -> String {
+        format!("m{i:06}")
+    }
+
+    #[test]
+    fn a_document_inflating_past_the_decompression_cap_is_truncated_at_the_byte_boundary() {
+        const PARAS: usize = 20_000;
+        // Repetitive filler is what gives a docx its inflation ratio; the
+        // per-paragraph marker keeps every paragraph the same width.
+        let para = |i: usize| {
+            format!(
+                "<w:p><w:r><w:t>{} {}</w:t></w:r></w:p>",
+                marker(i),
+                "filler ".repeat(24)
+            )
+        };
+        let xml = format!(
+            "{XML_HEAD}{}{XML_TAIL}",
+            (0..PARAS).map(para).collect::<String>()
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bomb.docx");
+        write_docx(&path, &xml);
+
+        // The bomb shape: a small file on disk that inflates by orders of
+        // magnitude. Without the cap the whole inflated stream is resident.
+        let on_disk = std::fs::metadata(&path).unwrap().len();
+        assert!(
+            xml.len() as u64 > on_disk * 20,
+            "fixture is not a compression bomb: {} inflated from {on_disk} on disk",
+            xml.len()
+        );
+
+        const CAP: u64 = 16 << 10;
+        let (sections, stats) = extract_sections(&path, CAP, 64 << 20);
+
+        // Paragraphs are fixed width, so the last one wholly inside the cap is
+        // arithmetic: the next one is at best half-read, never closes, and so
+        // can never reach `body`.
+        let last_whole = (CAP as usize - XML_HEAD.len()) / para(0).len();
+        assert!(last_whole > 0 && last_whole < PARAS);
+        assert!(stats.records > 0, "nothing was extracted before the cap");
+        // Cutting the stream mid-tag reads as EOF to quick-xml, so truncation
+        // is silent: the caller sees a clean document, just a shorter one.
+        assert_eq!(stats.junk, 0);
+        for present in [marker(0), marker(last_whole - 1)] {
+            assert!(
+                sections.iter().any(|s| s.contains(&present)),
+                "{present} sits inside the cap but was not extracted"
+            );
+        }
+        for absent in [marker(last_whole), marker(PARAS - 1)] {
+            assert!(
+                sections.iter().all(|s| !s.contains(&absent)),
+                "{absent} sits past the {CAP}-byte cap but was still read"
+            );
+        }
+        let extracted: usize = sections.iter().map(|s| s.len()).sum();
+        assert!(
+            extracted < xml.len() / 100,
+            "extracted {extracted} bytes of a {}-byte stream: it was read whole",
+            xml.len()
+        );
+    }
+
+    #[test]
+    fn a_single_paragraph_stops_absorbing_text_at_the_body_cap() {
+        const CAP: usize = 8 << 10;
+        const RUNS: usize = 4_000;
+        // Fixed-width runs with no whitespace between them: the paragraph
+        // buffer holds exactly `i * run_bytes` before run `i` is considered.
+        let run = |i: usize| format!("<w:r><w:t>{}{}</w:t></w:r>", marker(i), "x".repeat(57));
+        let run_bytes = marker(0).len() + 57;
+        let xml = format!(
+            "{XML_HEAD}<w:p>{}</w:p>{XML_TAIL}",
+            (0..RUNS).map(run).collect::<String>()
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("one-huge-paragraph.docx");
+        write_docx(&path, &xml);
+
+        let (sections, stats) = extract_sections(&path, 64 << 20, CAP);
+        assert!(stats.records > 0);
+
+        // A lone paragraph is only ever cut mid-paragraph, never overlapped, so
+        // the sections concatenate back into exactly what the buffer held.
+        let buffered = sections.concat();
+        assert!(
+            buffered.len() <= CAP + run_bytes,
+            "paragraph buffer reached {} bytes against a {CAP}-byte cap",
+            buffered.len()
+        );
+        let last_accepted = CAP / run_bytes - 1;
+        assert!(buffered.contains(&marker(last_accepted)));
+        assert!(!buffered.contains(&marker(last_accepted + 1)));
+        assert!(!buffered.contains(&marker(RUNS - 1)));
+    }
+
+    #[test]
+    fn a_never_closed_paragraph_ends_extraction_instead_of_growing_without_bound() {
+        // `para` only drains at `</w:p>`, so a paragraph that never closes is
+        // the shape that drove RSS to 1.68 GB. Its buffer is not observable
+        // from outside — what is observable is that the run ends, reports the
+        // unterminated document as junk, and emits nothing.
+        let run = |i: usize| format!("<w:r><w:t>{}{}</w:t></w:r>", marker(i), "x".repeat(57));
+        let xml = format!("{XML_HEAD}<w:p>{}", (0..4_000).map(run).collect::<String>());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("unterminated.docx");
+        write_docx(&path, &xml);
+
+        let (sections, stats) = extract_sections(&path, 64 << 20, 8 << 10);
+        assert!(sections.is_empty());
+        assert_eq!(stats.records, 0);
+        assert_eq!(stats.junk, 1);
+    }
+
+    #[test]
+    fn a_well_formed_document_keeps_its_paragraphs_and_pstyle_headings() {
+        let xml = format!(
+            "{XML_HEAD}\
+             <w:p><w:pPr><w:pStyle w:val=\"Heading1\"/></w:pPr><w:r><w:t>Quarterly Report</w:t></w:r></w:p>\
+             <w:p><w:r><w:t>Subscription revenue</w:t></w:r><w:r><w:t> grew again.</w:t></w:r></w:p>\
+             <w:p><w:pPr><w:pStyle w:val=\"Heading2\"/></w:pPr><w:r><w:t>Outlook</w:t></w:r></w:p>\
+             <w:p><w:r><w:t>Cash flow supports investment.</w:t></w:r></w:p>\
+             {XML_TAIL}"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("report.docx");
+        write_docx(&path, &xml);
+
+        let mut records = Vec::new();
+        let stats = extract_bounded(
+            &path,
+            &mut |r| {
+                records.push(r);
+                true
+            },
+            super::MAX_DECOMPRESSED_BYTES,
+            super::MAX_BODY_BYTES,
+        )
+        .unwrap();
+
+        assert_eq!(stats.junk, 0);
+        assert_eq!(records.len(), 1);
+        let fields = &records[0].fields;
+        assert_eq!(fields["title"], "Quarterly Report");
+        assert_eq!(
+            fields["headings"],
+            serde_json::json!(["Quarterly Report", "Outlook"])
+        );
+        let body = fields["body"].as_str().unwrap();
+        assert_eq!(
+            body,
+            "Quarterly Report\n\nSubscription revenue grew again.\n\nOutlook\n\nCash flow supports investment."
+        );
+    }
+
+    #[test]
+    fn a_container_without_word_document_xml_is_counted_as_junk_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("not-a-docx.docx");
+        write_container(
+            &path,
+            &[("[Content_Types].xml", "<Types/>"), ("xl/workbook.xml", "")],
+        );
+
+        let (sections, stats) = extract_sections(&path, super::MAX_DECOMPRESSED_BYTES, 64 << 20);
+        assert!(sections.is_empty());
+        assert_eq!(stats.records, 0);
+        assert_eq!(stats.junk, 1);
+    }
 }

--- a/engine/crates/xerj-autoindex/src/extract/html.rs
+++ b/engine/crates/xerj-autoindex/src/extract/html.rs
@@ -219,7 +219,19 @@ fn parse(html: &str) -> Doc {
             // never buffered, never flushed, and a `<` in JS cannot be mistaken
             // for a tag and eat the rest of the page. XHTML-style `<script/>`
             // has no contents to skip.
-            if !close && matches!(name.as_str(), "script" | "style") && !self_closing {
+            // The name scan above stops at any byte outside [A-Za-z0-9!], so
+            // `<script-loader>` yields the name `script`. Entering raw-text
+            // mode on that would skip to a `</script>` the document never
+            // contains — `raw_text_end` rightly refuses `</script-loader>` —
+            // and swallow everything after it. Custom element names are
+            // REQUIRED to contain a hyphen, so this is a live shape. Only
+            // treat the name as the raw-text element when it actually ended
+            // there: whitespace, `/`, or `>`.
+            let name_ended = bytes
+                .get(j)
+                .is_some_and(|&c| c.is_ascii_whitespace() || c == b'/' || c == b'>');
+            if !close && name_ended && matches!(name.as_str(), "script" | "style") && !self_closing
+            {
                 i = raw_text_end(bytes, tag_end + 1, name.as_bytes());
                 continue;
             }
@@ -600,6 +612,34 @@ mod tests {
             assert!(
                 !body.contains(leak),
                 "{leak:?} was indexed as prose: {body:?}"
+            );
+        }
+    }
+
+    /// A custom element whose name merely STARTS with a raw-text element's
+    /// name is an ordinary element. Custom element names are required to
+    /// contain a hyphen, so `<script-loader>` is a real shape — and reading
+    /// it as `script` would enter raw-text mode looking for a `</script>`
+    /// the document does not contain, discarding everything after it.
+    #[test]
+    fn a_custom_element_named_after_a_raw_text_element_does_not_swallow_the_page() {
+        for (tag, marker) in [("script-loader", "SLOAD"), ("style-sheet", "SSHEET")] {
+            let (_, recs) = run(
+                "custom.html",
+                &format!("<p>alpha</p><{tag} data-k=\"{marker}\">middle</{tag}><p>omega</p>"),
+            );
+            let body = body_of(&recs[0]);
+            assert!(
+                body.contains("alpha") && body.contains("omega"),
+                "<{tag}> swallowed the page: {body:?}"
+            );
+            assert!(
+                body.contains("middle"),
+                "<{tag}> content was dropped: {body:?}"
+            );
+            assert!(
+                !body.contains(marker),
+                "attribute leaked into body: {body:?}"
             );
         }
     }

--- a/engine/crates/xerj-autoindex/src/extract/html.rs
+++ b/engine/crates/xerj-autoindex/src/extract/html.rs
@@ -340,3 +340,216 @@ fn decode_entities(s: &str) -> String {
         .replace("&apos;", "'")
         .replace("&nbsp;", " ")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(name: &str, html: &str) -> (ExtractStats, Vec<RawRecord>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        std::fs::write(&path, html).unwrap();
+        let mut recs = Vec::new();
+        let stats = extract(&path, false, &mut |r| {
+            recs.push(r);
+            true
+        })
+        .unwrap();
+        (stats, recs)
+    }
+
+    fn body_of(rec: &RawRecord) -> &str {
+        rec.fields["body"].as_str().unwrap()
+    }
+
+    fn table_html(header: Option<[&str; 2]>, data_rows: usize) -> String {
+        let mut h = String::from("<html><body><table>");
+        if let Some([a, b]) = header {
+            h.push_str(&format!("<tr><th>{a}</th><th>{b}</th></tr>"));
+        }
+        for i in 1..=data_rows {
+            h.push_str(&format!("<tr><td>item{i}</td><td>{i}</td></tr>"));
+        }
+        h.push_str("</table></body></html>");
+        h
+    }
+
+    #[test]
+    fn a_prose_page_becomes_one_document_of_title_headings_and_tag_free_body() {
+        let (stats, recs) = run(
+            "page.html",
+            "<html><head><title>Quarterly Report</title></head><body>\
+             <h1>Revenue</h1><p>Growth was steady.</p>\
+             <h2>Costs</h2><div>Cloud costs declined.</div></body></html>",
+        );
+        assert_eq!(stats.records, 1);
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].locator, "s0");
+        assert_eq!(
+            recs[0].fields["title"],
+            serde_json::json!("Quarterly Report")
+        );
+        assert_eq!(
+            recs[0].fields["headings"],
+            serde_json::json!(["Revenue", "Costs"])
+        );
+        let body = body_of(&recs[0]);
+        assert!(body.contains("Growth was steady."));
+        assert!(body.contains("Cloud costs declined."));
+        assert!(
+            !body.contains('<') && !body.contains("div"),
+            "markup leaked into the body: {body:?}"
+        );
+    }
+
+    #[test]
+    fn attributes_and_comments_never_reach_the_body() {
+        let (_, recs) = run(
+            "attrs.html",
+            "<html><body><p class=\"lede\">visible</p><!-- hidden note -->\
+             <a href=\"https://example.com/hidden-path\" title=\"hidden title\">link text</a>\
+             </body></html>",
+        );
+        let body = body_of(&recs[0]);
+        assert!(body.contains("visible") && body.contains("link text"));
+        assert!(
+            !body.contains("hidden") && !body.contains("class") && !body.contains("href"),
+            "attribute or comment text was indexed: {body:?}"
+        );
+    }
+
+    #[test]
+    fn character_entities_are_unescaped_in_the_title_and_the_body() {
+        let (_, recs) = run(
+            "ents.html",
+            "<html><head><title>Q4 &amp; FY</title></head><body>\
+             <p>5 &lt; 10 &gt; 2, &quot;quoted&quot; &amp; &#39;single&#39;&nbsp;spaced</p>\
+             </body></html>",
+        );
+        assert_eq!(recs[0].fields["title"], serde_json::json!("Q4 & FY"));
+        let body = body_of(&recs[0]);
+        assert!(body.contains("5 < 10 > 2"), "{body:?}");
+        assert!(body.contains("\"quoted\" & 'single' spaced"), "{body:?}");
+        assert!(!body.contains("&amp;") && !body.contains("&lt;"));
+    }
+
+    /// DEFECT, pinned as CURRENT behaviour — not a contract worth keeping.
+    ///
+    /// `skip_until` suppresses the *tags* inside `<script>`/`<style>` but the
+    /// text branch of the tokenizer appends to `cur_text` unconditionally, and
+    /// the closing tag `continue`s without discarding it. The buffered CSS/JS
+    /// is therefore flushed into the body at the next tag boundary, so page
+    /// scripts and stylesheets are indexed as prose.
+    ///
+    /// When the tokenizer is fixed, this test fails: invert the assertion
+    /// rather than deleting it.
+    #[test]
+    fn script_and_style_text_still_reaches_the_body() {
+        let (_, recs) = run(
+            "skip.html",
+            "<html><head><style>.lede{color:#fff}</style>\
+             <script>var token=1;</script></head><body><p>visible</p></body></html>",
+        );
+        let body = body_of(&recs[0]);
+        assert!(body.contains("visible"));
+        assert!(
+            body.contains(".lede{color:#fff}") && body.contains("var token=1;"),
+            "script/style suppression now works — flip this assertion: {body:?}"
+        );
+    }
+
+    #[test]
+    fn a_dominant_table_becomes_one_record_per_row_named_from_its_header_cells() {
+        let (stats, recs) = run("t.html", &table_html(Some(["Product Name", "Qty"]), 5));
+        assert_eq!(stats.records, 5);
+        assert_eq!(recs.len(), 5);
+        assert_eq!(recs[0].fields["Product_Name"], serde_json::json!("item1"));
+        assert_eq!(recs[0].fields["Qty"], serde_json::json!("1"));
+        assert_eq!(recs[4].fields["Product_Name"], serde_json::json!("item5"));
+        assert!(
+            recs.iter().all(|r| r.fields.len() == 2),
+            "the header row must not become a record"
+        );
+        let locs: Vec<&str> = recs.iter().map(|r| r.locator.as_str()).collect();
+        assert_eq!(locs, ["row1", "row2", "row3", "row4", "row5"]);
+        assert!(recs.iter().all(|r| r.group.is_none()));
+    }
+
+    #[test]
+    fn a_headerless_table_gets_positional_column_names_and_keeps_its_first_row() {
+        let (stats, recs) = run("t.html", &table_html(None, 6));
+        assert_eq!(stats.records, 6, "no header row means no row is consumed");
+        assert_eq!(recs[0].locator, "row0");
+        assert_eq!(recs[0].fields["col_1"], serde_json::json!("item1"));
+        assert_eq!(recs[0].fields["col_2"], serde_json::json!("1"));
+    }
+
+    #[test]
+    fn empty_cells_are_omitted_rather_than_indexed_as_blank_values() {
+        let mut h = String::from("<html><body><table><tr><th>A &amp; B</th><th>Note</th></tr>");
+        for i in 1..=5 {
+            h.push_str(&format!("<tr><td>x&lt;{i}</td><td>  </td></tr>"));
+        }
+        h.push_str("</table></body></html>");
+        let (stats, recs) = run("cells.html", &h);
+        assert_eq!(stats.records, 5);
+        assert_eq!(recs[0].fields["A_B"], serde_json::json!("x<1"));
+        assert_eq!(
+            recs[0].fields.len(),
+            1,
+            "the blank Note cell must not be stored"
+        );
+    }
+
+    /// DEFECT, pinned as CURRENT behaviour.
+    ///
+    /// A table under the 5-row dominance threshold loses its content twice
+    /// over: it is not emitted as rows, and `flush_text` has already diverted
+    /// every cell into `cur_cell` instead of `doc.body`, so the cells are not
+    /// in the document record either. Small tables — the common case on a
+    /// documentation page — are silently unindexed.
+    #[test]
+    fn a_table_below_the_dominance_threshold_leaves_its_cells_unindexed() {
+        let (stats, recs) = run(
+            "small.html",
+            "<html><body><h1>Head</h1><p>prose</p>\
+             <table><tr><td>cellA</td><td>cellB</td></tr></table>\
+             <p>after</p></body></html>",
+        );
+        assert_eq!(stats.records, 1, "falls back to the document record");
+        let body = body_of(&recs[0]);
+        assert!(body.contains("prose") && body.contains("after"));
+        assert!(
+            !body.contains("cellA") && !body.contains("cellB"),
+            "small-table cells are now indexed — flip this assertion: {body:?}"
+        );
+    }
+
+    #[test]
+    fn a_page_without_a_title_falls_back_to_a_heading_then_to_the_file_stem() {
+        let (_, recs) = run(
+            "fallback.html",
+            "<html><body><h2>Only Heading</h2><p>x</p></body></html>",
+        );
+        assert_eq!(recs[0].fields["title"], serde_json::json!("Only Heading"));
+
+        let (_, recs) = run("stem-name.html", "<html><body><p>x</p></body></html>");
+        assert_eq!(recs[0].fields["title"], serde_json::json!("stem-name"));
+        assert!(recs[0].fields.get("headings").is_none());
+    }
+
+    #[test]
+    fn unclosed_and_nonsense_markup_is_never_fatal() {
+        let (stats, recs) = run(
+            "junk.html",
+            "<<<>>> <div class=\"unclosed <p>dangling &amp; text <script>x=1;",
+        );
+        assert_eq!(stats.junk, 0);
+        assert_eq!(stats.records, 1, "a broken page still yields a document");
+        assert_eq!(recs[0].fields["title"], serde_json::json!("junk"));
+
+        let (stats, recs) = run("empty.html", "");
+        assert_eq!(stats.records, 1);
+        assert_eq!(body_of(&recs[0]), "");
+    }
+}

--- a/engine/crates/xerj-autoindex/src/extract/html.rs
+++ b/engine/crates/xerj-autoindex/src/extract/html.rs
@@ -148,7 +148,6 @@ fn parse(html: &str) -> Doc {
     let mut i = 0usize;
     let mut text_sink: Vec<&'static str> = Vec::new(); // element context stack (interned kinds)
     let mut cur_text = String::new();
-    let mut skip_until: Option<&'static str> = None; // script/style
 
     // table state
     let mut in_table = false;
@@ -234,20 +233,22 @@ fn parse(html: &str) -> Doc {
             }
             let tag_end = k.min(bytes.len());
 
-            if let Some(until) = skip_until {
-                if close && name == until {
-                    skip_until = None;
-                }
-                i = tag_end + 1;
+            flush_text(&mut cur_text, &text_sink, &mut doc, &mut cur_cell);
+
+            // Raw-text elements. Their contents are code, so jump the cursor
+            // straight to the literal close tag rather than tokenizing them:
+            // never buffered, never flushed, and a `<` in JS cannot be mistaken
+            // for a tag and eat the rest of the page. XHTML-style `<script/>`
+            // has no contents to skip.
+            if !close
+                && matches!(name.as_str(), "script" | "style")
+                && bytes.get(tag_end - 1) != Some(&b'/')
+            {
+                i = raw_text_end(bytes, tag_end + 1, name.as_bytes());
                 continue;
             }
 
-            flush_text(&mut cur_text, &text_sink, &mut doc, &mut cur_cell);
-
             match (close, name.as_str()) {
-                (false, "script") | (false, "style") => {
-                    skip_until = Some(if name == "script" { "script" } else { "style" });
-                }
                 (false, "title") => text_sink.push("title"),
                 (true, "title") => {
                     text_sink.pop();
@@ -322,6 +323,26 @@ fn parse(html: &str) -> Doc {
     }
     flush_text(&mut cur_text, &text_sink, &mut doc, &mut cur_cell);
     doc
+}
+
+/// Offset of the `<` opening `</name...>` at or after `from`, or EOF if there
+/// is none — an unterminated raw-text element runs to the end of the file, as
+/// it does in a browser.
+fn raw_text_end(bytes: &[u8], from: usize, name: &[u8]) -> usize {
+    let mut p = from.min(bytes.len());
+    while let Some(off) = memchr::memchr(b'<', &bytes[p..]) {
+        let at = p + off;
+        let after = at + 2 + name.len();
+        if bytes.get(at + 1) == Some(&b'/')
+            && after <= bytes.len()
+            && bytes[at + 2..after].eq_ignore_ascii_case(name)
+            && !bytes.get(after).is_some_and(u8::is_ascii_alphanumeric)
+        {
+            return at;
+        }
+        p = at + 1;
+    }
+    bytes.len()
 }
 
 fn normalize_ws(s: &str) -> String {
@@ -433,28 +454,82 @@ mod tests {
         assert!(!body.contains("&amp;") && !body.contains("&lt;"));
     }
 
-    /// DEFECT, pinned as CURRENT behaviour — not a contract worth keeping.
-    ///
-    /// `skip_until` suppresses the *tags* inside `<script>`/`<style>` but the
-    /// text branch of the tokenizer appends to `cur_text` unconditionally, and
-    /// the closing tag `continue`s without discarding it. The buffered CSS/JS
-    /// is therefore flushed into the body at the next tag boundary, so page
-    /// scripts and stylesheets are indexed as prose.
-    ///
-    /// When the tokenizer is fixed, this test fails: invert the assertion
-    /// rather than deleting it.
+    /// Inline scripts routinely carry API keys and endpoints; indexing them
+    /// would put those in `_source`. Prose on both sides of a skipped element
+    /// still has to survive.
     #[test]
-    fn script_and_style_text_still_reaches_the_body() {
+    fn script_and_style_text_never_reaches_the_body() {
         let (_, recs) = run(
             "skip.html",
-            "<html><head><style>.lede{color:#fff}</style>\
-             <script>var token=1;</script></head><body><p>visible</p></body></html>",
+            "<html><head><title>Doc</title><style>.lede{color:#fff}</style>\
+             <script>var token=1;</script></head><body><p>before</p>\
+             <script>cfg={api:'https://secret.example/v1',key:'abc123'}</script>\
+             <p>after</p></body></html>",
+        );
+        assert_eq!(recs[0].fields["title"], serde_json::json!("Doc"));
+        let body = body_of(&recs[0]);
+        assert!(
+            body.contains("before") && body.contains("after"),
+            "{body:?}"
+        );
+        for leak in ["lede", "color", "token", "secret.example", "abc123", "cfg"] {
+            assert!(
+                !body.contains(leak),
+                "{leak:?} was indexed as prose: {body:?}"
+            );
+        }
+    }
+
+    /// `<` inside JS/CSS is an operator, not a tag. Tokenizing it would run the
+    /// tag scan past `</script>` and drop the remainder of the page.
+    #[test]
+    fn a_less_than_inside_a_script_does_not_swallow_the_rest_of_the_page() {
+        let (_, recs) = run(
+            "lt.html",
+            "<html><body><p>alpha</p><script>if(a<b){s=\"x>y\";}</script>\
+             <style>@media (max-width:40em){.a{top:0}}</style>\
+             <p>omega</p></body></html>",
         );
         let body = body_of(&recs[0]);
-        assert!(body.contains("visible"));
+        assert!(body.contains("alpha") && body.contains("omega"), "{body:?}");
         assert!(
-            body.contains(".lede{color:#fff}") && body.contains("var token=1;"),
-            "script/style suppression now works — flip this assertion: {body:?}"
+            !body.contains("max-width") && !body.contains('{'),
+            "{body:?}"
+        );
+    }
+
+    /// `</SCRIPT >` is the same terminator; an XHTML-style `<script src=… />`
+    /// has no contents, so it must not put the tokenizer into raw-text mode.
+    #[test]
+    fn raw_text_ends_at_a_case_insensitive_or_spaced_close_and_self_closing_skips_nothing() {
+        let (_, recs) = run(
+            "case.html",
+            "<html><body><SCRIPT>hidden=1;</SCRIPT >kept one\
+             <script src=\"app.js\"/><p>kept two</p></body></html>",
+        );
+        let body = body_of(&recs[0]);
+        assert!(
+            body.contains("kept one") && body.contains("kept two"),
+            "{body:?}"
+        );
+        assert!(!body.contains("hidden"), "{body:?}");
+    }
+
+    /// An unclosed `<script>` swallows the rest of the file, as a real HTML
+    /// parser does — there is no terminator, so the tail is code. It is
+    /// bounded to the tail: text before the tag was already flushed.
+    #[test]
+    fn an_unclosed_script_drops_the_tail_but_keeps_the_text_before_it() {
+        let (stats, recs) = run(
+            "trunc.html",
+            "<html><body><h1>Head</h1><p>kept</p><script>var token=1;<p>lost</p>",
+        );
+        assert_eq!(stats.records, 1);
+        let body = body_of(&recs[0]);
+        assert!(body.contains("kept"), "{body:?}");
+        assert!(
+            !body.contains("token") && !body.contains("lost"),
+            "{body:?}"
         );
     }
 

--- a/engine/crates/xerj-autoindex/src/extract/html.rs
+++ b/engine/crates/xerj-autoindex/src/extract/html.rs
@@ -210,28 +210,7 @@ fn parse(html: &str) -> Doc {
                 j += 1;
             }
             let name = html[name_start..j].to_lowercase();
-            // find tag end, respecting quoted attrs
-            let mut k = j;
-            let mut quote: Option<u8> = None;
-            while k < bytes.len() {
-                let c = bytes[k];
-                match quote {
-                    Some(q) => {
-                        if c == q {
-                            quote = None;
-                        }
-                    }
-                    None => {
-                        if c == b'"' || c == b'\'' {
-                            quote = Some(c);
-                        } else if c == b'>' {
-                            break;
-                        }
-                    }
-                }
-                k += 1;
-            }
-            let tag_end = k.min(bytes.len());
+            let (tag_end, self_closing) = scan_tag(bytes, j);
 
             flush_text(&mut cur_text, &text_sink, &mut doc, &mut cur_cell);
 
@@ -240,10 +219,7 @@ fn parse(html: &str) -> Doc {
             // never buffered, never flushed, and a `<` in JS cannot be mistaken
             // for a tag and eat the rest of the page. XHTML-style `<script/>`
             // has no contents to skip.
-            if !close
-                && matches!(name.as_str(), "script" | "style")
-                && bytes.get(tag_end - 1) != Some(&b'/')
-            {
+            if !close && matches!(name.as_str(), "script" | "style") && !self_closing {
                 i = raw_text_end(bytes, tag_end + 1, name.as_bytes());
                 continue;
             }
@@ -325,9 +301,81 @@ fn parse(html: &str) -> Doc {
     doc
 }
 
+/// Where the attribute scanner stands, which is what decides whether a `/`
+/// closes the tag or is just a byte of an attribute value.
+#[derive(PartialEq)]
+enum Attr {
+    /// Between attributes, or inside an attribute name.
+    Bare,
+    /// Just past `=`, with the value not yet started.
+    BeforeValue,
+    /// Inside an unquoted value, where every byte up to the next whitespace
+    /// or `>` belongs to the value.
+    Unquoted,
+}
+
+/// Offset of the tag's `>` (or EOF) given `from` at the end of its name, plus
+/// whether the tag self-closes.
+///
+/// The byte before `>` cannot answer the second question on its own: a slash
+/// is also legal inside an unquoted attribute value, as in
+/// `<script src=/cdn/lib/>`. Reading that as `/>` would skip raw-text mode for
+/// an element that is never void and does have contents to skip. Only a slash
+/// outside quotes and outside an unquoted value closes the tag.
+fn scan_tag(bytes: &[u8], from: usize) -> (usize, bool) {
+    let mut k = from;
+    let mut quote: Option<u8> = None;
+    let mut attr = Attr::Bare;
+    let mut self_closing = false;
+    while k < bytes.len() {
+        let c = bytes[k];
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                    attr = Attr::Bare;
+                }
+            }
+            None => {
+                if c == b'>' {
+                    break;
+                }
+                // Only a slash immediately before `>` closes the tag; anything
+                // following one reopens attribute scanning.
+                self_closing = false;
+                match c {
+                    b'"' | b'\'' => quote = Some(c),
+                    b'=' if attr != Attr::Unquoted => attr = Attr::BeforeValue,
+                    // `<p a= />` makes the slash itself the value.
+                    b'/' if attr == Attr::BeforeValue => attr = Attr::Unquoted,
+                    b'/' if attr == Attr::Bare => self_closing = true,
+                    _ if c.is_ascii_whitespace() => {
+                        if attr == Attr::Unquoted {
+                            attr = Attr::Bare;
+                        }
+                    }
+                    _ => {
+                        if attr == Attr::BeforeValue {
+                            attr = Attr::Unquoted;
+                        }
+                    }
+                }
+            }
+        }
+        k += 1;
+    }
+    (k, self_closing)
+}
+
 /// Offset of the `<` opening `</name...>` at or after `from`, or EOF if there
 /// is none — an unterminated raw-text element runs to the end of the file, as
 /// it does in a browser.
+///
+/// Only an *appropriate* end tag terminates raw text: HTML5 lets the name be
+/// followed by whitespace, `/` or `>` and nothing else, so `</script-foo>` is
+/// script text that the surrounding code goes on hiding. Accepting any
+/// non-alphanumeric follower would end the skip at `-`, `_` or `.` and index
+/// the code after it.
 fn raw_text_end(bytes: &[u8], from: usize, name: &[u8]) -> usize {
     let mut p = from.min(bytes.len());
     while let Some(off) = memchr::memchr(b'<', &bytes[p..]) {
@@ -336,7 +384,9 @@ fn raw_text_end(bytes: &[u8], from: usize, name: &[u8]) -> usize {
         if bytes.get(at + 1) == Some(&b'/')
             && after <= bytes.len()
             && bytes[at + 2..after].eq_ignore_ascii_case(name)
-            && !bytes.get(after).is_some_and(u8::is_ascii_alphanumeric)
+            && bytes
+                .get(after)
+                .is_some_and(|&c| c.is_ascii_whitespace() || c == b'/' || c == b'>')
         {
             return at;
         }
@@ -513,6 +563,45 @@ mod tests {
             "{body:?}"
         );
         assert!(!body.contains("hidden"), "{body:?}");
+    }
+
+    /// A slash also ends an unquoted attribute value, and `script` is never a
+    /// void element — so the byte before `>` cannot decide self-closing on its
+    /// own, and `<script src=/cdn/lib/>` still has contents to skip.
+    #[test]
+    fn a_slash_ending_an_unquoted_attribute_value_does_not_read_as_self_closing() {
+        let (_, recs) = run(
+            "unquoted-slash.html",
+            "<html><body><p>alpha</p><script src=/cdn/lib/>var leak=\"SEKRIT\";</script>\
+             <p>omega</p></body></html>",
+        );
+        let body = body_of(&recs[0]);
+        assert!(body.contains("alpha") && body.contains("omega"), "{body:?}");
+        for leak in ["SEKRIT", "leak", "cdn"] {
+            assert!(
+                !body.contains(leak),
+                "{leak:?} was indexed as prose: {body:?}"
+            );
+        }
+    }
+
+    /// Raw text ends only at an *appropriate* end tag: HTML5 requires
+    /// whitespace, `/` or `>` after the name, so `</script-foo>` is script
+    /// text. Any other follower — `_` and `.` alike — is the same case.
+    #[test]
+    fn a_run_on_end_tag_name_does_not_end_raw_text_early() {
+        let (_, recs) = run(
+            "runon.html",
+            "<p>alpha</p><script>a=1;</script-foo>b=\"LEAK2\";</script><p>omega</p>",
+        );
+        let body = body_of(&recs[0]);
+        assert!(body.contains("alpha") && body.contains("omega"), "{body:?}");
+        for leak in ["LEAK2", "a=1", "script"] {
+            assert!(
+                !body.contains(leak),
+                "{leak:?} was indexed as prose: {body:?}"
+            );
+        }
     }
 
     /// An unclosed `<script>` swallows the rest of the file, as a real HTML

--- a/engine/crates/xerj-autoindex/src/extract/json.rs
+++ b/engine/crates/xerj-autoindex/src/extract/json.rs
@@ -96,3 +96,122 @@ fn emit(v: Value, locator: &str, sink: Sink, stats: &mut ExtractStats) -> bool {
         group: None,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(text: &str) -> (ExtractStats, Vec<RawRecord>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.json");
+        std::fs::write(&path, text).unwrap();
+        let mut recs = Vec::new();
+        let stats = extract(&path, false, &mut |r| {
+            recs.push(r);
+            true
+        })
+        .unwrap();
+        (stats, recs)
+    }
+
+    #[test]
+    fn an_array_of_objects_becomes_one_record_per_element() {
+        let (stats, recs) = run(
+            r#"[{"id":1,"user":{"name":"ann","addr":{"city":"NY"}},"tags":["a","b"]},{"id":2}]"#,
+        );
+        assert_eq!(stats.records, 2);
+        assert_eq!(stats.junk, 0);
+        assert_eq!(recs[0].locator, "e0");
+        assert_eq!(recs[1].locator, "e1");
+        assert_eq!(recs[0].fields["id"], serde_json::json!(1));
+        assert_eq!(
+            recs[0].fields["user_name"],
+            serde_json::json!("ann"),
+            "two levels of nesting flatten into a_b keys"
+        );
+        assert_eq!(recs[0].fields["user_addr_city"], serde_json::json!("NY"));
+        assert_eq!(
+            recs[0].fields["tags"],
+            serde_json::json!(["a", "b"]),
+            "an array of scalars stays an array"
+        );
+        assert_eq!(recs[1].fields.len(), 1, "absent keys are not filled in");
+    }
+
+    #[test]
+    fn a_wrapper_object_lifts_its_largest_array_and_shares_the_outer_scalars() {
+        let (stats, recs) = run(r#"{"generated":"2026-01-01","count":2,
+                "items":[{"id":1},{"id":2,"generated":"per-item"}],
+                "errors":[{"e":1}]}"#);
+        assert_eq!(stats.records, 2, "records come from the biggest array");
+        assert_eq!(recs[0].locator, "items:e0");
+        assert_eq!(recs[0].fields["generated"], serde_json::json!("2026-01-01"));
+        assert_eq!(recs[0].fields["count"], serde_json::json!(2));
+        assert_eq!(
+            recs[1].fields["generated"],
+            serde_json::json!("per-item"),
+            "the element wins a collision with a shared field"
+        );
+        assert_eq!(
+            recs[0].fields["errors"],
+            serde_json::json!(r#"[{"e":1}]"#),
+            "the other arrays of objects travel as JSON strings"
+        );
+    }
+
+    #[test]
+    fn an_object_with_no_repeating_array_is_a_single_document_record() {
+        let (stats, recs) =
+            run(r#"{"meta":"m","nested":{"deep":{"deeper":{"x":1}}},"items":[{"id":1}]}"#);
+        assert_eq!(stats.records, 1);
+        assert_eq!(recs[0].locator, "doc");
+        assert_eq!(recs[0].fields["meta"], serde_json::json!("m"));
+        assert_eq!(
+            recs[0].fields["items"],
+            serde_json::json!(r#"[{"id":1}]"#),
+            "a single-element array is below the record-lifting threshold"
+        );
+        assert_eq!(
+            recs[0].fields["nested_deep_deeper"],
+            serde_json::json!(r#"{"x":1}"#),
+            "structure past two levels is stored as a JSON string"
+        );
+    }
+
+    #[test]
+    fn a_bare_scalar_document_is_wrapped_in_a_value_field() {
+        let (stats, recs) = run("42");
+        assert_eq!(stats.records, 1);
+        assert_eq!(recs[0].locator, "doc");
+        assert_eq!(recs[0].fields["value"], serde_json::json!(42));
+
+        let (stats, recs) = run("[1,2,3]");
+        assert_eq!(stats.records, 3, "array elements each become a record");
+        assert_eq!(recs[2].fields["value"], serde_json::json!(3));
+    }
+
+    #[test]
+    fn a_data_field_in_the_provenance_namespace_is_renamed_not_dropped() {
+        let (_, recs) = run(r#"{"ax_kind":"invoice","ok":1}"#);
+        assert_eq!(recs[0].fields["data_ax_kind"], serde_json::json!("invoice"));
+        assert!(recs[0].fields.get("ax_kind").is_none());
+    }
+
+    #[test]
+    fn truncated_json_is_junk_filed_and_emits_nothing() {
+        let (stats, recs) = run(r#"{"a":1,"#);
+        assert_eq!((stats.records, stats.junk), (0, 1));
+        assert!(recs.is_empty());
+
+        let (stats, recs) = run("not json at all");
+        assert_eq!((stats.records, stats.junk), (0, 1));
+        assert!(recs.is_empty());
+    }
+
+    #[test]
+    fn an_empty_array_yields_nothing_at_all_without_being_junk() {
+        let (stats, recs) = run("[]");
+        assert_eq!((stats.records, stats.junk), (0, 0));
+        assert!(recs.is_empty());
+    }
+}

--- a/engine/crates/xerj-autoindex/src/extract/jsonl.rs
+++ b/engine/crates/xerj-autoindex/src/extract/jsonl.rs
@@ -95,3 +95,105 @@ fn trim_ws(b: &[u8]) -> &[u8] {
         .unwrap_or(start);
     &b[start..end]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(bytes: &[u8], limit: Option<u64>) -> (ExtractStats, Vec<RawRecord>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+        std::fs::write(&path, bytes).unwrap();
+        let mut recs = Vec::new();
+        let stats = extract(&path, false, limit, &mut |r| {
+            recs.push(r);
+            true
+        })
+        .unwrap();
+        (stats, recs)
+    }
+
+    fn locators(recs: &[RawRecord]) -> Vec<&str> {
+        recs.iter().map(|r| r.locator.as_str()).collect()
+    }
+
+    #[test]
+    fn every_line_is_one_record_located_at_the_byte_offset_it_starts_at() {
+        let (stats, recs) = run(b"{\"id\":1,\"m\":{\"k\":\"v\"}}\n{\"id\":2}\n", None);
+        assert_eq!(stats.records, 2);
+        assert_eq!(stats.junk, 0);
+        assert_eq!(
+            locators(&recs),
+            ["b0", "b23"],
+            "the second line starts after the 23 bytes of the first"
+        );
+        assert_eq!(recs[0].fields["id"], serde_json::json!(1));
+        assert_eq!(
+            recs[0].fields["m_k"],
+            serde_json::json!("v"),
+            "nested objects flatten exactly as in whole-file JSON"
+        );
+    }
+
+    #[test]
+    fn blank_lines_are_skipped_without_being_counted_as_junk() {
+        let (stats, recs) = run(b"{\"id\":1}\n\n   \n{\"id\":2}\n", None);
+        assert_eq!((stats.records, stats.junk), (2, 0));
+        assert_eq!(locators(&recs), ["b0", "b14"]);
+    }
+
+    #[test]
+    fn a_bad_line_is_junk_and_never_stops_the_lines_after_it() {
+        let (stats, recs) = run(b"{\"id\":1}\n[1,2]\n{oops\n{\"id\":3}\n", None);
+        assert_eq!(stats.records, 2);
+        assert_eq!(
+            stats.junk, 2,
+            "a valid non-object line is junk just like a parse failure"
+        );
+        assert_eq!(recs[1].fields["id"], serde_json::json!(3));
+    }
+
+    /// The distinction from `json::extract`: JSONL is line-framed, so a
+    /// pretty-printed document is not one record — it is one junk line per
+    /// physical line.
+    #[test]
+    fn a_pretty_printed_object_is_not_a_jsonl_stream() {
+        let (stats, recs) = run(b"{\n  \"id\": 1\n}\n", None);
+        assert_eq!(stats.records, 0);
+        assert_eq!(stats.junk, 3);
+        assert!(recs.is_empty());
+    }
+
+    /// Sampling stops mid-file: the last line arrives cut in half. That is a
+    /// truncation, not corrupt data, so it must not inflate the junk count the
+    /// catalog reports for the file.
+    #[test]
+    fn a_line_cut_short_by_a_sampling_limit_is_not_counted_as_junk() {
+        let data = b"{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n";
+        let (stats, recs) = run(data, Some(14));
+        assert_eq!(stats.records, 1);
+        assert_eq!(stats.junk, 0);
+        assert_eq!(locators(&recs), ["b0"]);
+
+        let (stats, _) = run(data, Some(27));
+        assert_eq!((stats.records, stats.junk), (3, 0), "the full stream fits");
+    }
+
+    #[test]
+    fn carriage_returns_are_trimmed_but_still_counted_in_the_offset() {
+        let (stats, recs) = run(b"{\"id\":1}\r\n{\"id\":2}\r\n", None);
+        assert_eq!((stats.records, stats.junk), (2, 0));
+        assert_eq!(locators(&recs), ["b0", "b10"]);
+    }
+
+    #[test]
+    fn a_line_over_the_cap_is_junk_rather_than_a_giant_record() {
+        let mut data = vec![b'{'];
+        data.resize(MAX_LINE + 1, b' ');
+        data.extend_from_slice(b"}\n{\"id\":2}\n");
+        let (stats, recs) = run(&data, None);
+        assert_eq!(stats.junk, 1);
+        assert_eq!(stats.records, 1, "the stream continues after the cap");
+        assert_eq!(recs[0].fields["id"], serde_json::json!(2));
+    }
+}

--- a/engine/crates/xerj-autoindex/src/extract/logs.rs
+++ b/engine/crates/xerj-autoindex/src/extract/logs.rs
@@ -46,6 +46,45 @@ enum Kind {
     Syslog,
 }
 
+impl Kind {
+    /// Tie-break rank for the file-level election, lowest wins. Deliberately
+    /// the order `parse_kind` tries the templates in, so an ambiguous FILE
+    /// resolves the way an ambiguous LINE does — most specific first. The app
+    /// template demands an ISO timestamp *and* a level keyword; CLF demands a
+    /// quoted request line *and* a 3-digit status; the syslog pattern is by
+    /// far the loosest (`Mon dd HH:MM:SS host prog: rest`) and will claim
+    /// lines the other two describe better. Every variant has a distinct
+    /// rank, which is what makes the ordering total.
+    fn specificity(self) -> u8 {
+        match self {
+            Kind::App => 0,
+            Kind::Clf => 1,
+            Kind::Syslog => 2,
+        }
+    }
+}
+
+/// Elect the one template the whole file is parsed with.
+///
+/// `votes` is a `HashMap`, so this comparator has to be TOTAL: anything left
+/// tied would be settled by the map's per-instance random hash seed, and the
+/// same file would parse differently on every run. That is not a cosmetic
+/// difference here — every line that does not match the elected template is
+/// demoted to a continuation and glued onto the previous record's `message`,
+/// so a flipped election changes which lines are records at all.
+///
+/// Most matching lines wins; a tie goes to the most specific template, since
+/// electing the loose one drops the fields the specific one would have named.
+fn elect_kind(votes: &std::collections::HashMap<Kind, usize>) -> Option<Kind> {
+    votes
+        .iter()
+        .min_by(|(a_kind, a_n), (b_kind, b_n)| {
+            b_n.cmp(a_n)
+                .then_with(|| a_kind.specificity().cmp(&b_kind.specificity()))
+        })
+        .map(|(k, _)| *k)
+}
+
 /// Used by the sniffer: does this line look like any known log template?
 pub fn probe_line(line: &str) -> bool {
     parse_kind(line).is_some()
@@ -209,7 +248,7 @@ pub fn extract(
                 }
                 seen += 1;
                 if seen >= 200 || votes.values().sum::<usize>() >= 120 {
-                    elected = votes.iter().max_by_key(|(_, v)| **v).map(|(k, _)| *k);
+                    elected = elect_kind(&votes);
                 }
                 pk.or(elected)
             }
@@ -274,5 +313,95 @@ mod tests {
         assert_eq!(m["level"], serde_json::json!("INFO"));
         assert_eq!(m["tenant"], serde_json::json!("t-n"));
         assert_eq!(m["message"], serde_json::json!("Segment merge."));
+    }
+
+    const APP_LINE: &str = r#"2026-03-17 00:00:13,529 INFO  [ingest-svc] tenant=t-n user=u-1153 latency_ms=221 msg="Segment merge.""#;
+    const CLF_LINE: &str = r#"198.192.155.112 - - [01/Mar/2026:00:00:03 +0000] "GET /api/v1/x HTTP/1.1" 200 20854 "-" "Mozilla/5.0""#;
+
+    /// Every election builds its own `HashMap`, and every fresh map gets its
+    /// own random hash seed — so 500 in-process elections over one unchanged
+    /// tally sample 500 different iteration orders. `max_by_key` settled a tie
+    /// by whichever of them came last.
+    #[test]
+    fn a_tied_template_election_elects_the_most_specific_template_every_run() {
+        for _ in 0..500 {
+            let votes: std::collections::HashMap<Kind, usize> =
+                [(Kind::Clf, 7), (Kind::App, 7), (Kind::Syslog, 7)]
+                    .into_iter()
+                    .collect();
+            assert_eq!(
+                elect_kind(&votes),
+                Some(Kind::App),
+                "a three-way tie goes to the app template, the most constrained one"
+            );
+
+            let votes: std::collections::HashMap<Kind, usize> =
+                [(Kind::Syslog, 5), (Kind::Clf, 5)].into_iter().collect();
+            assert_eq!(
+                elect_kind(&votes),
+                Some(Kind::Clf),
+                "syslog is the loosest template and never wins a tie"
+            );
+
+            let votes: std::collections::HashMap<Kind, usize> =
+                [(Kind::Syslog, 6), (Kind::App, 5), (Kind::Clf, 5)]
+                    .into_iter()
+                    .collect();
+            assert_eq!(
+                elect_kind(&votes),
+                Some(Kind::Syslog),
+                "specificity is only the tie-break; a real majority still wins"
+            );
+
+            assert_eq!(elect_kind(&Default::default()), None);
+        }
+    }
+
+    /// The end-to-end symptom: a file whose first 120 parsed lines split 60/60
+    /// between two templates. Whichever kind is elected, every later line that
+    /// does not match it is demoted to a continuation, so the flip changed the
+    /// RECORD COUNT of an unchanged file from run to run.
+    #[test]
+    fn a_file_tied_between_two_templates_parses_identically_every_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tied.log");
+        let mut text = String::new();
+        for i in 0..120 {
+            text.push_str(if i % 2 == 0 { APP_LINE } else { CLF_LINE });
+            text.push('\n');
+        }
+        // Read after the election has been settled by the 120-line tie.
+        for _ in 0..10 {
+            text.push_str(CLF_LINE);
+            text.push('\n');
+        }
+        std::fs::write(&path, &text).unwrap();
+
+        for _ in 0..200 {
+            let mut recs = Vec::new();
+            let stats = extract(&path, false, None, &mut |r| {
+                recs.push(r);
+                true
+            })
+            .unwrap();
+            assert_eq!(
+                stats.records, 120,
+                "the app template is elected, so the 10 trailing CLF lines are \
+                 continuations of record 120, not 10 records of their own"
+            );
+            assert_eq!(recs[0].fields["level"], serde_json::json!("INFO"));
+            assert_eq!(
+                recs[119].fields["ip"],
+                serde_json::json!("198.192.155.112"),
+                "lines parsed before the election keep their own template"
+            );
+            let tail = recs[119].fields["message"].as_str().unwrap();
+            assert_eq!(
+                tail.lines().count(),
+                11,
+                "a CLF record has no message of its own, so the field is the \
+                 empty seed plus the 10 absorbed continuation lines"
+            );
+        }
     }
 }

--- a/engine/crates/xerj-autoindex/src/extract/sqlite_x.rs
+++ b/engine/crates/xerj-autoindex/src/extract/sqlite_x.rs
@@ -113,3 +113,181 @@ pub fn extract(path: &Path, per_table_limit: Option<u64>, sink: Sink) -> Result<
     }
     Ok(stats)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a real database with the bundled driver the extractor itself uses.
+    fn db(dir: &tempfile::TempDir, name: &str, sql: &str) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(sql).unwrap();
+        path
+    }
+
+    fn run(path: &Path, per_table_limit: Option<u64>) -> (ExtractStats, Vec<RawRecord>) {
+        let mut recs = Vec::new();
+        let stats = extract(path, per_table_limit, &mut |r| {
+            recs.push(r);
+            true
+        })
+        .unwrap();
+        (stats, recs)
+    }
+
+    #[test]
+    fn every_row_of_every_table_is_a_record_grouped_and_located_by_table_and_rowid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = db(
+            &dir,
+            "shop.db",
+            r#"CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT);
+               INSERT INTO authors VALUES (1,'Ann'),(2,'Bob');
+               CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT);
+               INSERT INTO books VALUES (1,'First');"#,
+        );
+        let (stats, recs) = run(&path, None);
+        assert_eq!(stats.records, 3);
+        assert_eq!(stats.junk, 0);
+        assert_eq!(
+            recs.iter()
+                .map(|r| (r.group.clone().unwrap(), r.locator.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("authors".into(), "tauthors:r1".to_string()),
+                ("authors".into(), "tauthors:r2".to_string()),
+                ("books".into(), "tbooks:r1".to_string()),
+            ],
+            "tables are walked in name order and each is its own dataset"
+        );
+        assert_eq!(recs[0].fields["name"], serde_json::json!("Ann"));
+        assert!(
+            recs[0].fields.get("rowid").is_none(),
+            "the rowid drives the locator and is never a field"
+        );
+    }
+
+    #[test]
+    fn column_names_are_sanitized_and_null_and_blob_cells_are_omitted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = db(
+            &dir,
+            "types.db",
+            r#"CREATE TABLE t (id INTEGER PRIMARY KEY, "full name" TEXT, score REAL,
+                               note TEXT, pic BLOB);
+               INSERT INTO t VALUES (1,'Ann Lee',9.5,NULL,x'0102');
+               INSERT INTO t VALUES (2,'Bob Ray',7.25,'hi',NULL);"#,
+        );
+        let (_, recs) = run(&path, None);
+        assert_eq!(recs[0].fields["full_name"], serde_json::json!("Ann Lee"));
+        assert_eq!(recs[0].fields["id"], serde_json::json!(1));
+        assert_eq!(recs[0].fields["score"], serde_json::json!(9.5));
+        assert!(
+            recs[0].fields.get("note").is_none(),
+            "a NULL cell is absent, not empty"
+        );
+        assert!(
+            recs[0].fields.get("pic").is_none(),
+            "a BLOB carries no text to index"
+        );
+        assert_eq!(recs[1].fields["note"], serde_json::json!("hi"));
+    }
+
+    #[test]
+    fn a_table_without_a_rowid_falls_back_to_ordinal_locators() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = db(
+            &dir,
+            "norowid.db",
+            r#"CREATE TABLE books (isbn TEXT PRIMARY KEY, title TEXT) WITHOUT ROWID;
+               INSERT INTO books VALUES ('111','First'),('222','Second');"#,
+        );
+        let (stats, recs) = run(&path, None);
+        assert_eq!(stats.records, 2);
+        assert_eq!(
+            recs.iter().map(|r| r.locator.as_str()).collect::<Vec<_>>(),
+            ["tbooks:o0", "tbooks:o1"]
+        );
+        assert_eq!(recs[0].fields["isbn"], serde_json::json!("111"));
+    }
+
+    #[test]
+    fn views_and_sqlite_internal_tables_are_never_extracted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = db(
+            &dir,
+            "views.db",
+            r#"CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+               INSERT INTO t (v) VALUES ('a'),('b');
+               CREATE VIEW v_t AS SELECT * FROM t;
+               CREATE TABLE blank (x INTEGER);"#,
+        );
+        let (stats, recs) = run(&path, None);
+        assert_eq!(stats.records, 2, "an empty table contributes no records");
+        assert!(
+            recs.iter().all(|r| r.group.as_deref() == Some("t")),
+            "{recs:?}"
+        );
+    }
+
+    #[test]
+    fn the_row_limit_applies_to_each_table_independently() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = db(
+            &dir,
+            "sample.db",
+            r#"CREATE TABLE a (id INTEGER PRIMARY KEY);
+               INSERT INTO a VALUES (1),(2),(3);
+               CREATE TABLE b (id INTEGER PRIMARY KEY);
+               INSERT INTO b VALUES (1),(2),(3);"#,
+        );
+        let (stats, recs) = run(&path, Some(1));
+        assert_eq!(stats.records, 2, "one row sampled from each of two tables");
+        assert_eq!(
+            recs.iter()
+                .map(|r| r.group.clone().unwrap())
+                .collect::<Vec<_>>(),
+            ["a", "b"]
+        );
+    }
+
+    #[test]
+    fn a_zero_byte_database_yields_no_records_and_no_junk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.db");
+        std::fs::write(&path, b"").unwrap();
+        let (stats, recs) = run(&path, None);
+        assert_eq!((stats.records, stats.junk), (0, 0));
+        assert!(recs.is_empty());
+    }
+
+    /// Unlike every text extractor, a corrupt database is a hard error rather
+    /// than a junk count — there is no partial parse to salvage. The caller
+    /// junk-files the file with this message, so the failure is recorded and
+    /// never fatal, but nothing is extracted from the readable pages.
+    #[test]
+    fn a_corrupt_database_fails_the_file_instead_of_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let good = db(
+            &dir,
+            "good.db",
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES (1,'a');",
+        );
+        let bytes = std::fs::read(&good).unwrap();
+        let path = dir.path().join("corrupt.db");
+        std::fs::write(&path, &bytes[..bytes.len() / 2]).unwrap();
+
+        let mut seen = 0usize;
+        let err = extract(&path, None, &mut |_r| {
+            seen += 1;
+            true
+        })
+        .unwrap_err();
+        assert_eq!(seen, 0);
+        assert!(
+            err.to_string().contains("malformed") || err.to_string().contains("not a database"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/engine/crates/xerj-autoindex/src/extract/xml_x.rs
+++ b/engine/crates/xerj-autoindex/src/extract/xml_x.rs
@@ -1,7 +1,8 @@
 //! XML — pull-parsed (quick-xml), O(depth) memory.
 //! The record element is elected generically: the most frequent tag (in the
 //! first 4096 start events) that carries structure (attributes or element
-//! children). No repeating structured tag → the whole document is one record.
+//! children), ties going to the outermost then the lowest-named tag. No
+//! repeating structured tag → the whole document is one record.
 
 use super::{sanitize_field_name, ExtractStats, RawRecord, Sink, MAX_FIELDS_PER_RECORD};
 use anyhow::Result;
@@ -224,8 +225,8 @@ fn elect_record_tag(path: &Path, gzip: bool) -> Result<Option<String>> {
     let mut reader = Reader::from_reader(r);
     reader.config_mut().trim_text(true);
     let mut buf = Vec::new();
-    // tag -> (count, has_structure)
-    let mut counts: HashMap<String, (usize, bool)> = HashMap::new();
+    // tag -> (count, has_structure, shallowest depth seen)
+    let mut counts: HashMap<String, (usize, bool, usize)> = HashMap::new();
     let mut parents: Vec<String> = Vec::new();
     let mut seen = 0usize;
     loop {
@@ -254,9 +255,11 @@ fn elect_record_tag(path: &Path, gzip: bool) -> Result<Option<String>> {
             }
         };
         if !parents.is_empty() {
-            let entry = counts.entry(name.clone()).or_insert((0, false));
+            let depth = parents.len();
+            let entry = counts.entry(name.clone()).or_insert((0, false, depth));
             entry.0 += 1;
             entry.1 |= has_attr;
+            entry.2 = entry.2.min(depth);
             if let Some(p) = parents.last() {
                 if let Some(pe) = counts.get_mut(p) {
                     pe.1 = true;
@@ -272,10 +275,20 @@ fn elect_record_tag(path: &Path, gzip: bool) -> Result<Option<String>> {
         }
         buf.clear();
     }
+    // The ordering must be TOTAL: `counts` is a HashMap, so any candidate left
+    // tied would be settled by a per-map random hash seed and the same file
+    // would index to a different shape on every run. Most occurrences wins;
+    // a tie goes to the outermost tag (a wrapper that repeats as often as a
+    // child is the record, and the child is one of its fields); a tie at the
+    // same depth goes to the lowest name, which is arbitrary but stable.
     Ok(counts
         .into_iter()
-        .filter(|(_, (n, structured))| *n >= 3 && *structured)
-        .max_by_key(|(_, (n, _))| *n)
+        .filter(|(_, (n, structured, _))| *n >= 3 && *structured)
+        .min_by(|(a_tag, (a_n, _, a_depth)), (b_tag, (b_n, _, b_depth))| {
+            b_n.cmp(a_n)
+                .then_with(|| a_depth.cmp(b_depth))
+                .then_with(|| a_tag.cmp(b_tag))
+        })
         .map(|(k, _)| k))
 }
 
@@ -413,21 +426,15 @@ mod tests {
         assert!(recs.is_empty());
     }
 
-    /// DEFECT, pinned as CURRENT behaviour.
-    ///
-    /// `elect_record_tag` picks the winner with `max_by_key` over a `HashMap`,
-    /// which breaks ties by iteration order — and that order is randomly
-    /// seeded per map. When two structured tags occur the same number of times
-    /// (here the `item` wrapper and its `price` child, three each) the elected
-    /// record element differs BETWEEN RUNS on the same file: the records carry
-    /// different fields each time, so re-indexing an unchanged file rewrites
-    /// every document under the same locator.
-    ///
-    /// A deterministic tie-break (outermost tag, or lowest name) would fix it;
-    /// when it lands this test fails and should be replaced by the
-    /// stable-election assertion.
+    /// Each election builds a fresh `HashMap`, and every fresh map gets its own
+    /// random hash seed — so 200 in-process elections over one unchanged file
+    /// sample 200 different iteration orders. Before the tie-break was total,
+    /// this split the winner between `item` and its equally-frequent `price`
+    /// child; the record COUNT held at 3 but the fields changed run to run, so
+    /// re-indexing an unchanged file rewrote every document under the same
+    /// locator.
     #[test]
-    fn a_tied_record_tag_election_picks_an_arbitrary_winner_each_run() {
+    fn a_tied_record_tag_election_elects_the_outermost_tag_every_run() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tie.xml");
         std::fs::write(
@@ -442,6 +449,11 @@ mod tests {
 
         let mut shapes = std::collections::BTreeSet::new();
         for _ in 0..200 {
+            assert_eq!(
+                elect_record_tag(&path, false).unwrap().as_deref(),
+                Some("item"),
+                "the wrapper is the record; `price` is one of its fields"
+            );
             let mut n = 0usize;
             let mut first = String::new();
             extract(&path, false, &mut |r| {
@@ -454,16 +466,43 @@ mod tests {
                 true
             })
             .unwrap();
-            assert_eq!(n, 3, "the record COUNT is stable whichever tag wins");
+            assert_eq!(n, 3);
             shapes.insert(first);
         }
         assert_eq!(
             shapes,
-            ["cur,text", "id,price,price_cur"]
+            ["id,price,price_cur"]
                 .into_iter()
                 .map(String::from)
                 .collect::<std::collections::BTreeSet<_>>(),
-            "the tie-break became deterministic — replace this test"
+            "one input must yield exactly one record shape"
         );
+    }
+
+    /// Depth cannot separate sibling wrappers, so the last key has to.
+    #[test]
+    fn a_tie_at_the_same_depth_is_settled_by_the_lowest_tag_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("siblings.xml");
+        std::fs::write(
+            &path,
+            r#"<catalog>
+                 <beta id="1"><v>1</v></beta><alpha id="1"><v>1</v></alpha>
+                 <beta id="2"><v>2</v></beta><alpha id="2"><v>2</v></alpha>
+                 <beta id="3"><v>3</v></beta><alpha id="3"><v>3</v></alpha>
+               </catalog>"#,
+        )
+        .unwrap();
+
+        for _ in 0..200 {
+            assert_eq!(
+                elect_record_tag(&path, false).unwrap().as_deref(),
+                Some("alpha")
+            );
+        }
+        let (stats, recs) = run(&std::fs::read_to_string(&path).unwrap());
+        assert_eq!(stats.records, 3, "only the elected tag emits records");
+        assert_eq!(recs[0].fields["id"], serde_json::json!("1"));
+        assert_eq!(recs[0].fields["v"], serde_json::json!("1"));
     }
 }

--- a/engine/crates/xerj-autoindex/src/extract/xml_x.rs
+++ b/engine/crates/xerj-autoindex/src/extract/xml_x.rs
@@ -278,3 +278,192 @@ fn elect_record_tag(path: &Path, gzip: bool) -> Result<Option<String>> {
         .max_by_key(|(_, (n, _))| *n)
         .map(|(k, _)| k))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(xml: &str) -> (ExtractStats, Vec<RawRecord>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.xml");
+        std::fs::write(&path, xml).unwrap();
+        let mut recs = Vec::new();
+        let stats = extract(&path, false, &mut |r| {
+            recs.push(r);
+            true
+        })
+        .unwrap();
+        (stats, recs)
+    }
+
+    #[test]
+    fn the_repeating_structured_element_becomes_one_record_per_occurrence() {
+        let (stats, recs) = run(r#"<catalog site="shop">
+                 <item id="1"><name>Widget</name></item>
+                 <item id="2"><name>Gadget</name></item>
+                 <item id="3"><name>Doohickey</name></item>
+                 <item id="4"><name>Thing</name><price cur="USD">4.50</price></item>
+               </catalog>"#);
+        assert_eq!(stats.records, 4);
+        assert_eq!(stats.junk, 0);
+        assert_eq!(
+            recs.iter().map(|r| r.locator.as_str()).collect::<Vec<_>>(),
+            ["e0", "e1", "e2", "e3"]
+        );
+        assert_eq!(
+            recs[0].fields["id"],
+            serde_json::json!("1"),
+            "attributes of the record element are top-level fields"
+        );
+        assert_eq!(
+            recs[0].fields["name"],
+            serde_json::json!("Widget"),
+            "child text is keyed by the child element path"
+        );
+        assert!(
+            recs[0].fields.get("site").is_none(),
+            "the root element is not part of a record"
+        );
+        assert_eq!(recs[3].fields["price"], serde_json::json!("4.50"));
+        assert_eq!(
+            recs[3].fields["price_cur"],
+            serde_json::json!("USD"),
+            "a child's attribute is prefixed with the child's path"
+        );
+    }
+
+    #[test]
+    fn a_self_closing_element_is_emitted_from_its_attributes_alone() {
+        let (stats, recs) =
+            run(r#"<rows><row a="1" b="x"/><row a="2" b="y"/><row a="3" b="z"/></rows>"#);
+        assert_eq!(stats.records, 3, "no End event must not lose the record");
+        assert_eq!(recs[2].fields["a"], serde_json::json!("3"));
+        assert_eq!(recs[2].fields["b"], serde_json::json!("z"));
+    }
+
+    #[test]
+    fn a_child_element_repeated_inside_a_record_becomes_a_multi_valued_field() {
+        let (stats, recs) = run(r#"<catalog>
+                 <item id="1"><tag>red</tag><tag>blue</tag></item>
+                 <item id="2"><tag>green</tag></item>
+                 <item id="3"><tag>red</tag></item>
+               </catalog>"#);
+        assert_eq!(stats.records, 3);
+        assert_eq!(recs[0].fields["tag"], serde_json::json!(["red", "blue"]));
+        assert_eq!(
+            recs[1].fields["tag"],
+            serde_json::json!("green"),
+            "a single occurrence stays a scalar"
+        );
+    }
+
+    #[test]
+    fn a_document_with_no_repeating_element_becomes_one_record_keyed_by_path() {
+        let (stats, recs) = run(
+            r#"<config><server><host>localhost</host><port>8080</port></server><debug>true</debug></config>"#,
+        );
+        assert_eq!(stats.records, 1);
+        assert_eq!(recs[0].locator, "doc");
+        assert_eq!(
+            recs[0].fields["server_host"],
+            serde_json::json!("localhost")
+        );
+        assert_eq!(recs[0].fields["server_port"], serde_json::json!("8080"));
+        assert_eq!(
+            recs[0].fields["debug"],
+            serde_json::json!("true"),
+            "the root element is stripped from every key"
+        );
+    }
+
+    #[test]
+    fn entities_are_unescaped_and_cdata_is_kept_verbatim() {
+        let (_, recs) =
+            run(r#"<doc><p>5 &lt; 10 &amp; rising</p><p><![CDATA[<b>raw</b>]]></p></doc>"#);
+        let p = recs[0].fields["p"].as_array().unwrap();
+        assert!(p.contains(&serde_json::json!("5 < 10 & rising")));
+        assert!(p.contains(&serde_json::json!("<b>raw</b>")));
+    }
+
+    #[test]
+    fn a_truncated_document_is_junk_filed_and_keeps_what_it_parsed() {
+        let (stats, recs) =
+            run(r#"<catalog><item id="1"><name>A</name></item><item id="2"><name>B<"#);
+        assert_eq!(stats.junk, 1);
+        assert_eq!(stats.records, 1);
+        assert_eq!(
+            recs[0].fields["item_id"],
+            serde_json::json!(["1", "2"]),
+            "everything read before the break is still emitted"
+        );
+
+        let (stats, recs) = run("<a><b>1</c></a>");
+        assert_eq!(stats.junk, 1, "a mismatched end tag ends the parse");
+        assert_eq!(recs[0].fields["b"], serde_json::json!("1"));
+    }
+
+    #[test]
+    fn text_that_is_not_xml_yields_nothing_at_all() {
+        let (stats, recs) = run("not xml at all, just words");
+        assert_eq!(
+            (stats.records, stats.junk),
+            (0, 0),
+            "text outside any element is dropped; the caller junk-files the file"
+        );
+        assert!(recs.is_empty());
+    }
+
+    /// DEFECT, pinned as CURRENT behaviour.
+    ///
+    /// `elect_record_tag` picks the winner with `max_by_key` over a `HashMap`,
+    /// which breaks ties by iteration order — and that order is randomly
+    /// seeded per map. When two structured tags occur the same number of times
+    /// (here the `item` wrapper and its `price` child, three each) the elected
+    /// record element differs BETWEEN RUNS on the same file: the records carry
+    /// different fields each time, so re-indexing an unchanged file rewrites
+    /// every document under the same locator.
+    ///
+    /// A deterministic tie-break (outermost tag, or lowest name) would fix it;
+    /// when it lands this test fails and should be replaced by the
+    /// stable-election assertion.
+    #[test]
+    fn a_tied_record_tag_election_picks_an_arbitrary_winner_each_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tie.xml");
+        std::fs::write(
+            &path,
+            r#"<catalog>
+                 <item id="1"><price cur="USD">9.99</price></item>
+                 <item id="2"><price cur="EUR">19.99</price></item>
+                 <item id="3"><price cur="USD">4.50</price></item>
+               </catalog>"#,
+        )
+        .unwrap();
+
+        let mut shapes = std::collections::BTreeSet::new();
+        for _ in 0..200 {
+            let mut n = 0usize;
+            let mut first = String::new();
+            extract(&path, false, &mut |r| {
+                if n == 0 {
+                    let mut keys: Vec<&str> = r.fields.keys().map(|k| k.as_str()).collect();
+                    keys.sort_unstable();
+                    first = keys.join(",");
+                }
+                n += 1;
+                true
+            })
+            .unwrap();
+            assert_eq!(n, 3, "the record COUNT is stable whichever tag wins");
+            shapes.insert(first);
+        }
+        assert_eq!(
+            shapes,
+            ["cur,text", "id,price,price_cur"]
+                .into_iter()
+                .map(String::from)
+                .collect::<std::collections::BTreeSet<_>>(),
+            "the tie-break became deterministic — replace this test"
+        );
+    }
+}

--- a/engine/crates/xerj-autoindex/src/infer/entities.rs
+++ b/engine/crates/xerj-autoindex/src/infer/entities.rs
@@ -21,6 +21,21 @@ impl Entity {
             Entity::Uuid => "uuid",
         }
     }
+
+    /// Tie-break rank for a field-level election, lowest wins. Kept in the
+    /// order `classify` below tries the tests in — most specific first — so an
+    /// ambiguous FIELD resolves the way an ambiguous VALUE does: an exact
+    /// `IpAddr` parse, then the fixed 36-char uuid shape, then email, then the
+    /// loosest test, url. Distinct per variant, which is what makes an
+    /// ordering built on it total. Change this only alongside `classify`.
+    pub fn precedence(&self) -> u8 {
+        match self {
+            Entity::Ip => 0,
+            Entity::Uuid => 1,
+            Entity::Email => 2,
+            Entity::Url => 3,
+        }
+    }
 }
 
 struct Res {

--- a/engine/crates/xerj-autoindex/src/infer/mod.rs
+++ b/engine/crates/xerj-autoindex/src/infer/mod.rs
@@ -334,6 +334,52 @@ fn p95(samples: &[u32]) -> u32 {
     v[((v.len() - 1) * 95) / 100]
 }
 
+/// Elect the date encoding recorded in the field's mapping.
+///
+/// `date_hits` is a `HashMap`, so this comparator has to be TOTAL: anything
+/// left tied would be settled by the map's per-instance random hash seed, and
+/// the same sample would write a different `date_enc` on every run — which
+/// then reaches the catalog and the coercion plan (`coerce::plan_from_specs`),
+/// where the elected encoding decides how bare integers are read.
+///
+/// Most evidence wins; a tie goes to the lowest `DateEnc` in declaration
+/// order. That order is not arbitrary: it is the order `parse_date_str` tries
+/// the encodings in, richest first — rfc3339 carries an explicit zone,
+/// iso-naive and space-naive carry a time we have to assume is UTC, date-only
+/// carries no time at all. On a genuine 50/50 split (a field mixing
+/// `2026-03-17T00:00:13` with `2026-03-17 00:00:13`) we name the encoding that
+/// concedes the least. It is also the order `date_evidence` is sorted in, so
+/// the elected encoding is always the first of the tied ones listed there.
+fn elect_date_enc(date_hits: &HashMap<DateEnc, u64>) -> Option<DateEnc> {
+    date_hits
+        .iter()
+        .min_by(|(a_enc, a_n), (b_enc, b_n)| b_n.cmp(a_n).then_with(|| a_enc.cmp(b_enc)))
+        .map(|(k, _)| *k)
+}
+
+/// Elect the field's semantic entity tag (keyword + `semantic`).
+///
+/// `entity` is a `HashMap`, so the comparator has to be TOTAL for the same
+/// reason as above. Note that a tie cannot change TODAY's verdict: the caller
+/// demands the winner hold ≥90% of the field's values, and two entities each
+/// holding ≥90% of the same sample is arithmetically impossible. That safety
+/// is an accident of one constant, not a property of this election — relax the
+/// supermajority to a plurality and the hash seed picks the mapping. Ordering
+/// it totally costs nothing and does not wait for that edit.
+///
+/// Most values wins; a tie goes to the most specific classifier, so a field
+/// split between shapes is tagged the way `entities::classify` tags a value
+/// that could be read as either.
+fn elect_entity(entity: &HashMap<Entity, u64>) -> Option<Entity> {
+    entity
+        .iter()
+        .min_by(|(a_ent, a_n), (b_ent, b_n)| {
+            b_n.cmp(a_n)
+                .then_with(|| a_ent.precedence().cmp(&b_ent.precedence()))
+        })
+        .map(|(k, _)| *k)
+}
+
 /// Infer the full field spec list for a dataset. `records` = sampled record
 /// count (for null ratios). Two passes so epoch candidates can corroborate
 /// against elected date fields.
@@ -382,12 +428,7 @@ pub fn infer_fields(
         // string dates
         let date_total: u64 = acc.date_hits.values().sum();
         if acc.str_n > 0 && th95(date_total) && date_total > 0 {
-            let elected = acc
-                .date_hits
-                .iter()
-                .max_by_key(|(_, v)| **v)
-                .map(|(k, _)| *k)
-                .unwrap();
+            let elected = elect_date_enc(&acc.date_hits).unwrap();
             spec.es_type = "date".into();
             spec.date_enc = Some(elected.as_str().into());
             let mut ev: Vec<(DateEnc, u64)> = acc.date_hits.iter().map(|(k, v)| (*k, *v)).collect();
@@ -445,12 +486,7 @@ pub fn infer_fields(
             continue;
         }
         // strings → entity / keyword / text
-        let ent = acc
-            .entity
-            .iter()
-            .max_by_key(|(_, v)| **v)
-            .filter(|(_, v)| **v * 10 >= n * 9 && n >= 20)
-            .map(|(k, _)| *k);
+        let ent = elect_entity(&acc.entity).filter(|e| acc.entity[e] * 10 >= n * 9 && n >= 20);
         if let Some(e) = ent {
             spec.es_type = "keyword".into();
             spec.semantic = Some(e.as_str().into());
@@ -573,4 +609,136 @@ pub fn elect_time_field(specs: &[FieldSpec]) -> Option<String> {
                 .then_with(|| b.name.cmp(&a.name))
         })
         .map(|s| s.name.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every election runs over a freshly built `HashMap`, and every fresh map
+    /// gets its own random hash seed — so 500 in-process elections sample 500
+    /// different iteration orders. `max_by_key` settled a tie by whichever of
+    /// them came last.
+    #[test]
+    fn a_tied_date_encoding_election_elects_the_richest_encoding_every_run() {
+        for _ in 0..500 {
+            let hits: HashMap<DateEnc, u64> = [
+                (DateEnc::SpaceNaive, 10),
+                (DateEnc::IsoNaive, 10),
+                (DateEnc::DateOnly, 10),
+            ]
+            .into_iter()
+            .collect();
+            assert_eq!(
+                elect_date_enc(&hits),
+                Some(DateEnc::IsoNaive),
+                "of the tied encodings, iso-naive concedes the least"
+            );
+
+            let hits: HashMap<DateEnc, u64> = [(DateEnc::Clf, 4), (DateEnc::Rfc2822, 4)]
+                .into_iter()
+                .collect();
+            assert_eq!(elect_date_enc(&hits), Some(DateEnc::Clf));
+
+            let hits: HashMap<DateEnc, u64> = [(DateEnc::DateOnly, 9), (DateEnc::Rfc3339, 8)]
+                .into_iter()
+                .collect();
+            assert_eq!(
+                elect_date_enc(&hits),
+                Some(DateEnc::DateOnly),
+                "declaration order is only the tie-break; more evidence still wins"
+            );
+
+            assert_eq!(elect_date_enc(&HashMap::new()), None);
+        }
+    }
+
+    /// The end-to-end symptom: one unchanged sample, split 50/50 between two
+    /// string encodings, must always write the same `date_enc` into the spec —
+    /// that string reaches the catalog and `coerce::plan_from_specs`.
+    #[test]
+    fn a_field_tied_between_two_date_encodings_maps_identically_every_run() {
+        for _ in 0..200 {
+            let mut acc = FieldAcc::default();
+            for i in 0..10 {
+                acc.add(&Value::String(format!("2026-03-{:02}T00:00:13", i + 1)));
+                acc.add(&Value::String(format!("2026-03-{:02} 00:00:13", i + 1)));
+            }
+            assert_eq!(acc.date_hits[&DateEnc::IsoNaive], 10);
+            assert_eq!(acc.date_hits[&DateEnc::SpaceNaive], 10);
+
+            let mut fields = HashMap::new();
+            fields.insert("ts".to_string(), acc);
+            let specs = infer_fields(&fields, 20, true);
+            assert_eq!(specs.len(), 1);
+            assert_eq!(specs[0].es_type, "date");
+            assert_eq!(
+                specs[0].date_enc.as_deref(),
+                Some(DateEnc::IsoNaive.as_str())
+            );
+            assert_eq!(
+                specs[0].date_evidence,
+                [
+                    "iso-naive (assumed UTC): 10".to_string(),
+                    "yyyy-mm-dd hh:mm:ss (assumed UTC): 10".to_string(),
+                ],
+                "the elected encoding is the first of the tied ones listed"
+            );
+        }
+    }
+
+    #[test]
+    fn a_tied_entity_election_elects_the_most_specific_entity_every_run() {
+        for _ in 0..500 {
+            let votes: HashMap<Entity, u64> = [
+                (Entity::Url, 6),
+                (Entity::Uuid, 6),
+                (Entity::Ip, 6),
+                (Entity::Email, 6),
+            ]
+            .into_iter()
+            .collect();
+            assert_eq!(
+                elect_entity(&votes),
+                Some(Entity::Ip),
+                "an exact IpAddr parse is the most specific classifier"
+            );
+
+            let votes: HashMap<Entity, u64> =
+                [(Entity::Url, 3), (Entity::Email, 3)].into_iter().collect();
+            assert_eq!(elect_entity(&votes), Some(Entity::Email));
+
+            let votes: HashMap<Entity, u64> =
+                [(Entity::Url, 7), (Entity::Ip, 6)].into_iter().collect();
+            assert_eq!(
+                elect_entity(&votes),
+                Some(Entity::Url),
+                "precedence is only the tie-break; more values still wins"
+            );
+
+            assert_eq!(elect_entity(&HashMap::new()), None);
+        }
+    }
+
+    /// Pins the reason the entity tie is latent rather than live: the ≥90%
+    /// supermajority gate rejects any tied field, so the winner never reaches
+    /// the spec. If this test starts failing because the gate was relaxed, the
+    /// total ordering in `elect_entity` is the only thing keeping the mapping
+    /// stable — do not remove it.
+    #[test]
+    fn a_tied_entity_field_is_rejected_by_the_supermajority_gate() {
+        let mut acc = FieldAcc::default();
+        for i in 0..15u32 {
+            acc.add(&Value::String(format!("10.0.0.{i}")));
+            acc.add(&Value::String(format!(
+                "741e7b6b-dbd2-4a7f-93a9-4ba50fb561{i:02}"
+            )));
+        }
+        assert_eq!(acc.entity[&Entity::Ip], 15);
+        assert_eq!(acc.entity[&Entity::Uuid], 15);
+        let mut fields = HashMap::new();
+        fields.insert("addr".to_string(), acc);
+        let specs = infer_fields(&fields, 30, true);
+        assert_eq!(specs[0].semantic, None, "neither side holds 90% of 30");
+    }
 }

--- a/engine/crates/xerj-console-api/src/auth/magic.rs
+++ b/engine/crates/xerj-console-api/src/auth/magic.rs
@@ -379,3 +379,236 @@ fn ip_from_headers(headers: &HeaderMap) -> String {
     }
     "unknown".to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::http::HeaderValue;
+    use tempfile::TempDir;
+    use tokio::sync::Barrier;
+
+    use super::*;
+    use crate::state::ClusterMode;
+
+    /// Console state with the `.xerj_*` system indices in place. We skip
+    /// `bootstrap::run` — redeem only touches magic links, users and audit,
+    /// and dashboard seeding would dominate the runtime of a test that races
+    /// hundreds of redemptions.
+    fn test_state() -> (ConsoleState, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = xerj_common::config::Config::default();
+        cfg.server.data_dir = dir.path().to_str().unwrap().to_string();
+        let engine = xerj_engine::Engine::new(cfg).expect("engine");
+        indices::ensure_all(&engine).expect("system indices");
+        let state = ConsoleState::new(engine, "local".into(), [0u8; 32], ClusterMode::Standalone);
+        (state, dir)
+    }
+
+    /// Write an invite link for `token` plus the pending invitee row it
+    /// points at — the same pair `issue` persists. `ttl_ms` may be negative
+    /// to mint an already-expired link.
+    async fn mint_invite(state: &ConsoleState, token: &str, ttl_ms: i64) {
+        let user_id = format!("invitee-{token}");
+        let user = store::User {
+            id: user_id.clone(),
+            email: format!("{token}@example.com"),
+            display_name: String::new(),
+            role: "editor".to_string(),
+            status: store::UserStatus::Pending,
+            created_at: now_iso(),
+            last_seen_at: None,
+        };
+        store::upsert_user(&state.engine, &user).await.unwrap();
+
+        let link = store::MagicLink {
+            id: sha256_hex(token.as_bytes()),
+            purpose: "invite".to_string(),
+            user_id: Some(user_id),
+            email: Some(user.email),
+            role: "editor".to_string(),
+            created_by: "admin-test".to_string(),
+            created_at: now_iso(),
+            expires_at: crate::time::epoch_ms_to_iso(now_epoch_ms() + ttl_ms),
+            used_at: None,
+        };
+        store::put_magic_link(&state.engine, &link).await.unwrap();
+    }
+
+    /// Drive the handler exactly as axum would. Every call declares its own
+    /// source IP so the per-IP limiter (10/min) never fires — a 429 would
+    /// silently stand in for a rejected redemption and hide the invariant
+    /// under test.
+    async fn redeem_as(state: &ConsoleState, token: &str, ip: &str) -> ConsoleResult<Response> {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_str(ip).unwrap());
+        redeem(
+            State(state.clone()),
+            headers,
+            Json(RedeemBody {
+                token: token.to_string(),
+            }),
+        )
+        .await
+    }
+
+    async fn used_at_of(state: &ConsoleState, token: &str) -> Option<String> {
+        store::get_magic_link(&state.engine, &sha256_hex(token.as_bytes()))
+            .await
+            .unwrap()
+            .expect("link row must survive redemption")
+            .used_at
+    }
+
+    /// #76 S5-3: the used-check and the `mark_magic_link_used` commit are
+    /// separated by several awaits, so without the redeem gate every racer
+    /// passes the used-check on one token and they all go on to consume it —
+    /// the single-use rule then rests on whatever the store does with the
+    /// colliding writes, not on this handler. Race a fresh token per round,
+    /// many rounds, and pin both halves of the guarantee: one winner, and
+    /// losers rejected as *used* (the generic 401) rather than surfacing a
+    /// write collision from underneath.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn racing_redemptions_of_one_token_mint_exactly_one_session() {
+        const ROUNDS: usize = 25;
+        const RACERS: usize = 6;
+
+        let (state, _dir) = test_state();
+
+        for round in 0..ROUNDS {
+            let token = format!("race-token-{round}");
+            mint_invite(&state, &token, INVITE_TTL_MS).await;
+
+            let start = Arc::new(Barrier::new(RACERS));
+            let mut racers = Vec::with_capacity(RACERS);
+            for racer in 0..RACERS {
+                let state = state.clone();
+                let token = token.clone();
+                let start = start.clone();
+                racers.push(tokio::spawn(async move {
+                    start.wait().await;
+                    redeem_as(&state, &token, &format!("10.0.{round}.{racer}")).await
+                }));
+            }
+
+            let mut winners = 0usize;
+            let mut losses = Vec::new();
+            for racer in racers {
+                match racer.await.expect("redeem must not panic") {
+                    Ok(_) => winners += 1,
+                    Err(e) => losses.push(e),
+                }
+            }
+
+            assert_eq!(
+                winners, 1,
+                "round {round}: exactly one of {RACERS} concurrent redemptions may mint a session"
+            );
+            for loss in &losses {
+                assert!(
+                    matches!(loss, ConsoleApiError::Unauthorized(_)),
+                    "round {round}: a losing racer must get the generic 401, got {loss}"
+                );
+            }
+            assert_eq!(
+                state.enrollment_sessions.len(),
+                round + 1,
+                "round {round}: one enrollment session per token, never two"
+            );
+            assert!(
+                used_at_of(&state, &token).await.is_some(),
+                "round {round}: the winning redemption must leave the link consumed"
+            );
+        }
+    }
+
+    /// The gate serializes redemptions but must not reject them: two invitees
+    /// redeeming their own links at the same instant both get a session. This
+    /// is also the control for the test above — it proves the racing harness
+    /// can produce more than one winner, so `winners == 1` there is the
+    /// single-use rule holding, not the harness serializing the calls.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn racing_redemptions_of_distinct_tokens_all_succeed() {
+        const RACERS: usize = 6;
+
+        let (state, _dir) = test_state();
+        for racer in 0..RACERS {
+            mint_invite(&state, &format!("distinct-token-{racer}"), INVITE_TTL_MS).await;
+        }
+
+        let start = Arc::new(Barrier::new(RACERS));
+        let mut racers = Vec::with_capacity(RACERS);
+        for racer in 0..RACERS {
+            let state = state.clone();
+            let start = start.clone();
+            racers.push(tokio::spawn(async move {
+                start.wait().await;
+                redeem_as(
+                    &state,
+                    &format!("distinct-token-{racer}"),
+                    &format!("10.1.0.{racer}"),
+                )
+                .await
+            }));
+        }
+        for racer in racers {
+            let outcome = racer.await.expect("redeem must not panic");
+            assert!(
+                outcome.is_ok(),
+                "a distinct token must still redeem under contention: {:?}",
+                outcome.err()
+            );
+        }
+        assert_eq!(state.enrollment_sessions.len(), RACERS);
+    }
+
+    /// An invite past its `expires_at` is refused, and refusing it neither
+    /// mints a session nor consumes the link.
+    #[tokio::test]
+    async fn an_expired_token_is_refused_and_never_mints_a_session() {
+        let (state, _dir) = test_state();
+        mint_invite(&state, "stale-token", -60_000).await;
+
+        let outcome = redeem_as(&state, "stale-token", "10.2.0.1").await;
+        assert!(
+            matches!(outcome, Err(ConsoleApiError::Unauthorized(_))),
+            "an expired link must be refused with the generic 401"
+        );
+        assert!(state.enrollment_sessions.is_empty());
+        assert!(
+            used_at_of(&state, "stale-token").await.is_none(),
+            "a refused redemption must not consume the link"
+        );
+    }
+
+    /// Replay of a consumed token is refused and leaves the original
+    /// consumption record intact — a second attempt must not re-stamp
+    /// `used_at` and so blur who redeemed the link and when.
+    #[tokio::test]
+    async fn an_already_redeemed_token_cannot_be_replayed() {
+        let (state, _dir) = test_state();
+        mint_invite(&state, "replay-token", INVITE_TTL_MS).await;
+
+        redeem_as(&state, "replay-token", "10.3.0.1")
+            .await
+            .expect("first redemption");
+        let consumed_at = used_at_of(&state, "replay-token").await;
+        assert!(consumed_at.is_some());
+
+        let outcome = redeem_as(&state, "replay-token", "10.3.0.2").await;
+        assert!(
+            matches!(outcome, Err(ConsoleApiError::Unauthorized(_))),
+            "a redeemed link must be refused with the generic 401"
+        );
+        assert_eq!(
+            state.enrollment_sessions.len(),
+            1,
+            "the replay must not mint a second enrollment session"
+        );
+        assert_eq!(
+            used_at_of(&state, "replay-token").await,
+            consumed_at,
+            "the replay must not re-stamp used_at"
+        );
+    }
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -21458,7 +21458,8 @@ fn parse_passage_guard(ids: &Value) -> Option<HashSet<String>> {
 /// file descriptor instead of one per ingest shard — the ingest-shard count
 /// scales with CPU cores, so N indices held ~N×cores WAL fds open and exhausted
 /// the (low, ~256) macOS file-descriptor limit at a few hundred datasets.
-/// Absent => the global `engine.ingest_shards` default (backward compatible).
+/// Absent, or out of `1..=MAX_PER_INDEX_WAL_SHARDS` => the global
+/// `engine.ingest_shards` default (backward compatible).
 ///
 /// MUST be persisted at create and honored on open so the WAL *write* layout
 /// stays consistent (doc routing is `xxh3(id) & (num_shards-1)`). Replay itself
@@ -21469,9 +21470,18 @@ fn wal_shards_override_from_settings(settings: &Value) -> Option<usize> {
     settings
         .pointer("/index/xerj_ingest_shards")
         .and_then(Value::as_u64)
-        .filter(|&n| n >= 1)
+        .filter(|&n| (1..=MAX_PER_INDEX_WAL_SHARDS).contains(&n))
         .map(|n| n as usize)
 }
+
+/// Ceiling for the per-index override, mirroring the `engine.ingest_shards`
+/// limit enforced by `EngineConfig::validate`. The global setting is validated
+/// at startup; this one arrives in an index-create request body (es_compat
+/// threads `settings` through untouched) and `IndexStore::open` eagerly creates
+/// a directory and opens a WAL file descriptor per shard, so an unbounded value
+/// is a create-time fd exhaustion — the exact failure this setting exists to
+/// prevent.
+const MAX_PER_INDEX_WAL_SHARDS: u64 = 256;
 
 fn store_config_from(config: &Config, wal_shards_override: Option<usize>) -> IndexStoreConfig {
     let sync_mode = match config.storage.wal_sync {
@@ -32512,3 +32522,9 @@ mod flush_memory_integration_tests {
 // its own file (src/graph.rs) instead of growing this one.
 #[path = "graph.rs"]
 pub mod graph;
+
+// Child module (same `#[path]` reason as `graph`): the WAL-shard override
+// helpers are private free functions of this module.
+#[cfg(test)]
+#[path = "wal_shard_settings_tests.rs"]
+mod wal_shard_settings_tests;

--- a/engine/crates/xerj-engine/src/wal_shard_settings_tests.rs
+++ b/engine/crates/xerj-engine/src/wal_shard_settings_tests.rs
@@ -1,0 +1,262 @@
+//! Regressions for the per-index WAL shard override (`index.xerj_ingest_shards`).
+//!
+//! The override exists because each index eagerly opens one WAL file descriptor
+//! per ingest shard, and the ingest-shard count scales with CPU cores: a few
+//! hundred autoindex datasets exhausted the macOS fd limit. Two properties have
+//! to hold or the fix is worse than the bug — the value must be *ignored* unless
+//! it is a sane count, and it must be honored identically at create and on
+//! reopen, since the WAL write layout (`wal/*.wal` vs `wal/s{N}/*.wal`) and doc
+//! routing both derive from it.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+
+use super::{store_config_from, wal_shards_override_from_settings};
+use crate::Engine;
+
+fn settings_with(shards: Value) -> Value {
+    json!({ "index": { "xerj_ingest_shards": shards } })
+}
+
+/// The `s{N}` shard subdirectories under an index's WAL root. Zero of them means
+/// the single-shard (legacy root) layout; `IndexStore::open` creates one per
+/// shard whenever the count is > 1, so this is the on-disk witness of the shard
+/// count the store was actually opened with.
+fn wal_shard_dirs(index_dir: &Path) -> usize {
+    std::fs::read_dir(index_dir.join("wal"))
+        .expect("wal dir")
+        .flatten()
+        .filter(|e| {
+            e.path().is_dir()
+                && e.file_name()
+                    .to_string_lossy()
+                    .strip_prefix('s')
+                    .is_some_and(|n| n.parse::<usize>().is_ok())
+        })
+        .count()
+}
+
+fn root_wal_files(index_dir: &Path) -> usize {
+    std::fs::read_dir(index_dir.join("wal"))
+        .expect("wal dir")
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "wal"))
+        .count()
+}
+
+/// `engine.ingest_shards` defaults to a fraction of the host's core count, so a
+/// test that let it default would silently assert nothing on a 1- or 2-core
+/// runner (the default would already be 1). Pin it well above 1.
+fn config_for(dir: &TempDir) -> Config {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.engine.ingest_shards = 8;
+    config
+}
+
+#[test]
+fn a_positive_wal_shard_count_in_index_settings_is_used() {
+    assert_eq!(
+        wal_shards_override_from_settings(&settings_with(json!(1))),
+        Some(1)
+    );
+    assert_eq!(
+        wal_shards_override_from_settings(&settings_with(json!(4))),
+        Some(4)
+    );
+    assert_eq!(
+        wal_shards_override_from_settings(&settings_with(json!(256))),
+        Some(256),
+        "256 is the documented ceiling and must still be accepted"
+    );
+}
+
+#[test]
+fn an_absent_wal_shard_setting_leaves_the_engine_default_in_charge() {
+    for absent in [
+        Value::Null,
+        json!({}),
+        json!({ "index": {} }),
+        json!({ "index": { "number_of_shards": 1 } }),
+        json!({ "xerj_ingest_shards": 1 }),
+        json!({ "index.xerj_ingest_shards": 1 }),
+    ] {
+        assert_eq!(
+            wal_shards_override_from_settings(&absent),
+            None,
+            "no override should be read from {absent}"
+        );
+    }
+}
+
+#[test]
+fn zero_and_negative_wal_shard_counts_are_ignored_never_used_as_a_count() {
+    for bad in [json!(0), json!(-1), json!(-8)] {
+        assert_eq!(
+            wal_shards_override_from_settings(&settings_with(bad.clone())),
+            None,
+            "{bad} must not become a shard count"
+        );
+    }
+}
+
+#[test]
+fn non_numeric_wal_shard_values_are_ignored_never_coerced() {
+    for bad in [
+        json!("4"),
+        json!("many"),
+        json!(4.5),
+        json!(true),
+        json!([4]),
+        json!({ "value": 4 }),
+        Value::Null,
+    ] {
+        assert_eq!(
+            wal_shards_override_from_settings(&settings_with(bad.clone())),
+            None,
+            "{bad} must not become a shard count"
+        );
+    }
+}
+
+/// The value arrives straight off an index-create request body, and every shard
+/// costs a directory plus a permanently open WAL file descriptor at
+/// `IndexStore::open`. An out-of-range count is refused outright rather than
+/// clamped, so a typo falls back to the engine default instead of quietly
+/// running with a shard count nobody asked for.
+#[test]
+fn absurdly_large_wal_shard_counts_are_refused_and_never_opened() {
+    for absurd in [json!(257), json!(100_000), json!(u64::MAX)] {
+        assert_eq!(
+            wal_shards_override_from_settings(&settings_with(absurd.clone())),
+            None,
+            "{absurd} exceeds the 256 ceiling and must be refused"
+        );
+    }
+}
+
+#[test]
+fn the_store_config_takes_its_wal_shard_count_from_the_override_when_present() {
+    let dir = TempDir::new().expect("temp dir");
+    let config = config_for(&dir);
+
+    assert_eq!(store_config_from(&config, None).num_wal_shards, 8);
+    assert_eq!(store_config_from(&config, Some(1)).num_wal_shards, 1);
+    assert_eq!(store_config_from(&config, Some(2)).num_wal_shards, 2);
+}
+
+/// The whole point of persisting the setting: create and reopen must agree on
+/// the shard count. If reopen fell back to `engine.ingest_shards`, the reopened
+/// store would write into `wal/s{N}/` while the create-time entries live in
+/// `wal/`, splitting the layout under a single index.
+#[tokio::test]
+async fn a_pinned_wal_shard_count_survives_reopen_with_every_document_intact() {
+    let dir = TempDir::new().expect("temp dir");
+    let config = config_for(&dir);
+    let pinned_dir = dir.path().join("pinned");
+    let default_dir = dir.path().join("spread");
+
+    // Deliberately below the flush thresholds: the documents stay in the
+    // memtable + WAL, so surviving a reopen means the WAL was replayed out of
+    // the layout the persisted shard count selected, not read back from a
+    // segment that would have survived either way.
+    async fn write_docs(idx: &crate::Index, range: std::ops::Range<u32>) {
+        for i in range {
+            idx.index_document(
+                Some(format!("doc-{i}")),
+                json!({ "body": format!("payload {i}") }),
+            )
+            .await
+            .expect("index document");
+        }
+    }
+
+    async fn assert_docs(idx: &crate::Index, count: u32) {
+        for i in 0..count {
+            let doc = idx
+                .get_document(&format!("doc-{i}"))
+                .await
+                .expect("get document")
+                .unwrap_or_else(|| panic!("doc-{i} was lost"));
+            assert_eq!(doc["body"], json!(format!("payload {i}")));
+        }
+        let all = idx
+            .search(
+                &xerj_query::parse_request(&json!({ "query": { "match_all": {} }, "size": 0 }))
+                    .unwrap(),
+            )
+            .await
+            .expect("search");
+        assert_eq!(
+            all.total.value, count as u64,
+            "every document must be searchable after reopen"
+        );
+    }
+
+    {
+        let engine = Engine::new(config.clone()).expect("engine");
+        engine
+            .create_index_with_settings("pinned", Schema::empty(), settings_with(json!(1)))
+            .expect("create pinned index");
+        engine
+            .create_index("spread", Schema::empty())
+            .expect("create default index");
+
+        let idx = engine.get_index("pinned").expect("pinned index");
+        write_docs(&idx, 0..25).await;
+        write_docs(&engine.get_index("spread").expect("spread index"), 0..1).await;
+
+        assert_eq!(
+            wal_shard_dirs(&pinned_dir),
+            0,
+            "one WAL shard means no s{{N}} subdirectories"
+        );
+        assert_eq!(
+            root_wal_files(&pinned_dir),
+            1,
+            "one WAL shard means exactly one WAL file"
+        );
+        // Control: without the setting the same engine config opens the
+        // core-scaled layout, so the assertions above are driven by the
+        // setting and not by an engine that only ever opens one shard.
+        assert_eq!(wal_shard_dirs(&default_dir), 8);
+    }
+
+    {
+        let engine = Engine::new(config.clone()).expect("reopen engine");
+        let idx = engine
+            .get_index("pinned")
+            .expect("pinned index after reopen");
+        assert_docs(&idx, 25).await;
+
+        assert_eq!(
+            wal_shard_dirs(&pinned_dir),
+            0,
+            "reopen must honor the persisted shard count, not engine.ingest_shards"
+        );
+        assert_eq!(
+            wal_shard_dirs(&default_dir),
+            8,
+            "an index without the setting keeps the default"
+        );
+
+        // Writes taken by the *reopened* store must land in the same layout —
+        // this is where a create/open mismatch would split the WAL.
+        write_docs(&idx, 25..50).await;
+        assert_eq!(wal_shard_dirs(&pinned_dir), 0);
+        assert_eq!(root_wal_files(&pinned_dir), 1);
+    }
+
+    {
+        let engine = Engine::new(config).expect("second reopen engine");
+        let idx = engine
+            .get_index("pinned")
+            .expect("pinned index after second reopen");
+        assert_docs(&idx, 50).await;
+        assert_eq!(wal_shard_dirs(&pinned_dir), 0);
+    }
+}

--- a/engine/crates/xerj-server/src/main.rs
+++ b/engine/crates/xerj-server/src/main.rs
@@ -1315,15 +1315,22 @@ fn raise_nofile_limit() {
 /// process on the signal instead: no panic, no core, and the conventional
 /// 128+13 status that shells report as 141.
 ///
-/// Process-global, so it reaches the server too. Its client sockets are NOT
-/// exposed: `std` writes those with `MSG_NOSIGNAL` (`SO_NOSIGPIPE` on macOS),
-/// so a client that disconnects mid-response still surfaces as `EPIPE` and
-/// cannot signal us. Its own stdout does change — the startup banner no longer
-/// aborts when the pipe has no reader, but tracing output, which discards
-/// write errors, no longer keeps a server alive past a vanished stdout either:
-/// the next log line terminates it. Supervised deployments point stdout at a
-/// file or `/dev/null` (`brain`'s boot path included), so in practice this
-/// only reaches `xerj | reader-that-leaves`.
+/// Process-global, so it reaches the server too, where the guarantee is
+/// narrower than the syscall alone would suggest. A plain socket write goes out
+/// as `send()` with `MSG_NOSIGNAL` (`SO_NOSIGPIPE` on macOS) and surfaces
+/// `EPIPE`, but `write_vectored` lowers to `writev()`, which takes no flags
+/// argument and so cannot carry it: a vectored write to an RST-broken socket
+/// under `SIG_DFL` does die on the signal. What protects the server is the
+/// runtime, not the write path — tokio/hyper is readiness-driven, observes the
+/// peer's reset on the read side, and tears the connection down before reaching
+/// a body `writev`. Confirmed empirically under sustained mid-write aborts
+/// (640+ RSTs, none of them signalled us), so it holds for this architecture
+/// rather than for socket writes in general. Its own stdout does change — the
+/// startup banner no longer aborts when the pipe has no reader, but tracing
+/// output, which discards write errors, no longer keeps a server alive past a
+/// vanished stdout either: the next log line terminates it. Supervised
+/// deployments point stdout at a file or `/dev/null` (`brain`'s boot path
+/// included), so in practice this only reaches `xerj | reader-that-leaves`.
 #[cfg(unix)]
 fn restore_default_sigpipe() {
     unsafe {

--- a/engine/crates/xerj-server/src/main.rs
+++ b/engine/crates/xerj-server/src/main.rs
@@ -1305,6 +1305,32 @@ fn raise_nofile_limit() {
     }
 }
 
+/// Restore the default SIGPIPE disposition, which the Rust runtime replaces
+/// with `SIG_IGN` before `main` runs. Under `SIG_IGN` a write to a pipe whose
+/// reader has gone returns `EPIPE`, `println!` turns that into a panic
+/// ("failed printing to stdout: Broken pipe"), and the release profile's
+/// `panic = "abort"` turns THAT into a core dump — so `xerj autoindex map |
+/// head -80`, and every other `xerj … | head`, dumped core and lost the
+/// command's real exit status. With `SIG_DFL` the kernel terminates the
+/// process on the signal instead: no panic, no core, and the conventional
+/// 128+13 status that shells report as 141.
+///
+/// Process-global, so it reaches the server too. Its client sockets are NOT
+/// exposed: `std` writes those with `MSG_NOSIGNAL` (`SO_NOSIGPIPE` on macOS),
+/// so a client that disconnects mid-response still surfaces as `EPIPE` and
+/// cannot signal us. Its own stdout does change — the startup banner no longer
+/// aborts when the pipe has no reader, but tracing output, which discards
+/// write errors, no longer keeps a server alive past a vanished stdout either:
+/// the next log line terminates it. Supervised deployments point stdout at a
+/// file or `/dev/null` (`brain`'s boot path included), so in practice this
+/// only reaches `xerj | reader-that-leaves`.
+#[cfg(unix)]
+fn restore_default_sigpipe() {
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
 /// The ordered `(rlim_cur, rlim_max)` pairs to try for RLIMIT_NOFILE, highest
 /// first. Pure, so the macOS-only `RLIM_INFINITY` path is unit-testable without
 /// a Mac. Every pair uses `rlim_max == rlim_cur` — a CONCRETE value: macOS
@@ -1370,6 +1396,11 @@ mod nofile_tests {
 }
 
 fn main() -> Result<()> {
+    // Before anything can write to stdout, including the `--help`/`--version`
+    // fast paths inside `parse_args`.
+    #[cfg(unix)]
+    restore_default_sigpipe();
+
     #[cfg(unix)]
     raise_nofile_limit();
 

--- a/engine/crates/xerj-server/tests/sigpipe.rs
+++ b/engine/crates/xerj-server/tests/sigpipe.rs
@@ -1,0 +1,102 @@
+//! `xerj … | head` must not dump core.
+//!
+//! The Rust runtime installs `SIG_IGN` for SIGPIPE before `main`, so a write to
+//! a pipe whose reader has left returns `EPIPE`, `println!` panics on it
+//! ("failed printing to stdout"), and the release profile's `panic = "abort"`
+//! turns that panic into a core dump — the reported `xerj autoindex map |
+//! head -80` failure, which also swallowed the command's real exit status.
+//! `main` restores `SIG_DFL` so the kernel terminates us on the signal instead.
+//!
+//! Both tests drive `--help`: it is the only long stdout-only path that needs
+//! neither a running server nor a fixture, and it prints through the same
+//! `println!` that panicked.
+
+#![cfg(unix)]
+
+use std::io::Read;
+use std::os::fd::AsRawFd;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Command, ExitStatus, Stdio};
+
+fn assert_died_quietly_on_sigpipe(status: ExitStatus, stderr: &[u8]) {
+    let stderr = String::from_utf8_lossy(stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "a closed stdout must not panic; stderr was: {stderr}"
+    );
+    assert!(
+        !status.core_dumped(),
+        "a closed stdout must not dump core; status was {status:?}"
+    );
+    assert_eq!(
+        status.signal(),
+        Some(libc::SIGPIPE),
+        "expected termination by SIGPIPE (shell status 141), got {status:?}; stderr: {stderr}"
+    );
+}
+
+/// The reader is dropped *before* the child is spawned, so there is no window
+/// in which the write could have succeeded and no timing assumption at all.
+#[test]
+fn stdout_pipe_without_a_reader_dies_on_sigpipe_instead_of_aborting() {
+    let (reader, writer) = std::io::pipe().expect("create pipe");
+    drop(reader);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_xerj"))
+        .arg("--help")
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn xerj --help");
+    let out = child.wait_with_output().expect("wait for xerj --help");
+
+    assert_died_quietly_on_sigpipe(out.status, &out.stderr);
+}
+
+/// The reported shape: a reader that consumes a prefix and then leaves, as
+/// `head -80` does. Linux-only because it needs `F_SETPIPE_SZ` to shrink the
+/// pipe below the help text — that is what guarantees the child is still
+/// mid-write when the reader goes, rather than having already buffered
+/// everything into a 64 KiB pipe and exited 0.
+#[cfg(target_os = "linux")]
+#[test]
+fn reader_leaving_mid_stream_dies_on_sigpipe_instead_of_aborting() {
+    const PEEK: usize = 8;
+
+    let full = Command::new(env!("CARGO_BIN_EXE_xerj"))
+        .arg("--help")
+        .output()
+        .expect("run xerj --help");
+    let (mut reader, writer) = std::io::pipe().expect("create pipe");
+    // Shrinking bottoms out at one page; the kernel reports what it did set.
+    let capacity = unsafe { libc::fcntl(writer.as_raw_fd(), libc::F_SETPIPE_SZ, 4096) };
+    assert!(
+        capacity > 0,
+        "F_SETPIPE_SZ failed: {}",
+        std::io::Error::last_os_error()
+    );
+    // Not a flake when it trips: the child must still owe bytes after we have
+    // read PEEK of them, or it finishes cleanly and proves nothing.
+    assert!(
+        full.stdout.len() > capacity as usize + PEEK,
+        "`xerj --help` is {} bytes, which no longer exceeds the {capacity}-byte pipe — \
+         drive this test with a longer-output subcommand",
+        full.stdout.len()
+    );
+
+    let child = Command::new(env!("CARGO_BIN_EXE_xerj"))
+        .arg("--help")
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn xerj --help");
+    let mut prefix = [0u8; PEEK];
+    reader
+        .read_exact(&mut prefix)
+        .expect("read the head of the stream");
+    drop(reader);
+
+    let out = child.wait_with_output().expect("wait for xerj --help");
+
+    assert_died_quietly_on_sigpipe(out.status, &out.stderr);
+}

--- a/xerj-ux/test/brain-map-pipeline.test.mjs
+++ b/xerj-ux/test/brain-map-pipeline.test.mjs
@@ -1,0 +1,227 @@
+// THE MAP — offline contract tests for the bounded knowledge-graph pipeline.
+//
+// The pipeline is pure, deterministic and dependency-free, so the claims it
+// is sold on are testable without a browser, a server or a corpus:
+//
+//   * "13 groups at any scale"  — clusters.length ≤ MAP_TOP_CLUSTERS + 1
+//   * "byte-identical across runs" — same rows in, same partition out
+//   * the honesty row must reconcile: every fetched link is either a merged
+//     link constituent or a counted self-loop, never silently dropped
+//
+// Run: node --test xerj-ux/test/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MAP_TOP_CLUSTERS,
+  mulberry32,
+  internEdges,
+  contractSequence,
+  components,
+  labelProp,
+  rankClusters,
+  buildBundles,
+} from '../src/ux/brain-map-pipeline.js';
+
+const DAY = 86_400_000;
+const T0 = 1_700_000_000_000; // fixed epoch — no Date.now() in fixtures
+
+/**
+ * A synthetic vault with real community structure: `folders` folders,
+ * `filesPerFolder` documents each, every document split into `sections`
+ * sections chained by `sequence` links (so stage 1 has something to
+ * contract). Cross-file links are dense inside a folder and sparse
+ * across folders, which is what makes label propagation find groups
+ * rather than one blob.
+ *
+ * A fraction of links are retired (invalidAt in the past) so the
+ * live/total accounting is exercised too.
+ */
+function makeVault({ folders, filesPerFolder, sections = 3, crossPerFile = 4, seed = 42 }) {
+  const rnd = mulberry32(seed);
+  const rows = [];
+  const node = (fo, fi, s) => `f${fo}/doc${fi}#s${s}`;
+  const path = (fo, fi) => `vault/area${fo}/doc${fi}.md`;
+  let id = 0;
+  const push = (src, dst, type, srcFile, weight) => {
+    // ~8% of links are retired before the as-of instant we query at.
+    const retired = rnd() < 0.08;
+    rows.push({
+      id: `e${id++}`,
+      src,
+      dst,
+      type,
+      weight,
+      validAt: T0 - 30 * DAY,
+      invalidAt: retired ? T0 - 5 * DAY : null,
+      srcFile,
+    });
+  };
+
+  for (let fo = 0; fo < folders; fo++) {
+    for (let fi = 0; fi < filesPerFolder; fi++) {
+      // reading-order chain inside the document
+      for (let s = 0; s + 1 < sections; s++) {
+        push(node(fo, fi, s), node(fo, fi, s + 1), 'sequence', path(fo, fi), 1);
+      }
+      // intra-folder authored links (dense → a community per folder)
+      for (let k = 0; k < crossPerFile; k++) {
+        const other = Math.floor(rnd() * filesPerFolder);
+        if (other === fi) continue;
+        push(
+          node(fo, fi, Math.floor(rnd() * sections)),
+          node(fo, other, 0),
+          rnd() < 0.5 ? 'wikilink' : 'pathcite',
+          path(fo, fi),
+          1 + Math.floor(rnd() * 3),
+        );
+      }
+      // folder adjacency — the weak signal the percolation guard drops
+      if (fi > 0) push(node(fo, fi, 0), node(fo, fi - 1, 0), 'same_dir', path(fo, fi), 1);
+      // sparse cross-folder bridge
+      if (rnd() < 0.05) {
+        const fo2 = Math.floor(rnd() * folders);
+        if (fo2 !== fo) push(node(fo, fi, 0), node(fo2, 0, 0), 'mdlink', path(fo, fi), 1);
+      }
+    }
+  }
+  return rows;
+}
+
+/** The full pipeline, as the view runs it. */
+function runPipeline(rows, asOf = T0) {
+  const g = internEdges(rows);
+  const fg = contractSequence(g);
+  fg.typeNamesRef = g.typeNames; // labelProp's same_dir guard reads this
+  const comps = components(fg);
+  const labels = labelProp(fg, comps);
+  const { clusters, clusterOfFile } = rankClusters(g, fg, comps, labels, asOf);
+  const bundles = buildBundles(fg, clusterOfFile, clusters.length);
+  return { g, fg, comps, clusters, clusterOfFile, bundles };
+}
+
+/** Canonical, comparable shape — Maps and typed arrays don't JSON-compare. */
+function canonical({ clusters, clusterOfFile, bundles }) {
+  return JSON.stringify({
+    clusters: clusters.map((c) => ({
+      files: [...c.files],
+      isElse: c.isElse,
+      score: c.score,
+      linkTotal: c.linkTotal,
+      linkLive: c.linkLive,
+      noteCount: c.noteCount,
+      dirLabel: c.dirLabel,
+      dirDupe: c.dirDupe,
+      hubFile: c.hubFile,
+    })),
+    clusterOfFile: [...clusterOfFile],
+    bundles: bundles.map((b) => [b.a, b.b, b.count ?? null]),
+  });
+}
+
+// Scales chosen to straddle the interesting boundaries: fewer folders than
+// the cluster cap, exactly the cap, and far more than it.
+const SCALES = [
+  { name: 'small vault (8 folders)', folders: 8, filesPerFolder: 6 },
+  { name: 'at the cluster cap (12 folders)', folders: 12, filesPerFolder: 10 },
+  { name: 'well past the cap (40 folders)', folders: 40, filesPerFolder: 15 },
+  { name: 'large vault (120 folders)', folders: 120, filesPerFolder: 20 },
+];
+
+for (const scale of SCALES) {
+  test(`bounded to ${MAP_TOP_CLUSTERS} + 1 groups — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const out = runPipeline(rows);
+
+    assert.ok(rows.length > 0, 'fixture produced no links');
+    assert.ok(
+      out.clusters.length <= MAP_TOP_CLUSTERS + 1,
+      `${rows.length} links produced ${out.clusters.length} groups, cap is ${MAP_TOP_CLUSTERS + 1}`,
+    );
+    // At most one pooled "everything else" body.
+    assert.ok(out.clusters.filter((c) => c.isElse).length <= 1, 'more than one "everything else" body');
+  });
+
+  test(`every file lands in exactly one group — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const { fg, clusters, clusterOfFile } = runPipeline(rows);
+
+    assert.equal(clusterOfFile.length, fg.F);
+    for (let f = 0; f < fg.F; f++) {
+      assert.ok(clusterOfFile[f] >= 0, `file-node ${f} was assigned to no group`);
+      assert.ok(clusterOfFile[f] < clusters.length, `file-node ${f} points past the group list`);
+    }
+    // Membership lists and the index agree in both directions.
+    const seen = new Set();
+    clusters.forEach((c, ci) => {
+      for (const f of c.files) {
+        assert.equal(clusterOfFile[f], ci, `file-node ${f} is in group ${ci}'s list but indexed elsewhere`);
+        assert.ok(!seen.has(f), `file-node ${f} appears in two groups`);
+        seen.add(f);
+      }
+    });
+    assert.equal(seen.size, fg.F, 'group membership does not cover every file-node');
+  });
+
+  test(`no fetched link is silently dropped — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const { fg } = runPipeline(rows);
+
+    // The honesty row's stated invariant, from the contractSequence comment:
+    // fetched = Σ merged-link constituents + selfLoops.
+    const constituents = fg.fEdges.reduce((acc, e) => acc + e.length, 0);
+    assert.equal(
+      constituents + fg.selfLoops,
+      rows.length,
+      'links vanished between the fetch and the merged graph',
+    );
+  });
+
+  test(`identical input yields an identical partition — ${scale.name}`, () => {
+    const a = runPipeline(makeVault(scale));
+    const b = runPipeline(makeVault(scale));
+    assert.equal(canonical(a), canonical(b), 'pipeline output is not deterministic');
+  });
+
+  test(`bundles stay within the pairwise bound — ${scale.name}`, () => {
+    const rows = makeVault(scale);
+    const { clusters, bundles } = runPipeline(rows);
+    const c = clusters.length;
+    assert.ok(
+      bundles.length <= (c * (c - 1)) / 2,
+      `${bundles.length} bundles exceeds the C·(C−1)/2 = ${(c * (c - 1)) / 2} bound for ${c} groups`,
+    );
+  });
+}
+
+test('a retired link is counted but not scored as live', () => {
+  const rows = [
+    { id: 'a', src: 'n1', dst: 'n2', type: 'wikilink', weight: 5, validAt: T0 - DAY, invalidAt: null, srcFile: 'x/a.md' },
+    { id: 'b', src: 'n2', dst: 'n3', type: 'wikilink', weight: 7, validAt: T0 - DAY, invalidAt: T0 - 1, srcFile: 'x/b.md' },
+    { id: 'c', src: 'n3', dst: 'n1', type: 'wikilink', weight: 2, validAt: T0 - DAY, invalidAt: null, srcFile: 'x/c.md' },
+  ];
+  const { clusters } = runPipeline(rows, T0);
+  const total = clusters.reduce((acc, c) => acc + c.linkTotal, 0);
+  const live = clusters.reduce((acc, c) => acc + c.linkLive, 0);
+  assert.equal(total, 3, 'all three links should be counted');
+  assert.equal(live, 2, 'the retired link should not count as live');
+});
+
+test('as-of replay: querying before a link was retired sees it live', () => {
+  const rows = [
+    { id: 'a', src: 'n1', dst: 'n2', type: 'wikilink', weight: 1, validAt: T0 - 10 * DAY, invalidAt: null, srcFile: 'x/a.md' },
+    { id: 'b', src: 'n2', dst: 'n3', type: 'wikilink', weight: 1, validAt: T0 - 10 * DAY, invalidAt: T0 - 2 * DAY, srcFile: 'x/b.md' },
+  ];
+  const now = runPipeline(rows, T0);
+  const before = runPipeline(rows, T0 - 5 * DAY);
+  const liveNow = now.clusters.reduce((acc, c) => acc + c.linkLive, 0);
+  const liveBefore = before.clusters.reduce((acc, c) => acc + c.linkLive, 0);
+  assert.equal(liveNow, 1, 'the retired link should be expired at the present instant');
+  assert.equal(liveBefore, 2, 'replayed before its retirement, the link should be live again');
+});
+
+test('an empty graph produces no groups rather than throwing', () => {
+  const { clusters, bundles } = runPipeline([]);
+  assert.equal(clusters.length, 0);
+  assert.equal(bundles.length, 0);
+});


### PR DESCRIPTION
Cuts **v1.0.0-rc.9**. Headline, stated plainly because it is the most serious defect this project has shipped: **the Windows binaries published as rc.4 through rc.8 could not start.**

```
Error: xerj-console bootstrap
Caused by: internal: create .xerj_users: storage error: I/O error: Access is denied. (os error 5)
```

`fsync_dir` was `File::open(dir)` + `sync_all()` with no platform gate, and obtaining a directory handle that way always fails on Windows with `ERROR_ACCESS_DENIED` — std cannot pass `FILE_FLAG_BACKUP_SEMANTICS`. `IndexStore::save_snapshot` calls it, so every index creation errored and the unconditional console bootstrap made that fatal at startup. It landed 2026-07-12 with the durability chain, and `xerj.org/get.ps1` kept installing it for three weeks.

Nothing caught it because **no CI job had ever run the binary anywhere except Ubuntu** — `release.yml` built eight targets and executed none of them. The `autoindex-fd-smoke` matrix added in #84 is what surfaced it, on its first run, and it now boots the server, writes a document, reads it back and autoindexes 400 datasets on Windows and macOS on every PR.

## What else is in it

**Security** — the self-contained half of the post-audit backlog (#83): snapshot `location` escaping `data_dir` via a `..` that resolved to a nonexistent target (#73), index-name validation missing at the create boundary (#80), the field limit not applied to explicit mapping updates (#76 S5-5), unserialised magic-link redemption (#76 S5-3), and node identity leaking from unauthenticated `cluster/info` (#76 AUTHZ-2). Plus one found while writing tests: `index.xerj_ingest_shards` was accepted with only a `>= 1` check and reaches an eager per-shard fd-opening loop, so `{"xerj_ingest_shards": 100000}` was a single-request descriptor exhaustion. Now bounded to `1..=256`, refused rather than clamped.

**Test coverage: 1,420 → 1,486 Rust test functions**, plus 23 offline tests for THE MAP's bounded-graph claims (which shipped in rc.7 with no automated test in any language behind them), and a CI gate that runs the second-brain, MCP and autoindex use-case harnesses that were manual until now. Every security guard was adversarially verified by reverting the production fix and requiring the new test to go red.

**Writing those tests found four real bugs, all fixed here:**

1. Inline `<script>`/`<style>` contents were indexed as prose — so inline config carrying API keys and endpoints went into `_source`. Two narrower ways the leak survived a first attempt (`<script src=/cdn/lib/>`, `</script-foo>`) were caught in review and closed, and a regression that first fix introduced — `<script-loader>`, a legal Web Component name, swallowing the rest of the page — is fixed too.
2. XML record election was non-deterministic (`max_by_key` over a `HashMap`); 200 elections over one fixture split 89/111, so each build gave documents a different field set under the same `_id`. Three further elections with the same defect — the log template an entire file is parsed with, the date encoding written into the mapping, and a field's entity type — are now total as well.
3. `xerj … | head` core-dumped instead of exiting.
4. A test that had been measuring the CI runner's core count: `reindex_pages_past_10k_via_keyset` fails on any real machine and passes on two-core CI, so `cargo test --workspace` was red for every developer and green for the project. The `_reindex` path itself is fine — verified end to end over HTTP at `total: 10050, created: 10050, batches: 11`.

## Verification

- Full workspace suite on real multi-core hardware: **1,489 passed / 0 failed**. Before this branch it could not pass at all, because of (4).
- ES-compat conformance: **1360 passed / 0 failed / 3 skipped**.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Use-case smoke (brain transcript, MCP tool surface, autoindex discovery) passes on this exact tree.
- The 8-target Release matrix went green on main before this branch was cut.

## Not included

**PR #85** (selective semantic hydration). Its correctness holds — nine refutation attempts against the ranking equivalence all failed — but review confirmed it makes *steady-state* kNN slower: projection-mode segments never populate the stored-value cache, so they stay eligible forever and re-run an O(section) winner hydration on every query. Detail on #85.

Known-open and stated in the CHANGELOG rather than implied: per-brain authorization (#79), cluster transport auth (#75), `x-forwarded-for` trust (#76 S5-4), and silent DOCX truncation at the decompression cap.