### PR TITLE
fix(engine): bucket_script resolves TSVB filter_ratio's _count + null/ternary script

### DIFF
--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -1007,9 +1007,15 @@ fn resolve_bucket_script(
             None => return json!({"value": Value::Null}),
         };
         let v = if let Some(m) = metric {
-            sib.get(m)
-                .and_then(|x| x.get("value"))
-                .and_then(Value::as_f64)
+            if m == "_count" {
+                sib.get("doc_count").and_then(Value::as_f64)
+            } else {
+                sib.get(m).and_then(|x| {
+                    x.get("value")
+                        .and_then(Value::as_f64)
+                        .or_else(|| x.as_f64())
+                })
+            }
         } else {
             sib.get("value").and_then(Value::as_f64)
         };
@@ -12220,6 +12226,40 @@ mod tests {
         let agg = json!({ "uniq": { "cardinality": { "field": "tag" } } });
         let result = run_aggs(&agg, &docs());
         assert_eq!(result["uniq"]["value"], 2);
+    }
+
+    // Regression: `bucket_script` referencing a sibling `filter` agg's doc
+    // count via the special `_count` buckets_path segment (e.g.
+    // `"numerator": "numerator>_count"`) always resolved to null, because
+    // the lookup only checked for a field literally named `_count` with a
+    // nested `.value` — which doesn't exist on a `filter` agg's bucket
+    // (`{"doc_count": N}`). This is exactly the shape Kibana/OSD's TSVB
+    // `filter_ratio` metric compiles to, so every `filter_ratio` panel
+    // (e.g. the sample Flights dashboard's "Delays & Cancellations")
+    // silently rendered as all-null.
+    #[test]
+    fn bucket_script_resolves_sibling_filter_doc_count_via_underscore_count() {
+        let docs = vec![
+            json!({"status": "delayed"}),
+            json!({"status": "delayed"}),
+            json!({"status": "ok"}),
+            json!({"status": "ok"}),
+        ];
+        let agg = json!({
+            "numerator": { "filter": { "term": { "status": "delayed" } } },
+            "denominator": { "filter": { "match_all": {} } },
+            "ratio": {
+                "bucket_script": {
+                    "buckets_path": { "numerator": "numerator>_count", "denominator": "denominator>_count" },
+                    "script": "params.numerator / params.denominator"
+                }
+            }
+        });
+        let result = run_aggs(&agg, &docs);
+        let ratio = result["ratio"]["value"]
+            .as_f64()
+            .expect("bucket_script must resolve _count buckets_path, not stay null");
+        assert!((ratio - 0.5).abs() < 1e-9);
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -1033,22 +1033,73 @@ fn resolve_bucket_script(
 
 /// Evaluate a simple arithmetic / comparison expression against a params map.
 ///
-/// Supports: numbers (incl. decimals), `params.<name>` identifiers,
+/// Supports: numbers (incl. decimals), `params.<name>` identifiers, the
+/// `null` literal (only meaningful in `==`/`!=` comparisons — matches ES
+/// bucket_script scripts like Kibana/OSD TSVB's `filter_ratio`, which
+/// guards against missing siblings with `params.x != null && ...`),
 /// operators `+ - * / %`, comparisons `< > <= >= == !=` (yield 0.0 or 1.0),
-/// logical `&&` / `||` (yield 0.0 or 1.0), and parentheses.  Honors
-/// standard precedence.  Returns `None` on parse failure.
+/// logical `&&` / `||` (yield 0.0 or 1.0), the ternary `cond ? a : b`, and
+/// parentheses. Honors standard precedence. Returns `None` on parse failure.
 fn eval_script_expr(script: &str, params: &HashMap<String, f64>) -> Option<f64> {
     let tokens = tokenize_script(script, params)?;
-    let rpn = shunting_yard(&tokens)?;
+    eval_tokens(&tokens)
+}
+
+/// Evaluate a token slice, handling the ternary operator (which the
+/// operator-precedence shunting-yard below doesn't model) by splitting on
+/// the first top-level `?` / matching `:` and recursing before falling
+/// back to ordinary shunting-yard + RPN evaluation.
+fn eval_tokens(toks: &[Tok]) -> Option<f64> {
+    if let Some((q_idx, c_idx)) = find_ternary_split(toks) {
+        let cond = eval_tokens(&toks[..q_idx])?;
+        return if cond != 0.0 {
+            eval_tokens(&toks[q_idx + 1..c_idx])
+        } else {
+            eval_tokens(&toks[c_idx + 1..])
+        };
+    }
+    let rpn = shunting_yard(toks)?;
     evaluate_rpn(&rpn)
+}
+
+/// Find the first top-level (paren-depth 0) `?` and its matching top-level
+/// `:`. Returns `None` when there's no ternary at this nesting level.
+fn find_ternary_split(toks: &[Tok]) -> Option<(usize, usize)> {
+    let mut depth = 0i32;
+    let mut q_idx = None;
+    for (i, t) in toks.iter().enumerate() {
+        match t {
+            Tok::LParen => depth += 1,
+            Tok::RParen => depth -= 1,
+            Tok::Question if depth == 0 => {
+                q_idx = Some(i);
+                break;
+            }
+            _ => {}
+        }
+    }
+    let q = q_idx?;
+    let mut depth = 0i32;
+    for (i, t) in toks.iter().enumerate().skip(q + 1) {
+        match t {
+            Tok::LParen => depth += 1,
+            Tok::RParen => depth -= 1,
+            Tok::Colon if depth == 0 => return Some((q, i)),
+            _ => {}
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone)]
 enum Tok {
     Num(f64),
+    Null,
     Op(&'static str),
     LParen,
     RParen,
+    Question,
+    Colon,
 }
 
 fn tokenize_script(s: &str, params: &HashMap<String, f64>) -> Option<Vec<Tok>> {
@@ -1087,6 +1138,8 @@ fn tokenize_script(s: &str, params: &HashMap<String, f64>) -> Option<Vec<Tok>> {
             if let Some(rest) = ident.strip_prefix("params.") {
                 let v = *params.get(rest)?;
                 toks.push(Tok::Num(v));
+            } else if ident == "null" {
+                toks.push(Tok::Null);
             } else {
                 let v = *params.get(ident)?;
                 toks.push(Tok::Num(v));
@@ -1142,6 +1195,12 @@ fn tokenize_script(s: &str, params: &HashMap<String, f64>) -> Option<Vec<Tok>> {
             ')' => {
                 toks.push(Tok::RParen);
             }
+            '?' => {
+                toks.push(Tok::Question);
+            }
+            ':' => {
+                toks.push(Tok::Colon);
+            }
             ';' => {} // ignore trailing semicolons
             _ => return None,
         }
@@ -1167,7 +1226,7 @@ fn shunting_yard(toks: &[Tok]) -> Option<Vec<Tok>> {
     let mut ops: Vec<Tok> = Vec::new();
     for t in toks {
         match t {
-            Tok::Num(_) => out.push(t.clone()),
+            Tok::Num(_) | Tok::Null => out.push(t.clone()),
             Tok::Op(o) => {
                 while let Some(Tok::Op(top)) = ops.last() {
                     if precedence(top) >= precedence(o) {
@@ -1187,6 +1246,11 @@ fn shunting_yard(toks: &[Tok]) -> Option<Vec<Tok>> {
                     }
                 }
             }
+            // `eval_tokens` always strips ternary tokens out via
+            // `find_ternary_split` before a slice reaches shunting_yard —
+            // reaching here means an unbalanced/nested `?`/`:` this
+            // evaluator doesn't support.
+            Tok::Question | Tok::Colon => return None,
         }
     }
     while let Some(op) = ops.pop() {
@@ -1198,89 +1262,96 @@ fn shunting_yard(toks: &[Tok]) -> Option<Vec<Tok>> {
     Some(out)
 }
 
+/// A resolved operand on the RPN evaluation stack — either a real number or
+/// the `null` literal, which only `==`/`!=` know how to compare against.
+#[derive(Debug, Clone, Copy)]
+enum EvalVal {
+    Num(f64),
+    Null,
+}
+
 fn evaluate_rpn(rpn: &[Tok]) -> Option<f64> {
-    let mut stack: Vec<f64> = Vec::new();
+    let mut stack: Vec<EvalVal> = Vec::new();
     for t in rpn {
         match t {
-            Tok::Num(n) => stack.push(*n),
+            Tok::Num(n) => stack.push(EvalVal::Num(*n)),
+            Tok::Null => stack.push(EvalVal::Null),
             Tok::Op(op) => {
                 let b = stack.pop()?;
                 let a = stack.pop()?;
-                let r = match *op {
-                    "+" => a + b,
-                    "-" => a - b,
-                    "*" => a * b,
-                    "/" => {
-                        if b == 0.0 {
-                            return None;
-                        } else {
-                            a / b
+                let r = if *op == "==" || *op == "!=" {
+                    let eq = match (a, b) {
+                        (EvalVal::Num(x), EvalVal::Num(y)) => (x - y).abs() < 1e-9,
+                        (EvalVal::Null, EvalVal::Null) => true,
+                        _ => false,
+                    };
+                    EvalVal::Num(if eq == (*op == "==") { 1.0 } else { 0.0 })
+                } else {
+                    let (EvalVal::Num(a), EvalVal::Num(b)) = (a, b) else {
+                        return None;
+                    };
+                    EvalVal::Num(match *op {
+                        "+" => a + b,
+                        "-" => a - b,
+                        "*" => a * b,
+                        "/" => {
+                            if b == 0.0 {
+                                return None;
+                            } else {
+                                a / b
+                            }
                         }
-                    }
-                    "%" => {
-                        if b == 0.0 {
-                            return None;
-                        } else {
-                            a % b
+                        "%" => {
+                            if b == 0.0 {
+                                return None;
+                            } else {
+                                a % b
+                            }
                         }
-                    }
-                    "<" => {
-                        if a < b {
-                            1.0
-                        } else {
-                            0.0
+                        "<" => {
+                            if a < b {
+                                1.0
+                            } else {
+                                0.0
+                            }
                         }
-                    }
-                    ">" => {
-                        if a > b {
-                            1.0
-                        } else {
-                            0.0
+                        ">" => {
+                            if a > b {
+                                1.0
+                            } else {
+                                0.0
+                            }
                         }
-                    }
-                    "<=" => {
-                        if a <= b {
-                            1.0
-                        } else {
-                            0.0
+                        "<=" => {
+                            if a <= b {
+                                1.0
+                            } else {
+                                0.0
+                            }
                         }
-                    }
-                    ">=" => {
-                        if a >= b {
-                            1.0
-                        } else {
-                            0.0
+                        ">=" => {
+                            if a >= b {
+                                1.0
+                            } else {
+                                0.0
+                            }
                         }
-                    }
-                    "==" => {
-                        if (a - b).abs() < 1e-9 {
-                            1.0
-                        } else {
-                            0.0
+                        "&&" => {
+                            if a != 0.0 && b != 0.0 {
+                                1.0
+                            } else {
+                                0.0
+                            }
                         }
-                    }
-                    "!=" => {
-                        if (a - b).abs() >= 1e-9 {
-                            1.0
-                        } else {
-                            0.0
+                        "||" => {
+                            if a != 0.0 || b != 0.0 {
+                                1.0
+                            } else {
+                                0.0
+                            }
                         }
-                    }
-                    "&&" => {
-                        if a != 0.0 && b != 0.0 {
-                            1.0
-                        } else {
-                            0.0
-                        }
-                    }
-                    "||" => {
-                        if a != 0.0 || b != 0.0 {
-                            1.0
-                        } else {
-                            0.0
-                        }
-                    }
-                    _ => return None,
+                        _ => return None,
+                    })
                 };
                 stack.push(r);
             }
@@ -1288,7 +1359,10 @@ fn evaluate_rpn(rpn: &[Tok]) -> Option<f64> {
         }
     }
     if stack.len() == 1 {
-        Some(stack[0])
+        match stack[0] {
+            EvalVal::Num(n) => Some(n),
+            EvalVal::Null => None,
+        }
     } else {
         None
     }
@@ -12260,6 +12334,66 @@ mod tests {
             .as_f64()
             .expect("bucket_script must resolve _count buckets_path, not stay null");
         assert!((ratio - 0.5).abs() < 1e-9);
+    }
+
+    // Regression: the exact `bucket_script` shape Kibana/OSD's TSVB
+    // `filter_ratio` metric generates guards its division with a ternary
+    // and explicit `null` checks — e.g.
+    // `params.numerator != null && params.denominator != null &&
+    //  params.denominator > 0 ? params.numerator / params.denominator : 0`.
+    // The script evaluator's tokenizer treated the bare word `null` as an
+    // unresolvable `params.*` identifier lookup (returning `None` and
+    // aborting the whole script), and had no support for `?:` at all — so
+    // this exact real-world script always failed to parse, independent of
+    // the `_count` buckets_path bug fixed above. Covers both null-literal
+    // comparisons and the ternary in one shot, matching the live TSVB
+    // request captured while debugging the sample Flights dashboard.
+    #[test]
+    fn bucket_script_supports_null_literal_and_ternary_like_tsvb_filter_ratio() {
+        let docs = vec![
+            json!({"status": "delayed"}),
+            json!({"status": "delayed"}),
+            json!({"status": "ok"}),
+            json!({"status": "ok"}),
+        ];
+        let agg = json!({
+            "numerator": { "filter": { "term": { "status": "delayed" } } },
+            "denominator": { "filter": { "match_all": {} } },
+            "ratio": {
+                "bucket_script": {
+                    "buckets_path": { "numerator": "numerator>_count", "denominator": "denominator>_count" },
+                    "script": "params.numerator != null && params.denominator != null && params.denominator > 0 ? params.numerator / params.denominator : 0"
+                }
+            }
+        });
+        let result = run_aggs(&agg, &docs);
+        let ratio = result["ratio"]["value"]
+            .as_f64()
+            .expect("bucket_script must evaluate the ternary/null-guarded script, not stay null");
+        assert!((ratio - 0.5).abs() < 1e-9);
+    }
+
+    // Same script, but the denominator is 0 (no docs at all): the ternary's
+    // `params.denominator > 0` guard must select the `: 0` branch instead
+    // of dividing by zero.
+    #[test]
+    fn bucket_script_ternary_false_branch_avoids_division_by_zero() {
+        let docs: Vec<Value> = vec![];
+        let agg = json!({
+            "numerator": { "filter": { "term": { "status": "delayed" } } },
+            "denominator": { "filter": { "match_all": {} } },
+            "ratio": {
+                "bucket_script": {
+                    "buckets_path": { "numerator": "numerator>_count", "denominator": "denominator>_count" },
+                    "script": "params.numerator != null && params.denominator != null && params.denominator > 0 ? params.numerator / params.denominator : 0"
+                }
+            }
+        });
+        let result = run_aggs(&agg, &docs);
+        let ratio = result["ratio"]["value"]
+            .as_f64()
+            .expect("ternary false branch must still resolve to a number");
+        assert!((ratio - 0.0).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes `bucket_script` so it correctly resolves the exact pattern Kibana/OpenSearch Dashboards' TSVB `filter_ratio` metric compiles to — found live while testing the sample "[Flights] Global Flight Dashboard": the "Delays & Cancellations" panel (a `filter_ratio` line chart) rendered as a flat, empty 0% line for every time bucket.

Two independent bugs in the same function, both required to fix the panel:

**1. `_count` buckets_path segment not resolved (`resolve_bucket_script`)**

TSVB's `filter_ratio` generates a `filter` sub-agg named "numerator" and another named "denominator", then a `bucket_script` referencing each one's doc count via `"numerator>_count"` / `"denominator>_count"`. `resolve_bucket_script`'s lookup only checked for a field literally named `_count` with a nested `.value` (`sib.get("_count").and_then(|x| x.get("value"))`) — but a `filter` (singular) aggregation's bucket is shaped `{"doc_count": N}`, not `{"_count": {"value": N}}`. The special `_count` → `doc_count` mapping already existed elsewhere in this file (`get_bucket_metric_value`, `extract_bucket_value_opt`) but was never applied here, so any `bucket_script` referencing a sibling `filter`'s count always resolved to `null`.

**2. Script evaluator had no `null` literal or ternary support**

The real script TSVB sends is:
```
params.numerator != null && params.denominator != null && params.denominator > 0
  ? params.numerator / params.denominator : 0
```
`eval_script_expr`'s tokenizer treated the bare word `null` as a `params.<name>` lookup (always failing — no such param — aborting the whole parse), and had no `?`/`:` support at all. So this exact script could never evaluate, independent of fix #1.

## How this was found
Confirmed via a temporary debug log of the real request body xerj received from a live OSD instance (removed before this PR) — the panel's actual query didn't match my first, simpler manual reproduction, which is what surfaced bug #2.

## Fix
- `resolve_bucket_script`: added the same `_count` → `doc_count` special case (+ `.as_f64()` fallback for plain-numeric siblings) already used elsewhere in this file.
- `eval_script_expr`: added a `null` literal token (meaningful only in `==`/`!=`, matching how TSVB actually uses it), and ternary `cond ? a : b` via a pre-pass that splits the token stream on the first top-level `?`/matching `:` and recurses — rather than folding it into the operator-precedence shunting-yard, which doesn't model ternary well as a plain binary op.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p xerj-engine -p xerj-api --all-targets -- -D warnings`
- [x] `cargo test -p xerj-engine --lib` (287/289 — the 2 failures are the pre-existing, unrelated `snapshot_path_security_tests` failures also present on `upstream/main`)
- [x] 3 new regression tests: `bucket_script_resolves_sibling_filter_doc_count_via_underscore_count`, `bucket_script_supports_null_literal_and_ternary_like_tsvb_filter_ratio`, `bucket_script_ternary_false_branch_avoids_division_by_zero` (denominator=0 guard)
- [x] Live verification: rebuilt a combined test binary with this fix, redeployed against the real Kibana sample Flights dataset — `curl` against the exact captured live request now returns real ratios (was all-null before) for all 27 buckets, and the "[Flights] Delays & Cancellations" dashboard panel renders a populated area chart instead of a flat empty 0% line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PRCbyt7Y2HDyhG1tbQTeL
