### PR TITLE
fix(api): send X-OpenSearch-Version on responses to OpenSearch callers

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -91,7 +91,10 @@ const FALLBACK_OPENSEARCH_VERSION: &str = "2.11.0";
 ///    recognized Elasticsearch client, or no recognizable client at all,
 ///    is unchanged pre-existing behavior — plain Elasticsearch,
 ///    `EsVersion::default()`.
-fn resolve_compat_version(state: &AppState, headers: &axum::http::HeaderMap) -> EsVersion {
+pub(crate) fn resolve_compat_version(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+) -> EsVersion {
     let mut version = EsVersion::default();
     let cfg = &state.config.compat;
     let is_opensearch = is_opensearch_caller(state, headers);

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -810,17 +810,35 @@ pub fn build_es_compat_router(state: AppState) -> Router {
 /// Elastic-specific identity marker to a client we've already decided isn't
 /// Elastic. A `Warning` header is included for Elastic callers only, for the
 /// same reason.
+///
+/// A real OpenSearch server also sends `X-OpenSearch-Version: OpenSearch/<n>
+/// (opensearch)` on every response, verified against a real OpenSearch 3.7.0
+/// container — an OpenSearch-detected caller gets the equivalent header
+/// here, built from the same version xerj already reports in `GET /`'s
+/// `version` block (`es_compat::resolve_compat_version`), so the two stay in
+/// sync by construction. Found missing while chasing an OpenSearch
+/// Dashboards Timeline (Timelion) panel that rendered empty against xerj but
+/// correctly against real OpenSearch for the byte-identical aggregation
+/// response body — this header was the one structural difference between
+/// the two.
 async fn es_headers_middleware(
     State(state): State<AppState>,
     req: Request,
     next: Next,
 ) -> Response {
     let is_opensearch = es_compat::is_opensearch_caller(&state, req.headers());
+    let opensearch_version =
+        is_opensearch.then(|| es_compat::resolve_compat_version(&state, req.headers()).number);
     let mut resp = next.run(req).await;
     let headers = resp.headers_mut();
     if is_opensearch {
         headers.remove("x-elastic-product");
         headers.remove("warning");
+        if let Some(number) = opensearch_version {
+            if let Ok(v) = HeaderValue::from_str(&format!("OpenSearch/{number} (opensearch)")) {
+                headers.insert("x-opensearch-version", v);
+            }
+        }
     } else {
         headers.insert(
             "x-elastic-product",
@@ -1000,6 +1018,69 @@ mod tests {
             acao(cfg, "https://anything.example").await.as_deref(),
             Some("*"),
             "allow_any_origin must restore Access-Control-Allow-Origin: *"
+        );
+    }
+
+    fn test_state(distribution: &str) -> AppState {
+        let dir = tempfile::tempdir().expect("tempdir").keep();
+        let mut config = xerj_common::config::Config::default();
+        config.server.data_dir = dir.to_string_lossy().into_owned();
+        config.storage.wal_sync = xerj_common::config::WalSync::Async;
+        config.compat.distribution = distribution.to_string();
+        let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+        let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+        AppState::new(config, engine, metrics)
+    }
+
+    async fn headers_for(distribution: &str) -> axum::http::HeaderMap {
+        let app =
+            Router::new()
+                .route("/", get(|| async { "ok" }))
+                .layer(middleware::from_fn_with_state(
+                    test_state(distribution),
+                    es_headers_middleware,
+                ));
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        app.oneshot(req).await.unwrap().headers().clone()
+    }
+
+    /// Regression: a real OpenSearch server sends `X-OpenSearch-Version` on
+    /// every response — verified against a real OpenSearch 3.7.0 container
+    /// while chasing an OpenSearch Dashboards Timeline panel that rendered
+    /// empty against xerj but correctly against real OpenSearch for a
+    /// byte-identical aggregation response body. This header was the one
+    /// structural difference between the two.
+    #[tokio::test]
+    async fn opensearch_caller_gets_x_opensearch_version_header() {
+        let headers = headers_for("opensearch").await;
+        assert_eq!(
+            headers
+                .get("x-opensearch-version")
+                .and_then(|v| v.to_str().ok()),
+            Some("OpenSearch/2.11.0 (opensearch)"),
+            "an OpenSearch-detected caller must get the real-OpenSearch-shaped version header"
+        );
+        assert!(
+            !headers.contains_key("x-elastic-product"),
+            "must not also send the Elastic-specific product header"
+        );
+    }
+
+    /// An Elastic-shaped caller gets neither the OpenSearch header (never
+    /// sent by real OpenSearch) nor is affected by this change — it keeps
+    /// the pre-existing `x-elastic-product` marker.
+    #[tokio::test]
+    async fn elastic_caller_does_not_get_opensearch_version_header() {
+        let headers = headers_for("elasticsearch").await;
+        assert!(
+            !headers.contains_key("x-opensearch-version"),
+            "an Elastic-shaped caller must never see the OpenSearch identity header"
+        );
+        assert_eq!(
+            headers
+                .get("x-elastic-product")
+                .and_then(|v| v.to_str().ok()),
+            Some("Elasticsearch")
         );
     }
 }


### PR DESCRIPTION
## Summary
A real OpenSearch server sends `X-OpenSearch-Version: OpenSearch/<n> (opensearch)` on every response — verified against a real OpenSearch 3.7.0 container. xerj never sent this header at all.

## How this was found
While chasing a report of an OpenSearch Dashboards Timeline (Timelion) panel rendering empty against xerj, I spun up a real OpenSearch 3.7.0 container side-by-side, indexed equivalent data, and ran the byte-identical aggregation query against both. The response *bodies* were structurally identical — a recursive key/type diff found zero differences at any level. The response *headers* were not: real OpenSearch sends `X-OpenSearch-Version`, xerj doesn't.

## Fix
`es_headers_middleware` now sends this header for any caller already detected (or forced via `--compat-distribution opensearch`) as OpenSearch, built from the same version xerj already reports in `GET /`'s `version` block (`es_compat::resolve_compat_version`, now `pub(crate)` so the middleware can reuse it) — the two stay in sync by construction, no duplicated version string. An Elastic-shaped caller is unaffected: it keeps the existing `x-elastic-product` marker and never sees this header, matching real OpenSearch's own behavior of never sending it.

## Note
This header alone did **not** fix the Timeline panel — a separate, deeper bug in cross-index `query_string` field resolution was the actual cause (see the companion PR). But it's a genuine, independently-correct gap versus real OpenSearch's wire behavior, worth sending regardless — some OpenSearch-ecosystem client code may reasonably branch on its presence.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p xerj-api --all-targets -- -D warnings`
- [x] `cargo test -p xerj-api --lib` (102/102)
- [x] 2 new regression tests: `opensearch_caller_gets_x_opensearch_version_header`, `elastic_caller_does_not_get_opensearch_version_header`
- [x] Live-verified via `curl -D -` against a running instance: header present and correctly formatted for an OpenSearch-detected caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PRCbyt7Y2HDyhG1tbQTeL
