### PR TITLE
fix(engine): query_string with no default_field searches every text field

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -28191,14 +28191,40 @@ fn query_node_to_fts(
         } => {
             // Honor top-level `query_string.boost` like the Match arm above.
             let b = boost.unwrap_or(1.0);
-            let field = default_field
-                .as_deref()
-                .or_else(|| text_fields.first().map(|s| s.as_str()))
-                .unwrap_or("_all");
-            // Keyword default field: whole-value term (keyword analyzer).
-            if exact_fields.contains(field) {
-                return Some(FtsQuery::Term(FtsTerm::boosted(field, query.as_str(), b)));
+            // An explicit `default_field` searches exactly that one field —
+            // unchanged single-field behavior, including the keyword
+            // whole-value-term shortcut.
+            if let Some(field) = default_field.as_deref() {
+                if exact_fields.contains(field) {
+                    return Some(FtsQuery::Term(FtsTerm::boosted(field, query.as_str(), b)));
+                }
+                let registry = AnalyzerRegistry::default();
+                let analyzer = registry.get_analyzer("standard")?;
+                let tokens = analyzer.analyze(query);
+                if tokens.is_empty() {
+                    return None;
+                }
+                let mut bool_q = FtsBool::new().boost(b);
+                for token in &tokens {
+                    bool_q = bool_q.should(FtsQuery::Term(FtsTerm::new(field, &token.text)));
+                }
+                return Some(FtsQuery::Bool(Box::new(bool_q)));
             }
+            // No `default_field`: real ES/OpenSearch searches every mapped
+            // text field (`index.query.default_field` defaults to `"*"`).
+            // This used to fall back to `text_fields.first()` — an
+            // arbitrary single field picked by schema order — silently
+            // missing every match in every OTHER text field. Found live: a
+            // `query_string` with no field, run across a multi-index search
+            // spanning indices with different schemas, undercounted matches
+            // by two orders of magnitude (18 of ~14,074) because only one
+            // unrelated field was ever checked.
+            let fallback = ["_all".to_string()];
+            let fields: &[String] = if text_fields.is_empty() {
+                &fallback
+            } else {
+                text_fields
+            };
             let registry = AnalyzerRegistry::default();
             let analyzer = registry.get_analyzer("standard")?;
             let tokens = analyzer.analyze(query);
@@ -28207,7 +28233,10 @@ fn query_node_to_fts(
             }
             let mut bool_q = FtsBool::new().boost(b);
             for token in &tokens {
-                bool_q = bool_q.should(FtsQuery::Term(FtsTerm::new(field, &token.text)));
+                for field in fields {
+                    bool_q =
+                        bool_q.should(FtsQuery::Term(FtsTerm::new(field.as_str(), &token.text)));
+                }
             }
             Some(FtsQuery::Bool(Box::new(bool_q)))
         }
@@ -30830,6 +30859,45 @@ mod fts_projection_tests {
                     }
                     other => panic!("expected two terms, got {:?}", other),
                 }
+            }
+            other => panic!("expected bool, got {:?}", other),
+        }
+    }
+
+    /// Regression: `query_string` with no `default_field` set (ES/OpenSearch
+    /// semantics — `index.query.default_field` defaults to `"*"`, i.e.
+    /// search every mapped text field) used to pick only `text_fields[0]`,
+    /// an arbitrary single field chosen by schema order. Any match in every
+    /// OTHER text field was silently missed. Found live: a Kibana/OSD
+    /// Timelion panel's `query_string` (used to select which index's docs
+    /// to count inside a `filters` aggregation) undercounted matches by two
+    /// orders of magnitude because the schema's first text field happened
+    /// not to be the one holding the searched value.
+    #[test]
+    fn query_string_with_no_default_field_searches_every_text_field() {
+        let q = QueryNode::QueryString {
+            query: "needle".into(),
+            default_field: None,
+            default_operator: None,
+            boost: None,
+        };
+        let text_fields = vec!["agent".to_string(), "message".to_string()];
+        let fq = query_node_to_fts(&q, &text_fields, &kw(&[])).expect("projects");
+        match fq {
+            FtsQuery::Bool(b) => {
+                let fields: Vec<&str> = b
+                    .should
+                    .iter()
+                    .map(|s| match s {
+                        FtsQuery::Term(t) => t.field.as_str(),
+                        other => panic!("expected term, got {:?}", other),
+                    })
+                    .collect();
+                assert!(
+                    fields.contains(&"message"),
+                    "must search every text field, not just the first — got {fields:?}"
+                );
+                assert!(fields.contains(&"agent"), "got {fields:?}");
             }
             other => panic!("expected bool, got {:?}", other),
         }


### PR DESCRIPTION
## Summary
`query_string` with no explicit `default_field` used to search only `text_fields[0]` — one arbitrary field, picked by schema declaration order — instead of ES/OpenSearch's actual default (`index.query.default_field` defaults to `"*"`, i.e. every mapped text field). Any match in every other text field was silently missed.

## How this was found
Root-causing an OpenSearch Dashboards Timeline (Timelion) panel that rendered empty. Timelion's `.opensearch(index, ...)` datasource selects which index's documents to count using a `filters` aggregation with a field-less `query_string` matching the literal index name — against a document field OSD's own sample data seeds with that exact value. Reproduced directly with `curl`: on an index whose schema didn't happen to put that field first, the same query matched **18 documents instead of the true ~14,074** — off by two orders of magnitude, with no error, no warning, just quietly wrong.

## Fix
When no `default_field` is given, the projection now builds the token-OR across **every** entry in `text_fields`, not just the first. An explicit `default_field` is unchanged — still single-field behavior, including the keyword whole-value-term shortcut for exact-typed fields. The genuine no-text-fields-mapped edge case still falls back to the `_all` sentinel, same as before.

## Note
This fix alone does not fully resolve the Timeline panel — a second, deeper bug was also found in this investigation: the same `filters`-aggregation-with-`query_string` pattern, combined with an *outer* query filter, drops to 0 matches specifically when the search spans **multiple indices** (`_all`) — even though `hits.total` is computed correctly across those same indices. That one is still open; will follow up with a separate PR once root-caused (it lives in cross-index aggregation dispatch, not this projection). Also related: #101 (a real-but-insufficient-alone fix for the same investigation).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p xerj-engine --all-targets -- -D warnings`
- [x] `cargo test -p xerj-engine --lib` (275/277 — the 2 failures are the pre-existing, unrelated `snapshot_path_security_tests` failures also present on `upstream/main`)
- [x] New regression test: `query_string_with_no_default_field_searches_every_text_field`
- [x] Live verification: the minimal repro (`filters` agg + field-less `query_string`, single index) went from undercounting to matching every mapped text field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PRCbyt7Y2HDyhG1tbQTeL
