### PR TITLE
fix(api): merge keyed (object-shaped) bucket aggs across multi-index search

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -4132,8 +4132,93 @@ fn merge_metric_agg(old: &Value, new: &Value) -> Option<Value> {
 fn merge_bucket_agg(old: &Value, new: &Value) -> Option<Value> {
     let old_obj = old.as_object()?;
     let new_obj = new.as_object()?;
-    let old_buckets = old_obj.get("buckets")?.as_array()?;
-    let new_buckets = new_obj.get("buckets")?.as_array()?;
+    let old_buckets_val = old_obj.get("buckets")?;
+    let new_buckets_val = new_obj.get("buckets")?;
+
+    // Keyed multi-bucket aggs — `filters` in its default named-filter form,
+    // or `terms`/`range`/`date_range` with `keyed: true` — represent
+    // `buckets` as a JSON OBJECT (bucket name -> bucket body), not an
+    // array; the object's own key IS the bucket identity, no `key`/
+    // `key_as_string` field to extract. Falling through to the array-only
+    // path below made this whole function return `None` for a keyed agg
+    // (`.as_array()` on an object is `None`), and the caller's fallback
+    // "replace only if old was empty" check made the SAME mistake
+    // (`.as_array()` on the keyed buckets object), so across N indices
+    // only the first index's contribution to a keyed bucket ever survived
+    // — every other index's matching documents were silently dropped from
+    // a multi-index search's aggregation, even though `hits.total` summed
+    // correctly across the same indices. Found live via a Kibana/OSD
+    // Timelion panel's `filters` + `query_string` aggregation returning
+    // doc_count 0 across `_all` despite the target index alone holding
+    // thousands of matches.
+    if let (Some(old_map), Some(new_map)) =
+        (old_buckets_val.as_object(), new_buckets_val.as_object())
+    {
+        let mut merged_map = old_map.clone();
+        for (key, b) in new_map {
+            let Some(b_obj) = b.as_object() else { continue };
+            match merged_map.get_mut(key) {
+                Some(existing) => {
+                    let Some(existing_obj) = existing.as_object_mut() else {
+                        continue;
+                    };
+                    let a_count = existing_obj
+                        .get("doc_count")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    let b_count = b_obj.get("doc_count").and_then(Value::as_u64).unwrap_or(0);
+                    existing_obj.insert("doc_count".to_string(), json!(a_count + b_count));
+                    for (k, v) in b_obj {
+                        if k == "doc_count" {
+                            continue;
+                        }
+                        if let Some(old_v) = existing_obj.get(k).cloned() {
+                            if let Some(m) = merge_metric_agg(&old_v, v) {
+                                existing_obj.insert(k.clone(), m);
+                            } else if let Some(m) = merge_bucket_agg(&old_v, v) {
+                                existing_obj.insert(k.clone(), m);
+                            } else if let Some(m) = merge_single_bucket_agg(&old_v, v) {
+                                existing_obj.insert(k.clone(), m);
+                            }
+                            // else keep existing
+                        } else {
+                            existing_obj.insert(k.clone(), v.clone());
+                        }
+                    }
+                }
+                None => {
+                    merged_map.insert(key.clone(), b.clone());
+                }
+            }
+        }
+        let summable = |k: &str| -> bool {
+            matches!(
+                k,
+                "sum_other_doc_count" | "doc_count_error_upper_bound" | "bg_count" | "doc_count"
+            )
+        };
+        let mut out = serde_json::Map::new();
+        for (k, v) in old_obj.iter().chain(new_obj.iter()) {
+            if k == "buckets" {
+                continue;
+            }
+            match v {
+                Value::Number(n) if summable(k) => {
+                    let acc =
+                        out.get(k).and_then(Value::as_u64).unwrap_or(0) + n.as_u64().unwrap_or(0);
+                    out.insert(k.clone(), json!(acc));
+                }
+                _ => {
+                    out.entry(k.clone()).or_insert_with(|| v.clone());
+                }
+            }
+        }
+        out.insert("buckets".to_string(), Value::Object(merged_map));
+        return Some(Value::Object(out));
+    }
+
+    let old_buckets = old_buckets_val.as_array()?;
+    let new_buckets = new_buckets_val.as_array()?;
 
     fn bucket_key(b: &Value) -> String {
         if let Some(k) = b.get("key_as_string").and_then(Value::as_str) {
@@ -4280,6 +4365,89 @@ fn merge_bucket_agg(old: &Value, new: &Value) -> Option<Value> {
     }
     out.insert("buckets".to_string(), Value::Array(merged_buckets));
     Some(Value::Object(out))
+}
+
+#[cfg(test)]
+mod merge_bucket_agg_keyed_tests {
+    use super::*;
+
+    // Regression: a keyed multi-bucket agg (`filters` in its default
+    // named-filter form; also `terms`/`range`/`date_range` with
+    // `keyed: true`) represents `buckets` as a JSON OBJECT, not an array.
+    // `merge_bucket_agg` used to require `.as_array()`, so it silently
+    // returned `None` for this shape — and the caller's array-only
+    // fallback replace-check made the identical mistake — so across a
+    // multi-index search only the FIRST index's contribution to a keyed
+    // bucket ever survived; every other index's matching documents were
+    // dropped from the merged aggregation despite `hits.total` correctly
+    // summing across the same indices. Found live via a Kibana/OSD
+    // Timelion panel's `filters` + `query_string` aggregation reporting
+    // doc_count 0 on a multi-index (`_all`) search.
+    #[test]
+    fn keyed_filters_agg_sums_doc_count_across_indices() {
+        let from_index_a = json!({
+            "buckets": {
+                "mykey": {"doc_count": 0}
+            }
+        });
+        let from_index_b = json!({
+            "buckets": {
+                "mykey": {"doc_count": 3769}
+            }
+        });
+        let merged =
+            merge_bucket_agg(&from_index_a, &from_index_b).expect("keyed buckets must merge");
+        assert_eq!(
+            merged["buckets"]["mykey"]["doc_count"], 3769,
+            "doc_count from every index must be summed, not just the first"
+        );
+    }
+
+    /// The keyed merge must also recurse into nested sub-aggregations
+    /// (e.g. a `date_histogram` inside a `filters` bucket, the exact shape
+    /// Timelion sends) rather than dropping them or keeping only one
+    /// index's contribution.
+    #[test]
+    fn keyed_filters_agg_merges_nested_sub_aggregation() {
+        let from_index_a = json!({
+            "buckets": {
+                "mykey": {
+                    "doc_count": 5,
+                    "inner": {"value": 10.0}
+                }
+            }
+        });
+        let from_index_b = json!({
+            "buckets": {
+                "mykey": {
+                    "doc_count": 7,
+                    "inner": {"value": 20.0}
+                }
+            }
+        });
+        let merged = merge_bucket_agg(&from_index_a, &from_index_b)
+            .expect("keyed buckets with nested sub-aggs must merge");
+        assert_eq!(merged["buckets"]["mykey"]["doc_count"], 12);
+        // `merge_metric_agg` doesn't recombine plain untracked `value`
+        // pairs (no internal tracking to average correctly), so it keeps
+        // the existing value rather than guessing — the important
+        // regression coverage here is that doc_count summed and the
+        // sub-agg key survived the merge at all (previously the whole
+        // bucket from index B was dropped).
+        assert!(merged["buckets"]["mykey"]["inner"].is_object());
+    }
+
+    /// A bucket key present only in the SECOND index (a filter with no
+    /// matches from the first index at all) must still appear in the
+    /// merged result, not be silently dropped.
+    #[test]
+    fn keyed_filters_agg_adds_new_key_from_second_index() {
+        let from_index_a = json!({"buckets": {"a": {"doc_count": 3}}});
+        let from_index_b = json!({"buckets": {"b": {"doc_count": 4}}});
+        let merged = merge_bucket_agg(&from_index_a, &from_index_b).expect("must merge");
+        assert_eq!(merged["buckets"]["a"]["doc_count"], 3);
+        assert_eq!(merged["buckets"]["b"]["doc_count"], 4);
+    }
 }
 
 fn synthetic_transform_object_ext2(


### PR DESCRIPTION
## Summary
**This is the actual root cause** of an OpenSearch Dashboards Timeline (Timelion) panel that rendered empty against xerj. Multi-index search runs the same aggregation independently per index and merges the per-index results — `merge_bucket_agg`, the merger for multi-bucket aggregations, only handled **array**-shaped `buckets` (`terms`, `date_histogram`, ...). A **keyed** multi-bucket agg — `filters` in its default named-filter form, or `terms`/`range`/`date_range` with `keyed: true` — represents `buckets` as a JSON **object** (bucket name → bucket body), not an array. For that shape the function always returned `None` (`.as_array()` on an object is `None`).

The caller's fallback path made the identical mistake (also called `.as_array()` on the keyed buckets object), so `should_replace` was always `false`. Net effect: **across N indices, only the first index's contribution to a keyed bucket ever survived** — every other index's matching documents were silently dropped from the merged aggregation, even though `hits.total` summed correctly across those same indices. The query matching was fine; only the aggregation merge was broken.

## How this was found
Root-causing an OpenSearch Dashboards Timeline panel across three layers, in order:
1. First found and fixed `query_string` picking only the first text field with no `default_field` (#102) — real, but insufficient alone.
2. Then found `X-OpenSearch-Version` missing from xerj's responses (#101) — real, also insufficient alone.
3. With both applied, the exact real Timelion query (captured live via temporary request logging, removed before this PR) still returned `doc_count: 0` for the target index's `filters` bucket on a multi-index (`_all`) search — while the identical query on a **single** index returned the correct count. That isolated it to the merge step, not query execution.

Traced to `merge_bucket_agg`: reproduced directly — `filters` + field-less `query_string`, run on `_all` across 26 indices, one of which alone holds ~14,074 matching documents, returned `doc_count: 0` for that filter bucket. Whichever index xerj happened to process first (almost never the one actually being searched for — most of the 26 indices are internal `.xerj_*`/`.kibana_1` system indices) "won", and the real index's contribution — sent later in iteration order — was discarded by the broken merge.

## Fix
Added a keyed-object merge path to `merge_bucket_agg`, parallel to the existing array path: sum `doc_count` per matching object key, recursively merge nested sub-aggregations the same way the array path already does (reusing `merge_metric_agg` / `merge_bucket_agg` / `merge_single_bucket_agg`), and add any key present in only one side. Falls through to the pre-existing array path unchanged for every non-keyed aggregation — zero behavior change for `terms`, `date_histogram`, `histogram`, `range` (non-keyed), `composite`, etc.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p xerj-api --all-targets -- -D warnings`
- [x] `cargo test -p xerj-api --lib` (112/112)
- [x] 3 new regression tests: `keyed_filters_agg_sums_doc_count_across_indices`, `keyed_filters_agg_merges_nested_sub_aggregation`, `keyed_filters_agg_adds_new_key_from_second_index`
- [x] Live verification, full chain: rebuilt a combined binary with this fix + #101 + #102 + the two other fixes from the same session (#95, #99), redeployed against the real long-running test environment, re-ran the exact captured live Timelion request — `doc_count` went from `0` to the correct `3769`, `avg(bytes)` buckets went from all-null to 143/171 real values. Confirmed in the browser: the "(Timeline) Avg bytes over time" panel — empty since before this investigation started — now renders a populated line chart, matching its TSVB sibling panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PRCbyt7Y2HDyhG1tbQTeL
