### PR TITLE
fix(api): enforce the real ES runtime-field type allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — runtime-field types (can break existing mappings)
+
+- **`mappings.runtime` is now validated against ES's runtime-field type
+  registry**, not against the mapping-property type list. Runtime fields
+  have their own, much smaller registry in ES: `boolean`, `composite`,
+  `date`, `double`, `geo_point`, `ip`, `keyword`, `long`, `lookup`.
+  Anything else is refused at index creation with the same
+  `mapper_parsing_exception` ES emits ("The mapper type [x] declared on
+  runtime field [f] does not exist…").
+
+  This cuts both ways, and both directions were wrong before:
+
+  - **Newly rejected.** Types that are perfectly valid *mapping
+    properties* but illegal under `runtime` — `text`, `match_only_text`,
+    `nested`, `object`, `geo_shape`, `shape`, `point`, `dense_vector`,
+    `sparse_vector`, `binary`, `percolator`, `completion`, `histogram`,
+    `alias`, `join`, `version`, `constant_keyword`, `wildcard`,
+    `date_nanos`, the range types, and the narrow numerics (`integer`,
+    `short`, `byte`, `float`, `half_float`, `scaled_float`,
+    `unsigned_long`, which collapse into `long`/`double` at runtime) —
+    used to be accepted with a `200`. **A mapping that declared any of
+    these under `mappings.runtime` will now fail to create.** Change the
+    entry to the runtime type ES would have required (usually `keyword`,
+    `long` or `double`), or move the field into `properties`.
+  - **Newly accepted.** `composite` and `lookup` are runtime-ONLY types
+    and are absent from the property list, so they were previously
+    rejected outright — even though `lookup` runtime fields are
+    implemented on the search path (via search-body `runtime_mappings`)
+    and covered by the conformance suite. Both are now accepted under
+    `mappings.runtime`.
+
+  Scope: this is `PUT /{index}` **validation** only. It does not change
+  evaluation: `mappings.runtime` is still stored and never evaluated —
+  runtime fields are only computed when supplied in the search body as
+  `runtime_mappings`. Search-body `runtime_mappings` and
+  `PUT /{index}/_mapping` still do not validate runtime types at all
+  (they never did) — unchanged here.
+
+  Prior to this, the rule was half-enforced: `flat_object`/`flattened`
+  were special-cased into a `400` while every other ES-forbidden type
+  passed.
+
 ## [1.0.0-rc.9] - 2026-08-01
 
 Ninth release candidate: the **cross-platform correctness release**.

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -997,13 +997,7 @@ fn validate_runtime_fields(rt: &serde_json::Map<String, Value>) -> Result<(), St
             continue;
         };
         if let Some(t) = obj.get("type").and_then(Value::as_str) {
-            // `flattened`/`flat_object` are valid *mapping* property types
-            // but not valid *runtime field* types in real ES — runtime
-            // fields are restricted to a small scalar/composite set.
-            // is_supported_field_type is shared with the mapping-properties
-            // path (validate_properties), so this exclusion has to live
-            // here rather than narrowing that shared list.
-            if t == "flattened" || t == "flat_object" || !is_supported_field_type(t) {
+            if !is_supported_runtime_field_type(t) {
                 return Err(format!(
                     "Failed to parse mapping: The mapper type [{t}] declared on runtime field [{name}] does not exist. It might have been created within a future version or requires a plugin to be installed. Check the documentation."
                 ));
@@ -1011,6 +1005,46 @@ fn validate_runtime_fields(rt: &serde_json::Map<String, Value>) -> Result<(), St
         }
     }
     Ok(())
+}
+
+/// The runtime-field type allowlist.
+///
+/// Runtime fields have their OWN, much smaller type registry in ES than
+/// mapping properties do: `IndicesModule#getRuntimeFields` registers
+/// exactly `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,
+/// `keyword`, `long` and `lookup`, and `RuntimeField.parseRuntimeFields`
+/// rejects anything else with the same "mapper type […] does not exist"
+/// message this module emits. So a type being a perfectly valid *mapping
+/// property* type says nothing about whether it is legal under
+/// `mappings.runtime` — `text`, `nested`, `geo_shape`, `dense_vector`,
+/// `binary`, `percolator`, `flattened`/`flat_object` and the narrower
+/// numerics (`integer`, `float`, `scaled_float`, …, which collapse into
+/// `long`/`double` at runtime) are all rejected by real ES.
+///
+/// Deliberately NOT expressed as "is_supported_field_type minus
+/// exclusions": that shared list is the mapping-properties list, and
+/// every future addition to it would silently widen this one. The two
+/// registries are independent in ES and are kept independent here.
+fn is_supported_runtime_field_type(t: &str) -> bool {
+    matches!(
+        t,
+        "boolean"
+            | "composite"
+            | "date"
+            | "double"
+            | "geo_point"
+            | "ip"
+            | "keyword"
+            | "long"
+            // `lookup` runtime fields resolve each hit against another
+            // index; the search path implements them for search-body
+            // `runtime_mappings` (see the `type: lookup` branch in the
+            // fields-API fetch), and `search/390_lookup_fields.yml`
+            // exercises them. Neither `lookup` nor `composite` is a
+            // mapping-PROPERTY type, so validating `mappings.runtime`
+            // against the property list rejected both outright.
+            | "lookup"
+    )
 }
 
 fn is_supported_field_type(t: &str) -> bool {
@@ -1070,6 +1104,206 @@ fn is_supported_field_type(t: &str) -> bool {
             | "aggregate_metric_double"
             | "passthrough"
     )
+}
+
+#[cfg(test)]
+mod runtime_field_type_tests {
+    //! `mappings.runtime` used to be validated against the
+    //! MAPPING-PROPERTY type list with `flattened`/`flat_object` carved
+    //! out by hand, so the rule was half-enforced: `flat_object` was a
+    //! 400 while `text`, `nested`, `geo_shape`, `dense_vector`,
+    //! `binary`, `percolator` and the narrow numerics — all of which
+    //! real ES rejects just as hard — were a 200. Worse, the two types
+    //! that ARE runtime-only (`composite`, `lookup`) are absent from the
+    //! mapping-property list and were therefore rejected outright, so
+    //! the validator was wrong in both directions.
+    use super::*;
+    use axum::{
+        body::{to_bytes, Body},
+        http::Request,
+    };
+    use tower::ServiceExt;
+    use xerj_common::{
+        config::{Config, WalSync},
+        metrics::Metrics,
+    };
+    use xerj_engine::Engine;
+
+    fn runtime(name: &str, ty: &str) -> serde_json::Map<String, Value> {
+        json!({name: {"type": ty}})
+            .as_object()
+            .expect("object")
+            .clone()
+    }
+
+    /// Every type real ES registers as a runtime field
+    /// (`IndicesModule#getRuntimeFields`) must be accepted.
+    #[test]
+    fn accepts_the_real_es_runtime_field_types() {
+        for ty in [
+            "boolean",
+            "composite",
+            "date",
+            "double",
+            "geo_point",
+            "ip",
+            "keyword",
+            "long",
+            "lookup",
+        ] {
+            assert!(
+                validate_runtime_fields(&runtime("rf", ty)).is_ok(),
+                "runtime field type [{ty}] is legal in ES and must be accepted"
+            );
+        }
+    }
+
+    /// `composite` and `lookup` are runtime-only — they are NOT mapping
+    /// property types, so validating against the shared property list
+    /// rejected them. `lookup` in particular is implemented by the
+    /// search path and covered by `search/390_lookup_fields.yml`.
+    #[test]
+    fn accepts_runtime_only_types_absent_from_the_property_list() {
+        for ty in ["composite", "lookup"] {
+            assert!(
+                !is_supported_field_type(ty),
+                "[{ty}] is not a mapping-property type — that is the point of this test"
+            );
+            assert!(
+                validate_runtime_fields(&runtime("rf", ty)).is_ok(),
+                "runtime-only type [{ty}] must be accepted under mappings.runtime"
+            );
+        }
+    }
+
+    /// Valid mapping-property types that ES nonetheless refuses under
+    /// `mappings.runtime`. `flat_object`/`flattened` were the only two
+    /// previously rejected; the rest are the half of the rule that was
+    /// missing.
+    #[test]
+    fn rejects_property_types_es_forbids_in_runtime_fields() {
+        for ty in [
+            "text",
+            "match_only_text",
+            "nested",
+            "object",
+            "geo_shape",
+            "shape",
+            "point",
+            "dense_vector",
+            "sparse_vector",
+            "binary",
+            "percolator",
+            "completion",
+            "histogram",
+            "alias",
+            "join",
+            "version",
+            "constant_keyword",
+            "wildcard",
+            "date_nanos",
+            "integer",
+            "short",
+            "byte",
+            "float",
+            "half_float",
+            "scaled_float",
+            "unsigned_long",
+            "ip_range",
+            "date_range",
+            "rank_feature",
+            "token_count",
+            "aggregate_metric_double",
+            "flattened",
+            "flat_object",
+        ] {
+            assert!(
+                is_supported_field_type(ty),
+                "[{ty}] must be a valid mapping-property type for this test to mean anything"
+            );
+            let err = validate_runtime_fields(&runtime("rf", ty)).expect_err(&format!(
+                "runtime field type [{ty}] is forbidden by ES and must be rejected"
+            ));
+            assert_eq!(
+                err,
+                format!(
+                    "Failed to parse mapping: The mapper type [{ty}] declared on runtime field [rf] does not exist. It might have been created within a future version or requires a plugin to be installed. Check the documentation."
+                ),
+                "rejection must carry ES's mapper-type-does-not-exist wording"
+            );
+        }
+    }
+
+    /// Unknown types stay rejected. A runtime field with no `type` at
+    /// all keeps passing — real ES rejects that too ("No type specified
+    /// for runtime field"), but that is a separate, pre-existing
+    /// divergence this patch deliberately does not change, and the test
+    /// pins the current behaviour so the difference stays visible.
+    #[test]
+    fn unknown_types_rejected_and_typeless_entries_still_pass() {
+        assert!(validate_runtime_fields(&runtime("rf", "invalid")).is_err());
+        let typeless = json!({"rf": {"script": {"source": "emit(1)"}}})
+            .as_object()
+            .expect("object")
+            .clone();
+        assert!(validate_runtime_fields(&typeless).is_ok());
+    }
+
+    fn test_state() -> AppState {
+        let dir = tempfile::tempdir().expect("tempdir").keep();
+        let mut config = Config::default();
+        config.server.data_dir = dir.to_string_lossy().into_owned();
+        config.storage.wal_sync = WalSync::Async;
+        let metrics = Metrics::new().expect("metrics");
+        let engine = Engine::new(config.clone()).expect("engine");
+        AppState::new(config, engine, metrics)
+    }
+
+    async fn create_index_with_runtime_type(ty: &str) -> (StatusCode, Value) {
+        let router = crate::router::build_es_compat_router(test_state());
+        let response = router
+            .oneshot(
+                Request::put(format!("/rt-type-{ty}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"mappings": {"runtime": {"rf": {"type": ty}}}}).to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("create response");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response bytes");
+        let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn create_index_rejects_a_text_runtime_field_over_http() {
+        let (status, body) = create_index_with_runtime_type("text").await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "ES rejects text runtime fields; got {status} {body}"
+        );
+        assert_eq!(body["error"]["type"], "mapper_parsing_exception", "{body}");
+        assert_eq!(
+            body["error"]["reason"],
+            "Failed to parse mapping: The mapper type [text] declared on runtime field [rf] does not exist. It might have been created within a future version or requires a plugin to be installed. Check the documentation.",
+            "{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_index_accepts_a_lookup_runtime_field_over_http() {
+        let (status, body) = create_index_with_runtime_type("lookup").await;
+        assert!(
+            status.is_success(),
+            "lookup is a legal ES runtime field type; got {status} {body}"
+        );
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/engine/tests/es-compat-yaml/yaml/indices/indices.create/10_basic.yml
+++ b/engine/tests/es-compat-yaml/yaml/indices/indices.create/10_basic.yml
@@ -285,6 +285,96 @@
   - match: { error.reason: "Failed to parse mapping: The mapper type [invalid] declared on runtime field [content] does not exist. It might have been created within a future version or requires a plugin to be installed. Check the documentation." }
 
 ---
+"Create index with a mapping-only type as a runtime field type":
+  # Runtime fields have their own, much smaller type registry than
+  # mapping properties: text/nested/geo_shape/dense_vector/binary/
+  # percolator/flattened and the narrow numerics are all valid property
+  # types and all rejected under `runtime`.
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            runtime:
+              content:
+                type: text
+
+  - match: { error.type: "mapper_parsing_exception" }
+  - match: { error.reason: "Failed to parse mapping: The mapper type [text] declared on runtime field [content] does not exist. It might have been created within a future version or requires a plugin to be installed. Check the documentation." }
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            runtime:
+              content:
+                type: integer
+
+  - match: { error.type: "mapper_parsing_exception" }
+  - match: { error.reason: "Failed to parse mapping: The mapper type [integer] declared on runtime field [content] does not exist. It might have been created within a future version or requires a plugin to be installed. Check the documentation." }
+
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            runtime:
+              content:
+                type: geo_shape
+
+  - match: { error.type: "mapper_parsing_exception" }
+  - match: { error.reason: "Failed to parse mapping: The mapper type [geo_shape] declared on runtime field [content] does not exist. It might have been created within a future version or requires a plugin to be installed. Check the documentation." }
+
+---
+"Create index with the supported runtime field types":
+  # The full registry: boolean, composite, date, double, geo_point, ip,
+  # keyword, long, lookup. `composite` and `lookup` are runtime-ONLY —
+  # they are not legal mapping property types.
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            runtime:
+              rt_boolean:
+                type: boolean
+              rt_composite:
+                type: composite
+                script:
+                  source: "emit('a', 1)"
+                fields:
+                  a:
+                    type: long
+              rt_date:
+                type: date
+              rt_double:
+                type: double
+              rt_geo_point:
+                type: geo_point
+              rt_ip:
+                type: ip
+              rt_keyword:
+                type: keyword
+              rt_long:
+                type: long
+              rt_lookup:
+                type: lookup
+                target_index: rt_lookup_target
+                input_field: rt_keyword
+                target_field: _id
+                fetch_fields: [ "city" ]
+
+  - do:
+      indices.get_mapping:
+        index: test_index
+
+  - is_true: test_index.mappings
+
+---
 "Create index with invalid multi-field type":
   - requires:
       cluster_features: [ "mapper.unknown_field_mapping_update_error_message" ]


### PR DESCRIPTION
Closes #98.

Runtime-field validation was half-enforced after the flat_object work: it rejected `flat_object` and `flattened` while still accepting `text`, `nested`, `geo_shape`, `dense_vector`, `binary` and `percolator`, none of which real ES permits in a runtime field.

Chose option (a), enforce the real allowlist. The target version is pinned by the repo itself (the YAML runner comments that xerj reports ES 8.13.0 wire compatibility, and `GET /` returns 8.13.0), so the allowlist is ES 8.13's set rather than a guess.

Behaviour change worth noting in the changelog: mappings declaring a runtime field of a now-rejected type will start failing. That is the point, but it is not backward compatible.