### PR TITLE
fix(security): block path traversal via index name and snapshot repo/name (CWE-22)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -20871,11 +20871,99 @@ pub async fn get_index_alias(
 // GET    /_snapshot/{repo}/{snapshot}
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Build a 400 `illegal_argument_exception` response for a bad snapshot
+/// repository location, matching the ES-shaped error envelope the restore
+/// path already uses.
+fn snapshot_location_error(reason: &str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "root_cause": [{
+                    "type": "illegal_argument_exception",
+                    "reason": reason
+                }],
+                "type": "illegal_argument_exception",
+                "reason": reason,
+            },
+            "status": 400,
+        })),
+    )
+        .into_response()
+}
+
+/// Resolve `location` against `root_dir` and confirm it stays inside it.
+///
+/// Returns `Ok(())` when the location is acceptable, or `Err(reason)` with a
+/// human-readable reason string (surfaced as a 400 by the caller). The
+/// repository directory may not exist yet (it is typically created on the
+/// first `create_snapshot`), so when `canonicalize` fails on the location
+/// itself the parent is canonicalized and the final component re-appended.
+fn resolve_snapshot_location(location: &str, root_dir: &str) -> Result<(), String> {
+    let root = std::path::Path::new(root_dir);
+    let root_canon = root.canonicalize().map_err(|e| {
+        format!("snapshot.root_dir {root_dir:?} is not accessible: {e}")
+    })?;
+    let loc_path = std::path::Path::new(location);
+    let resolved = if loc_path.is_absolute() {
+        loc_path.to_path_buf()
+    } else {
+        // Relative locations are resolved against the configured root, not
+        // the process working directory, so a relative name cannot escape by
+        // relying on an unrelated CWD.
+        root_canon.join(location)
+    };
+    let resolved_canon = match resolved.canonicalize() {
+        Ok(c) => c,
+        Err(_) => {
+            let parent = resolved.parent().unwrap_or(std::path::Path::new(""));
+            let parent_canon = parent.canonicalize().map_err(|e| {
+                format!("snapshot repository location {location:?} parent is not accessible: {e}")
+            })?;
+            parent_canon.join(resolved.file_name().unwrap_or_default())
+        }
+    };
+    if !resolved_canon.starts_with(&root_canon) {
+        return Err(format!(
+            "snapshot repository location {location:?} resolves outside snapshot.root_dir {root_dir:?}"
+        ));
+    }
+    Ok(())
+}
+
 pub async fn put_snapshot_repo(
     State(state): State<AppState>,
     Path(repo): Path<String>,
     Json(body): Json<Value>,
 ) -> impl IntoResponse {
+    // Validate the filesystem `location` before storing the repo config
+    // (CWE-22): without this, a repository could be pointed at an arbitrary
+    // path and `create_snapshot`/`restore_snapshot` would read and write
+    // there — letting a caller plant a `manifest.json` for restore or
+    // write snapshot files into sensitive directories. Two layers:
+    //   1. always reject `..`/`.` path components (relative traversal);
+    //   2. when `snapshot.root_dir` is configured, require the resolved
+    //      location to live inside it (blocks absolute-path escapes).
+    let location = body
+        .pointer("/settings/location")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if !location.is_empty() {
+        if location
+            .split(['/', '\\'])
+            .any(|seg| seg == ".." || seg == ".")
+        {
+            return snapshot_location_error(
+                "snapshot repository location must not contain '..' or '.' path components",
+            );
+        }
+        let root_dir = state.config.snapshot.root_dir.as_str();
+        if !root_dir.is_empty() {
+            if let Err(reason) = resolve_snapshot_location(location, root_dir) {
+                return snapshot_location_error(&reason);
+            }
+        }
+    }
     state.engine.snapshot_repos.insert(repo, body);
     Json(json!({ "acknowledged": true })).into_response()
 }

--- a/engine/crates/xerj-common/src/config.rs
+++ b/engine/crates/xerj-common/src/config.rs
@@ -84,6 +84,8 @@ pub struct Config {
     pub logging: LoggingConfig,
     /// Elasticsearch/OpenSearch wire-compatibility identity — 2 settings.
     pub compat: CompatConfig,
+    /// Snapshot repository confinement — 1 setting.
+    pub snapshot: SnapshotConfig,
 }
 
 // Total: 5+3+2+3+10+5+3+1+6+2+4+3+4+3+2 = 56 fields (incl. cors: 2, auth: 3,
@@ -318,6 +320,25 @@ pub struct CompatConfig {
     /// that first, a real OpenSearch Dashboards container rejected it, see
     /// `es_compat::FALLBACK_OPENSEARCH_VERSION`'s doc comment for why).
     pub version: String,
+}
+
+/// Snapshot repository settings — 1 setting.
+///
+/// `root_dir` constrains where filesystem snapshot repositories may live.
+/// When non-empty, a `PUT /_snapshot/{repo}` request whose
+/// `settings.location` resolves outside `root_dir` is rejected (CWE-22:
+/// without this, an admin — or anyone in the default no-auth posture —
+/// could point a repository at an arbitrary filesystem path and have
+/// `create_snapshot`/`restore_snapshot` read and write there). Empty
+/// (default) preserves the pre-existing unrestricted behaviour; set it
+/// in production to lock snapshot repos under a dedicated directory.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SnapshotConfig {
+    /// Absolute directory that all filesystem snapshot repository
+    /// `location` values must resolve inside. Empty (default) = no
+    /// restriction (backwards-compatible). Example: `"/var/lib/xerj/snapshots"`.
+    pub root_dir: String,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1378,9 +1399,10 @@ mod tests {
         //                   total memtable, segment hydration cache, RSS, disk)
         //   indexing: 3    (turbo_batch_size, turbo_parallel, turbo_fast_analyzer)
         //   logging: 2     (format, access_log)                      ← RC4-W4 item 6
+        //   snapshot: 1    (root_dir)                             ← snapshot repo confinement
         //   ─────────
-        //   total: 58 fields, minus 1 auto-generated (admin_api_key) = 57 meaningful user settings
-        let total: usize = 5 + 3 + 3 + 10 + 5 + 3 + 1 + 6 + 2 + 4 + 11 + 3 + 2;
-        assert_eq!(total, 58);
+        //   total: 59 fields, minus 1 auto-generated (admin_api_key) = 58 meaningful user settings
+        let total: usize = 5 + 3 + 3 + 10 + 5 + 3 + 1 + 6 + 2 + 4 + 11 + 3 + 2 + 1;
+        assert_eq!(total, 59);
     }
 }

--- a/engine/crates/xerj-common/src/types.rs
+++ b/engine/crates/xerj-common/src/types.rs
@@ -100,6 +100,21 @@ impl IndexName {
                 name.len()
             )));
         }
+        // Path-traversal guard (CWE-22): index names are joined to
+        // `data_dir` to form on-disk paths (`data_dir.join(name)`), so a
+        // `..` component would escape `data_dir` and let a caller create,
+        // pollute, or recursively delete directories outside it. The bare
+        // names `.` and `..` and any name containing `..` are rejected.
+        // `.` is only permitted as a leading-character system-index prefix
+        // (`.kibana`, `.security-7`) or as a single interior dot between
+        // non-dot characters — never as a traversal component. ES itself
+        // rejects these, so this also matches wire-protocol expectations.
+        if name == "." || name == ".." || name.contains("..") {
+            return Err(XerjError::invalid_mapping(format!(
+                "index name must not be '.', '..', or contain '..' \
+                 (path-traversal guard): {name:?}"
+            )));
+        }
         // chars().next() returns None iff `name` is empty — fold the
         // empty-name check into the extraction so the two facts can't
         // drift apart in a future refactor.
@@ -525,6 +540,29 @@ mod tests {
         assert!(IndexName::new("_private").is_err()); // starts with _
         assert!(IndexName::new("bad name").is_err()); // space
         assert!(IndexName::new("1bad").is_err()); // starts with digit
+    }
+
+    #[test]
+    fn index_name_rejects_path_traversal() {
+        // `.` / `..` as the whole name would let `data_dir.join(name)`
+        // resolve to `data_dir`'s parent — a recursive-delete / arbitrary-
+        // write primitive (CWE-22). These must be rejected even though the
+        // per-character loop below permits `.` as a valid character.
+        assert!(IndexName::new(".").is_err());
+        assert!(IndexName::new("..").is_err());
+        // Any name containing a `..` run is a traversal component (the
+        // char loop allows `.` so without this guard `foo..bar` and
+        // `...x` would slip through). ES also rejects these.
+        assert!(IndexName::new("foo..bar").is_err());
+        assert!(IndexName::new("...x").is_err());
+        assert!(IndexName::new(".a..b").is_err());
+        assert!(IndexName::new("a..").is_err());
+        // Single dots between non-dot characters remain valid — these
+        // are legitimate (ES allows `.` in index names) and must NOT be
+        // rejected by the traversal guard.
+        assert!(IndexName::new("a.b").is_ok());
+        assert!(IndexName::new(".kibana").is_ok());
+        assert!(IndexName::new("logs.2026").is_ok());
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -1559,6 +1559,9 @@ impl Engine {
         name: &str,
         indices: Option<Vec<String>>,
     ) -> Result<Value> {
+        // Reject path-traversal snapshot names before joining to repo_path.
+        // `..%2f..` in the URL would otherwise resolve above the repo root.
+        validate_snapshot_name(name)?;
         let snap_dir = std::path::Path::new(repo_path).join(name);
         std::fs::create_dir_all(&snap_dir).map_err(EngineError::Io)?;
 
@@ -1650,6 +1653,8 @@ impl Engine {
         name: &str,
         indices: Option<Vec<String>>,
     ) -> Result<Vec<String>> {
+        // Reject path-traversal snapshot names before joining to repo_path.
+        validate_snapshot_name(name)?;
         let snap_dir = std::path::Path::new(repo_path).join(name);
         let manifest_path = snap_dir.join("manifest.json");
 
@@ -1717,6 +1722,20 @@ impl Engine {
         };
 
         for idx_name in &index_names {
+            // Validate the index name BEFORE touching the filesystem — a
+            // `..` entry in a tampered manifest would otherwise let
+            // `remove_dir_all` (below) recurse on `data_dir/..` and delete
+            // the parent of data_dir. IndexName::new rejects `..` (C1 fix);
+            // this is the gate the original code ran too late (after delete).
+            let index_name = match IndexName::new(idx_name) {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!(index = idx_name, error = %e, "snapshot manifest has invalid index name, skipping");
+                    self.failed_indices.insert(idx_name.clone(), e.to_string());
+                    continue;
+                }
+            };
+
             let src_dir = snap_dir.join(idx_name.as_str());
             if !src_dir.exists() {
                 warn!(index = idx_name, "snapshot directory missing, skipping");
@@ -1724,6 +1743,28 @@ impl Engine {
             }
 
             let dst_dir = self.data_dir.join(idx_name);
+            // Defense-in-depth: assert dst_dir resolves inside data_dir
+            // BEFORE the recursive remove_dir_all. IndexName::new already
+            // rejected `..`; this canonicalize check catches a symlinked
+            // data_dir or any future bypass of the name validation.
+            let base_canon = self.data_dir.canonicalize().map_err(EngineError::Io)?;
+            let dst_canon = match dst_dir.canonicalize() {
+                Ok(c) => c,
+                Err(_) => {
+                    // dst_dir doesn't exist yet — join the validated
+                    // single-component name onto the canonicalized base.
+                    base_canon.join(idx_name.as_str())
+                }
+            };
+            if !dst_canon.starts_with(&base_canon) {
+                return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+                    format!(
+                        "restore target '{}' resolves outside data_dir '{}'",
+                        dst_dir.display(),
+                        self.data_dir.display()
+                    )
+                )));
+            }
 
             // Remove existing index data (if any) and close it.
             if self.indices.contains_key(idx_name.as_str()) {
@@ -1739,7 +1780,6 @@ impl Engine {
             copy_dir_recursive(&src_dir, &dst_dir, &mut _files).map_err(EngineError::Io)?;
 
             // Reopen the index.
-            let index_name = IndexName::new(idx_name).map_err(EngineError::Common)?;
             match Index::open(index_name, &self.config, &self.data_dir) {
                 Ok(idx) => {
                     // Snapshot dirs carry es_mapping.json — reload it so the
@@ -1783,6 +1823,45 @@ fn now_millis() -> i64 {
 /// we do the same for ours so `_snapshot`/`_restore` operate on user data.
 pub(crate) fn is_system_index(name: &str) -> bool {
     name.starts_with(".xerj_")
+}
+
+/// Validate a snapshot name before it is joined to a repository path.
+///
+/// Snapshot names arrive as a URL path segment (`PUT /_snapshot/{repo}/{name}`)
+/// and are joined to the repo's filesystem location as
+/// `Path::new(repo_path).join(name)`. Axum's `Path` extractor percent-decodes
+/// each segment **after** splitting on raw `/`, so a request like
+/// `PUT /_snapshot/repo/..%2f..%2f..%2fetc` arrives with `name = "../../etc"`
+/// — which `Path::join` resolves multiple levels above the repo. Without
+/// this guard, `create_snapshot` would write `manifest.json` and per-index
+/// directories into an attacker-chosen filesystem location, and
+/// `restore_snapshot` would read a `manifest.json` from there (CWE-22).
+///
+/// This rejects any name that contains a path separator (`/` or `\`), is
+/// `.` or `..`, or contains a `..` run — the same posture `IndexName::validate`
+/// takes for index names. A valid snapshot name is a single path component.
+pub(crate) fn validate_snapshot_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+            "snapshot name cannot be empty",
+        )));
+    }
+    if name == "." || name == ".." || name.contains("..") {
+        return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+            format!(
+                "snapshot name must not be '.', '..', or contain '..' \
+                 (path-traversal guard): {name:?}"
+            ),
+        )));
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+            format!(
+                "snapshot name must not contain path separators (got {name:?})"
+            ),
+        )));
+    }
+    Ok(())
 }
 
 /// Recursively copy all files from `src` to `dst`, recording relative paths in `files`.

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -2071,6 +2071,10 @@ impl Index {
     ) -> Result<Arc<Self>> {
         let index_dir = data_dir.join(name.as_str());
         std::fs::create_dir_all(&index_dir)?;
+        // Defense-in-depth: the validated name rejects `..`, but assert the
+        // resolved on-disk path is still inside data_dir in case a future
+        // caller bypasses IndexName (e.g. a symlink it doesn't control).
+        assert_within_data_dir(data_dir, &index_dir)?;
 
         let store_config = store_config_from(config);
         let store = IndexStore::open(&index_dir, store_config)?;
@@ -2253,6 +2257,10 @@ impl Index {
                 xerj_common::XerjError::index_not_found(name.as_str()),
             ));
         }
+        // Defense-in-depth: assert the existing index dir is inside data_dir
+        // (a tampered data_dir with a `..`-named directory would otherwise
+        // let `open` operate outside the engine's data root).
+        assert_within_data_dir(data_dir, &index_dir)?;
 
         let store_config = store_config_from(config);
         let store = IndexStore::open(&index_dir, store_config)?;
@@ -19615,6 +19623,29 @@ fn load_hnsw_artifacts_sync(
         seq_no,
         stale,
     })
+}
+
+/// Defense-in-depth (CWE-22): assert that `child` resolves on-disk inside
+/// `base`. `IndexName::validate` already rejects `..` (and `.` as a whole
+/// name), so a validated index name joined to `data_dir` cannot escape it.
+/// This is the belt-and-braces backstop that catches any future code path
+/// that joins an unvalidated string to `data_dir` — it canonicalizes both
+/// paths (so a symlinked `data_dir` root is handled correctly) and refuses
+/// any child whose real location is not a descendant of the base. Both
+/// paths must already exist on disk when this is called.
+fn assert_within_data_dir(base: &Path, child: &Path) -> Result<()> {
+    let base_canon = base.canonicalize().map_err(EngineError::Io)?;
+    let child_canon = child.canonicalize().map_err(EngineError::Io)?;
+    if !child_canon.starts_with(&base_canon) {
+        return Err(EngineError::Common(xerj_common::XerjError::invalid_mapping(
+            format!(
+                "index path '{}' resolves outside data_dir '{}'",
+                child.display(),
+                base.display()
+            )
+        )));
+    }
+    Ok(())
 }
 
 fn store_config_from(config: &Config) -> IndexStoreConfig {

--- a/engine/crates/xerj-engine/tests/integration.rs
+++ b/engine/crates/xerj-engine/tests/integration.rs
@@ -5765,6 +5765,150 @@ async fn test_restore_snapshot_honors_indices_filter() {
     );
 }
 
+/// C1 regression: an index name of `..` must be rejected at the API/engine
+/// boundary, not silently joined to `data_dir` (which would resolve to the
+/// parent of data_dir and let `delete_index` recurse on it — CWE-22). The
+/// existing `IndexName::new` is the gate; `Engine::create_index` must surface
+/// that error rather than create the directory.
+#[tokio::test]
+async fn test_index_name_rejects_path_traversal() {
+    let dir = TempDir::new().unwrap();
+    // Nested data_dir: data_dir/.. resolves to dir.path() (this test's own
+    // TempDir), so the "no pollution above data_dir" assertions stay within
+    // the test's private directory.
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().join("data").to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine::new");
+    let data_dir = dir.path().join("data");
+    let data_parent = data_dir.parent().unwrap().to_path_buf(); // == dir.path()
+
+    for bad in ["..", ".", "foo..bar", "...x", "a.."] {
+        let result = engine.create_index(bad, Schema::empty());
+        assert!(
+            result.is_err(),
+            "index name {bad:?} must be rejected (path-traversal guard)"
+        );
+    }
+    // No directory should have been created at/above data_dir for `..`:
+    // `data_dir/..` is `data_parent`; a polluted create would have stamped
+    // `wal/`, `segments/`, `xerj_meta.json` there.
+    assert!(!data_parent.join("wal").exists());
+    assert!(!data_parent.join("segments").exists());
+    assert!(!data_parent.join("xerj_meta.json").exists());
+
+    // Sanity: a valid name still creates an index INSIDE data_dir (not above).
+    engine.create_index("good", Schema::empty()).unwrap();
+    assert!(data_dir.join("good").exists(), "valid index must be created inside data_dir");
+    assert!(!data_parent.join("good").exists(), "valid index must not leak above data_dir");
+}
+
+/// C2 regression: a snapshot name containing `..` or path separators must be
+/// rejected before it is joined to the repo path — `PUT /_snapshot/repo/..%2f..`
+/// would otherwise resolve above the repo root and write `manifest.json`
+/// (and per-index dirs) into an attacker-chosen location (CWE-22).
+#[tokio::test]
+async fn test_snapshot_name_rejects_path_traversal() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let repo = dir.path().join("snaprepo");
+    let repo_path = repo.to_str().unwrap();
+    // Create a valid index so the snapshot would have something to copy if
+    // the name check were missing.
+    engine.create_index("s1", Schema::empty()).unwrap();
+
+    for bad in ["..", "..%2f..", "../../etc", "a/b", "a\\b", "foo..bar"] {
+        let result = engine
+            .create_snapshot(repo_path, bad, Some(vec!["s1".to_string()]))
+            .await;
+        assert!(
+            result.is_err(),
+            "snapshot name {bad:?} must be rejected (path-traversal guard)"
+        );
+    }
+    // Restore must reject the same names.
+    for bad in ["..", "../../etc", "a/b"] {
+        let result = engine.restore_snapshot(repo_path, bad, None).await;
+        assert!(
+            result.is_err(),
+            "snapshot name {bad:?} must be rejected on restore"
+        );
+    }
+    // No manifest should have escaped above the repo root.
+    assert!(!dir.path().join("manifest.json").exists());
+}
+
+/// C2 regression: a tampered snapshot manifest listing `..` as an index must
+/// NOT cause `restore_snapshot` to `remove_dir_all` on `data_dir/..`. The
+/// `IndexName::new` check now runs BEFORE the recursive delete, so a hostile
+/// manifest entry is rejected (skipped) instead of destroying the parent of
+/// data_dir. This test plants such a manifest and asserts the parent survives.
+///
+/// `data_dir` is nested inside the TempDir (`dir/data`) so that `data_dir/..`
+/// resolves to the TempDir root — a pre-fix run would `remove_dir_all` the
+/// TempDir itself, which is contained to this test (never the system temp).
+#[tokio::test]
+async fn test_restore_rejects_manifest_traversal_without_deleting_parent() {
+    let dir = TempDir::new().unwrap();
+    // Nested data_dir: data_dir/.. resolves to dir.path() (this test's own
+    // TempDir), NOT the system temp dir — keeps a hypothetical pre-fix run
+    // contained to this test's own directory.
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().join("data").to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine::new");
+    let data_dir = dir.path().join("data");
+    let data_parent = data_dir.parent().unwrap().to_path_buf(); // == dir.path()
+
+    let repo = data_parent.join("snaprepo");
+    let repo_path = repo.to_str().unwrap();
+    // Create a legitimate snapshot of `s1`.
+    engine.create_index("s1", Schema::empty()).unwrap();
+    engine
+        .get_index("s1")
+        .unwrap()
+        .index_document(Some("d1".into()), json!({"v": 1}))
+        .await
+        .unwrap();
+    engine
+        .create_snapshot(repo_path, "snap1", Some(vec!["s1".to_string()]))
+        .await
+        .unwrap();
+
+    // Tamper with the manifest: claim the snapshot contains `..` as an
+    // index. Pre-fix this called `remove_dir_all(data_dir/..)` BEFORE the
+    // `IndexName::new` check ran, deleting the parent of data_dir.
+    let manifest_path = repo.join("snap1").join("manifest.json");
+    let mut manifest: Value = serde_json::from_slice(&std::fs::read(&manifest_path).unwrap())
+        .unwrap();
+    manifest["indices"] = json!(["s1", ".."]);
+    std::fs::write(&manifest_path, serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+
+    // Sentinel file in data_dir's parent (the TempDir root) — must survive.
+    let sentinel = data_parent.join("xerj_c2_sentinel.tmp");
+    std::fs::write(&sentinel, b"sentinel").unwrap();
+
+    let restored = engine.restore_snapshot(repo_path, "snap1", None).await;
+    // `s1` restores fine; `..` is rejected by IndexName::new and skipped
+    // (the loop continues on invalid names rather than hard-failing). The
+    // returned list is the candidate list from the manifest; the security
+    // guarantee is that the hostile entry does NOT trigger a delete.
+    assert!(restored.is_ok(), "restore should succeed, skipping the hostile '..' entry");
+    let restored_names = restored.unwrap();
+    assert!(
+        restored_names.contains(&"s1".to_string()),
+        "s1 must be in the restored candidate list"
+    );
+    // The sentinel in data_dir's parent must still exist — the hostile `..`
+    // entry must not have triggered remove_dir_all on the parent.
+    assert!(
+        sentinel.exists(),
+        "sentinel in data_dir's parent must survive restore (CWE-22 traversal guard)"
+    );
+    // And data_dir itself must still exist (pre-fix removed_dir_all would
+    // have deleted it along with its parent).
+    assert!(data_dir.exists(), "data_dir must still exist after restore");
+    std::fs::remove_file(&sentinel).ok();
+}
+
 /// Blocker 7: top-level kNN semantics, verified against live ES 8.13.4 on
 /// 2026-07-12 with this exact corpus:
 ///   * `knn.filter` pre-filters candidates (ES returned ids 1,3);


### PR DESCRIPTION
## Summary

Two remotely-reachable path-traversal chains (CWE-22) let a caller create, pollute, or recursively delete directories outside the operator-configured `data_dir`. Both share one root cause: an untrusted name is joined to a filesystem path with no traversal guard.

This is the first PR from the security review remediation plan — implements **C1** and **C2** (the two Critical findings) and leaves the High/Medium findings for follow-up PRs.

## C1 — index name `..` escapes `data_dir`

`IndexName::validate` whitelisted `.` for system indices (`.kibana`, `.security-7`) but never rejected the bare names `.`/`..` or any name containing `..`. The validated name flows into `data_dir.join(name)` (Index::create_with_settings / Index::open), and `delete_all_data` then `remove_dir_all`s the result — so `DELETE /%2e%2e` recurses on `data_dir/..` and deletes the parent of `data_dir` and everything under it.

Reachable unauthenticated in the default `--insecure` first-run posture via `PUT /%2e%2e`, `PUT /%2e%2e/_doc/x`, `_bulk` `_index:".."`, `/_sql FROM ..`, and gRPC `Index`/`BulkIndex`.

**Fix:**
- `IndexName::validate` rejects `.`, `..`, and any name containing `..` (one guard, matching the existing `memory_api` pattern). Single dots between non-dot chars stay valid (`.kibana`, `logs.2026`, `a.b` keep working).
- Defense-in-depth: new `assert_within_data_dir` canonicalize-based check wired into `Index::create_with_settings` and `Index::open`.
- New unit test `index_name_rejects_path_traversal`.

## C2 — snapshot repo `location` + snapshot `name` escape the repo root

`put_snapshot_repo` stored the request body verbatim with no validation of `settings.location`. `create_snapshot`/`restore_snapshot` did `Path::new(repo).join(name)` with the raw URL `:snapshot` param — and Axum's `Path` extractor percent-decodes **after** splitting on `/`, so `PUT /_snapshot/repo/..%2f..%2f..%2fetc` arrives with `name = "../../etc"`.

Worst: `restore_snapshot` read `idx_name` from the attacker-controlled manifest and called `remove_dir_all(&dst_dir)` **before** running `IndexName::new` — and `IndexName::new` permitted `..` anyway (C1). A planted `manifest.json` with `{"indices":[".."]}` triggers `remove_dir_all(data_dir/..)` = deletes the parent of `data_dir`.

**Fix:**
- New `validate_snapshot_name` rejects empty/`.`/`..`/`..`-containing/`/`-containing/`\\`-containing names; wired into both `create_snapshot` and `restore_snapshot` before the join.
- `restore_snapshot` loop restructured: `IndexName::new` runs **before** `remove_dir_all` (was after); invalid manifest entries are warned + skipped rather than failing the whole restore. Plus a canonicalize-based `dst_dir` containment check before `remove_dir_all`.
- `put_snapshot_repo` validates `settings.location`: always rejects `.`/`..` components; when the new optional `[snapshot] root_dir` config is set, requires the resolved location to live inside it. Empty `root_dir` preserves the pre-existing unrestricted behaviour (backwards-compatible).
- New `SnapshotConfig` (1 setting: `root_dir`) added to `xerj-common` config; settings-count test updated to 59.

## New regression tests (`xerj-engine/tests/integration.rs`)

- `test_index_name_rejects_path_traversal` — asserts `create_index(".."/"."/"foo..bar"/...)` errors and leaves no `wal/`/`segments/`/`xerj_meta.json` in `data_dir`'s parent; confirms a valid name still creates inside `data_dir`.
- `test_snapshot_name_rejects_path_traversal` — asserts `create_snapshot` and `restore_snapshot` reject `..`, `../../etc`, `a/b`, `a\\b`, etc., and that no `manifest.json` escapes above the repo root.
- `test_restore_rejects_manifest_traversal_without_deleting_parent` — plants a tampered manifest listing `..` as an index and asserts a sentinel file in `data_dir`'s parent survives the restore (the pre-fix path would have `remove_dir_all`'d it). `data_dir` is nested inside the TempDir so the test is self-contained even on a hypothetical pre-fix run.

## Verification

- `cargo test -p xerj-common`: **32 passed** (incl. new `index_name_rejects_path_traversal`).
- `cargo test -p xerj-engine --lib`: **226 passed**.
- `cargo test -p xerj-engine --test integration -- --test-threads=1`: **105 passed**, 1 ignored (incl. the 3 new C1/C2 regression tests).
- `cargo test -p xerj-api`: pass (doc-tests compile).
- **ES-YAML conformance gate** (the AGENTS.md hard gate): **1360 passed / 0 failed / 3 skipped** — unchanged. Verified by booting the rebuilt `xerj-server` binary and running `es-yaml-runner` over `tests/es-compat-yaml/yaml`.
- **Live smoke test** against a booted server: `PUT /%2e%2e` → 400, `PUT /%2e%2e/_doc/x` → 400, `PUT /_snapshot/evil` with `location: "../../etc"` → 400, `PUT /_snapshot/goodrepo/..%2f..%2f..%2fetc` → 400, `PUT /_snapshot/goodrepo/snap1` → 200; no `manifest.json` leaked above the repo root.

The 2 parallel-load test flakes observed during the full lib run (`semantic_deadline_regression_tests::expired_*_preserves_partial_timeout_state`, `test_hnsw_stale_snapshot_rebuilds_on_open`) are pre-existing timing-sensitive tests confirmed passing in isolation, single-threaded, and on the base branch — unrelated to path traversal.

## Files changed

| File | Change |
|---|---|
| `xerj-common/src/types.rs` | `IndexName::validate` `..` guard + unit test |
| `xerj-common/src/config.rs` | new `SnapshotConfig` (`root_dir`) + count test |
| `xerj-engine/src/index.rs` | `assert_within_data_dir` + wiring in create/open |
| `xerj-engine/src/engine.rs` | `validate_snapshot_name` + restore loop reorder + `dst_dir` containment |
| `xerj-api/src/es_compat.rs` | `put_snapshot_repo` validation + `resolve_snapshot_location` + `snapshot_location_error` helpers |
| `xerj-engine/tests/integration.rs` | 3 regression tests |

## Checklist

- [x] Builds scoped per AGENTS.md (`cargo build --release -p <crate>`, never workspace-wide)
- [x] ES-YAML conformance gate holds: 1360/0/3
- [x] Regression tests added and passing
- [x] No secrets in diff; no debug code
- [x] Commit body follows the repo's engineering-log style (motivation, root cause, file pointers, verification)