### PR TITLE
fix(engine) Fix transactional merge publication and rollback

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1031,6 +1031,233 @@ mod merge_publication_transaction_tests {
         (engine, index)
     }
 
+    async fn wait_for_repoint(index: &Index) {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while !index.test_merge_repoint_ready.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("merge did not reach the pre-apply gate");
+    }
+
+    #[tokio::test]
+    async fn apply_failure_restores_sources_survives_restart_and_retry() {
+        let dir = TempDir::new().unwrap();
+        let (engine, index) = fixture(&dir).await;
+        let before_ids: std::collections::HashSet<_> = index
+            .store
+            .snapshot()
+            .segments
+            .iter()
+            .map(|meta| meta.id.clone())
+            .collect();
+        index
+            .test_fail_merge_before_apply
+            .store(true, Ordering::Release);
+        assert!(index.run_merge_once().await.is_err());
+        let after_ids: std::collections::HashSet<_> = index
+            .store
+            .snapshot()
+            .segments
+            .iter()
+            .map(|meta| meta.id.clone())
+            .collect();
+        assert_eq!(after_ids, before_ids);
+        for (id, expected) in [("a", "old-a"), ("b", "old-b")] {
+            assert_eq!(
+                index.get_document(id).await.unwrap().unwrap()["value"],
+                expected
+            );
+        }
+        assert_eq!(
+            index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            2
+        );
+        drop(index);
+        drop(engine);
+
+        let reopened = Engine::new(config(&dir)).unwrap();
+        let reopened_index = reopened.get_index("post-save-panic").unwrap();
+        for (id, expected) in [("a", "old-a"), ("b", "old-b")] {
+            assert_eq!(
+                reopened_index.get_document(id).await.unwrap().unwrap()["value"],
+                expected
+            );
+        }
+        assert_eq!(reopened_index.run_merge_once().await.unwrap(), 1);
+        assert_eq!(reopened_index.store.snapshot().segments.len(), 1);
+        assert_eq!(
+            reopened_index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_preserves_concurrent_put_and_delete() {
+        let dir = TempDir::new().unwrap();
+        let (engine, index) = fixture(&dir).await;
+        index
+            .test_pause_merge_before_apply
+            .store(true, Ordering::Release);
+        index
+            .test_fail_merge_before_apply
+            .store(true, Ordering::Release);
+        let merge_index = Arc::clone(&index);
+        let merge = tokio::spawn(async move { merge_index.run_merge_once().await });
+        wait_for_repoint(&index).await;
+        index
+            .index_document(Some("a".into()), serde_json::json!({"value": "new-a"}))
+            .await
+            .unwrap();
+        assert!(index.delete_document("b").await.unwrap());
+        index
+            .test_pause_merge_before_apply
+            .store(false, Ordering::Release);
+        assert!(merge.await.unwrap().is_err());
+        assert_eq!(
+            index.get_document("a").await.unwrap().unwrap()["value"],
+            "new-a"
+        );
+        assert!(index.get_document("b").await.unwrap().is_none());
+        assert!(index.store.version_map.get("b").unwrap().deleted);
+        assert_eq!(
+            index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            1
+        );
+        drop(index);
+        drop(engine);
+        let reopened = Engine::new(config(&dir)).unwrap();
+        let reopened_index = reopened.get_index("post-save-panic").unwrap();
+        assert_eq!(
+            reopened_index.get_document("a").await.unwrap().unwrap()["value"],
+            "new-a"
+        );
+        assert!(reopened_index.get_document("b").await.unwrap().is_none());
+        assert!(reopened_index.store.version_map.get("b").unwrap().deleted);
+        assert_eq!(
+            reopened_index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_repoint_restores_inputs() {
+        let dir = TempDir::new().unwrap();
+        let (_engine, index) = fixture(&dir).await;
+        let before_ids: std::collections::HashSet<_> = index
+            .store
+            .snapshot()
+            .segments
+            .iter()
+            .map(|meta| meta.id.clone())
+            .collect();
+        index
+            .test_pause_merge_before_apply
+            .store(true, Ordering::Release);
+        let merge_index = Arc::clone(&index);
+        let merge = tokio::spawn(async move { merge_index.run_merge_once().await });
+        wait_for_repoint(&index).await;
+        merge.abort();
+        assert!(merge.await.unwrap_err().is_cancelled());
+        index
+            .test_pause_merge_before_apply
+            .store(false, Ordering::Release);
+        let after_ids: std::collections::HashSet<_> = index
+            .store
+            .snapshot()
+            .segments
+            .iter()
+            .map(|meta| meta.id.clone())
+            .collect();
+        assert_eq!(after_ids, before_ids);
+        for id in ["a", "b"] {
+            assert!(index.get_document(id).await.unwrap().is_some());
+            assert!(
+                before_ids.contains(index.store.version_map.get(id).unwrap().segment_id.as_ref())
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn partial_multi_batch_failure_is_reported_without_losing_either_batch() {
+        let dir = TempDir::new().unwrap();
+        let engine = Engine::new(config(&dir)).unwrap();
+        engine.create_index("multi-batch", Schema::empty()).unwrap();
+        let index = engine.get_index("multi-batch").unwrap();
+        for id in ["a", "b", "c", "d"] {
+            index
+                .index_document(
+                    Some(id.into()),
+                    serde_json::json!({"value": format!("source-{id}")}),
+                )
+                .await
+                .unwrap();
+            index.flush().await.unwrap();
+        }
+        assert_eq!(index.store.snapshot().segments.len(), 4);
+        index
+            .test_fail_merge_before_apply
+            .store(true, Ordering::Release);
+        assert!(index.run_merge_once().await.is_err());
+        assert_eq!(index.store.snapshot().segments.len(), 3);
+        for id in ["a", "b", "c", "d"] {
+            assert_eq!(
+                index.get_document(id).await.unwrap().unwrap()["value"],
+                format!("source-{id}")
+            );
+        }
+        assert_eq!(
+            index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            4
+        );
+        drop(index);
+        drop(engine);
+
+        let reopened = Engine::new(config(&dir)).unwrap();
+        let reopened_index = reopened.get_index("multi-batch").unwrap();
+        for id in ["a", "b", "c", "d"] {
+            assert_eq!(
+                reopened_index.get_document(id).await.unwrap().unwrap()["value"],
+                format!("source-{id}")
+            );
+        }
+        assert_eq!(
+            reopened_index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            4
+        );
+    }
+
     #[tokio::test]
     async fn panic_after_durable_snapshot_keeps_output_repoints_and_survives_restart() {
         let dir = TempDir::new().unwrap();
@@ -3559,6 +3786,12 @@ pub struct Index {
     publication_test_hook: Arc<parking_lot::RwLock<Option<PublicationTestHook>>>,
     #[cfg(test)]
     test_panic_after_merge_publish: Arc<AtomicBool>,
+    #[cfg(test)]
+    test_fail_merge_before_apply: Arc<AtomicBool>,
+    #[cfg(test)]
+    test_pause_merge_before_apply: Arc<AtomicBool>,
+    #[cfg(test)]
+    test_merge_repoint_ready: Arc<AtomicBool>,
     doc_count: Arc<AtomicU64>,
     /// Counter for `update` operations that detected no change to the
     /// existing source — surfaced via `indices.stats` as
@@ -4191,6 +4424,12 @@ impl Index {
             publication_test_hook: Arc::new(parking_lot::RwLock::new(None)),
             #[cfg(test)]
             test_panic_after_merge_publish: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            test_fail_merge_before_apply: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            test_pause_merge_before_apply: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            test_merge_repoint_ready: Arc::new(AtomicBool::new(false)),
             doc_count: Arc::new(AtomicU64::new(0)),
             noop_update_count: Arc::new(AtomicU64::new(0)),
             request_cache_seen: Arc::new(RwLock::new(RequestCacheSeen::with_capacity(65_536))),
@@ -4566,6 +4805,12 @@ impl Index {
             publication_test_hook: Arc::new(parking_lot::RwLock::new(None)),
             #[cfg(test)]
             test_panic_after_merge_publish: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            test_fail_merge_before_apply: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            test_pause_merge_before_apply: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            test_merge_repoint_ready: Arc::new(AtomicBool::new(false)),
             doc_count: Arc::new(AtomicU64::new(total_doc_count)),
             noop_update_count: Arc::new(AtomicU64::new(0)),
             request_cache_seen: Arc::new(RwLock::new(RequestCacheSeen::with_capacity(65_536))),
@@ -7354,7 +7599,28 @@ impl Index {
                         }
                     }
                     #[cfg(test)]
+                    {
+                        self.test_merge_repoint_ready.store(true, Ordering::Release);
+                        while self.test_pause_merge_before_apply.load(Ordering::Acquire) {
+                            tokio::task::yield_now().await;
+                        }
+                        self.test_merge_repoint_ready
+                            .store(false, Ordering::Release);
+                    }
+                    #[cfg(test)]
                     let apply_result = if self
+                        .test_fail_merge_before_apply
+                        .swap(false, Ordering::AcqRel)
+                    {
+                        Err(
+                            xerj_storage::index_store::MergePublicationError::NotPublished(
+                                xerj_storage::StorageError::MergeAborted(
+                                    "injected merge apply failure before snapshot publication"
+                                        .into(),
+                                ),
+                            ),
+                        )
+                    } else if self
                         .test_panic_after_merge_publish
                         .swap(false, Ordering::AcqRel)
                     {
@@ -7385,6 +7651,13 @@ impl Index {
                         // all seven hydration owners when this scope exits.
                         self.shortcut_count_cache
                             .retain(|(seg, _), _| seg != merged_meta.id.as_str());
+                        // `continue` bypasses the common top-up below. Launch
+                        // the next disjoint batch first so one failed apply
+                        // does not silently suppress the rest of this pass.
+                        if let Some((batch, metas)) = pending.take() {
+                            in_flight.push(spawn_one(batch, metas));
+                            pending = queue_iter.next();
+                        }
                         continue;
                     }
                     // `apply_merge` has made the output authoritative. No

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -997,6 +997,97 @@ impl<'a> Drop for MergeFlagClear<'a> {
 }
 
 #[cfg(test)]
+mod merge_publication_transaction_tests {
+    use super::*;
+    use crate::Engine;
+    use tempfile::TempDir;
+
+    fn config(dir: &TempDir) -> xerj_common::config::Config {
+        let mut config = xerj_common::config::Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        config.merge.min_segments = 2;
+        config.merge.min_merge_count = 2;
+        config.merge.max_merge_count = 2;
+        config
+    }
+
+    async fn fixture(dir: &TempDir) -> (Engine, Arc<Index>) {
+        let engine = Engine::new(config(dir)).unwrap();
+        engine
+            .create_index("post-save-panic", Schema::empty())
+            .unwrap();
+        let index = engine.get_index("post-save-panic").unwrap();
+        index
+            .index_document(Some("a".into()), serde_json::json!({"value": "old-a"}))
+            .await
+            .unwrap();
+        index.flush().await.unwrap();
+        index
+            .index_document(Some("b".into()), serde_json::json!({"value": "old-b"}))
+            .await
+            .unwrap();
+        index.flush().await.unwrap();
+        assert_eq!(index.store.snapshot().segments.len(), 2);
+        (engine, index)
+    }
+
+    #[tokio::test]
+    async fn panic_after_durable_snapshot_keeps_output_repoints_and_survives_restart() {
+        let dir = TempDir::new().unwrap();
+        let (engine, index) = fixture(&dir).await;
+        index
+            .test_panic_after_merge_publish
+            .store(true, Ordering::Release);
+        let merge_index = Arc::clone(&index);
+        let join = tokio::spawn(async move { merge_index.run_merge_once().await }).await;
+        assert!(join.unwrap_err().is_panic());
+
+        let snapshot = index.store.snapshot();
+        assert_eq!(snapshot.segments.len(), 1);
+        let output_id = snapshot.segments[0].id.clone();
+        drop(snapshot);
+        for (id, expected) in [("a", "old-a"), ("b", "old-b")] {
+            let entry = index.store.version_map.get(id).unwrap();
+            assert_eq!(entry.segment_id.as_ref(), output_id);
+            assert_eq!(
+                index.get_document(id).await.unwrap().unwrap()["value"],
+                expected
+            );
+        }
+        assert_eq!(
+            index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            2
+        );
+        drop(index);
+        drop(engine);
+
+        let reopened = Engine::new(config(&dir)).unwrap();
+        let reopened_index = reopened.get_index("post-save-panic").unwrap();
+        assert_eq!(reopened_index.store.snapshot().segments.len(), 1);
+        for (id, expected) in [("a", "old-a"), ("b", "old-b")] {
+            assert_eq!(
+                reopened_index.get_document(id).await.unwrap().unwrap()["value"],
+                expected
+            );
+        }
+        assert_eq!(
+            reopened_index
+                .search(&SearchRequest::default())
+                .await
+                .unwrap()
+                .total
+                .value,
+            2
+        );
+    }
+}
+
+#[cfg(test)]
 mod semantic_deadline_regression_tests {
     use super::*;
     use crate::Engine;
@@ -3466,6 +3557,8 @@ pub struct Index {
     write_publication: Arc<crate::write_publication::WritePublicationCoordinator>,
     #[cfg(test)]
     publication_test_hook: Arc<parking_lot::RwLock<Option<PublicationTestHook>>>,
+    #[cfg(test)]
+    test_panic_after_merge_publish: Arc<AtomicBool>,
     doc_count: Arc<AtomicU64>,
     /// Counter for `update` operations that detected no change to the
     /// existing source — surfaced via `indices.stats` as
@@ -4096,6 +4189,8 @@ impl Index {
             write_publication: crate::write_publication::WritePublicationCoordinator::new(),
             #[cfg(test)]
             publication_test_hook: Arc::new(parking_lot::RwLock::new(None)),
+            #[cfg(test)]
+            test_panic_after_merge_publish: Arc::new(AtomicBool::new(false)),
             doc_count: Arc::new(AtomicU64::new(0)),
             noop_update_count: Arc::new(AtomicU64::new(0)),
             request_cache_seen: Arc::new(RwLock::new(RequestCacheSeen::with_capacity(65_536))),
@@ -4469,6 +4564,8 @@ impl Index {
             write_publication: crate::write_publication::WritePublicationCoordinator::new(),
             #[cfg(test)]
             publication_test_hook: Arc::new(parking_lot::RwLock::new(None)),
+            #[cfg(test)]
+            test_panic_after_merge_publish: Arc::new(AtomicBool::new(false)),
             doc_count: Arc::new(AtomicU64::new(total_doc_count)),
             noop_update_count: Arc::new(AtomicU64::new(0)),
             request_cache_seen: Arc::new(RwLock::new(RequestCacheSeen::with_capacity(65_536))),
@@ -6592,6 +6689,9 @@ impl Index {
             // never got one, forcing the slow decode-stored fallback in
             // `rebuild_version_map_from_segments` on every reopen).
             Vec<(u64, String)>,
+            // Rolls pre-publication VersionMap repoints back unless the
+            // async driver commits them immediately after apply_merge.
+            xerj_storage::version_map::VersionRepointTransaction,
         );
 
         // Build the list of (batch, metas) pairs we'll launch.
@@ -7080,10 +7180,15 @@ impl Index {
                     // `set`: a doc updated while the merge ran already has a
                     // newer entry that must not be clobbered by the merged
                     // (older) copy.
+                    let mut version_repoints =
+                        xerj_storage::version_map::VersionRepointTransaction::with_capacity(
+                            Arc::clone(&store_for_task.version_map),
+                            ids_pairs.len().saturating_add(tomb_carry.len()),
+                        );
                     {
                         let merged_arc: Arc<str> = Arc::from(merged_meta.id.as_str());
                         for (seq_no, id) in &ids_pairs {
-                            store_for_task.version_map.set_if_latest(
+                            version_repoints.repoint_if_latest(
                                 id.as_str(),
                                 *seq_no,
                                 Arc::clone(&merged_arc),
@@ -7098,7 +7203,7 @@ impl Index {
                         // (`set_if_latest`): a doc re-indexed while the
                         // merge ran keeps its newer live entry.
                         for (seq, id) in &tomb_carry {
-                            store_for_task.version_map.set_if_latest(
+                            version_repoints.repoint_if_latest(
                                 id.as_str(),
                                 *seq,
                                 Arc::clone(&merged_arc),
@@ -7128,6 +7233,7 @@ impl Index {
                         merged_meta,
                         live_doc_count as usize,
                         ids_pairs,
+                        version_repoints,
                     ))
                 })
             })
@@ -7152,7 +7258,13 @@ impl Index {
             // order.
             let handle = in_flight.remove(0);
             match handle.await {
-                Ok(Some((batch_slice, merged_meta, live_doc_count, ids_pairs))) => {
+                Ok(Some((
+                    batch_slice,
+                    merged_meta,
+                    live_doc_count,
+                    ids_pairs,
+                    version_repoints,
+                ))) => {
                     // Warm the merged segment's stored slices BEFORE the
                     // swap makes it visible: the first sorted-candidates
                     // queries after a merge otherwise each pay the fresh
@@ -7241,8 +7353,33 @@ impl Index {
                             }
                         }
                     }
-                    if let Err(e) = self.store.apply_merge(&batch_slice, merged_meta.clone()) {
-                        tracing::warn!("merge: apply_merge failed: {e}");
+                    #[cfg(test)]
+                    let apply_result = if self
+                        .test_panic_after_merge_publish
+                        .swap(false, Ordering::AcqRel)
+                    {
+                        self.store.apply_merge_with_repoints_and_post_publish(
+                            &batch_slice,
+                            merged_meta.clone(),
+                            version_repoints,
+                            || panic!("injected panic after durable merge publication"),
+                        )
+                    } else {
+                        self.store.apply_merge_with_repoints(
+                            &batch_slice,
+                            merged_meta.clone(),
+                            version_repoints,
+                        )
+                    };
+                    #[cfg(not(test))]
+                    let apply_result = self.store.apply_merge_with_repoints(
+                        &batch_slice,
+                        merged_meta.clone(),
+                        version_repoints,
+                    );
+                    if let Err(e) = apply_result {
+                        tracing::warn!("merge: apply_merge failed: {e:?}");
+                        failed_batches.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         // Seeded shortcut counts for a segment that never
                         // became visible — drop them. The armed lease removes
                         // all seven hydration owners when this scope exits.

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -60,6 +60,514 @@ fn index_segment_hydration_budget(_config: &Config) -> Arc<SegmentHydrationBudge
     panic!("Index construction requires the process ResourceGovernor to be initialised");
 }
 
+#[cfg(test)]
+mod flush_publication_recovery_tests {
+    use super::*;
+    use serde_json::json;
+
+    static FLUSH_FAULT_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    fn text_schema() -> Schema {
+        let mut schema = Schema::empty();
+        schema
+            .add_field(FieldConfig::new("body", FieldType::Text))
+            .unwrap();
+        schema
+    }
+
+    fn vector_schema() -> Schema {
+        let mut schema = Schema::empty();
+        schema
+            .add_field(FieldConfig::new("embedding", FieldType::Vector))
+            .unwrap();
+        schema
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cancelling_flush_waiter_after_worker_start_still_restores() {
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let ledger: &'static crate::ingest_memory::Ledger =
+            Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine
+            .create_index("bm25-cancel-flush", text_schema())
+            .unwrap();
+        let idx = engine.get_index("bm25-cancel-flush").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(Some("winner".into()), json!({"body": "alpha"}))
+            .await
+            .unwrap();
+        let version_before_flush = idx.dataset_version.load(Ordering::Acquire);
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let entered_tx = parking_lot::Mutex::new(Some(entered_tx));
+        let release_rx = parking_lot::Mutex::new(Some(release_rx));
+        let hook = FlushPublisherTestHook {
+            callback: Arc::new(move || {
+                entered_tx.lock().take().unwrap().send(()).unwrap();
+                release_rx.lock().take().unwrap().recv().unwrap();
+                false
+            }),
+            after_warm: None,
+            ledger,
+            target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
+        };
+        let flush = {
+            let idx = Arc::clone(&idx);
+            tokio::spawn(FLUSH_PUBLISHER_TEST_HOOK.scope(hook, async move { idx.flush().await }))
+        };
+        tokio::task::spawn_blocking(move || entered_rx.recv().unwrap())
+            .await
+            .unwrap();
+        flush.abort();
+        assert!(flush.await.unwrap_err().is_cancelled());
+        let request = xerj_query::parse_request(&json!({
+            "query": {"match": {"body": "alpha"}}, "size": 10
+        }))
+        .unwrap();
+        assert!(
+            idx.search(&request).await.unwrap().hits.is_empty(),
+            "blocked finalizer fixture must prime the transient empty response"
+        );
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while idx.store.snapshot().segments.is_empty()
+                || idx.dataset_version.load(Ordering::Acquire) == version_before_flush
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached finalizer must publish after caller cancellation");
+        let result = idx.search(&request).await.unwrap();
+        assert_eq!(result.hits[0].id, "winner");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cancelled_vector_flush_completes_graph_before_wal_and_restarts_visible() {
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let ledger: &'static crate::ingest_memory::Ledger =
+            Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config.clone()).unwrap();
+        engine
+            .create_index("cancel-vector-flush", vector_schema())
+            .unwrap();
+        let idx = engine.get_index("cancel-vector-flush").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(
+            Some("vector-winner".into()),
+            json!({"embedding": [1.0, 0.0, 0.0]}),
+        )
+        .await
+        .unwrap();
+        let version_before_flush = idx.dataset_version.load(Ordering::Acquire);
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let entered_tx = parking_lot::Mutex::new(Some(entered_tx));
+        let release_rx = parking_lot::Mutex::new(Some(release_rx));
+        let hook = FlushPublisherTestHook {
+            callback: Arc::new(move || {
+                entered_tx.lock().take().unwrap().send(()).unwrap();
+                release_rx.lock().take().unwrap().recv().unwrap();
+                false
+            }),
+            after_warm: None,
+            ledger,
+            target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
+        };
+        let flush = {
+            let idx = Arc::clone(&idx);
+            tokio::spawn(FLUSH_PUBLISHER_TEST_HOOK.scope(hook, async move { idx.flush().await }))
+        };
+        tokio::task::spawn_blocking(move || entered_rx.recv().unwrap())
+            .await
+            .unwrap();
+        flush.abort();
+        assert!(flush.await.unwrap_err().is_cancelled());
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while idx.dataset_version.load(Ordering::Acquire) == version_before_flush {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached vector flush durability tail did not complete");
+        assert!(idx.hnsw_graph_path().exists());
+        assert!(idx.hnsw_ids_path().exists());
+        let segment_id = idx.store.snapshot().segments[0].id.clone();
+        let persisted_snapshot = std::fs::read_to_string(idx.data_dir.join("snapshot.json"))
+            .expect("forced WAL maintenance must persist the segment registry");
+        assert!(
+            persisted_snapshot.contains(segment_id.as_str()),
+            "WAL durability tail completed without persisting the segment"
+        );
+        assert!(idx.store.wal_dir().is_dir());
+        drop(idx);
+        drop(engine);
+
+        let restarted = crate::Engine::new(config).unwrap();
+        let idx = restarted.get_index("cancel-vector-flush").unwrap();
+        idx.abort_background_tasks();
+        let request = xerj_query::parse_request(&json!({
+            "knn": {
+                "field": "embedding",
+                "query_vector": [1.0, 0.0, 0.0],
+                "k": 1,
+                "num_candidates": 10
+            },
+            "size": 1
+        }))
+        .unwrap();
+        let result = idx.search(&request).await.unwrap();
+        assert_eq!(result.hits[0].id, "vector-winner");
+    }
+    #[test]
+    fn cancelling_waiter_while_blocking_worker_is_queued_still_restores() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+            let ledger: &'static crate::ingest_memory::Ledger =
+                Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+            let dir = tempfile::tempdir().unwrap();
+            let mut config = Config::default();
+            config.server.data_dir = dir.path().to_string_lossy().into_owned();
+            let engine = crate::Engine::new(config).unwrap();
+            engine
+                .create_index("bm25-queued-cancel", text_schema())
+                .unwrap();
+            let idx = engine.get_index("bm25-queued-cancel").unwrap();
+            idx.abort_background_tasks();
+            idx.index_document(Some("winner".into()), json!({"body": "alpha"}))
+                .await
+                .unwrap();
+
+            let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+            let blocker = tokio::task::spawn_blocking(move || release_rx.recv().unwrap());
+            let (queued_tx, queued_rx) = tokio::sync::oneshot::channel();
+            let queued_tx = parking_lot::Mutex::new(Some(queued_tx));
+            let spawn_signals = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let callback_spawn_signals = Arc::clone(&spawn_signals);
+            let hook = FlushPublisherTestHook {
+                callback: Arc::new(|| true),
+                after_warm: None,
+                ledger,
+                target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+                bypass_finalize_gate: true,
+                before_blocking_spawn: Some(Arc::new(move || {
+                    callback_spawn_signals.fetch_add(1, Ordering::AcqRel);
+                    if let Some(sender) = queued_tx.lock().take() {
+                        let _ = sender.send(());
+                    }
+                })),
+            };
+            let flush = {
+                let idx = Arc::clone(&idx);
+                tokio::spawn(
+                    FLUSH_PUBLISHER_TEST_HOOK.scope(hook, async move { idx.flush().await }),
+                )
+            };
+            while idx.memtable.doc_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+            queued_rx.await.unwrap();
+            // The sole blocking thread is occupied, so the finalizer closure
+            // (and its worker-owned guard/rollback payload) is queued.
+            flush.abort();
+            assert!(flush.await.unwrap_err().is_cancelled());
+            release_tx.send(()).unwrap();
+            blocker.await.unwrap();
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                while idx.memtable.doc_count() != 1 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("queued finalizer must run and restore after the blocking thread is released");
+            let request = xerj_query::parse_request(&json!({
+                "query": {"match": {"body": "alpha"}}, "size": 10
+            }))
+            .unwrap();
+            let result = idx.search(&request).await.unwrap();
+            assert_eq!(result.hits[0].id, "winner");
+            assert_eq!(idx.memtable.doc_count(), 1);
+            assert_eq!(
+                spawn_signals.load(Ordering::Acquire),
+                1,
+                "exactly one finalizer coordinator must enqueue a blocking worker"
+            );
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_prepublication_flush_restores_drained_documents() {
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let ledger: &'static crate::ingest_memory::Ledger =
+            Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config.clone()).unwrap();
+        engine
+            .create_index("bm25-failed-publication", text_schema())
+            .unwrap();
+        let idx = engine.get_index("bm25-failed-publication").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(Some("survivor".into()), json!({"body": "alpha alpha"}))
+            .await
+            .unwrap();
+
+        let hook = FlushPublisherTestHook {
+            callback: Arc::new(|| true),
+            after_warm: None,
+            ledger,
+            target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
+        };
+        let flush = FLUSH_PUBLISHER_TEST_HOOK
+            .scope(hook, async { idx.flush().await })
+            .await;
+        assert!(
+            flush.is_err(),
+            "the injected publisher failure must surface"
+        );
+        assert_eq!(
+            idx.memtable.doc_count(),
+            1,
+            "a failed publication must restore the drained live document"
+        );
+
+        let request = xerj_query::parse_request(&json!({
+            "query": {"match": {"body": "alpha"}},
+            "size": 10,
+            "track_total_hits": true
+        }))
+        .unwrap();
+        let result = idx.search(&request).await.unwrap();
+        assert_eq!(result.total.value, 1);
+        assert_eq!(result.hits[0].id, "survivor");
+        idx.flush().await.unwrap();
+        assert_eq!(idx.search(&request).await.unwrap().hits[0].id, "survivor");
+        drop(idx);
+        drop(engine);
+        let restarted = crate::Engine::new(config).unwrap();
+        let idx = restarted.get_index("bm25-failed-publication").unwrap();
+        idx.abort_background_tasks();
+        assert_eq!(idx.search(&request).await.unwrap().hits[0].id, "survivor");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_post_sidecar_segment_has_no_recovery_marker() {
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let ledger: &'static crate::ingest_memory::Ledger =
+            Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config.clone()).unwrap();
+        engine
+            .create_index("bm25-incomplete-orphan", text_schema())
+            .unwrap();
+        let idx = engine.get_index("bm25-incomplete-orphan").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(Some("survivor".into()), json!({"body": "alpha"}))
+            .await
+            .unwrap();
+        let hook = FlushPublisherTestHook {
+            callback: Arc::new(|| false),
+            after_warm: Some(Arc::new(|_| true)),
+            ledger,
+            target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
+        };
+        assert!(FLUSH_PUBLISHER_TEST_HOOK
+            .scope(hook, async { idx.flush().await })
+            .await
+            .is_err());
+        let segments_dir = idx.data_dir.join("segments");
+        let files: Vec<_> = std::fs::read_dir(&segments_dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .collect();
+        assert!(
+            files.iter().all(|path| !matches!(
+                path.extension().and_then(|extension| extension.to_str()),
+                Some("complete" | "ids")
+            )),
+            "failed pre-publication output must retain no recovery marker"
+        );
+        assert!(idx.store.snapshot().segments.is_empty());
+        drop(idx);
+        drop(engine);
+
+        let restarted = crate::Engine::new(config).unwrap();
+        let idx = restarted.get_index("bm25-incomplete-orphan").unwrap();
+        idx.abort_background_tasks();
+        assert!(idx.store.snapshot().segments.is_empty());
+        let request = xerj_query::parse_request(&json!({
+            "query": {"match": {"body": "alpha"}}, "size": 10
+        }))
+        .unwrap();
+        assert_eq!(idx.search(&request).await.unwrap().hits[0].id, "survivor");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn panicking_prepublication_finalizer_restores_drained_documents() {
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let ledger: &'static crate::ingest_memory::Ledger =
+            Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine.create_index("bm25-panic", text_schema()).unwrap();
+        let idx = engine.get_index("bm25-panic").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(Some("survivor".into()), json!({"body": "alpha"}))
+            .await
+            .unwrap();
+        let hook = FlushPublisherTestHook {
+            callback: Arc::new(|| panic!("injected finalizer panic")),
+            after_warm: None,
+            ledger,
+            target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
+        };
+        assert!(FLUSH_PUBLISHER_TEST_HOOK
+            .scope(hook, async { idx.flush().await })
+            .await
+            .is_err());
+        assert_eq!(idx.memtable.doc_count(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn failed_flush_does_not_restore_over_a_concurrent_newer_put() {
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let ledger: &'static crate::ingest_memory::Ledger =
+            Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine
+            .create_index("bm25-newer-put", text_schema())
+            .unwrap();
+        let idx = engine.get_index("bm25-newer-put").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(Some("same".into()), json!({"body": "old alpha"}))
+            .await
+            .unwrap();
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let entered_tx = parking_lot::Mutex::new(Some(entered_tx));
+        let release_rx = parking_lot::Mutex::new(Some(release_rx));
+        let hook = FlushPublisherTestHook {
+            callback: Arc::new(move || {
+                entered_tx.lock().take().unwrap().send(()).unwrap();
+                release_rx.lock().take().unwrap().recv().unwrap();
+                true
+            }),
+            after_warm: None,
+            ledger,
+            target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
+        };
+        let flush = {
+            let idx = Arc::clone(&idx);
+            tokio::spawn(FLUSH_PUBLISHER_TEST_HOOK.scope(hook, async move { idx.flush().await }))
+        };
+        tokio::task::spawn_blocking(move || entered_rx.recv().unwrap())
+            .await
+            .unwrap();
+        idx.index_document(Some("same".into()), json!({"body": "new beta"}))
+            .await
+            .unwrap();
+        release_tx.send(()).unwrap();
+        assert!(flush.await.unwrap().is_err());
+
+        let alpha = xerj_query::parse_request(&json!({
+            "query": {"match": {"body": "alpha"}}, "size": 10
+        }))
+        .unwrap();
+        let beta = xerj_query::parse_request(&json!({
+            "query": {"match": {"body": "beta"}}, "size": 10
+        }))
+        .unwrap();
+        assert!(idx.search(&alpha).await.unwrap().hits.is_empty());
+        assert_eq!(idx.search(&beta).await.unwrap().hits[0].id, "same");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn failed_flush_does_not_restore_over_a_concurrent_delete() {
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let ledger: &'static crate::ingest_memory::Ledger =
+            Box::leak(Box::new(crate::ingest_memory::Ledger::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine
+            .create_index("bm25-newer-delete", text_schema())
+            .unwrap();
+        let idx = engine.get_index("bm25-newer-delete").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(Some("same".into()), json!({"body": "alpha"}))
+            .await
+            .unwrap();
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let entered_tx = parking_lot::Mutex::new(Some(entered_tx));
+        let release_rx = parking_lot::Mutex::new(Some(release_rx));
+        let hook = FlushPublisherTestHook {
+            callback: Arc::new(move || {
+                entered_tx.lock().take().unwrap().send(()).unwrap();
+                release_rx.lock().take().unwrap().recv().unwrap();
+                true
+            }),
+            after_warm: None,
+            ledger,
+            target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
+        };
+        let flush = {
+            let idx = Arc::clone(&idx);
+            tokio::spawn(FLUSH_PUBLISHER_TEST_HOOK.scope(hook, async move { idx.flush().await }))
+        };
+        tokio::task::spawn_blocking(move || entered_rx.recv().unwrap())
+            .await
+            .unwrap();
+        assert!(idx.delete_document("same").await.unwrap());
+        release_tx.send(()).unwrap();
+        assert!(flush.await.unwrap().is_err());
+        let request = xerj_query::parse_request(&json!({
+            "query": {"match": {"body": "alpha"}}, "size": 10
+        }))
+        .unwrap();
+        assert!(idx.search(&request).await.unwrap().hits.is_empty());
+    }
+}
+
 struct HnswPublicationGuard {
     in_flight: Arc<AtomicU64>,
     generation: Arc<AtomicU64>,
@@ -6795,7 +7303,21 @@ impl Index {
                         // parks the ids in a graveyard swept by the last
                         // lease drop — so deferral is bounded by the
                         // longest-running in-flight query, not a restart.
-                        let (rm_files, rm_bytes) = self.store.retire_segment_files(&batch_slice);
+                        let (rm_files, rm_bytes) =
+                            match self.store.retire_segment_files(&batch_slice) {
+                                Ok(removed) => removed,
+                                Err(error) => {
+                                    tracing::error!(
+                                        merged_id = merged_meta.id.as_str(),
+                                        inputs = batch_slice.len(),
+                                        %error,
+                                        "merge committed but durable input retirement failed"
+                                    );
+                                    failed_batches
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                    (0, 0)
+                                }
+                            };
                         tracing::info!(
                             merged_id = merged_meta.id.as_str(),
                             inputs = batch_slice.len(),
@@ -14153,7 +14675,7 @@ impl Index {
     // ── Flush ─────────────────────────────────────────────────────────────────
 
     /// Flush the memtable to a new segment on disk, then build the FTS index.
-    pub async fn flush(&self) -> Result<()> {
+    pub async fn flush(self: &Arc<Self>) -> Result<()> {
         let (field_configs, excluded_fts_fields) = {
             let schema = self.schema.read().await;
             (
@@ -14180,94 +14702,97 @@ impl Index {
         let flush_test_hook = FLUSH_PUBLISHER_TEST_HOOK
             .try_with(FlushPublisherTestHook::clone)
             .ok();
-        let mut shard_futures = Vec::with_capacity(n_shards);
-        for shard_idx in 0..n_shards {
-            let sema = Arc::clone(&self.flush_sema);
-            let store = Arc::clone(&self.store);
-            let memtable = Arc::clone(&self.memtable);
-            let registry = Arc::clone(&self.registry);
-            let data_dir = self.data_dir.clone();
-            let field_configs = field_configs.clone();
-            let excluded_fts_fields = excluded_fts_fields.clone();
-            let warm_caches = self.publish_warm_caches();
-            #[cfg(test)]
-            let test_hook = flush_test_hook.clone();
-            shard_futures.push(tokio::spawn(async move {
-                let permit = sema.acquire_owned().await.ok();
-                let permit_cell = Arc::new(std::sync::Mutex::new(permit));
-                let permit_cell_cb = Arc::clone(&permit_cell);
-                let on_drained = move || {
-                    if let Ok(mut guard) = permit_cell_cb.lock() {
+        let flush_sema = Arc::clone(&self.flush_sema);
+        let store = Arc::clone(&self.store);
+        let memtable = Arc::clone(&self.memtable);
+        let registry = Arc::clone(&self.registry);
+        let data_dir = self.data_dir.clone();
+        let warm_caches = self.publish_warm_caches();
+        let index = Arc::clone(self);
+        // This coordinator is the cancellation boundary for the whole flush.
+        // If the request future is dropped, its JoinHandle detaches and the
+        // coordinator continues owning every shard publication transaction.
+        let coordinator = tokio::spawn(async move {
+            let mut shard_futures = Vec::with_capacity(n_shards);
+            for shard_idx in 0..n_shards {
+                let sema = Arc::clone(&flush_sema);
+                let store = Arc::clone(&store);
+                let memtable = Arc::clone(&memtable);
+                let registry = Arc::clone(&registry);
+                let data_dir = data_dir.clone();
+                let field_configs = field_configs.clone();
+                let excluded_fts_fields = excluded_fts_fields.clone();
+                let warm_caches = warm_caches.clone();
+                #[cfg(test)]
+                let test_hook = flush_test_hook.clone();
+                shard_futures.push(tokio::spawn(async move {
+                    let permit = sema.acquire_owned().await.ok();
+                    let permit_cell = Arc::new(std::sync::Mutex::new(permit));
+                    let permit_cell_cb = Arc::clone(&permit_cell);
+                    let on_drained = move || {
+                        if let Ok(mut guard) = permit_cell_cb.lock() {
+                            let _ = guard.take();
+                        }
+                    };
+                    let result = do_flush_shard(
+                        shard_idx,
+                        store,
+                        memtable,
+                        registry,
+                        data_dir,
+                        field_configs,
+                        excluded_fts_fields,
+                        on_drained,
+                        warm_caches,
+                        #[cfg(test)]
+                        test_hook,
+                    )
+                    .await;
+                    // Defensive: in case on_drained didn't fire.
+                    if let Ok(mut guard) = permit_cell.lock() {
                         let _ = guard.take();
                     }
-                };
-                let result = do_flush_shard(
-                    shard_idx,
-                    store,
-                    memtable,
-                    registry,
-                    data_dir,
-                    field_configs,
-                    excluded_fts_fields,
-                    on_drained,
-                    warm_caches,
-                    #[cfg(test)]
-                    test_hook,
-                )
-                .await;
-                // Defensive: in case on_drained didn't fire.
-                if let Ok(mut guard) = permit_cell.lock() {
-                    let _ = guard.take();
-                }
-                result
-            }));
-        }
-        let mut result: Result<()> = Ok(());
-        for fut in shard_futures {
-            match fut.await {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    result = Err(e);
-                }
-                Err(e) => {
-                    tracing::warn!("flush shard task panicked: {e}");
+                    result
+                }));
+            }
+            let mut result: Result<()> = Ok(());
+            for fut in shard_futures {
+                match fut.await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => result = Err(e),
+                    Err(error) => {
+                        result = Err(EngineError::Common(xerj_common::XerjError::internal(
+                            format!("flush shard task failed: {error}"),
+                        )));
+                    }
                 }
             }
-        }
-        // Force a global WAL maintenance pass (verified checkpoint +
-        // rotate + prune) at the user-visible flush boundary.
-        // `finalize_flush_with_publisher` time-gates this work (1 s
-        // window) on the hot per-shard path; the final flush must bypass
-        // the gate so the CLI session's last segment is definitely
-        // checkpointed when the CLI exits.
-        //
-        // RC4 W1 #8 — this used to pass `current_seq_no() - 1` as the
-        // checkpoint watermark: the LIVE global counter, covering every
-        // acked-but-unflushed doc in existence (docs bulked into other
-        // shards, docs that landed between a shard's drain and this
-        // call).  Maintenance then rotated + pruned their WAL entries
-        // while the docs still lived only in memtables — kill -9 lost
-        // all of them (live repro: 50/50 acked docs gone).  The durable
-        // watermark is now derived inside the store from the persisted
-        // snapshot, and prune verifies every entry before destroying it.
-        let _ = self.store.force_wal_maintenance();
-        // Flushing moves data from memtable → segments, which changes
-        // what the shortcut count paths compute.  Bump the dataset
-        // version so the response cache invalidates. P3.2: the new
-        // segments are immutable and don't invalidate any EXISTING
-        // segment's cached doc-values / stored fields, so we no longer
-        // clear those per-segment caches here — the version bump alone
-        // makes the query_cache miss.
-        self.dataset_version.fetch_add(1, Ordering::Release);
-        // Persist the HNSW graph alongside the segment durability
-        // event. v0.6.2 — pre-flush the graph could be reconstructed
-        // from the WAL on restart (slow); post-flush the WAL has been
-        // checkpointed past those vector inserts, so without this save
-        // a crash would lose the graph entirely. Failures are logged
-        // (warn!) inside save_hnsw_to_disk and do not fail the flush
-        // — losing a graph snapshot is recoverable; failing the flush
-        // is not.
-        let _ = self.save_hnsw_to_disk().await;
+            // Publication completion must invalidate results even when the
+            // request that initiated the flush was cancelled. The coordinator
+            // owns this transition, so it cannot be skipped with the waiter.
+            // The detached coordinator owns the complete durability tail.
+            // Persist the graph before WAL maintenance can checkpoint vector
+            // writes past the point from which restart can rebuild it.
+            if result.is_ok() {
+                if let Err(error) = index.save_hnsw_to_disk().await {
+                    result = Err(error);
+                }
+            }
+            if result.is_ok() {
+                if let Err(error) = index.store.force_wal_maintenance() {
+                    result = Err(error.into());
+                }
+            }
+            index.dataset_version.fetch_add(1, Ordering::Release);
+            index.query_cache.clear();
+            result
+        });
+        let result = match coordinator.await {
+            Ok(result) => result,
+            Err(error) => Err(EngineError::Common(xerj_common::XerjError::internal(
+                format!("flush coordinator failed: {error}"),
+            ))),
+        };
         result
     }
 
@@ -19874,6 +20399,8 @@ struct FlushPublisherTestHook {
     after_warm: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
     ledger: &'static crate::ingest_memory::Ledger,
     target_memtable: usize,
+    bypass_finalize_gate: bool,
+    before_blocking_spawn: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 #[cfg(test)]
 tokio::task_local! {
@@ -19899,6 +20426,20 @@ async fn do_flush_shard(
     warm_caches: PublishWarmCaches,
     #[cfg(test)] test_hook: Option<FlushPublisherTestHook>,
 ) -> Result<()> {
+    // Acquire admission before draining. Once the memtable has been drained
+    // there must be no cancellation point until a non-cancellable blocking
+    // worker owns both rollback data and the publication barrier.
+    #[cfg(test)]
+    let bypass_finalize_gate = test_hook
+        .as_ref()
+        .is_some_and(|hook| hook.bypass_finalize_gate);
+    #[cfg(not(test))]
+    let bypass_finalize_gate = false;
+    let fin_permit = if bypass_finalize_gate {
+        None
+    } else {
+        crate::flush_finalize_gate().acquire().await.ok()
+    };
     // V4 M4.5: no outer flush_lock — concurrent flushes are allowed.  The
     // memtable write lock below is the only atomicity point we need for
     // correctness (each concurrent flush drains a disjoint set of docs
@@ -20064,6 +20605,8 @@ async fn do_flush_shard(
         Some(pair) => pair,
         None => return Ok(()),
     };
+    let drained_fts = Arc::new(drained_fts);
+    let storage_drained = Arc::new(storage_drained);
 
     // RC4 W4 item 2: record flush latency. Armed only past the empty-drain
     // early-return above, so the histogram reflects real segment builds; fires
@@ -20081,6 +20624,7 @@ async fn do_flush_shard(
     let segments_dir = data_dir.join("segments");
     let registry_for_build = Arc::clone(&registry);
     let fts_doc_count = drained_fts.len();
+    let drained_fts_for_build = Arc::clone(&drained_fts);
     let segments_dir_for_dv = segments_dir.clone();
     let store_for_warm = Arc::clone(&store);
     // POV battery (B-3) caught that gating FTS+DV on the raw-bytes path
@@ -20095,6 +20639,11 @@ async fn do_flush_shard(
     let failed_warm_caches = warm_caches.clone();
     let warmed_segment_id = Arc::new(parking_lot::Mutex::new(None::<String>));
     let callback_warmed_segment_id = Arc::clone(&warmed_segment_id);
+    #[cfg(test)]
+    let before_blocking_spawn = test_hook
+        .as_ref()
+        .filter(|hook| hook.target_memtable == test_target)
+        .and_then(|hook| hook.before_blocking_spawn.as_ref().map(Arc::clone));
     let build_fts = move |meta: &xerj_storage::segment::SegmentMeta| -> xerj_storage::Result<()> {
         #[cfg(test)]
         let test_callback = test_hook
@@ -20120,16 +20669,17 @@ async fn do_flush_shard(
             let t_dv = std::time::Instant::now();
             {
                 let columns = build_doc_value_columns(
-                    drained_fts
+                    drained_fts_for_build
                         .iter()
                         .map(|(_id, _fields, src)| Some(src.as_ref())),
                 );
                 if !columns.is_empty() {
-                    if let Err(e) =
-                        write_doc_values_sidecar(&segments_dir_for_dv, meta.id.as_str(), &columns)
-                    {
-                        tracing::warn!("doc-values side-car write failed: {e}");
-                    }
+                    write_doc_values_sidecar(&segments_dir_for_dv, meta.id.as_str(), &columns)
+                        .map_err(|error| {
+                            xerj_storage::StorageError::Io(std::io::Error::other(format!(
+                                "doc-values side-car write failed: {error}"
+                            )))
+                        })?;
                 }
             }
             let dv_us = t_dv.elapsed().as_micros();
@@ -20146,12 +20696,14 @@ async fn do_flush_shard(
                     fts_writer.configure_field(field_name.clone(), cfg.clone());
                 }
                 let t_add = std::time::Instant::now();
-                fts_writer.add_documents_parallel(&drained_fts);
+                fts_writer.add_documents_parallel(&drained_fts_for_build);
                 fts_add_us = t_add.elapsed().as_micros();
                 let t_fin = std::time::Instant::now();
-                if let Err(e) = fts_writer.finish() {
-                    tracing::warn!("flush: FTS build failed: {e}");
-                }
+                fts_writer.finish().map_err(|error| {
+                    xerj_storage::StorageError::Io(std::io::Error::other(format!(
+                        "FTS side-car build failed: {error}"
+                    )))
+                })?;
                 fts_finish_us = t_fin.elapsed().as_micros();
             }
             if prof {
@@ -20187,7 +20739,7 @@ async fn do_flush_shard(
             Ok(())
         })?;
         let _ = &segments_dir;
-        let _ = &drained_fts;
+        let _ = &drained_fts_for_build;
 
         Ok(())
     };
@@ -20206,25 +20758,79 @@ async fn do_flush_shard(
     //      concurrent bulk clients' HTTP handling and the reader's search
     //      dispatch.
     let t_finalize = std::time::Instant::now();
-    let _fin_permit = crate::flush_finalize_gate().acquire().await.ok();
-    let finalize_join = tokio::task::spawn_blocking(move || {
-        // This lease lives in the blocking worker, not the async waiter:
-        // aborting an async task cannot cancel `spawn_blocking`.
-        let lease =
-            PrePublicationLease::tracked(failed_warm_caches, Arc::clone(&warmed_segment_id));
-        let result = crate::background_pool()
-            .install(|| store.finalize_flush_with_publisher(storage_drained, build_fts));
-        if matches!(result, Ok(Some(_))) {
-            // finalize_flush_with_publisher publishes the snapshot before it
-            // returns Some. Commit while still in the worker, with no await.
-            lease.commit();
+    let store_for_finalize = Arc::clone(&store);
+    let storage_drained_for_finalize = Arc::clone(&storage_drained);
+    let memtable_for_finalize = Arc::clone(&memtable);
+    let drained_fts_for_restore = Arc::clone(&drained_fts);
+    let version_map_for_restore = Arc::clone(&store.version_map);
+    // A dedicated async coordinator owns and awaits the queued blocking job.
+    // Dropping/cancelling the API caller merely detaches this coordinator;
+    // it continues to own the blocking JoinHandle and the worker-captured
+    // publication transaction until commit or rollback.
+    let finalize_coordinator = tokio::spawn(async move {
+        #[cfg(test)]
+        if let Some(callback) = before_blocking_spawn {
+            callback();
         }
-        result
-    })
-    .await;
+        tokio::task::spawn_blocking(move || {
+            let _fin_permit = fin_permit;
+            // This lease lives in the blocking worker, not either async waiter.
+            let lease =
+                PrePublicationLease::tracked(failed_warm_caches, Arc::clone(&warmed_segment_id));
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                crate::background_pool().install(|| {
+                    store_for_finalize
+                        .finalize_flush_with_publisher(&storage_drained_for_finalize, build_fts)
+                })
+            }));
+            if !matches!(
+                result,
+                Ok(Ok(
+                    xerj_storage::index_store::FlushFinalizeOutcome::Published { .. }
+                ))
+            ) {
+                let restore = storage_drained_for_finalize
+                    .entries
+                    .iter()
+                    .zip(drained_fts_for_restore.iter())
+                    .map(|(stored, (doc_id, fields, source))| {
+                        (
+                            stored.seq_no,
+                            doc_id.clone(),
+                            fields.clone(),
+                            Arc::clone(source),
+                        )
+                    })
+                    .collect();
+                memtable_for_finalize.restore_failed_flush(restore, &version_map_for_restore);
+            }
+            let result = match result {
+                Ok(result) => result,
+                Err(payload) => std::panic::resume_unwind(payload),
+            };
+            if matches!(
+                result,
+                Ok(xerj_storage::index_store::FlushFinalizeOutcome::Published { .. })
+            ) {
+                // finalize_flush_with_publisher publishes the snapshot before it
+                // returns Some. Commit while still in the worker, with no await.
+                lease.commit();
+            }
+            result
+        })
+        .await
+    });
+    let finalize_join = match finalize_coordinator.await {
+        Ok(join) => join,
+        Err(join_e) => {
+            return Err(EngineError::Common(xerj_common::XerjError::internal(
+                format!("flush coordinator task failed: {join_e}"),
+            )));
+        }
+    };
     let meta = match finalize_join {
-        Ok(Ok(Some(m))) => m,
-        Ok(Ok(None)) => {
+        Ok(Ok(xerj_storage::index_store::FlushFinalizeOutcome::Published { meta, .. })) => meta,
+        Ok(Ok(xerj_storage::index_store::FlushFinalizeOutcome::Empty)) => {
             tracing::warn!("storage finalize returned None — unexpected");
             return Ok(());
         }
@@ -20233,7 +20839,9 @@ async fn do_flush_shard(
         }
         Err(join_e) => {
             tracing::warn!("finalize spawn_blocking join failed: {join_e}");
-            return Ok(());
+            return Err(EngineError::Common(xerj_common::XerjError::internal(
+                format!("flush finalizer task failed before publication: {join_e}"),
+            )));
         }
     };
     if prof {
@@ -32869,6 +33477,8 @@ mod flush_memory_integration_tests {
             after_warm: None,
             ledger,
             target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
         };
 
         let flush = {
@@ -32939,6 +33549,8 @@ mod flush_memory_integration_tests {
             })),
             ledger,
             target_memtable: Arc::as_ptr(&idx.memtable) as usize,
+            bypass_finalize_gate: false,
+            before_blocking_spawn: None,
         };
 
         let result = do_flush_shard(
@@ -32954,11 +33566,15 @@ mod flush_memory_integration_tests {
             Some(hook),
         )
         .await;
-        if panic_after_warm {
-            assert!(result.is_ok(), "join panic is logged and kept non-fatal");
-        } else {
-            assert!(result.is_err());
-        }
+        assert!(
+            result.is_err(),
+            "publisher errors and panics must propagate to the flush caller"
+        );
+        assert_eq!(
+            idx.memtable.doc_count(),
+            1,
+            "pre-publication failure must restore the drained document"
+        );
         let segment_id = warmed_id.lock().clone().expect("warm hook did not run");
         assert!(!idx.stored_slices_cache.contains_key(&segment_id));
         assert!(!idx.dv_cache.contains_key(&segment_id));

--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -1191,6 +1191,45 @@ impl ShardedFtsMemtable {
             .insert_raw_bytes_with_seq(seq_no, doc_id, source_bytes);
     }
 
+    /// Restore documents drained by a flush whose pre-publication finalizer
+    /// failed. The caller supplies the exact text fields captured during the
+    /// original drain, avoiding schema re-inference on this rare recovery
+    /// path. Newer writes must be filtered by the caller before restoration.
+    pub(crate) fn restore_failed_flush(
+        &self,
+        entries: Vec<(u64, String, HashMap<String, String>, Arc<Value>)>,
+        version_map: &xerj_storage::version_map::VersionMap,
+    ) {
+        for (seq_no, doc_id, fields, source) in entries {
+            let shard_idx = self.shard_for_dynamic(&doc_id);
+            let mut shard = self.shards[shard_idx].write();
+            // This check deliberately happens while holding the owning shard
+            // lock. A concurrent PUT/DELETE publishes its version before it
+            // mutates this shard; checking outside the lock would allow a
+            // stale drained copy to overwrite the newer doc_id_index entry.
+            let Some(current) = version_map.get(&doc_id) else {
+                continue;
+            };
+            if current.seq_no != seq_no
+                || current.segment_id.as_ref() != xerj_storage::version_map::IN_MEMORY_SEGMENT_ID
+                || current.deleted
+            {
+                continue;
+            }
+            let analyzer = shard
+                .registry
+                .get_analyzer("default")
+                .or_else(|| shard.registry.get_analyzer("standard"))
+                .expect("standard analyzer always present");
+            let analyzed: Vec<(String, Vec<Token>)> = fields
+                .into_iter()
+                .map(|(field, text)| (field, analyzer.analyze(&text)))
+                .collect();
+            let size = (source.to_string().len() + doc_id.len()) * 3 + 64;
+            shard.insert_analyzed(seq_no, doc_id, source, &analyzed, size);
+        }
+    }
+
     /// Iterate every document in every shard as `(doc_id, Value)`.
     /// Clones each `Arc<Value>`'s inner so callers that expect an
     /// owned `Value` keep working.

--- a/engine/crates/xerj-storage/src/index_store.rs
+++ b/engine/crates/xerj-storage/src/index_store.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 
 use crate::backend::StorageBackend;
 use crate::segment::{SectionType, SegmentId, SegmentMeta, SegmentReader, SegmentWriter};
-use crate::version_map::{VersionMap, IN_MEMORY_SEGMENT_ID};
+use crate::version_map::{VersionMap, VersionRepointTransaction, IN_MEMORY_SEGMENT_ID};
 use crate::wal::{SyncMode, WalEntry, WalWriter};
 use crate::{Result, SeqNo, StorageError};
 
@@ -546,11 +546,29 @@ pub struct IndexStore {
     #[cfg(test)]
     fail_next_snapshot_save: std::sync::atomic::AtomicBool,
     #[cfg(test)]
+    fail_snapshot_save_after: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
     fail_next_wal_maintenance: std::sync::atomic::AtomicBool,
     #[cfg(test)]
     publication_failpoint: std::sync::atomic::AtomicU8,
     #[cfg(test)]
     orphan_disarm_fail_after: std::sync::atomic::AtomicUsize,
+}
+
+/// Authoritative publication state returned by transactional merge apply.
+#[derive(Debug)]
+pub enum MergePublicationOutcome {
+    Published { maintenance_deferred: bool },
+}
+
+/// Failure classification for transactional merge publication.
+#[derive(Debug)]
+pub enum MergePublicationError {
+    NotPublished(StorageError),
+    Indeterminate {
+        publication: StorageError,
+        rollback: StorageError,
+    },
 }
 
 /// Cached verification state of one rotated WAL generation.
@@ -636,6 +654,8 @@ impl IndexStore {
             wal_prune_cache: Mutex::new(std::collections::HashMap::new()),
             #[cfg(test)]
             fail_next_snapshot_save: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(test)]
+            fail_snapshot_save_after: std::sync::atomic::AtomicUsize::new(usize::MAX),
             #[cfg(test)]
             fail_next_wal_maintenance: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
@@ -2881,6 +2901,21 @@ impl IndexStore {
                 "injected post-publication snapshot save failure",
             )));
         }
+        #[cfg(test)]
+        {
+            let remaining = self.fail_snapshot_save_after.load(Ordering::Acquire);
+            if remaining != usize::MAX {
+                if remaining == 0 {
+                    self.fail_snapshot_save_after
+                        .store(usize::MAX, Ordering::Release);
+                    return Err(StorageError::Io(std::io::Error::other(
+                        "injected delayed snapshot save failure",
+                    )));
+                }
+                self.fail_snapshot_save_after
+                    .store(remaining - 1, Ordering::Release);
+            }
+        }
         let snap = self.snapshot.load();
         // P2.3 — `to_vec` (compact) not `to_vec_pretty`: the snapshot is a
         // machine-read manifest (loaded via `from_slice`), never
@@ -3332,21 +3367,69 @@ impl IndexStore {
     /// atomically replace merged segments with the merged result and update
     /// the version map.
     pub fn apply_merge(&self, merged_ids: &[SegmentId], new_meta: SegmentMeta) -> Result<()> {
+        self.apply_merge_inner(merged_ids, new_meta, None, || {})
+            .map(|_| ())
+            .map_err(|error| match error {
+                MergePublicationError::NotPublished(error) => error,
+                MergePublicationError::Indeterminate {
+                    publication,
+                    rollback,
+                } => StorageError::MergeAborted(format!(
+                    "merge publication is indeterminate: publication failed ({publication}); rollback persistence failed ({rollback})"
+                )),
+            })
+    }
+
+    /// Publish a merge and take ownership of its provisional version-map
+    /// repoints. The transaction commits at the exact durable manifest
+    /// boundary, before any fallible or panic-capable post-publication work.
+    pub fn apply_merge_with_repoints(
+        &self,
+        merged_ids: &[SegmentId],
+        new_meta: SegmentMeta,
+        version_repoints: VersionRepointTransaction,
+    ) -> std::result::Result<MergePublicationOutcome, MergePublicationError> {
+        self.apply_merge_inner(merged_ids, new_meta, Some(version_repoints), || {})
+    }
+
+    /// Test seam for exercising cancellation/panic immediately after durable
+    /// publication. Production callers use [`Self::apply_merge_with_repoints`].
+    #[doc(hidden)]
+    pub fn apply_merge_with_repoints_and_post_publish<F: FnOnce()>(
+        &self,
+        merged_ids: &[SegmentId],
+        new_meta: SegmentMeta,
+        version_repoints: VersionRepointTransaction,
+        post_publish: F,
+    ) -> std::result::Result<MergePublicationOutcome, MergePublicationError> {
+        self.apply_merge_inner(merged_ids, new_meta, Some(version_repoints), post_publish)
+    }
+
+    fn apply_merge_inner<F: FnOnce()>(
+        &self,
+        merged_ids: &[SegmentId],
+        new_meta: SegmentMeta,
+        version_repoints: Option<VersionRepointTransaction>,
+        post_publish: F,
+    ) -> std::result::Result<MergePublicationOutcome, MergePublicationError> {
         // Inputs still belong to the authoritative snapshot at this point.
         // Durably remove their ZID3 completion markers before committing the
         // replacement, so no crash after snapshot publication can resurrect
         // a partially retired input. The ids sidecars stay readable if this
         // step fails and the merge is aborted.
-        self.disarm_orphan_recovery_for_segments(merged_ids)?;
+        self.disarm_orphan_recovery_for_segments(merged_ids)
+            .map_err(MergePublicationError::NotPublished)?;
         // Sum the doc counts of the segments we're about to replace, so we can
         // tell whether this merge actually dropped any documents.
-        let merged_total: u64 = {
+        let (merged_total, previous_metas): (u64, Vec<SegmentMeta>) = {
             let snap = self.snapshot.load();
-            snap.segments
+            let previous: Vec<_> = snap
+                .segments
                 .iter()
                 .filter(|s| merged_ids.contains(&s.id))
-                .map(|s| s.doc_count)
-                .sum()
+                .cloned()
+                .collect();
+            (previous.iter().map(|meta| meta.doc_count).sum(), previous)
         };
         // Atomic replace via rcu — same race as `with_new_segment` in
         // `finalize_flush_with_publisher`: a concurrent flush appending
@@ -3354,6 +3437,54 @@ impl IndexStore {
         // segment swap. rcu retries on contention.
         self.snapshot
             .rcu(|old| Arc::new(old.replace_segments(merged_ids, new_meta.clone())));
+        if let Err(error) = self.save_snapshot() {
+            // Publication changed memory before manifest persistence. Restore
+            // the exact inputs only while this output remains authoritative;
+            // the RCU closure preserves any concurrent flush append.
+            let output_id = new_meta.id.clone();
+            self.snapshot.rcu(|current| {
+                let output_is_current = current.segments.iter().any(|meta| meta.id == output_id)
+                    && previous_metas.iter().all(|previous| {
+                        !current.segments.iter().any(|meta| meta.id == previous.id)
+                    });
+                if !output_is_current {
+                    return Arc::clone(current);
+                }
+                let mut segments: Vec<_> = current
+                    .segments
+                    .iter()
+                    .filter(|meta| meta.id != output_id)
+                    .cloned()
+                    .collect();
+                segments.extend(previous_metas.iter().cloned());
+                let max_seq_no = segments
+                    .iter()
+                    .map(|meta| meta.max_seq_no)
+                    .max()
+                    .unwrap_or(0);
+                Arc::new(IndexSnapshot {
+                    segments,
+                    generation: current.generation + 1,
+                    max_seq_no,
+                })
+            });
+            // The initial error can occur after rename. Best-effort persist
+            // the restored snapshot so memory and restart state converge.
+            return match self.save_snapshot() {
+                Ok(()) => Err(MergePublicationError::NotPublished(error)),
+                Err(rollback) => Err(MergePublicationError::Indeterminate {
+                    publication: error,
+                    rollback,
+                }),
+            };
+        }
+        // The replacement is now durable. Commit provisional repoints here,
+        // in the same synchronous ownership scope, so cancellation or panic
+        // after publication cannot roll them back to retired inputs.
+        if let Some(version_repoints) = version_repoints {
+            version_repoints.commit();
+        }
+        post_publish();
         // `remove_segment` does a full O(N) `DashMap::retain` over the ENTIRE
         // version map, holding each shard's write lock — a >1s read-collapse
         // under merge pressure once the map holds millions of entries (reads
@@ -3371,9 +3502,10 @@ impl IndexStore {
         if new_meta.doc_count < merged_total {
             self.version_map.remove_segment(merged_ids);
         }
-        self.save_snapshot()?;
         info!(merged = merged_ids.len(), "merge applied");
-        Ok(())
+        Ok(MergePublicationOutcome::Published {
+            maintenance_deferred: false,
+        })
     }
 
     /// Returns stats useful for triggering merges.
@@ -5564,5 +5696,49 @@ mod tests {
         // And ingest still works on the fresh store.
         store.index("x", serde_json::json!({"a": 1})).unwrap();
         assert!(store.version_map.get("x").is_some());
+    }
+
+    #[test]
+    fn apply_merge_manifest_failure_restores_exact_input_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_test_store(dir.path());
+        store.index("a", serde_json::json!({"value": "a"})).unwrap();
+        store.flush().unwrap().unwrap();
+        store.index("b", serde_json::json!({"value": "b"})).unwrap();
+        store.flush().unwrap().unwrap();
+        let before = store.snapshot();
+        assert_eq!(before.segments.len(), 2);
+        let before_ids: std::collections::HashSet<_> =
+            before.segments.iter().map(|meta| meta.id.clone()).collect();
+
+        let mut output = before.segments[0].clone();
+        output.id = "injected-unpublished-output".into();
+        output.seg_path = "segments/injected-unpublished-output.seg".into();
+        output.sidx_path = "segments/injected-unpublished-output.sidx".into();
+        let input_ids: Vec<_> = before.segments.iter().map(|meta| meta.id.clone()).collect();
+        // apply_merge first persists the authoritative inputs before it
+        // disarms recovery markers; fail the following publication save.
+        store.fail_snapshot_save_after.store(1, Ordering::Release);
+        assert!(store.apply_merge(&input_ids, output).is_err());
+
+        let after_ids: std::collections::HashSet<_> = store
+            .snapshot()
+            .segments
+            .iter()
+            .map(|meta| meta.id.clone())
+            .collect();
+        assert_eq!(after_ids, before_ids);
+        drop(before);
+        drop(store);
+
+        let reopened = open_test_store(dir.path());
+        let reopened_ids: std::collections::HashSet<_> = reopened
+            .snapshot()
+            .segments
+            .iter()
+            .map(|meta| meta.id.clone())
+            .collect();
+        assert_eq!(reopened_ids, before_ids);
+        assert_eq!(reopened.version_map.live_count(), 2);
     }
 }

--- a/engine/crates/xerj-storage/src/index_store.rs
+++ b/engine/crates/xerj-storage/src/index_store.rs
@@ -548,6 +548,8 @@ pub struct IndexStore {
     #[cfg(test)]
     fail_snapshot_save_after: std::sync::atomic::AtomicUsize,
     #[cfg(test)]
+    snapshot_save_failures_remaining: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
     fail_next_wal_maintenance: std::sync::atomic::AtomicBool,
     #[cfg(test)]
     publication_failpoint: std::sync::atomic::AtomicU8,
@@ -656,6 +658,8 @@ impl IndexStore {
             fail_next_snapshot_save: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             fail_snapshot_save_after: std::sync::atomic::AtomicUsize::new(usize::MAX),
+            #[cfg(test)]
+            snapshot_save_failures_remaining: std::sync::atomic::AtomicUsize::new(1),
             #[cfg(test)]
             fail_next_wal_maintenance: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
@@ -2906,11 +2910,20 @@ impl IndexStore {
             let remaining = self.fail_snapshot_save_after.load(Ordering::Acquire);
             if remaining != usize::MAX {
                 if remaining == 0 {
-                    self.fail_snapshot_save_after
-                        .store(usize::MAX, Ordering::Release);
-                    return Err(StorageError::Io(std::io::Error::other(
-                        "injected delayed snapshot save failure",
-                    )));
+                    let failures = self
+                        .snapshot_save_failures_remaining
+                        .fetch_sub(1, Ordering::AcqRel);
+                    if failures > 0 {
+                        if failures == 1 {
+                            self.fail_snapshot_save_after
+                                .store(usize::MAX, Ordering::Release);
+                            self.snapshot_save_failures_remaining
+                                .store(1, Ordering::Release);
+                        }
+                        return Err(StorageError::Io(std::io::Error::other(
+                            "injected delayed snapshot save failure",
+                        )));
+                    }
                 }
                 self.fail_snapshot_save_after
                     .store(remaining - 1, Ordering::Release);
@@ -5740,5 +5753,31 @@ mod tests {
             .collect();
         assert_eq!(reopened_ids, before_ids);
         assert_eq!(reopened.version_map.live_count(), 2);
+    }
+
+    #[test]
+    fn apply_merge_reports_indeterminate_when_publication_and_rollback_saves_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_test_store(dir.path());
+        store.index("a", serde_json::json!({"value": "a"})).unwrap();
+        store.flush().unwrap().unwrap();
+        store.index("b", serde_json::json!({"value": "b"})).unwrap();
+        store.flush().unwrap().unwrap();
+        let before = store.snapshot();
+        let mut output = before.segments[0].clone();
+        output.id = "indeterminate-output".into();
+        let input_ids: Vec<_> = before.segments.iter().map(|meta| meta.id.clone()).collect();
+        let transaction =
+            VersionRepointTransaction::with_capacity(Arc::clone(&store.version_map), 0);
+        // The pre-disarm input save succeeds; publication and rollback saves
+        // then both fail. The API must not claim exact rollback durability.
+        store.fail_snapshot_save_after.store(1, Ordering::Release);
+        store
+            .snapshot_save_failures_remaining
+            .store(2, Ordering::Release);
+        let error = store
+            .apply_merge_with_repoints(&input_ids, output, transaction)
+            .unwrap_err();
+        assert!(matches!(error, MergePublicationError::Indeterminate { .. }));
     }
 }

--- a/engine/crates/xerj-storage/src/index_store.rs
+++ b/engine/crates/xerj-storage/src/index_store.rs
@@ -133,7 +133,7 @@ impl IndexSnapshot {
 
 // ── Memtable entry ────────────────────────────────────────────────────────────
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MemEntry {
     pub seq_no: SeqNo,
     pub doc_id: String,
@@ -153,6 +153,15 @@ pub struct MemEntry {
 /// expensive segment + side-car I/O — unblocking ingest during the flush.
 pub struct DrainedMemtable {
     pub entries: Vec<MemEntry>,
+}
+
+#[derive(Debug)]
+pub enum FlushFinalizeOutcome {
+    Empty,
+    Published {
+        meta: SegmentMeta,
+        maintenance_deferred: bool,
+    },
 }
 
 // ── Fsck report types ─────────────────────────────────────────────────────────
@@ -534,6 +543,14 @@ pub struct IndexStore {
     /// ticks re-check only its remaining unproven `(doc_id, seq)` pairs
     /// against the version map and prune once the list drains.
     wal_prune_cache: Mutex<std::collections::HashMap<(usize, u64), WalGenVerdict>>,
+    #[cfg(test)]
+    fail_next_snapshot_save: std::sync::atomic::AtomicBool,
+    #[cfg(test)]
+    fail_next_wal_maintenance: std::sync::atomic::AtomicBool,
+    #[cfg(test)]
+    publication_failpoint: std::sync::atomic::AtomicU8,
+    #[cfg(test)]
+    orphan_disarm_fail_after: std::sync::atomic::AtomicUsize,
 }
 
 /// Cached verification state of one rotated WAL generation.
@@ -617,6 +634,14 @@ impl IndexStore {
             retired_segments: Mutex::new(Vec::new()),
             pending_deletes: Mutex::new(std::collections::HashMap::new()),
             wal_prune_cache: Mutex::new(std::collections::HashMap::new()),
+            #[cfg(test)]
+            fail_next_snapshot_save: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(test)]
+            fail_next_wal_maintenance: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(test)]
+            publication_failpoint: std::sync::atomic::AtomicU8::new(0),
+            #[cfg(test)]
+            orphan_disarm_fail_after: std::sync::atomic::AtomicUsize::new(usize::MAX),
         });
 
         // Rebuild version map from flushed segments first (so WAL replay can
@@ -742,14 +767,11 @@ impl IndexStore {
     /// that had been written to disk but hadn't yet reached the
     /// `save_snapshot()` step at line ~838 of `finalize_flush_with_publisher`.
     ///
-    /// Recovery strategy: read the `.ids` sidecar (`ZID1`/`ZID2`, written
-    /// at flush time as the very last side-car), which carries the
-    /// canonical (doc_count, min_seq, max_seq) the snapshot needs.  If
-    /// the sidecar is present and decodes cleanly, the segment was
-    /// fully flushed — the only thing missing is the snapshot pointer,
-    /// which we add here.  If the `.ids` sidecar is missing or corrupt,
-    /// the flush was genuinely incomplete and the file falls through to
-    /// `cleanup_orphaned_segment_files` for deletion.
+    /// Recovery strategy: legacy `ZID1`/`ZID2` flushes use their `.ids`
+    /// sidecar plus strict segment/header validation. New `ZID3` flushes
+    /// additionally require a valid `.complete` manifest that binds the
+    /// entire artifact family. If the applicable evidence is missing or
+    /// corrupt, cleanup removes the orphan instead of publishing it.
     ///
     /// Returns the number of segments recovered.
     fn recover_orphaned_segments(&self) -> Result<usize> {
@@ -826,8 +848,9 @@ impl IndexStore {
                 }
             }
 
-            // .ids sidecar must exist — it's the last write of the flush
-            // sequence, so its presence implies the segment is complete.
+            // Every generation needs a valid ids payload. For legacy ZID1/2
+            // it is recovery evidence only when the segment header agrees;
+            // ZID3 additionally requires its completion manifest below.
             let ids_bytes = match std::fs::read(&ids_path) {
                 Ok(b) => b,
                 Err(_) => continue,
@@ -836,7 +859,10 @@ impl IndexStore {
                 continue;
             }
             let magic = &ids_bytes[..4];
-            if magic != b"ZID1" && magic != b"ZID2" {
+            if magic != b"ZID1" && magic != b"ZID2" && magic != b"ZID3" {
+                continue;
+            }
+            if magic == b"ZID3" && !segments_dir.join(format!("{prefix}.complete")).exists() {
                 continue;
             }
             let num_docs =
@@ -844,7 +870,7 @@ impl IndexStore {
             if num_docs == 0 {
                 continue;
             }
-            let body: Vec<u8> = if magic == b"ZID2" {
+            let body: Vec<u8> = if magic == b"ZID2" || magic == b"ZID3" {
                 match lz4_flex::decompress_size_prepended(&ids_bytes[8..]) {
                     Ok(v) => v,
                     Err(_) => continue,
@@ -867,12 +893,15 @@ impl IndexStore {
                 if pos + id_len > body.len() {
                     break;
                 }
+                if std::str::from_utf8(&body[pos..pos + id_len]).is_err() {
+                    break;
+                }
                 pos += id_len;
                 min_seq = min_seq.min(seq);
                 max_seq = max_seq.max(seq);
                 parsed += 1;
             }
-            if parsed == 0 || min_seq == u64::MAX {
+            if parsed != num_docs || pos != body.len() || min_seq == u64::MAX {
                 continue;
             }
 
@@ -882,24 +911,35 @@ impl IndexStore {
             // rebuild applies its ZTB2 pairs and the deletes_present
             // gates stay on).
             let has_tombstones = match SegmentReader::open(&seg_path) {
-                Ok(r) => (r.header().flags & 0x0001) != 0,
+                Ok(r)
+                    if r.header().doc_count == num_docs
+                        && r.header().min_seq_no == min_seq
+                        && r.header().max_seq_no == max_seq =>
+                {
+                    let complete_path = segments_dir.join(format!("{prefix}.complete"));
+                    if complete_path.exists()
+                        && !self
+                            .validate_flush_completion_manifest(prefix, num_docs, min_seq, max_seq)
+                    {
+                        continue;
+                    }
+                    (r.header().flags & 0x0001) != 0
+                }
                 Err(_) => continue,
+                Ok(_) => continue,
             };
 
             let seg_meta = match std::fs::metadata(&seg_path) {
                 Ok(m) => m,
                 Err(_) => continue,
             };
-            let created_at_ms = seg_meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-                .map(|d| d.as_millis() as u64)
+            let created_at_ms = SegmentReader::open(&seg_path)
+                .map(|reader| reader.header().created_at_ms)
                 .unwrap_or(0);
 
             recovered.push(SegmentMeta {
                 id: prefix.to_string(),
-                doc_count: parsed,
+                doc_count: num_docs,
                 size_bytes: seg_meta.len(),
                 min_seq_no: min_seq,
                 max_seq_no: max_seq,
@@ -1000,6 +1040,19 @@ impl IndexStore {
         segment_id: &str,
         pairs: &[(u64, &str)],
     ) -> std::io::Result<()> {
+        self.write_ids_sidecar_with_magic(segment_id, pairs, b"ZID2")
+    }
+
+    fn write_ids_sidecar_v3(&self, segment_id: &str, pairs: &[(u64, &str)]) -> std::io::Result<()> {
+        self.write_ids_sidecar_with_magic(segment_id, pairs, b"ZID3")
+    }
+
+    fn write_ids_sidecar_with_magic(
+        &self,
+        segment_id: &str,
+        pairs: &[(u64, &str)],
+        magic: &[u8; 4],
+    ) -> std::io::Result<()> {
         let mut body: Vec<u8> =
             Vec::with_capacity(pairs.iter().map(|(_, id)| 8 + 2 + id.len()).sum::<usize>());
         for (seq_no, id) in pairs {
@@ -1009,7 +1062,7 @@ impl IndexStore {
         }
         let compressed = lz4_flex::compress_prepend_size(&body);
         let mut buf: Vec<u8> = Vec::with_capacity(8 + compressed.len());
-        buf.extend_from_slice(b"ZID2");
+        buf.extend_from_slice(magic);
         buf.extend_from_slice(&(pairs.len() as u32).to_le_bytes());
         buf.extend_from_slice(&compressed);
         let ids_path = self
@@ -1017,13 +1070,225 @@ impl IndexStore {
             .join("segments")
             .join(format!("{segment_id}.ids"));
         // RC4 W1 #10 — durable write (tmp + fsync + rename + dir fsync).
-        // The `.ids` side-car is the recovery marker
-        // `recover_orphaned_segments` relies on when a crash lands between
-        // the snapshot publish and the debounced `save_snapshot`; the WAL
-        // entries it supersedes are pruned within ~1 s of the flush.  A
-        // plain `fs::write` left it in the page cache — power loss after
-        // the prune GC'd the fully-flushed segment as an orphan.
+        // The `.ids` side-car carries the durable id/sequence payload used by
+        // recovery. ZID3 is not considered complete until the separately
+        // durable `.complete` manifest validates the full artifact family.
         xerj_common::fsio::write_file_durable(&ids_path, &buf)
+    }
+
+    /// Persist the flush completion manifest after every required artifact.
+    /// The manifest is an integrity envelope (IEEE CRC-32, not a cryptographic
+    /// identity): it binds the segment header coordinates and the exact set
+    /// of artifact names, sizes, and per-file CRCs visible at publication.
+    fn write_flush_completion_manifest(&self, meta: &SegmentMeta) -> std::io::Result<()> {
+        let segments_dir = self.data_dir.join("segments");
+        let prefix = format!("{}.", meta.id);
+        let mut artifacts = Vec::new();
+        for entry in std::fs::read_dir(&segments_dir)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !name.starts_with(&prefix) || name.ends_with(".complete") {
+                continue;
+            }
+            let metadata = entry.metadata()?;
+            let crc = Self::stream_file_crc32(&entry.path())?;
+            artifacts.push((name, metadata.len(), crc));
+        }
+        artifacts.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        if !Self::valid_flush_artifact_set(&meta.id, &artifacts) {
+            return Err(std::io::Error::other(
+                "flush artifact set is incomplete or contains an unknown role",
+            ));
+        }
+        let mut body = Vec::new();
+        body.extend_from_slice(b"ZCM1");
+        body.extend_from_slice(&(meta.id.len() as u16).to_le_bytes());
+        body.extend_from_slice(meta.id.as_bytes());
+        body.extend_from_slice(&meta.doc_count.to_le_bytes());
+        body.extend_from_slice(&meta.min_seq_no.to_le_bytes());
+        body.extend_from_slice(&meta.max_seq_no.to_le_bytes());
+        body.extend_from_slice(&(artifacts.len() as u32).to_le_bytes());
+        for (name, size, crc) in artifacts {
+            body.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            body.extend_from_slice(name.as_bytes());
+            body.extend_from_slice(&size.to_le_bytes());
+            body.extend_from_slice(&crc.to_le_bytes());
+        }
+        let envelope_crc = crc32fast::hash(&body);
+        body.extend_from_slice(&envelope_crc.to_le_bytes());
+        xerj_common::fsio::write_file_durable(
+            &segments_dir.join(format!("{}.complete", meta.id)),
+            &body,
+        )
+    }
+
+    fn stream_file_crc32(path: &Path) -> std::io::Result<u32> {
+        Self::stream_crc32_from_reader(std::fs::File::open(path)?)
+    }
+
+    fn stream_crc32_from_reader(mut reader: impl std::io::Read) -> std::io::Result<u32> {
+        let mut hasher = crc32fast::Hasher::new();
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let read = reader.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(hasher.finalize())
+    }
+
+    fn valid_flush_artifact_set(segment_id: &str, artifacts: &[(String, u64, u32)]) -> bool {
+        let prefix = format!("{segment_id}.");
+        let mut roles = std::collections::HashSet::new();
+        let mut fts: std::collections::HashMap<&str, std::collections::HashSet<&str>> =
+            std::collections::HashMap::new();
+        for (name, _, _) in artifacts {
+            if !name.starts_with(&prefix) || name.contains('/') || name.contains('\\') {
+                return false;
+            }
+            let rest = &name[prefix.len()..];
+            if matches!(rest, "seg" | "sidx" | "ids" | "dv") {
+                if !roles.insert(rest) {
+                    return false;
+                }
+                continue;
+            }
+            let Some((field, extension)) = rest.rsplit_once('.') else {
+                return false;
+            };
+            if field.is_empty()
+                || field.contains("..")
+                || !matches!(extension, "fst" | "post" | "meta" | "norms")
+                || !fts.entry(field).or_default().insert(extension)
+            {
+                return false;
+            }
+        }
+        roles.contains("seg")
+            && roles.contains("sidx")
+            && roles.contains("ids")
+            && fts.values().all(|extensions| {
+                ["fst", "post", "meta", "norms"]
+                    .iter()
+                    .all(|extension| extensions.contains(extension))
+            })
+    }
+
+    fn validate_flush_completion_manifest(
+        &self,
+        segment_id: &str,
+        doc_count: u64,
+        min_seq_no: u64,
+        max_seq_no: u64,
+    ) -> bool {
+        let dir = self.data_dir.join("segments");
+        const MAX_COMPLETION_MANIFEST_BYTES: u64 = 4 * 1024 * 1024;
+        let path = dir.join(format!("{segment_id}.complete"));
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            return false;
+        };
+        if metadata.len() > MAX_COMPLETION_MANIFEST_BYTES {
+            return false;
+        }
+        let Ok(bytes) = std::fs::read(path) else {
+            return false;
+        };
+        if bytes.len() < 4 + 2 + 8 * 3 + 4 + 4 || &bytes[..4] != b"ZCM1" {
+            return false;
+        }
+        let payload_len = bytes.len() - 4;
+        let expected_crc = u32::from_le_bytes(bytes[payload_len..].try_into().unwrap());
+        if crc32fast::hash(&bytes[..payload_len]) != expected_crc {
+            return false;
+        }
+        let mut pos = 4usize;
+        let take_u16 = |bytes: &[u8], pos: &mut usize| -> Option<u16> {
+            let value = u16::from_le_bytes(bytes.get(*pos..*pos + 2)?.try_into().ok()?);
+            *pos += 2;
+            Some(value)
+        };
+        let take_u32 = |bytes: &[u8], pos: &mut usize| -> Option<u32> {
+            let value = u32::from_le_bytes(bytes.get(*pos..*pos + 4)?.try_into().ok()?);
+            *pos += 4;
+            Some(value)
+        };
+        let take_u64 = |bytes: &[u8], pos: &mut usize| -> Option<u64> {
+            let value = u64::from_le_bytes(bytes.get(*pos..*pos + 8)?.try_into().ok()?);
+            *pos += 8;
+            Some(value)
+        };
+        let Some(id_len) = take_u16(&bytes, &mut pos).map(usize::from) else {
+            return false;
+        };
+        let Some(id_bytes) = bytes.get(pos..pos + id_len) else {
+            return false;
+        };
+        pos += id_len;
+        if id_bytes != segment_id.as_bytes()
+            || take_u64(&bytes, &mut pos) != Some(doc_count)
+            || take_u64(&bytes, &mut pos) != Some(min_seq_no)
+            || take_u64(&bytes, &mut pos) != Some(max_seq_no)
+        {
+            return false;
+        }
+        let Some(count) = take_u32(&bytes, &mut pos) else {
+            return false;
+        };
+        const MAX_MANIFEST_ARTIFACTS: u32 = 4096;
+        if count > MAX_MANIFEST_ARTIFACTS || count as usize > payload_len.saturating_sub(pos) / 14 {
+            return false;
+        }
+        let mut declared = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            let Some(name_len) = take_u16(&bytes, &mut pos).map(usize::from) else {
+                return false;
+            };
+            if name_len == 0 || name_len > 512 {
+                return false;
+            }
+            let Some(name_end) = pos.checked_add(name_len) else {
+                return false;
+            };
+            let Some(name) = bytes.get(pos..name_end) else {
+                return false;
+            };
+            pos = name_end;
+            let Ok(name) = std::str::from_utf8(name) else {
+                return false;
+            };
+            let Some(size) = take_u64(&bytes, &mut pos) else {
+                return false;
+            };
+            let Some(crc) = take_u32(&bytes, &mut pos) else {
+                return false;
+            };
+            declared.push((name.to_owned(), size, crc));
+        }
+        if pos != payload_len {
+            return false;
+        }
+        let prefix = format!("{segment_id}.");
+        let mut actual = Vec::new();
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return false;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !name.starts_with(&prefix) || name.ends_with(".complete") {
+                continue;
+            }
+            let Ok(metadata) = entry.metadata() else {
+                return false;
+            };
+            let Ok(crc) = Self::stream_file_crc32(&entry.path()) else {
+                return false;
+            };
+            actual.push((name, metadata.len(), crc));
+        }
+        actual.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        Self::valid_flush_artifact_set(segment_id, &declared) && declared == actual
     }
 
     /// Unlink every on-disk file belonging to the given segment ids — the
@@ -1077,6 +1342,101 @@ impl IndexStore {
         (removed_files, removed_bytes)
     }
 
+    /// Durably disarm ZID3 orphan recovery for snapshot-listed merge inputs
+    /// before the replacement snapshot is committed.
+    ///
+    /// Completion markers are removed before ids payloads. Removing ids is
+    /// required for legacy ZID1/ZID2 inputs, where ids alone are recovery
+    /// evidence. Snapshot-listed readers and restart rebuilds retain their
+    /// exact stored-section fallback when ids are absent.
+    pub fn disarm_orphan_recovery_for_segments(&self, segment_ids: &[SegmentId]) -> Result<()> {
+        // The hot flush path may debounce snapshot persistence. Persist the
+        // currently authoritative input set before removing its recovery
+        // markers; otherwise an aborted merge could make a recently flushed
+        // input neither snapshot-listed nor recoverable after restart.
+        self.save_snapshot()?;
+        self.unlink_recovery_markers(segment_ids, true)
+    }
+
+    /// Durably disarm every orphan-recovery generation for unpublished output.
+    ///
+    /// Completion markers are always attempted before ids. All requested
+    /// removals are attempted even after an error, and the directory is
+    /// fsynced before returning.
+    fn disarm_unpublished_segments(&self, segment_ids: &[SegmentId]) -> Result<()> {
+        self.unlink_recovery_markers(segment_ids, true)
+    }
+
+    fn rollback_unpublished_segment(&self, segment_id: &SegmentId) -> Result<()> {
+        let disarm = self.disarm_unpublished_segments(std::slice::from_ref(segment_id));
+        // Marker removal is the durability boundary. Remaining segment and
+        // sidecar files are unreachable cleanup and can be removed afterward.
+        self.delete_segment_files(std::slice::from_ref(segment_id));
+        disarm
+    }
+
+    fn abandon_unpublished_segment(
+        &self,
+        segment_id: &SegmentId,
+        publication_error: StorageError,
+    ) -> StorageError {
+        match self.rollback_unpublished_segment(segment_id) {
+            Ok(()) => publication_error,
+            Err(cleanup_error) => StorageError::Io(std::io::Error::other(format!(
+                "publication failed ({publication_error}); orphan-recovery disarm also failed ({cleanup_error})"
+            ))),
+        }
+    }
+
+    fn unlink_recovery_markers(
+        &self,
+        segment_ids: &[SegmentId],
+        remove_legacy_ids: bool,
+    ) -> Result<()> {
+        if segment_ids.is_empty() {
+            return Ok(());
+        }
+        let segments_dir = self.data_dir.join("segments");
+        let mut first_error: Option<std::io::Error> = None;
+        let mut operation = 0usize;
+        let suffixes: &[&str] = if remove_legacy_ids {
+            &["complete", "ids"]
+        } else {
+            &["complete"]
+        };
+        for suffix in suffixes {
+            for id in segment_ids {
+                let path = segments_dir.join(format!("{}.{suffix}", id.as_str()));
+                if let Err(error) = std::fs::remove_file(&path) {
+                    if error.kind() != std::io::ErrorKind::NotFound && first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+                #[cfg(test)]
+                if self.orphan_disarm_fail_after.load(Ordering::Acquire) == operation
+                    && first_error.is_none()
+                {
+                    first_error = Some(std::io::Error::other(format!(
+                        "injected orphan-recovery disarm failure after {}",
+                        path.display()
+                    )));
+                }
+                operation = operation.saturating_add(1);
+            }
+        }
+        if let Err(error) = xerj_common::fsio::fsync_dir(&segments_dir) {
+            if first_error.is_none() {
+                first_error = Some(error);
+            }
+        }
+        match first_error {
+            Some(error) => Err(StorageError::Io(std::io::Error::other(format!(
+                "orphan-recovery disarm incomplete: {error}"
+            )))),
+            None => Ok(()),
+        }
+    }
+
     /// Retire merged-away segments: delete their files **as soon as it is
     /// safe**, i.e. once no in-flight reader can still be holding a
     /// pre-merge segment list that references them.
@@ -1091,33 +1451,28 @@ impl IndexStore {
     /// [`SnapshotReadGuard`] lease; if any lease is outstanding the ids
     /// are parked in `retired_segments` and swept by the last lease drop.
     ///
-    /// The `.ids` side-car is unlinked IMMEDIATELY regardless of leases:
-    /// it is only read at open/recovery time (never on the query path),
-    /// and removing it up front keeps the disk-fix invariant that a crash
-    /// while deletions are deferred cannot let
-    /// `recover_orphaned_segments` resurrect the merged-away inputs as
-    /// duplicates on restart (recovery requires a valid `.ids`).  Any
-    /// other leftover files are removed by the on-open
-    /// `cleanup_orphaned_segment_files`.
+    /// Recovery evidence is unlinked IMMEDIATELY regardless of leases:
+    /// `.complete` first, then `.ids`. The segments directory is fsynced
+    /// before the ids enter the in-memory graveyard, so a crash while data
+    /// deletion is deferred cannot resurrect merged-away inputs. Any other
+    /// leftover files are removed by on-open orphan cleanup.
     ///
     /// Returns `(files_removed, bytes_removed)` — `(0, 0)` when deletion
     /// was deferred to the graveyard.
-    pub fn retire_segment_files(&self, segment_ids: &[SegmentId]) -> (usize, u64) {
+    pub fn retire_segment_files(&self, segment_ids: &[SegmentId]) -> Result<(usize, u64)> {
         if segment_ids.is_empty() {
-            return (0, 0);
+            return Ok((0, 0));
         }
-        // Kill the resurrection marker first (crash safety, see above).
-        let segments_dir = self.data_dir.join("segments");
-        for id in segment_ids {
-            let _ = std::fs::remove_file(segments_dir.join(format!("{}.ids", id.as_str())));
-        }
+        // Merge publication already removed completion markers before
+        // apply_merge. Remove ids as well before entering the graveyard.
+        self.disarm_unpublished_segments(segment_ids)?;
         {
             let mut graveyard = self.retired_segments.lock().unwrap();
             graveyard.extend_from_slice(segment_ids);
         }
         // Opportunistic sweep: deletes right away when no reader is active
         // (the common case), otherwise the last lease drop sweeps.
-        self.sweep_retired_segments()
+        Ok(self.sweep_retired_segments())
     }
 
     /// Delete the files of every graveyard segment, provided no read
@@ -1384,6 +1739,37 @@ impl IndexStore {
         Some(DrainedMemtable { entries })
     }
 
+    fn restore_internal_drain(&self, drained: &DrainedMemtable) {
+        let mut restored_bytes = 0u64;
+        for entry in &drained.entries {
+            let Some(current) = self.version_map.get(&entry.doc_id) else {
+                continue;
+            };
+            if current.seq_no != entry.seq_no || current.segment_id.as_ref() != IN_MEMORY_SEGMENT_ID
+            {
+                continue;
+            }
+            let shard = self.shard_for(&entry.doc_id);
+            let mut mem = self.memtable_shards[shard].lock().unwrap();
+            if mem.iter().any(|candidate| {
+                candidate.doc_id == entry.doc_id && candidate.seq_no == entry.seq_no
+            }) {
+                continue;
+            }
+            restored_bytes = restored_bytes.saturating_add(if !entry.source_bytes.is_empty() {
+                entry.source_bytes.len() as u64
+            } else {
+                entry
+                    .source
+                    .as_ref()
+                    .map_or(0, |source| source.to_string().len() as u64)
+            });
+            mem.push(entry.clone());
+        }
+        self.memtable_bytes
+            .fetch_add(restored_bytes, Ordering::Relaxed);
+    }
+
     /// Flush the memtable, but call `post_finish` with the fresh `SegmentMeta`
     /// BEFORE the in-memory snapshot is swapped.  This lets the caller write
     /// side-car files (e.g. the FTS index) that must be present *before*
@@ -1400,7 +1786,19 @@ impl IndexStore {
             Some(e) => e,
             None => return Ok(None),
         };
-        self.finalize_flush_with_publisher(drained, post_finish)
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.finalize_flush_with_publisher(&drained, post_finish)
+        }));
+        if !matches!(result, Ok(Ok(FlushFinalizeOutcome::Published { .. }))) {
+            self.restore_internal_drain(&drained);
+        }
+        match result {
+            Ok(result) => result.map(|outcome| match outcome {
+                FlushFinalizeOutcome::Empty => None,
+                FlushFinalizeOutcome::Published { meta, .. } => Some(meta),
+            }),
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     /// Finalise a flush using caller-supplied pre-drained memtable entries.
@@ -1411,15 +1809,15 @@ impl IndexStore {
     /// callers can release higher-level locks before calling this method.
     pub fn finalize_flush_with_publisher<F>(
         &self,
-        drained: DrainedMemtable,
+        drained: &DrainedMemtable,
         post_finish: F,
-    ) -> Result<Option<SegmentMeta>>
+    ) -> Result<FlushFinalizeOutcome>
     where
         F: FnOnce(&SegmentMeta) -> Result<()>,
     {
-        let entries = drained.entries;
+        let entries = &drained.entries;
         if entries.is_empty() {
-            return Ok(None);
+            return Ok(FlushFinalizeOutcome::Empty);
         }
 
         // THROWAWAY prof (XERJ_PROF): finalize phase breakdown.
@@ -1609,52 +2007,45 @@ impl IndexStore {
             info!(segment_id, object_key, "segment uploaded to object store");
         }
 
-        // V4 M4.8 — write a tiny `seg.ids` sidecar at flush time so
-        // `rebuild_version_map_from_segments` on reopen can pull
-        // `(doc_id, seq_no)` pairs directly without decoding the
-        // stored section + parsing JSON for every doc.  On the
-        // 66.5 M / 2 291-segment workload this drops cold restart
-        // from ~302 s to ~5 s and 15 GB peak RSS to ~500 MB.
-        //
-        // Format (V1, uncompressed):
-        //   "ZID1"            4 bytes magic
-        //   u32  num_docs
-        //   per doc:
-        //     u64  seq_no
-        //     u16  id_len
-        //     id_len bytes (UTF-8 doc_id)
-        //
-        // Format (V2, M5.18, LZ4-compressed):
-        //   "ZID2"            4 bytes magic
-        //   u32  num_docs
-        //   lz4_flex::compress_prepend_size(V1-body-sans-magic-and-numdocs)
-        //
-        // V2 compression ratio on real nginx ingest with synthetic
-        // doc_ids (`c0d0`, `c0d1`, …) runs 7-10× because the id
-        // stream has huge prefix repetition.  With real UUID-shaped
-        // ids LZ4 still gets ~2× because the u64 seq_nos step
-        // monotonically.  Reading V1 still works for old data dirs.
+        // Run the caller-supplied "build side-car files" step.  This must
+        // succeed BEFORE we publish the segment to the snapshot — otherwise
+        // a racing query could open the segment and find the side-cars
+        // (e.g. FTS index) missing, returning wrong results.
+        let t_pf = std::time::Instant::now();
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| post_finish(&meta))) {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                return Err(self.abandon_unpublished_segment(&segment_id, error));
+            }
+            Err(payload) => {
+                if let Err(cleanup_error) = self.rollback_unpublished_segment(&segment_id) {
+                    return Err(StorageError::Io(std::io::Error::other(format!(
+                        "publisher panicked; orphan-recovery disarm also failed ({cleanup_error})"
+                    ))));
+                }
+                std::panic::resume_unwind(payload);
+            }
+        }
+        let prof_pf_us = t_pf.elapsed().as_micros();
+
+        // Write the ZID3 document-ID sidecar only after every required caller
+        // sidecar succeeded. ZID3 itself is not evidence of completion:
+        // orphan recovery requires the completion manifest written
+        // immediately afterward. Keeping it after FTS/DV also avoids a
+        // misleading near-complete family when sidecar construction fails.
         {
             let pairs: Vec<(u64, &str)> = entries
                 .iter()
                 .filter(|e| e.source.is_some())
                 .map(|e| (e.seq_no, e.doc_id.as_str()))
                 .collect();
-            if let Err(e) = self.write_ids_sidecar(meta.id.as_str(), &pairs) {
-                tracing::warn!(
-                    segment_id = meta.id.as_str(),
-                    "failed to write seg.ids sidecar: {e}"
-                );
+            if let Err(error) = self.write_ids_sidecar_v3(meta.id.as_str(), &pairs) {
+                return Err(self.abandon_unpublished_segment(&segment_id, error.into()));
             }
         }
-
-        // Run the caller-supplied "build side-car files" step.  This must
-        // succeed BEFORE we publish the segment to the snapshot — otherwise
-        // a racing query could open the segment and find the side-cars
-        // (e.g. FTS index) missing, returning wrong results.
-        let t_pf = std::time::Instant::now();
-        post_finish(&meta)?;
-        let prof_pf_us = t_pf.elapsed().as_micros();
+        if let Err(error) = self.write_flush_completion_manifest(&meta) {
+            return Err(self.abandon_unpublished_segment(&segment_id, error.into()));
+        }
 
         // Update version map: point live docs at the new segment.
         //
@@ -1670,31 +2061,109 @@ impl IndexStore {
         // updates/deletes are left untouched.
         let t_vm = std::time::Instant::now();
         let segment_id_arc: std::sync::Arc<str> = std::sync::Arc::from(segment_id.as_str());
-        for entry in &entries {
-            if entry.source.is_some() {
-                self.version_map.repoint(
-                    &entry.doc_id,
-                    entry.seq_no,
-                    std::sync::Arc::clone(&segment_id_arc),
-                );
-            } else {
-                // RC4 W2 #14 — repoint the delete's tombstone off
-                // `__memtable__` onto the segment that now durably
-                // carries it (the ZTB2 section written above; the
-                // segment + section were fsynced by `writer.finish`).
-                // Guarded (`set_if_latest`): a doc re-indexed while this
-                // flush ran has a strictly newer live entry that must
-                // not be clobbered back to deleted.  Once
-                // segment-resident, `sweep_pending_deletes` unpins the
-                // WAL shard and `wal_pair_durable` lets the Delete
-                // entry prune.
-                self.version_map.set_if_latest(
-                    &entry.doc_id,
-                    entry.seq_no,
-                    std::sync::Arc::clone(&segment_id_arc),
-                    true,
-                );
+        let rollback_journal: Vec<(String, u64, Option<crate::version_map::VersionEntry>)> =
+            entries
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.doc_id.clone(),
+                        entry.seq_no,
+                        self.version_map.get(&entry.doc_id),
+                    )
+                })
+                .collect();
+        let publication = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            #[cfg(test)]
+            if self.publication_failpoint.load(Ordering::Acquire) == 1 {
+                panic!("injected failure before version-map publication");
             }
+            for entry in entries {
+                if entry.source.is_some() {
+                    self.version_map.repoint(
+                        &entry.doc_id,
+                        entry.seq_no,
+                        std::sync::Arc::clone(&segment_id_arc),
+                    );
+                } else {
+                    // RC4 W2 #14 — repoint the delete's tombstone off
+                    // `__memtable__` onto the segment that now durably
+                    // carries it (the ZTB2 section written above; the
+                    // segment + section were fsynced by `writer.finish`).
+                    // Guarded (`set_if_latest`): a doc re-indexed while this
+                    // flush ran has a strictly newer live entry that must
+                    // not be clobbered back to deleted.  Once
+                    // segment-resident, `sweep_pending_deletes` unpins the
+                    // WAL shard and `wal_pair_durable` lets the Delete
+                    // entry prune.
+                    self.version_map.set_if_latest(
+                        &entry.doc_id,
+                        entry.seq_no,
+                        std::sync::Arc::clone(&segment_id_arc),
+                        true,
+                    );
+                }
+                #[cfg(test)]
+                if self.publication_failpoint.load(Ordering::Acquire) == 2 {
+                    panic!("injected failure during version-map publication");
+                }
+                #[cfg(test)]
+                if self.publication_failpoint.load(Ordering::Acquire) == 5 {
+                    self.version_map.set(
+                        &entry.doc_id,
+                        entry.seq_no + 1,
+                        crate::version_map::IN_MEMORY_SEGMENT_ID,
+                        false,
+                    );
+                    panic!("injected newer PUT during publication rollback");
+                }
+                #[cfg(test)]
+                if self.publication_failpoint.load(Ordering::Acquire) == 6 {
+                    self.version_map
+                        .delete(
+                            &entry.doc_id,
+                            entry.seq_no + 1,
+                            crate::version_map::IN_MEMORY_SEGMENT_ID,
+                        )
+                        .unwrap();
+                    panic!("injected newer DELETE during publication rollback");
+                }
+            }
+            #[cfg(test)]
+            if self.publication_failpoint.load(Ordering::Acquire) == 3 {
+                panic!("injected failure immediately before snapshot publication");
+            }
+            self.snapshot
+                .rcu(|old| Arc::new(old.with_new_segment(meta.clone())));
+            #[cfg(test)]
+            if self.publication_failpoint.load(Ordering::Acquire) == 4 {
+                panic!("injected failure immediately after snapshot publication");
+            }
+        }));
+        if publication.is_err() {
+            let published = self
+                .snapshot
+                .load()
+                .segments
+                .iter()
+                .any(|candidate| candidate.id == segment_id);
+            if published {
+                warn!(
+                    segment_id,
+                    "post-publication panic caught; maintenance deferred"
+                );
+                return Ok(FlushFinalizeOutcome::Published {
+                    meta,
+                    maintenance_deferred: true,
+                });
+            }
+            for (doc_id, seq_no, prior) in rollback_journal.into_iter().rev() {
+                self.version_map
+                    .rollback_repoint(&doc_id, seq_no, &segment_id, prior);
+            }
+            let publication_error = StorageError::Io(std::io::Error::other(
+                "segment publication failed before snapshot commit",
+            ));
+            return Err(self.abandon_unpublished_segment(&segment_id, publication_error));
         }
         if prof {
             eprintln!(
@@ -1722,9 +2191,6 @@ impl IndexStore {
         // ~30 % of `_refresh` calls losing 1-2 docs after 6-doc
         // sequential PUTs in the YAML suite (110_field_collapsing
         // setup, et al.).
-        self.snapshot
-            .rcu(|old| Arc::new(old.with_new_segment(meta.clone())));
-
         // V4 M4 — checkpoint + rotate + prune, NOW time-gated.
         //
         // Pre-gate: this loop ran for ALL 16 WAL shards on EVERY
@@ -1782,7 +2248,17 @@ impl IndexStore {
             if let Err(e) = self.persist_pending_tombstones() {
                 warn!(error = %e, "tombstone persistence failed — deletes stay WAL-pinned");
             }
-            self.save_snapshot()?;
+            if let Err(error) = self.save_snapshot() {
+                warn!(error = %error, segment_id, "snapshot persistence deferred after in-memory publication; WAL remains authoritative");
+                info!(
+                    segment_id,
+                    doc_count, min_seq, max_seq, "segment published with deferred maintenance"
+                );
+                return Ok(FlushFinalizeOutcome::Published {
+                    meta,
+                    maintenance_deferred: true,
+                });
+            }
             // RC4 W1 #8 — verified maintenance (see
             // `wal_maintain_all_verified`).  The pre-fix loop here
             // checkpointed EVERY shard with THIS segment's `max_seq` and
@@ -1800,11 +2276,16 @@ impl IndexStore {
             // holding unproven entries are retained (that retention IS the
             // fix) and reclaimed on a later tick once their docs flush.
             let durable_max = self.snapshot.load().max_seq_no;
-            self.wal_maintain_all_verified(durable_max)?;
+            if let Err(error) = self.wal_maintain_all_verified(durable_max) {
+                warn!(error = %error, segment_id, "WAL maintenance deferred after segment publication");
+            }
         }
 
         info!(segment_id, doc_count, min_seq, max_seq, "segment flushed");
-        Ok(Some(meta))
+        Ok(FlushFinalizeOutcome::Published {
+            meta,
+            maintenance_deferred: false,
+        })
     }
 
     /// Flush if the memtable is over the configured threshold.
@@ -2075,6 +2556,12 @@ impl IndexStore {
     /// The caller must persist the snapshot (`save_snapshot`) BEFORE this
     /// runs so every segment the proofs point at is registered on disk.
     fn wal_maintain_all_verified(&self, durable_max_seq: SeqNo) -> Result<()> {
+        #[cfg(test)]
+        if self.fail_next_wal_maintenance.swap(false, Ordering::AcqRel) {
+            return Err(StorageError::Io(std::io::Error::other(
+                "injected post-publication WAL maintenance failure",
+            )));
+        }
         self.sweep_pending_deletes();
         for (ws_idx, ws) in self.wal_shards.iter().enumerate() {
             let mut wal = ws.lock().unwrap();
@@ -2388,6 +2875,12 @@ impl IndexStore {
     }
 
     fn save_snapshot(&self) -> Result<()> {
+        #[cfg(test)]
+        if self.fail_next_snapshot_save.swap(false, Ordering::AcqRel) {
+            return Err(StorageError::Io(std::io::Error::other(
+                "injected post-publication snapshot save failure",
+            )));
+        }
         let snap = self.snapshot.load();
         // P2.3 — `to_vec` (compact) not `to_vec_pretty`: the snapshot is a
         // machine-read manifest (loaded via `from_slice`), never
@@ -2559,10 +3052,12 @@ impl IndexStore {
             // decode path for legacy segments without the sidecar.
             let ids_path = segments_dir.join(format!("{}.ids", meta.id.as_str()));
             if let Ok(bytes) = std::fs::read(&ids_path) {
-                if bytes.len() >= 8 && (&bytes[..4] == b"ZID1" || &bytes[..4] == b"ZID2") {
+                if bytes.len() >= 8
+                    && (&bytes[..4] == b"ZID1" || &bytes[..4] == b"ZID2" || &bytes[..4] == b"ZID3")
+                {
                     let num = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
                     // V2 = LZ4-compressed body after the 8-byte header.
-                    let body: Vec<u8> = if &bytes[..4] == b"ZID2" {
+                    let body: Vec<u8> = if &bytes[..4] == b"ZID2" || &bytes[..4] == b"ZID3" {
                         match lz4_flex::decompress_size_prepended(&bytes[8..]) {
                             Ok(v) => v,
                             Err(e) => {
@@ -2837,6 +3332,12 @@ impl IndexStore {
     /// atomically replace merged segments with the merged result and update
     /// the version map.
     pub fn apply_merge(&self, merged_ids: &[SegmentId], new_meta: SegmentMeta) -> Result<()> {
+        // Inputs still belong to the authoritative snapshot at this point.
+        // Durably remove their ZID3 completion markers before committing the
+        // replacement, so no crash after snapshot publication can resurrect
+        // a partially retired input. The ids sidecars stay readable if this
+        // step fails and the merge is aborted.
+        self.disarm_orphan_recovery_for_segments(merged_ids)?;
         // Sum the doc counts of the segments we're about to replace, so we can
         // tell whether this merge actually dropped any documents.
         let merged_total: u64 = {
@@ -3389,6 +3890,644 @@ mod tests {
     }
 
     #[test]
+    fn completion_manifest_rejects_corruption_and_noncanonical_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_test_store(dir.path());
+        let segment_id = "12345678-1234-1234-1234-123456789abc";
+        let segments = dir.path().join("segments");
+        let seg_name = format!("{segment_id}.seg");
+        let sidx_name = format!("{segment_id}.sidx");
+        let ids_name = format!("{segment_id}.ids");
+        std::fs::write(segments.join(&seg_name), b"segment").unwrap();
+        std::fs::write(segments.join(&sidx_name), b"sidx").unwrap();
+        std::fs::write(segments.join(&ids_name), b"ids").unwrap();
+        let meta = SegmentMeta {
+            id: segment_id.to_owned(),
+            doc_count: 2,
+            size_bytes: 7,
+            min_seq_no: 10,
+            max_seq_no: 11,
+            created_at_ms: 0,
+            has_tombstones: false,
+            seg_path: seg_name.clone(),
+            sidx_path: format!("{segment_id}.sidx"),
+        };
+        store.write_flush_completion_manifest(&meta).unwrap();
+        assert!(store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+
+        let complete = segments.join(format!("{segment_id}.complete"));
+        let canonical = std::fs::read(&complete).unwrap();
+        let write_records = |records: &[(&str, u64, u32)]| {
+            let mut body = Vec::new();
+            body.extend_from_slice(b"ZCM1");
+            body.extend_from_slice(&(segment_id.len() as u16).to_le_bytes());
+            body.extend_from_slice(segment_id.as_bytes());
+            body.extend_from_slice(&2u64.to_le_bytes());
+            body.extend_from_slice(&10u64.to_le_bytes());
+            body.extend_from_slice(&11u64.to_le_bytes());
+            body.extend_from_slice(&(records.len() as u32).to_le_bytes());
+            for (name, size, crc) in records {
+                body.extend_from_slice(&(name.len() as u16).to_le_bytes());
+                body.extend_from_slice(name.as_bytes());
+                body.extend_from_slice(&size.to_le_bytes());
+                body.extend_from_slice(&crc.to_le_bytes());
+            }
+            body.extend_from_slice(&crc32fast::hash(&body).to_le_bytes());
+            std::fs::write(&complete, body).unwrap();
+        };
+        let seg_record = (seg_name.as_str(), 7, crc32fast::hash(b"segment"));
+        let sidx_record = (sidx_name.as_str(), 4, crc32fast::hash(b"sidx"));
+        let ids_record = (ids_name.as_str(), 3, crc32fast::hash(b"ids"));
+
+        let rewrite_crc = |bytes: &mut Vec<u8>| {
+            let payload_len = bytes.len() - 4;
+            let crc = crc32fast::hash(&bytes[..payload_len]);
+            bytes[payload_len..].copy_from_slice(&crc.to_le_bytes());
+        };
+        let mut unknown_version = canonical.clone();
+        unknown_version[..4].copy_from_slice(b"ZCM9");
+        rewrite_crc(&mut unknown_version);
+        std::fs::write(&complete, unknown_version).unwrap();
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+
+        let mut huge_count = canonical.clone();
+        let count_offset = 4 + 2 + segment_id.len() + 8 * 3;
+        huge_count[count_offset..count_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+        rewrite_crc(&mut huge_count);
+        std::fs::write(&complete, huge_count).unwrap();
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+
+        let mut corrupt_envelope = canonical.clone();
+        *corrupt_envelope.last_mut().unwrap() ^= 1;
+        std::fs::write(&complete, corrupt_envelope).unwrap();
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+
+        let mut corrupt_payload = canonical.clone();
+        corrupt_payload[6] ^= 1;
+        std::fs::write(&complete, corrupt_payload).unwrap();
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+
+        write_records(&[seg_record, sidx_record]);
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+        write_records(&[
+            (seg_name.as_str(), 8, seg_record.2),
+            sidx_record,
+            ids_record,
+        ]);
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+        write_records(&[(seg_name.as_str(), 7, 0), sidx_record, ids_record]);
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+        write_records(&[seg_record, sidx_record, ids_record]);
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+        write_records(&[seg_record, seg_record, sidx_record, ids_record]);
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+        write_records(&[("../escape", 7, seg_record.2), sidx_record, ids_record]);
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+
+        std::fs::write(&complete, canonical).unwrap();
+        std::fs::remove_file(segments.join(&ids_name)).unwrap();
+        assert!(!store.validate_flush_completion_manifest(segment_id, 2, 10, 11));
+        store.cleanup_orphaned_segment_files().unwrap();
+        assert!(!complete.exists(), "orphan cleanup must remove `.complete`");
+    }
+
+    #[test]
+    fn artifact_crc_streams_large_inputs_in_bounded_chunks() {
+        struct TrackingReader {
+            remaining: usize,
+            max_request: Arc<std::sync::atomic::AtomicUsize>,
+        }
+        impl std::io::Read for TrackingReader {
+            fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+                self.max_request.fetch_max(buffer.len(), Ordering::Relaxed);
+                let count = self.remaining.min(buffer.len());
+                buffer[..count].fill(0x5a);
+                self.remaining -= count;
+                Ok(count)
+            }
+        }
+        let max_request = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let total = 8 * 1024 * 1024 + 17;
+        let crc = IndexStore::stream_crc32_from_reader(TrackingReader {
+            remaining: total,
+            max_request: Arc::clone(&max_request),
+        })
+        .unwrap();
+        let mut expected = crc32fast::Hasher::new();
+        for _ in 0..128 {
+            expected.update(&[0x5a; 64 * 1024]);
+        }
+        expected.update(&[0x5a; 17]);
+        assert_eq!(crc, expected.finalize());
+        assert_eq!(max_request.load(Ordering::Relaxed), 64 * 1024);
+    }
+
+    #[test]
+    fn orphan_recovery_rejects_incomplete_v3_and_malformed_legacy_ids() {
+        enum Mutation {
+            V3WithoutComplete,
+            OversizedComplete,
+            LegacyPartial,
+            LegacyTrailing,
+            LegacyHeaderMismatch,
+            LegacyInvalidUtf8,
+        }
+        for mutation in [
+            Mutation::V3WithoutComplete,
+            Mutation::OversizedComplete,
+            Mutation::LegacyPartial,
+            Mutation::LegacyTrailing,
+            Mutation::LegacyHeaderMismatch,
+            Mutation::LegacyInvalidUtf8,
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let segment_id;
+            {
+                let store = open_test_store(dir.path());
+                store.save_snapshot().unwrap();
+                let empty_snapshot = std::fs::read(dir.path().join("snapshot.json")).unwrap();
+                store.index("doc", serde_json::json!({"v": 1})).unwrap();
+                segment_id = store.flush().unwrap().unwrap().id;
+                std::fs::write(dir.path().join("snapshot.json"), empty_snapshot).unwrap();
+                let segments = dir.path().join("segments");
+                let ids = segments.join(format!("{segment_id}.ids"));
+                let complete = segments.join(format!("{segment_id}.complete"));
+                if !matches!(mutation, Mutation::OversizedComplete) {
+                    std::fs::remove_file(&complete).unwrap();
+                }
+                match mutation {
+                    Mutation::V3WithoutComplete => {}
+                    Mutation::OversizedComplete => {
+                        std::fs::write(complete, vec![0u8; 4 * 1024 * 1024 + 1]).unwrap();
+                    }
+                    Mutation::LegacyPartial => {
+                        let mut bytes = Vec::from(&b"ZID1"[..]);
+                        bytes.extend_from_slice(&1u32.to_le_bytes());
+                        bytes.extend_from_slice(&1u64.to_le_bytes());
+                        bytes.extend_from_slice(&4u16.to_le_bytes());
+                        bytes.extend_from_slice(b"do");
+                        std::fs::write(ids, bytes).unwrap();
+                    }
+                    Mutation::LegacyTrailing => {
+                        let mut bytes = Vec::from(&b"ZID1"[..]);
+                        bytes.extend_from_slice(&1u32.to_le_bytes());
+                        bytes.extend_from_slice(&1u64.to_le_bytes());
+                        bytes.extend_from_slice(&3u16.to_le_bytes());
+                        bytes.extend_from_slice(b"doc");
+                        bytes.push(0xff);
+                        std::fs::write(ids, bytes).unwrap();
+                    }
+                    Mutation::LegacyHeaderMismatch => {
+                        store
+                            .write_ids_sidecar(&segment_id, &[(999, "doc")])
+                            .unwrap();
+                    }
+                    Mutation::LegacyInvalidUtf8 => {
+                        let mut bytes = Vec::from(&b"ZID1"[..]);
+                        bytes.extend_from_slice(&1u32.to_le_bytes());
+                        bytes.extend_from_slice(&1u64.to_le_bytes());
+                        bytes.extend_from_slice(&1u16.to_le_bytes());
+                        bytes.push(0xff);
+                        std::fs::write(ids, bytes).unwrap();
+                    }
+                }
+                drop(store);
+            }
+            let reopened = open_test_store(dir.path());
+            assert!(
+                reopened
+                    .snapshot()
+                    .segments
+                    .iter()
+                    .all(|segment| segment.id != segment_id),
+                "malformed/incomplete orphan was recovered"
+            );
+            assert!(
+                !dir.path()
+                    .join("segments")
+                    .join(format!("{segment_id}.seg"))
+                    .exists(),
+                "rejected orphan family must be cleaned"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_zid3_orphan_recovers_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let empty_snapshot;
+        let segment_id;
+        {
+            let store = open_test_store(dir.path());
+            store.save_snapshot().unwrap();
+            empty_snapshot = std::fs::read(dir.path().join("snapshot.json")).unwrap();
+            store.index("doc", serde_json::json!({"v": 1})).unwrap();
+            segment_id = store.flush().unwrap().unwrap().id;
+            assert!(dir
+                .path()
+                .join("segments")
+                .join(format!("{segment_id}.complete"))
+                .exists());
+        }
+        std::fs::write(dir.path().join("snapshot.json"), empty_snapshot).unwrap();
+        let reopened = open_test_store(dir.path());
+        assert_eq!(reopened.snapshot().segments.len(), 1);
+        assert_eq!(reopened.snapshot().segments[0].id, segment_id);
+        assert_eq!(
+            reopened.version_map.get("doc").unwrap().segment_id.as_ref(),
+            segment_id
+        );
+        drop(reopened);
+        let reopened_again = open_test_store(dir.path());
+        assert_eq!(reopened_again.snapshot().segments.len(), 1);
+        assert_eq!(reopened_again.snapshot().segments[0].id, segment_id);
+    }
+
+    #[test]
+    fn direct_flush_failure_restores_for_retry_and_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_test_store(dir.path());
+        store
+            .index("direct-survivor", serde_json::json!({"value": 7}))
+            .unwrap();
+        let failed = store.flush_with_publisher(|_| {
+            Err(StorageError::Io(std::io::Error::other(
+                "injected direct publisher failure",
+            )))
+        });
+        assert!(failed.is_err());
+        assert!(store.snapshot().segments.is_empty());
+        assert_eq!(
+            store
+                .memtable_shards
+                .iter()
+                .map(|shard| shard.lock().unwrap().len())
+                .sum::<usize>(),
+            1
+        );
+        assert_eq!(
+            store
+                .version_map
+                .get("direct-survivor")
+                .unwrap()
+                .segment_id
+                .as_ref(),
+            IN_MEMORY_SEGMENT_ID
+        );
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = store.flush_with_publisher(|_| -> Result<()> {
+                panic!("injected direct publisher panic")
+            });
+        }));
+        assert!(panicked.is_err());
+        assert_eq!(
+            store
+                .memtable_shards
+                .iter()
+                .map(|shard| shard.lock().unwrap().len())
+                .sum::<usize>(),
+            1,
+            "direct panic must restore exactly one retry owner"
+        );
+
+        let meta = store.flush().unwrap().expect("restored drain must retry");
+        assert_eq!(meta.doc_count, 1);
+        drop(store);
+
+        let reopened = open_test_store(dir.path());
+        assert_eq!(reopened.snapshot().segments.len(), 1);
+        assert_eq!(
+            reopened
+                .version_map
+                .get("direct-survivor")
+                .unwrap()
+                .segment_id
+                .as_ref(),
+            meta.id
+        );
+    }
+
+    #[test]
+    fn prepublication_rollback_cannot_recover_restored_nonmarker_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_test_store(dir.path());
+        store
+            .index("rollback-doc", serde_json::json!({"v": 1}))
+            .unwrap();
+        let drained = store.take_memtable_for_flush().unwrap();
+        store.publication_failpoint.store(1, Ordering::Release);
+        assert!(store
+            .finalize_flush_with_publisher(&drained, |_| Ok(()))
+            .is_err());
+        store.publication_failpoint.store(0, Ordering::Release);
+
+        let segments = dir.path().join("segments");
+        let segment_id = std::fs::read_dir(&segments)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .find_map(|entry| {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                name.strip_suffix(".seg").map(str::to_owned)
+            });
+        assert!(segment_id.is_none(), "ordinary cleanup should remove data");
+
+        // Model a crash image that retained non-marker files after the
+        // directory fsync. No complete/ids evidence may accompany them.
+        let fake_id = uuid::Uuid::new_v4().to_string();
+        std::fs::write(segments.join(format!("{fake_id}.seg")), b"leftover").unwrap();
+        std::fs::write(segments.join(format!("{fake_id}.sidx")), b"leftover").unwrap();
+        assert!(!segments.join(format!("{fake_id}.complete")).exists());
+        assert!(!segments.join(format!("{fake_id}.ids")).exists());
+        drop(store);
+
+        let reopened = open_test_store(dir.path());
+        assert!(reopened
+            .snapshot()
+            .segments
+            .iter()
+            .all(|segment| segment.id != fake_id));
+        assert!(!segments.join(format!("{fake_id}.seg")).exists());
+    }
+
+    #[test]
+    fn partial_multi_input_disarm_aborts_merge_and_restarts_inputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_test_store(dir.path());
+        store.index("merge-a", serde_json::json!({"v": 1})).unwrap();
+        store.flush().unwrap();
+        store.index("merge-b", serde_json::json!({"v": 2})).unwrap();
+        store.flush().unwrap();
+        let ids: Vec<_> = store
+            .snapshot()
+            .segments
+            .iter()
+            .map(|segment| segment.id.clone())
+            .collect();
+        assert_eq!(ids.len(), 2);
+        store.orphan_disarm_fail_after.store(0, Ordering::Release);
+        let executor = crate::merge::MergeExecutor::new(
+            Arc::clone(&store),
+            crate::merge::MergeConfig {
+                io_rate_mb_per_sec: 0,
+                ..Default::default()
+            },
+        );
+        assert!(executor.execute_merge(&ids).is_err());
+        assert_eq!(store.snapshot().segments.len(), 2);
+        for id in &ids {
+            assert!(!dir
+                .path()
+                .join("segments")
+                .join(format!("{id}.complete"))
+                .exists());
+            assert!(store.open_segment(id).is_ok());
+        }
+        store
+            .orphan_disarm_fail_after
+            .store(usize::MAX, Ordering::Release);
+        assert_eq!(
+            IndexStore::load_snapshot(dir.path())
+                .unwrap()
+                .unwrap()
+                .segments
+                .len(),
+            2,
+            "failed merge must not change the persisted snapshot"
+        );
+        drop(store);
+
+        let reopened = open_test_store(dir.path());
+        assert_eq!(reopened.snapshot().segments.len(), 2);
+        for id in &ids {
+            assert!(reopened.open_segment(id).is_ok());
+        }
+        assert!(reopened.version_map.get("merge-a").is_some());
+        assert!(reopened.version_map.get("merge-b").is_some());
+    }
+
+    fn rewrite_ids_as_legacy(segments: &Path, segment_id: &str, magic: &[u8; 4]) {
+        let path = segments.join(format!("{segment_id}.ids"));
+        let current = std::fs::read(&path).unwrap();
+        assert_eq!(&current[..4], b"ZID3");
+        let mut legacy = Vec::from(&magic[..]);
+        legacy.extend_from_slice(&current[4..8]);
+        if magic == b"ZID1" {
+            legacy.extend_from_slice(&lz4_flex::decompress_size_prepended(&current[8..]).unwrap());
+        } else {
+            legacy.extend_from_slice(&current[8..]);
+        }
+        std::fs::write(path, legacy).unwrap();
+        std::fs::remove_file(segments.join(format!("{segment_id}.complete"))).unwrap();
+    }
+
+    #[test]
+    fn valid_zid1_and_zid2_orphans_recover_exactly_once() {
+        for magic in [b"ZID1", b"ZID2"] {
+            let dir = tempfile::tempdir().unwrap();
+            let empty_snapshot;
+            let segment_id;
+            {
+                let store = open_test_store(dir.path());
+                store.save_snapshot().unwrap();
+                empty_snapshot = std::fs::read(dir.path().join("snapshot.json")).unwrap();
+                store
+                    .index("legacy-doc", serde_json::json!({"v": 1}))
+                    .unwrap();
+                segment_id = store.flush().unwrap().unwrap().id;
+            }
+            rewrite_ids_as_legacy(&dir.path().join("segments"), &segment_id, magic);
+            std::fs::write(dir.path().join("snapshot.json"), &empty_snapshot).unwrap();
+
+            let reopened = open_test_store(dir.path());
+            assert_eq!(reopened.snapshot().segments.len(), 1);
+            assert_eq!(reopened.snapshot().segments[0].id, segment_id);
+            assert_eq!(
+                reopened
+                    .version_map
+                    .get("legacy-doc")
+                    .unwrap()
+                    .segment_id
+                    .as_ref(),
+                segment_id
+            );
+            drop(reopened);
+
+            let reopened_again = open_test_store(dir.path());
+            assert_eq!(reopened_again.snapshot().segments.len(), 1);
+            assert_eq!(reopened_again.snapshot().segments[0].id, segment_id);
+        }
+    }
+
+    #[test]
+    fn snapshot_listed_legacy_segments_open_after_upgrade_without_complete_manifest() {
+        for magic in [b"ZID1", b"ZID2"] {
+            let dir = tempfile::tempdir().unwrap();
+            let segment_id;
+            {
+                let store = open_test_store(dir.path());
+                store
+                    .index("legacy-doc", serde_json::json!({"v": 1}))
+                    .unwrap();
+                segment_id = store.flush().unwrap().unwrap().id;
+            }
+            rewrite_ids_as_legacy(&dir.path().join("segments"), &segment_id, magic);
+
+            let reopened = open_test_store(dir.path());
+            assert_eq!(reopened.snapshot().segments.len(), 1);
+            assert_eq!(reopened.snapshot().segments[0].id, segment_id);
+            assert_eq!(
+                reopened
+                    .open_segment(&segment_id)
+                    .unwrap()
+                    .header()
+                    .doc_count,
+                1
+            );
+            assert_eq!(
+                reopened
+                    .version_map
+                    .get("legacy-doc")
+                    .unwrap()
+                    .segment_id
+                    .as_ref(),
+                segment_id
+            );
+        }
+    }
+
+    #[test]
+    fn postpublication_maintenance_failures_retain_wal_and_never_duplicate() {
+        for fail_snapshot in [true, false] {
+            let dir = tempfile::tempdir().unwrap();
+            let segment_id;
+            {
+                let store = open_test_store(dir.path());
+                store.index("only", serde_json::json!({"v": 1})).unwrap();
+                if fail_snapshot {
+                    store.fail_next_snapshot_save.store(true, Ordering::Release);
+                } else {
+                    store
+                        .fail_next_wal_maintenance
+                        .store(true, Ordering::Release);
+                }
+                let meta = store
+                    .flush()
+                    .expect("post-publication maintenance is deferred, not a flush error")
+                    .expect("one segment published");
+                segment_id = meta.id;
+                assert_eq!(store.snapshot().segments.len(), 1);
+                assert_eq!(
+                    store.version_map.get("only").unwrap().segment_id.as_ref(),
+                    segment_id
+                );
+                assert!(
+                    wal_bytes(&store).iter().any(|(_, bytes)| !bytes.is_empty()),
+                    "deferred maintenance must retain a replayable WAL"
+                );
+                assert!(store.flush().unwrap().is_none(), "retry must not duplicate");
+                assert_eq!(store.snapshot().segments.len(), 1);
+            }
+
+            let reopened = open_test_store(dir.path());
+            let snap = reopened.snapshot();
+            assert_eq!(snap.segments.len(), 1, "restart must recover exactly once");
+            assert_eq!(snap.segments[0].id, segment_id);
+            let live = reopened.version_map.get("only").unwrap();
+            assert!(!live.deleted);
+            assert_eq!(live.segment_id.as_ref(), segment_id);
+            drop(snap);
+            assert!(reopened.flush().unwrap().is_none());
+            assert_eq!(reopened.snapshot().segments.len(), 1);
+        }
+    }
+
+    #[test]
+    fn publication_journal_rolls_back_before_rcu_and_commits_after_rcu() {
+        for stage in 1u8..=4 {
+            let dir = tempfile::tempdir().unwrap();
+            let store = open_test_store(dir.path());
+            store.index("only", serde_json::json!({"v": 1})).unwrap();
+            let drained = store.take_memtable_for_flush().unwrap();
+            store.publication_failpoint.store(stage, Ordering::Release);
+            let outcome = store.finalize_flush_with_publisher(&drained, |_| Ok(()));
+
+            if stage <= 3 {
+                assert!(outcome.is_err(), "stage {stage} is pre-publication");
+                assert!(store.snapshot().segments.is_empty());
+                let current = store.version_map.get("only").unwrap();
+                assert_eq!(
+                    current.segment_id.as_ref(),
+                    crate::version_map::IN_MEMORY_SEGMENT_ID
+                );
+                assert!(
+                    std::fs::read_dir(dir.path().join("segments"))
+                        .unwrap()
+                        .flatten()
+                        .next()
+                        .is_none(),
+                    "precommit rollback must remove the complete artifact family"
+                );
+            } else {
+                let FlushFinalizeOutcome::Published {
+                    meta,
+                    maintenance_deferred,
+                } = outcome.unwrap()
+                else {
+                    panic!("post-RCU panic must return Published")
+                };
+                assert!(maintenance_deferred);
+                assert_eq!(store.snapshot().segments.len(), 1);
+                assert_eq!(store.snapshot().segments[0].id, meta.id);
+                assert_eq!(
+                    store.version_map.get("only").unwrap().segment_id.as_ref(),
+                    meta.id
+                );
+            }
+            assert!(
+                wal_bytes(&store).iter().any(|(_, bytes)| !bytes.is_empty()),
+                "publication failpoint must retain WAL"
+            );
+            drop(store);
+            let reopened = open_test_store(dir.path());
+            assert!(reopened
+                .version_map
+                .get("only")
+                .filter(|entry| !entry.deleted)
+                .is_some());
+            assert!(reopened.snapshot().segments.len() <= 1);
+        }
+    }
+
+    #[test]
+    fn publication_rollback_never_overwrites_newer_put_or_delete() {
+        for stage in [5u8, 6u8] {
+            let dir = tempfile::tempdir().unwrap();
+            let store = open_test_store(dir.path());
+            store.index("same", serde_json::json!({"v": 1})).unwrap();
+            let drained = store.take_memtable_for_flush().unwrap();
+            let old_seq = drained.entries[0].seq_no;
+            store.publication_failpoint.store(stage, Ordering::Release);
+            assert!(store
+                .finalize_flush_with_publisher(&drained, |_| Ok(()))
+                .is_err());
+            let current = store.version_map.get("same").unwrap();
+            assert_eq!(current.seq_no, old_seq + 1);
+            assert_eq!(current.deleted, stage == 6);
+            assert_eq!(
+                current.segment_id.as_ref(),
+                crate::version_map::IN_MEMORY_SEGMENT_ID
+            );
+            assert!(store.snapshot().segments.is_empty());
+            assert!(std::fs::read_dir(dir.path().join("segments"))
+                .unwrap()
+                .flatten()
+                .next()
+                .is_none());
+        }
+    }
+
+    #[test]
     fn raw_wal_batch_rejects_entire_invalid_batch_without_side_effects() {
         let invalid_payloads: &[&[u8]] = &[
             br#"{"truncated":"#,
@@ -3531,7 +4670,7 @@ mod tests {
             // (pre-fix: checkpoint covering B + rotate + prune = B's WAL
             // destroyed).
             store
-                .finalize_flush_with_publisher(drained, |_| Ok(()))
+                .finalize_flush_with_publisher(&drained, |_| Ok(()))
                 .unwrap();
             // The user-visible flush boundary forces maintenance again
             // (pre-fix with `current_seq_no() - 1`).
@@ -3623,7 +4762,7 @@ mod tests {
                 .unwrap();
         }
         store
-            .finalize_flush_with_publisher(drained, |_| Ok(()))
+            .finalize_flush_with_publisher(&drained, |_| Ok(()))
             .unwrap();
         store.force_wal_maintenance().unwrap();
 
@@ -4101,7 +5240,7 @@ mod tests {
         for id in &ids {
             assert!(segments_dir.join(format!("{id}.seg")).exists());
         }
-        let (files, _bytes) = store.retire_segment_files(&ids);
+        let (files, _bytes) = store.retire_segment_files(&ids).unwrap();
         assert!(
             files >= 2,
             "expected immediate deletion, removed {files} files"
@@ -4142,7 +5281,7 @@ mod tests {
         for id in &ids {
             store.evict_segment_reader_cache(id.as_str());
         }
-        let (files, _bytes) = store.retire_segment_files(&ids);
+        let (files, _bytes) = store.retire_segment_files(&ids).unwrap();
         assert_eq!(files, 0, "deletion must be deferred while a lease is held");
 
         let segments_dir = dir.path().join("segments");
@@ -4176,23 +5315,37 @@ mod tests {
     fn crash_with_deferred_retire_does_not_resurrect_inputs() {
         let dir = tempfile::tempdir().unwrap();
         let (store, ids, merged) = two_segments_merged(dir.path());
+        let segments_dir = dir.path().join("segments");
 
         // Hold a lease so retire defers, then "crash" (leak the lease and
-        // drop the store) — the input .seg files stay on disk, .ids gone.
+        // drop the store). apply_merge already persisted the post-merge
+        // snapshot and durably disarmed every recovery marker before commit.
         let leaked = store.snapshot();
-        let (files, _bytes) = store.retire_segment_files(&ids);
+        let (files, _bytes) = store.retire_segment_files(&ids).unwrap();
         assert_eq!(files, 0);
+        for id in &ids {
+            assert!(!segments_dir.join(format!("{id}.complete")).exists());
+            assert!(!segments_dir.join(format!("{id}.ids")).exists());
+        }
+
+        // The leased readers keep non-marker segment data alive. Model a crash
+        // at exactly this deferred-retirement point: data remains, while both
+        // recovery marker families are durably absent.
+        for id in &ids {
+            assert!(segments_dir.join(format!("{id}.seg")).exists());
+            assert!(!segments_dir.join(format!("{id}.complete")).exists());
+            assert!(!segments_dir.join(format!("{id}.ids")).exists());
+        }
         std::mem::forget(leaked);
         drop(store);
 
         // Reopen: recover_orphaned_segments must NOT resurrect the
-        // merged-away inputs (no .ids side-car), and the on-open cleanup
-        // must reclaim their leftover files.
+        // merged-away inputs, and on-open cleanup must reclaim their leftover
+        // non-marker files.
         let store2 = open_test_store(dir.path());
         let snap = store2.snapshot();
         assert_eq!(snap.segments.len(), 1, "only the merged segment survives");
         assert_eq!(snap.segments[0].id, merged.id);
-        let segments_dir = dir.path().join("segments");
         for id in &ids {
             assert!(
                 !segments_dir.join(format!("{id}.seg")).exists(),

--- a/engine/crates/xerj-storage/src/version_map.rs
+++ b/engine/crates/xerj-storage/src/version_map.rs
@@ -119,6 +119,127 @@ pub struct VersionMap {
     ghost_events: std::sync::atomic::AtomicU64,
 }
 
+#[derive(Debug)]
+struct VersionRepointChange {
+    doc_id: String,
+    previous: Option<VersionEntry>,
+    installed: VersionEntry,
+}
+
+/// Panic- and cancellation-safe group of physical version-map repoints.
+///
+/// Merge output identities are repointed before snapshot publication. Unless
+/// publication commits this transaction, drop restores only entries that
+/// still exactly match values installed by the transaction. A concurrent
+/// newer write or delete therefore always wins over rollback.
+pub struct VersionRepointTransaction {
+    map: Arc<VersionMap>,
+    changes: Vec<VersionRepointChange>,
+    committed: bool,
+}
+
+impl VersionRepointTransaction {
+    /// Reserve the complete rollback log before mutating the map.
+    pub fn with_capacity(map: Arc<VersionMap>, capacity: usize) -> Self {
+        Self {
+            map,
+            changes: Vec::with_capacity(capacity),
+            committed: false,
+        }
+    }
+
+    /// Conditionally repoint an entry and remember the exact displaced value.
+    pub fn repoint_if_latest(
+        &mut self,
+        doc_id: &str,
+        seq_no: SeqNo,
+        segment_id: Arc<str>,
+        deleted: bool,
+    ) {
+        debug_assert!(
+            self.changes.len() < self.changes.capacity(),
+            "merge rollback log must be reserved before repoint"
+        );
+        use dashmap::mapref::entry::Entry;
+        let (previous, installed) = match self.map.inner.entry(doc_id.to_owned()) {
+            Entry::Occupied(mut occupied) => {
+                if seq_no < occupied.get().seq_no {
+                    return;
+                }
+                let previous = occupied.get().clone();
+                let installed = VersionEntry {
+                    seq_no,
+                    segment_id,
+                    deleted,
+                    version: previous.version,
+                };
+                occupied.insert(installed.clone());
+                if previous.seq_no != seq_no || (deleted && !previous.deleted) {
+                    self.map.ghost_events.fetch_add(1, Ordering::Relaxed);
+                }
+                self.map.live_delta(!previous.deleted, !deleted);
+                (Some(previous), installed)
+            }
+            Entry::Vacant(vacant) => {
+                let installed = VersionEntry {
+                    seq_no,
+                    segment_id,
+                    deleted,
+                    version: 1,
+                };
+                vacant.insert(installed.clone());
+                if deleted {
+                    self.map.ghost_events.fetch_add(1, Ordering::Relaxed);
+                }
+                self.map.live_delta(false, !deleted);
+                (None, installed)
+            }
+        };
+        self.changes.push(VersionRepointChange {
+            doc_id: doc_id.to_owned(),
+            previous,
+            installed,
+        });
+    }
+
+    /// Keep all repoints after the snapshot publication succeeds.
+    pub fn commit(mut self) {
+        self.committed = true;
+    }
+
+    fn rollback(&mut self) {
+        use dashmap::mapref::entry::Entry;
+        for change in self.changes.drain(..).rev() {
+            let Entry::Occupied(mut occupied) = self.map.inner.entry(change.doc_id) else {
+                continue;
+            };
+            if occupied.get() != &change.installed {
+                continue;
+            }
+            let current_live = !occupied.get().deleted;
+            match change.previous {
+                Some(previous) => {
+                    let previous_live = !previous.deleted;
+                    occupied.insert(previous);
+                    self.map.live_delta(current_live, previous_live);
+                }
+                None => {
+                    occupied.remove();
+                    self.map.live_delta(current_live, false);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for VersionRepointTransaction {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.rollback();
+        }
+    }
+}
+
 impl VersionMap {
     /// Create an empty version map.
     pub fn new() -> Self {
@@ -653,6 +774,71 @@ mod tests {
         let e = vm.get("x").unwrap();
         assert_eq!((e.seq_no, e.version, e.deleted), (7, 1, false));
         assert_eq!(vm.live_count(), 1); // "x" live, "d" tombstoned
+    }
+
+    #[test]
+    fn merge_repoint_transaction_rolls_back_exact_previous_entries() {
+        let vm = Arc::new(VersionMap::new());
+        vm.set("live", 7, "input-a", false);
+        vm.set("tomb", 8, "input-b", true);
+        let live_before = vm.live_count();
+        {
+            let mut transaction = VersionRepointTransaction::with_capacity(Arc::clone(&vm), 3);
+            transaction.repoint_if_latest("live", 7, Arc::from("output"), false);
+            transaction.repoint_if_latest("tomb", 8, Arc::from("output"), true);
+            transaction.repoint_if_latest("new-tomb", 9, Arc::from("output"), true);
+            assert_eq!(&*vm.get("live").unwrap().segment_id, "output");
+            assert_eq!(&*vm.get("tomb").unwrap().segment_id, "output");
+        }
+        assert_eq!(&*vm.get("live").unwrap().segment_id, "input-a");
+        assert_eq!(&*vm.get("tomb").unwrap().segment_id, "input-b");
+        assert!(vm.get("new-tomb").is_none());
+        assert_eq!(vm.live_count(), live_before);
+    }
+
+    #[test]
+    fn merge_repoint_rollback_preserves_concurrent_update_and_delete() {
+        let vm = Arc::new(VersionMap::new());
+        vm.set("updated", 1, "input", false);
+        vm.set("deleted", 2, "input", false);
+        {
+            let mut transaction = VersionRepointTransaction::with_capacity(Arc::clone(&vm), 2);
+            transaction.repoint_if_latest("updated", 1, Arc::from("output"), false);
+            transaction.repoint_if_latest("deleted", 2, Arc::from("output"), false);
+            vm.set("updated", 10, IN_MEMORY_SEGMENT_ID, false);
+            vm.delete("deleted", 11, IN_MEMORY_SEGMENT_ID).unwrap();
+        }
+        let updated = vm.get("updated").unwrap();
+        assert_eq!(
+            (updated.seq_no, &*updated.segment_id, updated.deleted),
+            (10, IN_MEMORY_SEGMENT_ID, false)
+        );
+        let deleted = vm.get("deleted").unwrap();
+        assert_eq!(
+            (deleted.seq_no, &*deleted.segment_id, deleted.deleted),
+            (11, IN_MEMORY_SEGMENT_ID, true)
+        );
+    }
+
+    #[test]
+    fn merge_repoint_transaction_is_panic_safe_and_commit_is_final() {
+        let vm = Arc::new(VersionMap::new());
+        vm.set("doc", 1, "input", false);
+        let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe({
+            let vm = Arc::clone(&vm);
+            move || {
+                let mut transaction = VersionRepointTransaction::with_capacity(Arc::clone(&vm), 1);
+                transaction.repoint_if_latest("doc", 1, Arc::from("failed-output"), false);
+                panic!("injected merge worker panic after repoint");
+            }
+        }));
+        assert!(panic_result.is_err());
+        assert_eq!(&*vm.get("doc").unwrap().segment_id, "input");
+
+        let mut transaction = VersionRepointTransaction::with_capacity(Arc::clone(&vm), 1);
+        transaction.repoint_if_latest("doc", 1, Arc::from("committed-output"), false);
+        transaction.commit();
+        assert_eq!(&*vm.get("doc").unwrap().segment_id, "committed-output");
     }
 
     #[test]

--- a/engine/crates/xerj-storage/src/version_map.rs
+++ b/engine/crates/xerj-storage/src/version_map.rs
@@ -430,6 +430,38 @@ impl VersionMap {
         }
     }
 
+    /// Roll back a physical repoint iff the entry still names the failed
+    /// segment and sequence. Concurrent newer writes are therefore never
+    /// overwritten. `prior=None` removes an entry created solely by the
+    /// failed publication; `Some` restores the exact logical version.
+    pub(crate) fn rollback_repoint(
+        &self,
+        doc_id: &str,
+        seq_no: SeqNo,
+        failed_segment: &str,
+        prior: Option<VersionEntry>,
+    ) {
+        use dashmap::mapref::entry::Entry;
+        let Entry::Occupied(mut occupied) = self.inner.entry(doc_id.to_owned()) else {
+            return;
+        };
+        if occupied.get().seq_no != seq_no || occupied.get().segment_id.as_ref() != failed_segment {
+            return;
+        }
+        let old_live = !occupied.get().deleted;
+        match prior {
+            Some(prior) => {
+                let new_live = !prior.deleted;
+                occupied.insert(prior);
+                self.live_delta(old_live, new_live);
+            }
+            None => {
+                occupied.remove();
+                self.live_delta(old_live, false);
+            }
+        }
+    }
+
     /// Bump the `_version` of an EXISTING tombstone and return the bumped
     /// value.  ES semantics for `DELETE` of an already-deleted document:
     /// the delete reports `result: not_found` (404) but still increments


### PR DESCRIPTION
DEPENDS ON https://github.com/xerj-org/xerj/pull/135

## Summary

This change makes the production engine merge path transactional across provisional version-map ownership and durable segment-snapshot publication.

Before this change, a merge worker repointed live document identities to its output segment before `apply_merge` made that output authoritative. An apply error, task cancellation, or panic could leave the global version map aimed at an unpublished segment. Reads could then reject the still-authoritative input rows as stale and fail to resolve the replacement, producing missing documents even though the input segment files still existed.

The fix adds an RAII rollback transaction for provisional repoints, defines explicit publication outcomes at the storage boundary, restores the exact input snapshot when durable publication fails, commits repoints at the durable manifest boundary, and keeps disjoint pending merge batches moving after one batch fails.

## Root cause

The merge implementation crossed two publication mechanisms without one owner for the commit boundary:

1. The blocking merge worker changed `VersionMap` entries from input segment IDs to the provisional output segment ID.
2. The async merge driver later called storage to replace the authoritative input snapshot with the output and persist the new manifest.
3. Nothing owned an exact rollback log across those steps.
4. Dropping the worker result on error, cancellation, or panic did not restore the repoints.
5. `apply_merge` changed the in-memory RCU snapshot before saving the manifest, but a save failure did not restore the exact prior input metadata.
6. If both publication persistence and compensating rollback persistence failed, the API had no honest state classification.
7. In the multi-batch driver, the apply-error `continue` bypassed the common queue top-up, so one failed batch could silently suppress a later disjoint batch from the same pass.

This was an ownership and commit-boundary defect, not a ranking algorithm defect. The change is a prerequisite for a later collection-wide BM25 publication snapshot, but it contains no scorer, global-statistics, query-planning, or hydration optimization.

## What changes

### Conditional version-map transaction

`VersionRepointTransaction` reserves its complete rollback log before mutation, records the exact prior and installed `VersionEntry` for every accepted repoint, and rolls back on drop unless explicitly committed.

Rollback is conditional: an entry is restored only if it still exactly equals the value installed by this transaction. A newer concurrent PUT or DELETE therefore wins and is never overwritten by rollback. The transaction also restores `live_count` consistently and removes entries that did not exist before the provisional repoint.

### Tagged storage outcomes

Transactional merge publication now reports one of these states:

- `[PUBLISHED] MergePublicationOutcome::Published { maintenance_deferred }`: the replacement manifest is durable and provisional version-map repoints are committed. `maintenance_deferred` is currently always `false`; the field reserves an honest outcome for later fallible maintenance.
- `[NOT_PUBLISHED] MergePublicationError::NotPublished(error)`: the output did not become durably authoritative, exact inputs were restored in memory, compensating snapshot persistence succeeded, and dropping the repoint transaction restores only still-owned entries.
- `[INDETERMINATE] MergePublicationError::Indeterminate { publication, rollback }`: publication persistence failed and the compensating snapshot save also failed. The API deliberately does not claim that restart authority is known.

### Exact snapshot rollback

If the first manifest save fails after the RCU snapshot was changed, storage conditionally removes the unpublished output and restores the exact captured input `SegmentMeta` records while preserving unrelated concurrent segment appends. It then persists that restored snapshot.

Irreversible version-map cleanup runs only after durable snapshot publication. Provisional repoints commit synchronously immediately after the manifest save and before any test-injected post-publication panic can unwind the scope.

### Pending-batch control-flow fix discovered by the regression

The new four-segment regression exposed a separate scheduler defect. The apply-error branch incremented the failure count and immediately continued, skipping the shared in-flight queue replenishment. With merge parallelism one, a pending disjoint batch could therefore remain unlaunched.

The error branch now launches the next pending batch before continuing. The pass still reports failure, the failed batch retains all of its sources, and an independent batch can publish successfully. The regression verifies three resulting segments, four exact source values, total hits of four, and the same state after restart.

## Supported scope

This change covers the production server merge path implemented by `xerj-engine::index::Index::merge_pass_locked`, including:

- provisional repoints for surviving live documents;
- provisional repoints for carried tombstones;
- storage apply failure before durable publication;
- cancellation after repoint and before apply;
- panic immediately after durable manifest publication;
- concurrent PUT and DELETE while a merge is paused at the publication boundary;
- retry after a safely rolled-back failure;
- multiple disjoint merge batches when one apply fails;
- in-memory GET/search correctness and restart correctness for the tested boundaries.

The transaction is proportional to the number of surviving document and tombstone repoints in one merge output. It preallocates that rollback journal before changing shared state.

## Explicit caveats

### Legacy `MergeExecutor` remains unsupported

The hidden storage-only `MergeExecutor` is not the production server path and is not made safe by this PR. It emits Stored-only outputs, drops other query sections, calls the non-transactional `IndexStore::apply_merge`, and repoints the version map after the snapshot swap. It remains `#[doc(hidden)]`, is not re-exported from the crate root, and must not be wired into a real index. This PR fixes the engine-owned merge path, not that legacy helper.

### `Indeterminate` is classified but operational diagnostics are not finished

The storage API preserves both the original publication error and the compensating rollback-save error in `MergePublicationError::Indeterminate`. The production engine currently emits the detailed enum in its merge warning, counts the batch as failed, and ultimately reports the failed merge pass. It does not yet set a durable unhealthy-state latch, expose a dedicated metric/admin status, stop later merges automatically, or provide a repair command. Operators encountering `[INDETERMINATE]` must preserve the data directory and logs and inspect the authoritative manifest before retrying or restarting. A follow-up should promote this state into explicit health/telemetry and documented recovery UX.

### Deterministic fault tests are not process-kill tests

The suite injects save failures, cancellation, and a panic at exact boundaries and then reopens the index. It does not emulate power loss, filesystem corruption, or `SIGKILL` at every syscall boundary. Existing manifest atomic-write/fsync behavior remains the durability substrate.

### This is not the collection-wide ranking fix

This PR does not introduce a collection publication epoch, global BM25 statistics, a source-free global candidate collector, query retry on publication change, or O(global K) hydration. Those remain later North Star work and should build on this prerequisite.

## Deterministic manual reproduction

Use a shared target outside worktrees and run only the touched crates:

```bash
cd engine
export CARGO_TARGET_DIR=/workspace/targets/transactional-merge-publication
cargo test -j 32 -p xerj-engine merge_publication_transaction_tests --lib -- --nocapture
```

The five engine tests reproduce and prove:

- `[NOT_PUBLISHED]` apply failure restores exact sources, search totals, restart state, and permits a successful retry;
- rollback preserves a real concurrent PUT and DELETE, including the tombstone, across restart;
- aborting the Tokio merge task after provisional repoint drops the transaction and restores input ownership;
- one failed batch does not suppress a pending disjoint batch, and the pass still returns an error;
- panic immediately after durable manifest publication retains the output snapshot and output repoints across GET, search, and restart.

Run the rollback primitive and storage publication classifications directly:

```bash
cd engine
export CARGO_TARGET_DIR=/workspace/targets/transactional-merge-publication
cargo test -j 32 -p xerj-storage version_map::tests::merge_repoint --lib -- --nocapture
cargo test -j 32 -p xerj-storage apply_merge_manifest_failure_restores_exact_input_snapshot --lib -- --nocapture
cargo test -j 32 -p xerj-storage apply_merge_reports_indeterminate_when_publication_and_rollback_saves_fail --lib -- --nocapture
```

The three version-map tests prove exact restoration, concurrent-write/delete precedence, panic rollback, and final commit. The snapshot test proves exact input restoration survives reopen. The double-save-failure test proves the API returns `Indeterminate` instead of misreporting a safe rollback.

Run the complete contribution gates:

```bash
cd engine
export CARGO_TARGET_DIR=/workspace/targets/transactional-merge-publication
cargo test -j 32 -p xerj-storage
cargo test -j 32 -p xerj-engine --lib
cargo clippy -j 32 -p xerj-storage -p xerj-engine --all-targets -- -D warnings
cargo fmt --all --check
git diff --check ee8a2d739b585be69c4c5113f3bfe554c7b65d2b..HEAD
cargo build -j 32 -p xerj-server -p es-yaml-runner
$CARGO_TARGET_DIR/debug/xerj --insecure --data-dir <isolated-data-dir>
$CARGO_TARGET_DIR/debug/es-yaml-runner --url http://127.0.0.1:9200 --dir tests/es-compat-yaml/yaml
```

## Verified gates

- `[PASS]` Exact candidate commit: `05fd42770920aa116ede0e83e07e0440bd34be54`.
- `[PASS]` Exact candidate tree: `cf0cd6ae33c6d3a1c2e2f9e9b3ae230b29846eda`.
- `[PASS]` `xerj-storage`: 140 passed, 0 failed; doctests 1 passed, 1 ignored, 0 failed.
- `[PASS]` `xerj-engine --lib`: 359 passed, 0 failed.
- `[PASS]` Strict scoped all-target Clippy for `xerj-storage` and `xerj-engine` with `-D warnings`.
- `[PASS]` `cargo fmt --all --check`.
- `[PASS]` `git diff --check ee8a2d739b585be69c4c5113f3bfe554c7b65d2b..HEAD`.
- `[PASS]` Scoped development build of `xerj-server` and `es-yaml-runner`; sealed rebuild wall time 178.626 seconds.
- `[PASS]` Fresh ES-YAML against the exact preserved candidate binary: 1365 passed, 0 failed, 3 skipped, 1368 total; runner exit 0; wall time 213.925 seconds.
- `[PASS]` Cleanup verification: server and runner processes gone, port 9200 released, isolated runtime data removed, temporary Cargo target removed, source worktree clean with unchanged commit and tree.

## Sealed conformance evidence

Persistent evidence directory: `/workspace/north-star-evidence/transactional-merge-conformance-05fd427-v1`

- Evidence checksum manifest SHA-256: `30d669204b5f509799d4247e9f3fb376bb7a267b97d07d889735f00dec194144`.
- Candidate `xerj` binary SHA-256: `f7e896605405f1c892f111f7d22d9fb42c9df4e4638fd89d16d9f661d0d11c07`.
- Candidate `es-yaml-runner` SHA-256: `5757e3954545775354543164d6bdca3f7bf620c003503e9d123afdaaac2ff8a1`.
- Runner log SHA-256: `81be0ec5b217759de1e3a4cf7e66ab46689342fe7288a55e43fae9a82f2095a0`.
- Server log SHA-256: `377077c0505acce905cc19d1bb517e03e92a614bd9333e5dfa267784ac3cd6b3`.
- Provenance file SHA-256: `1fed2b8273b0b6d253eb7a180e7e77620450354ac60db11e0e73499d1bbcae65`.
- YAML suite aggregate SHA-256: `ed8997052eca17c25a5701ffc883228ccc0481b5472c5c3a3affb4945a1d5511`.
- YAML suite Git tree: `e2fd73e91eef7d593f81d3d85369cd177ce91732`.
- Runner source tree: `890d9c4af3e653378d943733a2f53094ec493674`.
- Server source tree: `e801d45f61029d26414c90e5161ea16d813f0a26`.

Verify retained payloads with:

```bash
cd /workspace/north-star-evidence/transactional-merge-conformance-05fd427-v1
sha256sum -c SHA256SUMS
```

## Commit stack and dependency

This contribution is intentionally based on the flush-publication recovery prerequisite:

- Base prerequisite: `ee8a2d739b585be69c4c5113f3bfe554c7b65d2b` — `fix(engine): recover failed flush publication atomically`.
- Commit 1: `eecaf0a59ac5f113026ee764d87c9935b7d47c29` — `fix(storage): roll back unpublished merge repoints`.
- Commit 2: `34fa244b84a99b099bdf494acb5868c7b663af73` — `test(storage): classify double merge-save failure`.
- Commit 3: `05fd42770920aa116ede0e83e07e0440bd34be54` — `test(engine): prove transactional merge promotion paths`.

Review this PR against the flush-publication branch at `ee8a2d7` while that prerequisite is pending. After the prerequisite merges, rebase the three-commit merge-publication stack onto current upstream `main` and rerun the hard gate against the rebased exact candidate.

## Files changed by this stack

- `engine/crates/xerj-storage/src/version_map.rs`: conditional RAII repoint transaction and primitive-level tests.
- `engine/crates/xerj-storage/src/index_store.rs`: tagged merge publication result, exact snapshot rollback, durable commit boundary, and deterministic save-failure tests.
- `engine/crates/xerj-engine/src/index.rs`: production merge integration, cancellation/panic/concurrency/restart tests, and pending-batch queue replenishment.

## Review focus

Please focus review on the durable commit boundary, conditional rollback predicate, concurrent snapshot preservation, `Indeterminate` classification, and the absence of an `await` between successful storage publication and prepublication-cache lease commit. The intentionally unsupported legacy `MergeExecutor` should not be treated as covered by this change.