### PR TITLE
fix(console): dashboard panels never authenticate to the data plane

### DIFF
--- a/engine/crates/xerj-console-api/src/data_sources.rs
+++ b/engine/crates/xerj-console-api/src/data_sources.rs
@@ -21,7 +21,8 @@
 
 use axum::{
     extract::{Path, State},
-    response::Response,
+    response::{IntoResponse, Response},
+    Json,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -187,6 +188,94 @@ pub async fn list_fields(
         })
         .collect();
     Ok(ok(json!({ "fields": fields, "total": fields.len() }), None))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SEARCH
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Run an ES-compat `_search` against a single index, authenticated by the
+/// caller's Console session instead of a data-plane API key.
+///
+/// **Why this exists.** The SPA's declarative dashboard panels
+/// (`xerj-ux/src/data/panel-query.js`) and the built-in dashboard adapters
+/// (`xerj-ux/src/data/backends/xerj.js`) used to `fetch()` `/{index}/_search`
+/// directly, same-origin, with no `Authorization` header at all. That is
+/// silently correct only when the engine is started with `--insecure`; on
+/// any auth-enabled deployment — the default, recommended posture — every
+/// such call gets a 401 the caller doesn't even look at (`backends/xerj.js`
+/// treats any failure as "no live adapter, fall back to mock"), so the
+/// entire "real dashboards" feature quietly regresses to demo data with no
+/// visible error. This endpoint reuses the session-cookie gate every other
+/// `data-sources` route already has (see `list_indices` / `list_fields`
+/// above) and talks to the engine in-process — no data-plane credential is
+/// needed at all, the same way `list_indices`/`list_fields` already read
+/// the schema/stats in-process.
+///
+/// **Scope.** Single, exact index names only, matching `list_fields`'s
+/// existing scope — no wildcard/`_all` resolution or multi-index merge
+/// here (that logic is non-trivial and already lives, correctly, in
+/// `xerj-api::es_compat`; duplicating a second copy risks exactly the kind
+/// of subtle merge bug that logic has already been hardened against).
+/// Callers that need a pattern get a clear `501`, not a silent wrong
+/// answer — consistent with how this file already treats non-`built-in`
+/// connections.
+pub async fn search(
+    State(state): State<ConsoleState>,
+    _sess: AuthSession,
+    Path((conn_id, index)): Path<(String, String)>,
+    Json(body): Json<Value>,
+) -> ConsoleResult<Response> {
+    if conn_id != BUILTIN_ID {
+        return Err(ConsoleApiError::NotImplemented(format!(
+            "connection '{conn_id}' adapter not yet implemented"
+        )));
+    }
+    if index.contains('*') || index == "_all" || index.split(',').count() > 1 {
+        return Err(ConsoleApiError::NotImplemented(
+            "panel search proxy supports a single exact index name only; \
+             wildcard/_all/multi-index queries are not yet implemented"
+                .into(),
+        ));
+    }
+    if indices::is_system_index(&index) {
+        return Err(ConsoleApiError::NotFound(format!("index {index}")));
+    }
+    let idx = state
+        .engine
+        .get_index(&index)
+        .map_err(|_| ConsoleApiError::NotFound(format!("index {index}")))?;
+
+    let req = xerj_query::parser::parse_request(&body)
+        .map_err(|e| ConsoleApiError::BadRequest(e.to_string()))?;
+    let result = idx
+        .search(&req)
+        .await
+        .map_err(|e| ConsoleApiError::Internal(e.to_string()))?;
+
+    let hits: Vec<Value> = result
+        .hits
+        .iter()
+        .map(|h| {
+            json!({
+                "_index": index,
+                "_id": h.id,
+                "_score": h.score,
+                "_source": h.source,
+            })
+        })
+        .collect();
+    let wire = json!({
+        "took": result.took_ms,
+        "timed_out": result.timed_out,
+        "hits": {
+            "total": { "value": result.total.value, "relation": result.total.relation },
+            "max_score": result.max_score,
+            "hits": hits,
+        },
+        "aggregations": result.aggs,
+    });
+    Ok(Json(wire).into_response())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/engine/crates/xerj-console-api/src/router.rs
+++ b/engine/crates/xerj-console-api/src/router.rs
@@ -140,6 +140,10 @@ pub fn xerj_console_router(state: ConsoleState) -> Router {
             "/_xerj-console/api/v1/data-sources/connections/:id/indices/:name/fields",
             get(data_sources::list_fields),
         )
+        .route(
+            "/_xerj-console/api/v1/data-sources/connections/:id/indices/:name/search",
+            post(data_sources::search),
+        )
         .with_state(state)
 }
 
@@ -173,5 +177,6 @@ pub fn known_routes() -> &'static [&'static str] {
         "/_xerj-console/api/v1/data-sources/connections",
         "/_xerj-console/api/v1/data-sources/connections/:id/indices",
         "/_xerj-console/api/v1/data-sources/connections/:id/indices/:name/fields",
+        "/_xerj-console/api/v1/data-sources/connections/:id/indices/:name/search",
     ]
 }

--- a/xerj-ux/src/data/backends/xerj.js
+++ b/xerj-ux/src/data/backends/xerj.js
@@ -64,11 +64,31 @@ export async function listIndices(baseUrl, signal) {
   return r.json().catch(() => []);
 }
 
-/** Generic ES-compat search against a single index (or wildcard). */
+/**
+ * Search a single index through the Console backend's session-authenticated
+ * proxy instead of an unauthenticated same-origin fetch straight to the
+ * ES-compat data plane. The old direct call carried no `Authorization`
+ * header, so it silently 401'd on any engine started WITHOUT `--insecure`
+ * — the default, recommended posture — and every caller here treats a
+ * failed search as "no live adapter, fall back to mock" (see `search()`
+ * below), so the built-in dashboards quietly showed demo data on a
+ * correctly-secured deployment with no visible error at all.
+ *
+ * `baseUrl` is intentionally unused for the request target: the proxy is
+ * always served by the SAME Console instance the SPA is loaded from (this
+ * backend only ever talks to the local/built-in engine — see `meta`
+ * above), so the path is resolved relative to the current origin, same as
+ * every other Console-backend call in this codebase. Kept as a parameter
+ * for call-site compatibility.
+ *
+ * Scope: single exact index name only — no wildcard/`_all` resolution.
+ * See `xerj-console-api::data_sources::search`'s doc comment for why.
+ */
 async function rawSearch(baseUrl, index, body, signal) {
-  const path = `/${encodeURIComponent(index)}/_search`;
-  const r = await fetch(baseUrl + path, {
+  const path = `/_xerj-console/api/v1/data-sources/connections/built-in/indices/${encodeURIComponent(index)}/search`;
+  const r = await fetch(path, {
     method: 'POST',
+    credentials: 'same-origin',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
     signal,

--- a/xerj-ux/src/data/panel-query.js
+++ b/xerj-ux/src/data/panel-query.js
@@ -154,8 +154,18 @@ function normalise(resp, built) {
   return out;
 }
 
+// Routed through the Console backend's own session-cookie auth instead of
+// a same-origin fetch straight to the ES-compat data plane. That direct
+// path carried no `Authorization` header at all, so it silently 401'd on
+// any engine started WITHOUT `--insecure` — the default, recommended
+// posture — leaving every custom panel stuck on "unconfigured"/error with
+// no indication why. The proxy runs the search in-process against the
+// engine, authenticated the same way `data-sources/connections/.../fields`
+// already is. See `xerj-console-api::data_sources::search` for the
+// server side and its scope note (single exact index name only, no
+// wildcard/`_all` yet).
 async function runQuery(built, signal) {
-  const path = `/${encodeURIComponent(built.index)}/_search`;
+  const path = `/_xerj-console/api/v1/data-sources/connections/built-in/indices/${encodeURIComponent(built.index)}/search`;
   const r = await fetch(path, {
     method: 'POST',
     credentials: 'same-origin',


### PR DESCRIPTION
## Summary

**High-impact bug: the entire "native dashboards" feature is silently broken on any XERJ deployment that follows the recommended security posture** — auth enabled, not `--insecure`. This is the *default* behavior on a correctly-secured instance, not an edge case.

Both the declarative user-panel query path (`xerj-ux/src/data/panel-query.js`) and the built-in dashboard adapters (`xerj-ux/src/data/backends/xerj.js`) `fetch()` `_search` directly from the browser, same-origin, straight against the ES-compat data plane — with **no `Authorization` header at all**. That data plane requires `Authorization: ApiKey <key>` whenever auth is enabled. The Console's own session cookie is a *completely separate* auth realm that `xerj-api`'s `auth_middleware` has zero awareness of (its own comment: *"Xerj Console... runs its own session-cookie auth, so this middleware never sees `/_xerj-console/*` requests"*). Every panel query therefore always got a 401.

**Nothing surfaces this to the user.** `backends/xerj.js`'s built-in adapters treat any failed request as "no live adapter yet, fall back to mock" — a deliberate design for genuinely-missing adapters, but it silently swallows a real 401 identically, so every built-in dashboard quietly renders demo numbers instead of the engine's actual data. Custom user dashboards fare only slightly better (an explicit "QUERY ERROR" note appears, but only if you know to look for it) — a user who never opens dev tools has no way to tell "my panel is misconfigured" from "I'm just not authenticated."

Found live while building an end-to-end NiFi → XERJ → native-dashboard demo: a custom dashboard's panels showed `unconfigured`/a raw 401 body, while `curl` against the *exact same query* with an admin API key returned real data immediately.

## Root cause vs. the intended architecture

`xerj-ux/src/data/data-sources.js` already solves this exact problem for connection/index/field listing — it routes those calls through `/_xerj-console/api/v1/data-sources/connections/...`, a Console backend surface authenticated by the same session cookie the rest of the SPA already carries. The Console backend then reads the engine **in-process** (`state.engine.get_index(...)`, `idx.stats()`, `idx.schema()`) — no HTTP round-trip, no data-plane API key needed at all, since the Console and the ES-compat layer are compiled into and run as the same binary.

Panel search queries never got the same treatment — they were added later (`panel-query.js`'s own header comment: *"closes the gap... without touching the 8-dashId dispatch in backends/xerj.js"*) as a same-origin fetch straight to the data plane, bypassing the already-working proxy pattern entirely.

## Fix

Extend the existing, already-proven proxy pattern to cover `_search` — no new auth mechanism invented:

- **`xerj-console-api::data_sources::search`** (new): a session-authenticated `POST /_xerj-console/api/v1/data-sources/connections/:id/indices/:name/search`. Parses the ES-compat body with the same `xerj_query::parser::parse_request` this module already uses internally, runs it in-process via `idx.search(&req)`, and reshapes the result into standard ES-compat wire JSON (`hits.total`, `hits.hits`, `aggregations`) — the frontend's existing response-parsing code needs zero changes.

  **Scope**: a single, exact index name only, matching `list_fields`'s existing scope on this connection. Wildcard/`_all`/multi-index resolution is a non-trivial correctness problem (accurate cross-index aggregation merging) that already lives, tested, in `xerj-api::es_compat`; duplicating a second copy here risks reintroducing exactly the kind of subtle merge bug that logic has already been hardened against. A pattern/`_all` request gets a clear `501`, not a silently wrong answer.

- **`panel-query.js` / `backends/xerj.js`**: `runQuery()` / `rawSearch()` now call the new proxy path instead of `/{index}/_search` directly. Both keep their existing response-normalisation code untouched.

## What this fixes vs. what's still open

**Fixed**: every single-index dashboard panel — the primary/common case for user-authored panels, and 5 of 6 `backends/xerj.js` adapters (`chat-events`, `vector-ops`, `agent-memory`, `anomalies`, `logs-ingest-events`).

**Not fixed by this PR** (pre-existing behavior, unchanged — flagging for visibility rather than silently expanding scope):
- `liveLogsOverview`'s `logs-*` wildcard and `liveSearchDiscover`'s `_all` case still hit the 501 guard and fall back to mock, same as before this fix for those two specific paths.
- The identical same-origin-fetch-with-no-auth pattern also exists in `xerj-ux/src/data/data-probe.js`, `brains-probe.js`, `second-brain-api.js`, and `xerj-ux/src/ux/brain-map.js` — found during this investigation, out of scope for a minimal fix, worth a follow-up issue.

## Test plan
- [x] `cargo fmt --check -p xerj-console-api`
- [x] `cargo clippy -p xerj-console-api --all-targets -- -D warnings`
- [x] `cargo test -p xerj-console-api --lib` (43/43, no regressions)
- [x] **Live end-to-end verification**: built the combined binary, deployed to a long-running test instance **with auth enabled** (no `--insecure`) against real data (a NiFi → Logback → XERJ log pipeline, `nifi-logs` index, ~1900 real documents). Created a dashboard with 3 panels (events table, count metric, timeseries line chart). Before this fix: all three showed `unconfigured` or a raw 401 body. After: all three render real data — confirmed via screenshot and the browser's network log showing 3× `POST .../indices/nifi-logs/search` → 200, zero direct `/_search` calls.
- [x] **No regression in `--insecure` mode**: restarted the same instance without auth, confirmed the same dashboard renders identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PRCbyt7Y2HDyhG1tbQTeL
