### PR TITLE
fix(console): keep the data-sources proxy out of the brain namespace

### DIFF
--- a/engine/crates/xerj-api/src/authz.rs
+++ b/engine/crates/xerj-api/src/authz.rs
@@ -139,15 +139,13 @@ use xerj_engine::rbac::Privilege;
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Index-name prefix reserved for agent-memory namespaces (`memory_api`) and
-/// second brains (`graph_api`). Kept in one place so the three writers of the
-/// name — `memory_api::MEMORY_PREFIX`, `graph_api::edges_index` and this
-/// module — cannot drift.
-pub const RESERVED_INDEX_PREFIX: &str = ".xerj-memory-";
-
-/// Is `index` inside the reserved namespace?
-pub fn is_reserved_index(index: &str) -> bool {
-    index.starts_with(RESERVED_INDEX_PREFIX)
-}
+/// second brains (`graph_api`), and the predicate over it. The definition
+/// lives in `xerj-common` because `xerj-console-api`'s data-sources proxy —
+/// a decoupled peer of this crate that reaches the engine outside this
+/// module's middleware — must refuse the same namespace; re-exported here so
+/// the writers of the name (`memory_api::MEMORY_PREFIX`,
+/// `graph_api::edges_index`) and this module keep one definition.
+pub use xerj_common::types::{is_reserved_index, RESERVED_INDEX_PREFIX};
 
 /// The edges index backing brain `brain` (SECOND_BRAIN_SPEC §1). This is the
 /// resource name a `role_descriptors` grant must name to unlock

--- a/engine/crates/xerj-common/src/types.rs
+++ b/engine/crates/xerj-common/src/types.rs
@@ -173,6 +173,28 @@ impl AsRef<str> for IndexName {
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
+// The reserved index namespace
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// Index-name prefix reserved for agent-memory namespaces and second brains.
+///
+/// This lives here — not in `xerj-api::authz`, where the namespace is
+/// enforced on the data plane — because more than one HTTP surface has to
+/// know it: `xerj-console-api`'s data-sources proxy talks to the engine
+/// in-process, outside `xerj-api`'s middleware stack, and the two crates
+/// are deliberately decoupled peers (neither may depend on the other).
+/// `xerj-common` is the one crate both already share, so the prefix cannot
+/// drift between the surfaces that guard it. `xerj-api::authz` re-exports
+/// both names; the writers of the name (`memory_api::MEMORY_PREFIX`,
+/// `graph_api::edges_index`) still resolve to this single definition.
+pub const RESERVED_INDEX_PREFIX: &str = ".xerj-memory-";
+
+/// Is `index` inside the reserved namespace?
+pub fn is_reserved_index(index: &str) -> bool {
+    index.starts_with(RESERVED_INDEX_PREFIX)
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
 // Field types
 // ═════════════════════════════════════════════════════════════════════════════
 

--- a/engine/crates/xerj-console-api/src/data_sources.rs
+++ b/engine/crates/xerj-console-api/src/data_sources.rs
@@ -34,6 +34,19 @@ use crate::response::ok;
 use crate::state::ConsoleState;
 use crate::time::now_iso;
 
+/// Indices the data-sources surface must pretend do not exist: the Console's
+/// own `.xerj_*` system indices, and the reserved `.xerj-memory-*` namespace
+/// holding per-tenant brains / agent memories. The latter is enforced on the
+/// data plane by `xerj-api`'s authz middleware, but the Console router is
+/// merged onto the engine routers *after* their layers, so that middleware
+/// never runs here and the in-process engine calls below carry no visibility
+/// scope (absent guard = engine-internal work, allow). This proxy is
+/// therefore its own boundary and must refuse the namespace itself — with
+/// the same NotFound as a system index, so existence doesn't leak.
+fn is_hidden_index(name: &str) -> bool {
+    indices::is_system_index(name) || xerj_common::types::is_reserved_index(name)
+}
+
 /// Connection record — one row in `.xerj_connections`. Phase-3 only
 /// surfaces the built-in adapter; adding new connections lands once the
 /// AEAD-at-rest path for `auth.secret` is implemented.
@@ -123,11 +136,11 @@ pub async fn list_indices(
     }
 
     // Walk the engine's indices via its public listing surface.  Skip
-    // `.xerj_*` system indices — they are an implementation detail,
-    // not user data sources.
+    // `.xerj_*` system indices and reserved `.xerj-memory-*` brains (see
+    // `is_hidden_index`) — neither is a user data source.
     let mut items: Vec<Value> = Vec::new();
     for name in state.engine.index_name_list() {
-        if indices::is_system_index(&name) {
+        if is_hidden_index(&name) {
             continue;
         }
         let idx = match state.engine.get_index(&name) {
@@ -167,7 +180,7 @@ pub async fn list_fields(
             "connection '{conn_id}' adapter not yet implemented"
         )));
     }
-    if indices::is_system_index(&index) {
+    if is_hidden_index(&index) {
         return Err(ConsoleApiError::NotFound(format!("index {index}")));
     }
     let idx = state
@@ -238,7 +251,7 @@ pub async fn search(
                 .into(),
         ));
     }
-    if indices::is_system_index(&index) {
+    if is_hidden_index(&index) {
         return Err(ConsoleApiError::NotFound(format!("index {index}")));
     }
     let idx = state

--- a/engine/crates/xerj-console-api/tests/console_cannot_read_a_brain.rs
+++ b/engine/crates/xerj-console-api/tests/console_cannot_read_a_brain.rs
@@ -1,0 +1,210 @@
+//! The Console data-sources proxy must not cross the per-tenant brain
+//! boundary (RC10 blocker B1).
+//!
+//! The data plane guards the reserved `.xerj-memory-*` namespace in
+//! `xerj_api::authz` middleware, but the Console router is merged onto the
+//! engine routers *after* their layers are applied (`xerj-server::main`), so
+//! that middleware never runs on `/_xerj-console/*` and no index-visibility
+//! scope is installed. The data-sources handlers talk to the engine
+//! in-process, where an absent guard means "engine-internal work, allow" —
+//! so any authenticated Console session of any role could read any tenant's
+//! brain through the search/fields/indices proxy. These tests pin the fix:
+//! the proxy refuses the reserved namespace itself, with the same NotFound
+//! it already gives `.xerj_*` system indices, so existence doesn't leak.
+
+use axum::{body::Body, http::Request, Router};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+use xerj_console_api::{
+    auth::{sessions, store},
+    state::ClusterMode,
+    xerj_console_router, ConsoleState,
+};
+use xerj_engine::Engine;
+
+/// A secret that must never appear in any Console response body.
+const ALICE_SECRET: &str = "alice-private-fact-9f83c1";
+
+struct TestApp {
+    router: Router,
+    cookie: String,
+    _dir: TempDir,
+}
+
+/// Boot the console with an authenticated owner session — the strongest
+/// role there is. If even the owner cannot reach a brain through the
+/// proxy, no session can.
+async fn boot_with_brain() -> TestApp {
+    let dir = TempDir::new().unwrap();
+    let mut cfg = Config::default();
+    cfg.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(cfg).expect("engine");
+    let outcome = xerj_console_api::bootstrap::run(&engine, dir.path(), "http://localhost:9200")
+        .await
+        .unwrap();
+    let state = ConsoleState::new(
+        engine.clone(),
+        "local".into(),
+        outcome.master_key,
+        ClusterMode::Standalone,
+    );
+
+    let user = store::User {
+        id: "owner-test".to_string(),
+        email: "owner@example.com".to_string(),
+        display_name: "Owner".to_string(),
+        role: "owner".to_string(),
+        status: store::UserStatus::Active,
+        created_at: xerj_console_api::time::now_iso(),
+        last_seen_at: Some(xerj_console_api::time::now_iso()),
+    };
+    store::upsert_user(&engine, &user).await.unwrap();
+    let (_session, signed) = sessions::mint_session(&state, &user.id, "passkey", None, None)
+        .await
+        .unwrap();
+    let cookie = format!("xerj_session={signed}");
+
+    // Another tenant's brain, exactly as memory_api provisions it: the
+    // namespace index plus its -edges sibling, both in the reserved prefix.
+    engine
+        .create_index(".xerj-memory-alice", Schema::empty())
+        .expect("create brain index");
+    engine
+        .create_index(".xerj-memory-alice-edges", Schema::empty())
+        .expect("create brain edges index");
+    let brain = engine.get_index(".xerj-memory-alice").unwrap();
+    brain
+        .create_document("m1".into(), json!({ "content": ALICE_SECRET }))
+        .await
+        .expect("write brain doc");
+
+    let router = xerj_console_router(state);
+    TestApp {
+        router,
+        cookie,
+        _dir: dir,
+    }
+}
+
+async fn body_json(resp: axum::response::Response) -> (axum::http::StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, v)
+}
+
+fn req(method: &str, path: &str, cookie: &str, body: Option<Value>) -> Request<Body> {
+    let body = match body {
+        Some(b) => Body::from(b.to_string()),
+        None => Body::empty(),
+    };
+    Request::builder()
+        .method(method)
+        .uri(path)
+        .header("cookie", cookie)
+        .header("content-type", "application/json")
+        .body(body)
+        .unwrap()
+}
+
+#[tokio::test]
+async fn search_cannot_read_a_brain() {
+    let app = boot_with_brain().await;
+
+    let r = app
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            "/_xerj-console/api/v1/data-sources/connections/built-in/indices/.xerj-memory-alice/search",
+            &app.cookie,
+            Some(json!({ "query": { "match_all": {} } })),
+        ))
+        .await
+        .unwrap();
+    let (status, body) = body_json(r).await;
+    assert_eq!(status, 404, "brain search must 404, got: {body}");
+    assert!(
+        !body.to_string().contains(ALICE_SECRET),
+        "brain content leaked: {body}"
+    );
+
+    // No existence oracle: a brain that exists and one that doesn't must be
+    // indistinguishable through this endpoint.
+    let r = app
+        .router
+        .oneshot(req(
+            "POST",
+            "/_xerj-console/api/v1/data-sources/connections/built-in/indices/.xerj-memory-nobody/search",
+            &app.cookie,
+            Some(json!({ "query": { "match_all": {} } })),
+        ))
+        .await
+        .unwrap();
+    let (ghost_status, ghost_body) = body_json(r).await;
+    assert_eq!(status, ghost_status);
+    assert_eq!(
+        body.to_string().replace("alice", "nobody"),
+        ghost_body.to_string(),
+        "existing vs missing brain must be indistinguishable"
+    );
+}
+
+#[tokio::test]
+async fn fields_do_not_leak_brain_mappings() {
+    let app = boot_with_brain().await;
+
+    for index in [".xerj-memory-alice", ".xerj-memory-alice-edges"] {
+        let r = app
+            .router
+            .clone()
+            .oneshot(req(
+                "GET",
+                &format!(
+                    "/_xerj-console/api/v1/data-sources/connections/built-in/indices/{index}/fields"
+                ),
+                &app.cookie,
+                None,
+            ))
+            .await
+            .unwrap();
+        let (status, body) = body_json(r).await;
+        assert_eq!(status, 404, "{index} fields must 404, got: {body}");
+    }
+}
+
+#[tokio::test]
+async fn index_listing_hides_brains() {
+    let app = boot_with_brain().await;
+
+    let r = app
+        .router
+        .oneshot(req(
+            "GET",
+            "/_xerj-console/api/v1/data-sources/connections/built-in/indices",
+            &app.cookie,
+            None,
+        ))
+        .await
+        .unwrap();
+    let (status, body) = body_json(r).await;
+    assert_eq!(status, 200);
+    let names: Vec<&str> = body["data"]["indices"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|i| i["name"].as_str())
+        .collect();
+    assert!(
+        !names.iter().any(|n| n.starts_with(".xerj-memory-")),
+        "brain names leaked into the listing: {names:?}"
+    );
+}


### PR DESCRIPTION
## Defect (RC10 blocker B1, HIGH)

The Console data-sources handlers — `search`, `list_fields`, `list_indices` in `engine/crates/xerj-console-api/src/data_sources.rs` — talk to the engine in-process, and the Console router is merged onto the engine routers **after** their layers are applied (`xerj-server/src/main.rs`, the `Router::merge` calls). So `xerj-api`'s `authz_middleware` never runs on these routes and no `IndexVisibility` scope is installed; `Engine::get_index`'s guard treats an absent scope as engine-internal work and allows everything. The handlers' only filter was `indices::is_system_index` (`.xerj_`, **underscore**), which does not match the reserved brain namespace `.xerj-memory-` (**hyphen**, `xerj-api::authz::RESERVED_INDEX_PREFIX`).

## Failure scenario

Any authenticated Console session, of **any** role:

```
POST /_xerj-console/api/v1/data-sources/connections/built-in/indices/.xerj-memory-alice/search
{"query":{"match_all":{}}}
```

returned the tenant's brain documents verbatim (reproduced in the regression test: 200 + full `_source`). The indices listing enumerated every brain's name, and the fields endpoint returned a brain's live mapping.

## Fix

The proxy is now its own boundary: all three handlers refuse the reserved namespace via a shared `is_hidden_index` predicate (system **or** reserved). `search`/`list_fields` return the exact NotFound shape a `.xerj_*` system index already gets, so an existing and a nonexistent brain are indistinguishable; `list_indices` filters the namespace out of enumeration.

**Single source of truth:** `RESERVED_INDEX_PREFIX` / `is_reserved_index` moved to `xerj-common::types`, re-exported from `xerj-api::authz` so every existing call site (`memory_api::MEMORY_PREFIX`, `graph_api::edges_index`, auth, authz tests) compiles unchanged. `xerj-common` was chosen because `xerj-api` and `xerj-console-api` are deliberately decoupled peers (both Cargo.tomls document this) — neither may depend on the other, and `xerj-common` is the crate both already share, so the prefix cannot drift between the two surfaces that guard it.

I audited the other Console handlers: the data-sources trio are the only routes that reach index data from a caller-supplied index name; everything else (dashboards, views, prefs, auth, alerts) operates on fixed `.xerj_*` constants.

## Tests

`engine/crates/xerj-console-api/tests/console_cannot_read_a_brain.rs` — written first and confirmed failing on unfixed main for the right reasons (search: 200 + leaked secret doc; fields: 200 + live mapping; listing: both brain names present):

- `search_cannot_read_a_brain` — 404, no content leak, and the response for an existing brain is byte-identical (modulo the caller-supplied name) to a nonexistent one
- `fields_do_not_leak_brain_mappings` — 404 for both the namespace index and its `-edges` sibling
- `index_listing_hides_brains` — no `.xerj-memory-*` name in enumeration

Suites run: `cargo test -p xerj-common` (54 ok), `cargo test -p xerj-console-api` (107 ok incl. new), `cargo test -p xerj-api` (all 10 binaries ok, incl. the authz reserved-namespace tests now exercising the re-export). `cargo fmt --check` and `cargo clippy -p xerj-console-api --tests` clean.

## Residual limitations (not fixed here)

- This guards the Console **data-sources proxy** only. The underlying architecture note stands: the Console router still runs outside `xerj-api`'s middleware stack, so any *future* console handler that resolves a caller-supplied index name must use the same predicate — the doc comment on `is_hidden_index` says so, but nothing structurally forces it.
- Other engine call sites that hardcode `.xerj-memory-` in docs/tests (e.g. `xerj-engine::rbac` doc examples) were left untouched; only the enforcing predicate was unified.
- The remaining RC10 blockers (perma-brick, DoS, agg undercount, cross-tenant destroy) are separate defects, not addressed here.