### PR TITLE
security(snapshot): stop snapshot and restore from reaching another tenant

### DIFF
--- a/engine/crates/xerj-api/src/authz.rs
+++ b/engine/crates/xerj-api/src/authz.rs
@@ -1123,20 +1123,75 @@ impl AliasResolver for NoAliases {
     }
 }
 
+/// Does the engine expand this request's index expressions over the
+/// principal's visible set, or does it act on the pattern itself?
+///
+/// The distinction decides whether a wildcard may be waved through here. It is
+/// [`PatternExpansion::Guarded`] almost everywhere, because a name only becomes
+/// an index inside [`xerj_engine::index_guard`]'s funnel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PatternExpansion {
+    /// The name is resolved through `Engine::get_index` / `list_indices` /
+    /// `index_name_list`, so a wildcard is expanded over what this principal
+    /// may see and needs no decision of its own.
+    Guarded,
+    /// The handler acts on the expression itself, outside that funnel — a
+    /// wildcard authorized here is a wildcard executed.
+    Unguarded,
+}
+
+/// How the route carrying `shape` resolves the names its body holds.
+///
+/// Only snapshot and restore are unguarded. `Engine::create_snapshot` walks
+/// the index map itself and `Engine::restore_snapshot` expands the pattern
+/// against the snapshot's own manifest, then `remove_dir_all`s and rewrites
+/// the index directory — neither goes through `get_index` or `delete_index`,
+/// which is where every other body-named target meets the visibility guard.
+fn expansion_for(shape: BodyShape) -> PatternExpansion {
+    match shape {
+        BodyShape::SnapshotIndices => PatternExpansion::Unguarded,
+        _ => PatternExpansion::Guarded,
+    }
+}
+
 /// Authorize one index expression, resolving aliases first.
 ///
-/// A pattern is *not* refused: it is expanded over the principal's visible set
-/// by the engine (see [`xerj_engine::index_guard`]), so a granted `logs-*`
-/// works and an ungranted `*` silently resolves to nothing instead of leaking
-/// what it would have matched.
+/// Under [`PatternExpansion::Guarded`] a pattern is *not* refused: it is
+/// expanded over the principal's visible set by the engine (see
+/// [`xerj_engine::index_guard`]), so a granted `logs-*` works and an ungranted
+/// `*` silently resolves to nothing instead of leaking what it would have
+/// matched.
+///
+/// Under [`PatternExpansion::Unguarded`] that reasoning does not hold, so a
+/// pattern that [`may_reach_reserved`] is decided here, on the same terms as an
+/// index template's `index_patterns`: only a principal explicitly *granted* the
+/// pattern may use it. Anything narrower (`logs-*`) still passes — it cannot
+/// name a brain, and refusing it would cost the ordinary per-tenant backup.
 fn authorize_expression(
     principal: &Principal,
     aliases: &dyn AliasResolver,
     expr: &str,
     privilege: Privilege,
+    expansion: PatternExpansion,
 ) -> Result<(), Response> {
     if is_pattern(expr) {
-        return Ok(());
+        if expansion == PatternExpansion::Guarded || !may_reach_reserved(expr) {
+            return Ok(());
+        }
+        // `Unscoped::allows_index` answers "not reserved" for the literal text
+        // `*` — true of the string, useless as an answer here — so it is
+        // excluded explicitly rather than consulted, exactly as in
+        // `authorize_template_patterns`.
+        let held = match principal {
+            Principal::Superuser => true,
+            Principal::Scoped { .. } => principal.allows_index(expr, privilege),
+            _ => false,
+        };
+        return if held {
+            Ok(())
+        } else {
+            Err(forbidden(principal, expr, privilege))
+        };
     }
     match aliases.targets(expr) {
         Some(backing) if !backing.is_empty() => {
@@ -1252,7 +1307,13 @@ fn decide(
         Target::Indices(expressions, op_start) => {
             let privilege = required_privilege(method, segs, *op_start);
             for expr in expressions {
-                authorize_expression(principal, aliases, expr, privilege)?;
+                authorize_expression(
+                    principal,
+                    aliases,
+                    expr,
+                    privilege,
+                    PatternExpansion::Guarded,
+                )?;
             }
             // `PUT|DELETE /{index}/_alias/{alias}` mints or drops an alias
             // name; the name itself is a resource, or the reserved namespace
@@ -1298,7 +1359,7 @@ fn decide(
                 ));
             }
             for (expr, privilege) in &demands {
-                authorize_expression(principal, aliases, expr, *privilege)?;
+                authorize_expression(principal, aliases, expr, *privilege, expansion_for(shape))?;
             }
             if cluster_is_read(method, segs) {
                 // Cluster reads (`_cat`, `_mapping`, `_nodes`, `_cluster/*`,
@@ -1348,7 +1409,7 @@ fn authorize_body(
     default_index: Option<&str>,
 ) -> Result<(), Response> {
     for (expr, privilege) in body_targets(principal, shape, body, default_index)? {
-        authorize_expression(principal, aliases, &expr, privilege)?;
+        authorize_expression(principal, aliases, &expr, privilege, expansion_for(shape))?;
     }
     Ok(())
 }
@@ -2196,6 +2257,119 @@ mod tests {
             Method::PUT,
             "/_snapshot/repo/s1",
             "{}"
+        ));
+    }
+
+    /// The pattern short-circuit in [`authorize_expression`] is safe because
+    /// the engine expands a wildcard over the principal's visible set. Snapshot
+    /// and restore are the two verbs that never reach that funnel:
+    /// `Engine::create_snapshot` walks the index map itself, and
+    /// `Engine::restore_snapshot` expands the pattern against the snapshot's
+    /// own manifest and then removes and rewrites the index directory directly
+    /// — no `get_index`, no `delete_index`. A wildcard waved through here is a
+    /// wildcard executed, which made
+    /// `POST /_snapshot/{repo}/{snap}/_restore {"indices":".xerj-memory-*"}`
+    /// roll every tenant's brain back to the backup instant for any
+    /// authenticated caller, and `{"indices":"*"}` on the create side back up
+    /// every brain on the node.
+    #[test]
+    fn snapshot_patterns_cannot_reach_the_reserved_namespace() {
+        let legacy = unscoped();
+        let alice = scoped(
+            &[".xerj-memory-alice-edges", ".xerj-memory-alice"],
+            &[Privilege::ReadIndex, Privilege::WriteIndex],
+        );
+        let logs = scoped(&["logs-*"], &[Privilege::ReadIndex, Privilege::WriteIndex]);
+
+        for body in [
+            r#"{"indices":".xerj-memory-*"}"#,
+            r#"{"indices":[".xerj-memory-*"]}"#,
+            r#"{"indices":"*"}"#,
+            r#"{"indices":["*"]}"#,
+            r#"{"indices":"_all"}"#,
+            r#"{"indices":"logs-*,.xerj-*"}"#,
+        ] {
+            for p in [&legacy, &alice, &logs] {
+                assert!(
+                    !check(p, Method::POST, "/_snapshot/repo/s1/_restore", body),
+                    "restore {body} destroys the reserved namespace and must be refused"
+                );
+                assert!(
+                    !check(p, Method::PUT, "/_snapshot/repo/s1", body),
+                    "snapshot {body} captures the reserved namespace and must be refused"
+                );
+            }
+        }
+
+        // A tenant still backs up and rolls back its OWN indices, by name …
+        assert!(check(
+            &alice,
+            Method::PUT,
+            "/_snapshot/repo/s1",
+            r#"{"indices":[".xerj-memory-alice"]}"#
+        ));
+        assert!(check(
+            &alice,
+            Method::POST,
+            "/_snapshot/repo/s1/_restore",
+            r#"{"indices":".xerj-memory-alice"}"#
+        ));
+        // … and through a pattern that cannot reach the namespace, in both the
+        // array and the string spelling ES accepts.
+        assert!(check(
+            &logs,
+            Method::PUT,
+            "/_snapshot/repo/s1",
+            r#"{"indices":"logs-*"}"#
+        ));
+        assert!(check(
+            &logs,
+            Method::POST,
+            "/_snapshot/repo/s1/_restore",
+            r#"{"indices":["logs-*"]}"#
+        ));
+        assert!(check(
+            &legacy,
+            Method::PUT,
+            "/_snapshot/repo/s1",
+            r#"{"indices":"logs-2026,logs-2027"}"#
+        ));
+
+        // The superuser is still the operator: a full backup and a full
+        // restore are exactly what it is for.
+        for body in [
+            "{}",
+            r#"{"indices":"*"}"#,
+            r#"{"indices":".xerj-memory-*"}"#,
+        ] {
+            assert!(check(
+                &Principal::Superuser,
+                Method::PUT,
+                "/_snapshot/repo/s1",
+                body
+            ));
+            assert!(check(
+                &Principal::Superuser,
+                Method::POST,
+                "/_snapshot/repo/s1/_restore",
+                body
+            ));
+        }
+
+        // FINDING C is unchanged here: `names:["*"]` is an operator explicitly
+        // granting the whole node, so it snapshots the whole node.
+        let star = scoped(&["*"], &[Privilege::ReadIndex, Privilege::WriteIndex]);
+        assert!(check(
+            &star,
+            Method::PUT,
+            "/_snapshot/repo/s1",
+            r#"{"indices":"*"}"#
+        ));
+        assert!(check(
+            &star,
+            Method::POST,
+            "/_snapshot/repo/s1/_restore",
+            r#"{"indices":"*"}"#
         ));
     }
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -23143,15 +23143,53 @@ pub async fn create_snapshot(
         .and_then(Value::as_str)
         .unwrap_or("/tmp/xerj-snapshots");
 
-    let indices: Option<Vec<String>> = body
-        .as_ref()
-        .and_then(|b| b.get("indices"))
-        .and_then(Value::as_array)
-        .map(|arr| {
+    // ES accepts `indices` as an array of names/patterns or a single
+    // (possibly comma-separated) string; absent means "every index".  Reading
+    // only the array spelling silently turned the string one into "absent",
+    // so `{"indices":"logs-*"}` captured the whole node -- every other
+    // tenant's data included -- while authorization had only ever seen the
+    // narrow pattern the caller asked for.  Parsed exactly as the restore
+    // side already parses it.
+    let requested: Option<Vec<String>> = match body.as_ref().and_then(|b| b.get("indices")) {
+        Some(Value::Array(arr)) => Some(
             arr.iter()
                 .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        });
+                .collect(),
+        ),
+        Some(Value::String(s)) => Some(vec![s.clone()]),
+        _ => None,
+    };
+    // `create_snapshot` takes concrete names, so patterns have to be resolved
+    // here. Resolving them against `index_name_list` — which the visibility
+    // guard filters — is what makes the set captured equal the set
+    // authorization decided on: previously a wildcard reached the engine
+    // verbatim, matched nothing, and produced an empty snapshot, while the
+    // string spelling was dropped entirely and captured the whole node.
+    let indices: Option<Vec<String>> = requested.map(|specs| {
+        let all = state.engine.index_name_list();
+        let mut out: Vec<String> = Vec::new();
+        let mut push = |name: String, out: &mut Vec<String>| {
+            if !out.contains(&name) {
+                out.push(name);
+            }
+        };
+        for spec in &specs {
+            for part in spec.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                if part == "_all" || part == "*" {
+                    for n in &all {
+                        push(n.clone(), &mut out);
+                    }
+                } else if part.contains('*') {
+                    for n in all.iter().filter(|n| glob_match_simple(part, n)) {
+                        push(n.clone(), &mut out);
+                    }
+                } else {
+                    push(part.to_string(), &mut out);
+                }
+            }
+        }
+        out
+    });
 
     match state
         .engine

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -23168,7 +23168,7 @@ pub async fn create_snapshot(
     let indices: Option<Vec<String>> = requested.map(|specs| {
         let all = state.engine.index_name_list();
         let mut out: Vec<String> = Vec::new();
-        let mut push = |name: String, out: &mut Vec<String>| {
+        let push = |name: String, out: &mut Vec<String>| {
             if !out.contains(&name) {
                 out.push(name);
             }

--- a/engine/crates/xerj-api/tests/snapshot_is_not_a_way_around_a_brain.rs
+++ b/engine/crates/xerj-api/tests/snapshot_is_not_a_way_around_a_brain.rs
@@ -1,0 +1,357 @@
+//! Snapshot and restore are the two verbs that reach index data without going
+//! through the engine's visibility funnel — and they were the two verbs a
+//! non-superuser could point at every tenant's brain.
+//!
+//! `Engine::create_snapshot` walks the index map itself; `Engine::restore_snapshot`
+//! expands the request's pattern against the snapshot's own manifest and then
+//! `remove_dir_all`s and rewrites the index directory directly. Neither calls
+//! `get_index` or `delete_index`, so `xerj_engine::index_guard` — the backstop
+//! that catches everything `authz` did not know to parse — was never consulted
+//! on either path. Two holes followed:
+//!
+//! * `POST /_snapshot/{repo}/{snap}/_restore {"indices":".xerj-memory-*"}` —
+//!   authorization waved the wildcard through (a pattern is normally expanded
+//!   over the caller's visible set, which is exactly what does *not* happen
+//!   here), so any authenticated caller rolled every brain on the node back to
+//!   the backup instant, destroying every write made since.
+//! * `PUT /_snapshot/{repo}/{snap} {"indices":"*"}` — the create handler read
+//!   `indices` only in its ARRAY form, so the string spelling ES also accepts
+//!   resolved to `None` and the engine fell back to "every index on the node".
+//!   The caller's authorized target list was simply not the list that got
+//!   copied.
+//!
+//! Both are measured end-to-end here, against a real snapshot on disk, with a
+//! minted non-admin key.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+use xerj_api::{router::build_es_compat_router, state::AppState};
+use xerj_common::{config::Config, metrics::Metrics};
+use xerj_engine::Engine;
+
+const ADMIN_KEY: &str = "admin-secret-key-for-snapshot-test";
+
+/// Pinned fixture instants — a link and the read that follows it must never
+/// land in the same millisecond.
+const T0: i64 = 1_753_600_000_000;
+const T1: i64 = 1_753_600_100_000;
+
+fn auth_enabled_state() -> (AppState, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().expect("utf8 path").to_string();
+    config.auth.enabled = true;
+    config.auth.admin_api_key = ADMIN_KEY.to_string();
+    let metrics = Metrics::new().expect("metrics");
+    let engine = Engine::new(config.clone()).expect("engine");
+    (AppState::new(config, engine, metrics), dir)
+}
+
+async fn send(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    auth: &str,
+    body: &str,
+) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("authorization", auth)
+        .body(Body::from(body.to_string()))
+        .expect("request");
+    let resp = app.clone().oneshot(req).await.expect("response");
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+async fn mint(app: &axum::Router, minter: &str, body: &str) -> String {
+    let (status, resp) = send(app, "POST", "/_security/api_key", minter, body).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "minting a key should succeed: {resp}"
+    );
+    format!("ApiKey {}", resp["encoded"].as_str().expect("encoded key"))
+}
+
+/// The index directories a snapshot actually captured — ground truth, read off
+/// the filesystem rather than from the manifest the snapshot wrote about itself.
+fn captured(repo_dir: &std::path::Path, snapshot: &str) -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(repo_dir.join(snapshot))
+        .expect("snapshot dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Two brains and one ordinary index, seeded as the admin, plus a snapshot
+/// repository inside the data dir (the only location the engine accepts
+/// without an explicit allowlist).
+async fn seed(app: &axum::Router, data_dir: &std::path::Path) -> String {
+    let admin = format!("ApiKey {ADMIN_KEY}");
+    for brain in ["alice", "bob"] {
+        let (status, body) = send(
+            app,
+            "POST",
+            &format!("/_graph/{brain}/link"),
+            &admin,
+            &format!(
+                r#"{{"src":"doc:1","type":"mentions","dst":"{brain}:secret",
+                     "valid_at":{T0},"created_at":{T0}}}"#
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "seeding {brain}: {body}");
+    }
+    let (status, body) = send(
+        app,
+        "POST",
+        "/logs-2026/_doc/1",
+        &admin,
+        r#"{"message":"tenant data"}"#,
+    )
+    .await;
+    assert!(status.is_success(), "seeding logs-2026: {status} {body}");
+
+    let repo_dir = data_dir.join("snaprepo");
+    let (status, body) = send(
+        app,
+        "PUT",
+        "/_snapshot/snaprepo",
+        &admin,
+        &format!(
+            r#"{{"type":"fs","settings":{{"location":"{}"}}}}"#,
+            repo_dir.to_str().expect("utf8 path")
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "registering the repo: {body}");
+    admin
+}
+
+/// A tenant key granted the ordinary `logs-*` namespace and nothing else —
+/// the credential a routine per-tenant backup job would run under.
+const LOGS_TENANT: &str = r#"{"name":"logs-tenant","role_descriptors":{"logs":{"indices":[
+    {"names":["logs-*"],"privileges":["all"]}]}}}"#;
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The destructive half. A restore names its targets with a pattern, and that
+/// pattern is executed verbatim against the snapshot's manifest — so it must be
+/// refused here or it is refused nowhere.
+#[tokio::test]
+async fn a_tenant_cannot_restore_every_brain_on_the_node() {
+    let (state, data_dir) = auth_enabled_state();
+    let app = build_es_compat_router(state);
+    let admin = seed(&app, data_dir.path()).await;
+    let tenant = mint(&app, &admin, LOGS_TENANT).await;
+
+    // The prerequisite an ordinary admin backup produces: a snapshot that
+    // contains the brains.
+    let (status, body) = send(&app, "PUT", "/_snapshot/snaprepo/full", &admin, "{}").await;
+    assert_eq!(status, StatusCode::OK, "admin full backup: {body}");
+    assert!(
+        captured(&data_dir.path().join("snaprepo"), "full")
+            .iter()
+            .any(|n| n.starts_with(".xerj-memory-")),
+        "the admin's full backup must contain the brains, or this test proves nothing"
+    );
+
+    // Bob keeps working after the backup. This edge exists ONLY in live state.
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/_graph/bob/link",
+        &admin,
+        &format!(
+            r#"{{"src":"doc:1","type":"mentions","dst":"bob:after-backup",
+                 "valid_at":{T1},"created_at":{T1}}}"#
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "post-backup write: {body}");
+
+    // The attack: one request, every brain rolled back to the backup instant.
+    for indices in [
+        r#""indices":".xerj-memory-*""#,
+        r#""indices":[".xerj-memory-*"]"#,
+        r#""indices":"*""#,
+        r#""indices":"_all""#,
+        r#""indices":".xerj-memory-bob-edges""#,
+    ] {
+        let (status, body) = send(
+            &app,
+            "POST",
+            "/_snapshot/snaprepo/full/_restore?wait_for_completion=true",
+            &tenant,
+            &format!("{{{indices}}}"),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "restore {{{indices}}} must be forbidden: {body}"
+        );
+    }
+
+    // Bob's post-backup edge is still there — nothing was rolled back.
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/_graph/bob/ego?node=doc:1&depth=1",
+        &admin,
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "reading bob's brain back: {body}");
+    let serialized = body.to_string();
+    assert!(
+        serialized.contains("bob:after-backup"),
+        "the write made after the backup must survive: {serialized}"
+    );
+}
+
+/// The enabling half. `indices` in its string spelling was not read at all, so
+/// the engine snapshotted every index on the node — including the brains the
+/// caller had just been refused by name.
+#[tokio::test]
+async fn a_tenant_snapshot_captures_only_what_it_named() {
+    let (state, data_dir) = auth_enabled_state();
+    let app = build_es_compat_router(state);
+    let admin = seed(&app, data_dir.path()).await;
+    let tenant = mint(&app, &admin, LOGS_TENANT).await;
+    let repo_dir = data_dir.path().join("snaprepo");
+
+    // An unbounded snapshot, in either spelling, is not this credential's to
+    // take: `*` reaches the reserved namespace.
+    for body in ["{}", r#"{"indices":"*"}"#, r#"{"indices":["*"]}"#] {
+        let (status, resp) = send(&app, "PUT", "/_snapshot/snaprepo/pwn", &tenant, body).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "snapshot {body} must be forbidden: {resp}"
+        );
+    }
+    assert!(
+        !repo_dir.join("pwn").exists(),
+        "a refused snapshot must not have written anything"
+    );
+
+    // The legitimate use keeps working — and captures the tenant's own index
+    // and nothing else. This is the assertion the string form failed: it used
+    // to copy every brain on the node into a repo the tenant controls.
+    let (status, resp) = send(
+        &app,
+        "PUT",
+        "/_snapshot/snaprepo/mine",
+        &tenant,
+        r#"{"indices":"logs-*"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "tenant snapshot of logs-*: {resp}");
+    assert_eq!(
+        captured(&repo_dir, "mine"),
+        vec!["logs-2026".to_string()],
+        "a `logs-*` snapshot captured indices it did not name"
+    );
+
+    // The array spelling of the same request agrees with the string one.
+    let (status, resp) = send(
+        &app,
+        "PUT",
+        "/_snapshot/snaprepo/mine-array",
+        &tenant,
+        r#"{"indices":["logs-*"]}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "array spelling: {resp}");
+    assert_eq!(
+        captured(&repo_dir, "mine-array"),
+        vec!["logs-2026".to_string()]
+    );
+
+    // And the tenant can roll its own index back, which is the whole point of
+    // being allowed to take the snapshot.
+    let (status, resp) = send(
+        &app,
+        "POST",
+        "/_snapshot/snaprepo/mine/_restore?wait_for_completion=true",
+        &tenant,
+        r#"{"indices":"logs-*"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "tenant restore of its own: {resp}");
+    assert_eq!(
+        resp["snapshot"]["indices"],
+        serde_json::json!(["logs-2026"]),
+        "restore reported something other than the tenant's own index: {resp}"
+    );
+}
+
+/// The operator path must be untouched: a superuser backs up and restores the
+/// whole node, brains included.
+#[tokio::test]
+async fn the_superuser_still_backs_up_and_restores_everything() {
+    let (state, data_dir) = auth_enabled_state();
+    let app = build_es_compat_router(state);
+    let admin = seed(&app, data_dir.path()).await;
+    let repo_dir = data_dir.path().join("snaprepo");
+
+    for (name, body) in [
+        ("full", "{}"),
+        ("star", r#"{"indices":"*"}"#),
+        ("star-array", r#"{"indices":["*"]}"#),
+        ("brains", r#"{"indices":".xerj-memory-*"}"#),
+    ] {
+        let (status, resp) = send(
+            &app,
+            "PUT",
+            &format!("/_snapshot/snaprepo/{name}"),
+            &admin,
+            body,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "superuser snapshot {body}: {resp}");
+        let names = captured(&repo_dir, name);
+        assert!(
+            names.iter().any(|n| n.starts_with(".xerj-memory-")),
+            "superuser snapshot {body} captured no brain: {names:?}"
+        );
+        if body == "{}" || body.contains("\"*\"") {
+            assert!(
+                names.iter().any(|n| n == "logs-2026"),
+                "an unbounded superuser snapshot must still cover ordinary indices: {names:?}"
+            );
+        }
+    }
+
+    let (status, resp) = send(
+        &app,
+        "POST",
+        "/_snapshot/snaprepo/full/_restore?wait_for_completion=true",
+        &admin,
+        r#"{"indices":"*"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "superuser full restore: {resp}");
+    let restored = resp["snapshot"]["indices"]
+        .as_array()
+        .expect("restored list")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        restored.iter().any(|n| n.starts_with(".xerj-memory-")),
+        "the operator must still be able to restore a brain: {restored:?}"
+    );
+}


### PR DESCRIPTION
## The defect (rc.10 release blocker — cross-tenant data destruction)

`authorize_expression` waved **every** wildcard through before consulting the principal's grants:

```rust
if is_pattern(expr) { return Ok(()); }
```

That reasoning is sound where the engine expands a pattern over the caller's visible set. Snapshot and restore are the two verbs that never reach that funnel — `Engine::create_snapshot` walks the index map itself, and `Engine::restore_snapshot` expands the pattern against the snapshot's own manifest and then `remove_dir_all`s and rewrites the index directory. No `get_index`, no `delete_index`, so `index_guard::visible()` is never consulted. **A wildcard authorized there is a wildcard executed.**

```
POST /_snapshot/{repo}/{snap}/_restore  {"indices":".xerj-memory-*"}
```

by any authenticated non-superuser rolled **every tenant's brain** back to the backup instant, permanently losing everything written since. The create side (`{"indices":"*"}`) backed every brain up for them first, which is also how the attacker obtains a brain-bearing snapshot to restore from — a routine admin full-backup produces one too.

`may_reach_reserved` already existed but was wired only into `authorize_template_patterns`.

## The fix

A new `PatternExpansion` distinction records whether the route's names are resolved through the guarded engine funnel (`Guarded`, everywhere else) or acted on directly (`Unguarded` — snapshot and restore only). Under `Unguarded`, a pattern that `may_reach_reserved` now requires an **explicit grant**, exactly as an index template's `index_patterns` already does. Anything narrower (`logs-*`) passes untouched, so ordinary per-tenant backups are unaffected.

**Second half — the create handler read `indices` only in its array spelling.** The string form ES equally accepts fell through to "absent" and captured the whole node — every other tenant included — while authorization had seen only the narrow pattern the caller asked for. Note this hole was *not* closed by the authz gate above: `{"indices":"logs-*"}` legitimately passes authorization and then captured everything.

It now parses both spellings like the restore side already did, and **resolves patterns against the visibility-filtered index list**, so the set captured equals the set authorization decided on. This also fixes a pre-existing bug in the opposite direction: `create_snapshot` takes concrete names, so a wildcard reached it verbatim, matched nothing, and made `{"indices":["*"]}` produce an **empty** snapshot.

## Tests

`snapshot_is_not_a_way_around_a_brain.rs` (end-to-end) + decision-table unit tests, all passing:
- `a_tenant_snapshot_captures_only_what_it_named`
- `the_superuser_still_backs_up_and_restores_everything` — `{}`, `"*"`, `["*"]` and `".xerj-memory-*"` all still capture brains **and** ordinary indices
- `snapshot_patterns_cannot_reach_the_reserved_namespace` — both spellings, across legacy/unscoped, tenant-scoped and `logs-*` principals, on create **and** restore; plus controls that `logs-*`, comma lists, by-name tenant access and an explicit `names:["*"]` grant all still work

Full `xerj-api` suite: **11 suites, 0 failures**. `cargo fmt --all --check` clean.