### PR TITLE
fix(autoindex): refuse unsupported corpus reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed — fail-closed autoindex restart semantics
+### Changed — autoindex refuses reruns that would strand documents
 
-- **`autoindex --fresh` no longer discards a durable resume plan.** A durable
-  plan contains the alias, path, graph, and stale-record knowledge needed for
-  safe reconciliation. `--fresh` is accepted only when the selected state
-  directory has no durable plan and never cleans the destination. An
-  independent rebuild must use a new state directory, new prefix, and new brain
-  namespace when graph detection is enabled (or disable graph writes), be
-  validated, and only then replace the old reader target. The shared catalog
-  and old target require explicit, validated cleanup. Membership additions and
-  removals are refused; same-path replacement remains supported.
+- **Deleting an indexed file and rerunning `xerj autoindex` now fails instead
+  of exiting 0.** Nothing in the pipeline removes the documents, aliases,
+  graph edges or catalog entries that the deleted file published, so a rerun
+  that ignored the deletion left them live and searchable with no source file
+  behind them. The rerun is now refused before any remote call other than the
+  endpoint-readiness ping: no mapping, delete-by-query, bulk, refresh, graph
+  or catalog write is attempted, and the journal is not appended to. The error
+  names every removed file and its content key and gives three recovery
+  routes — restore the files and rerun, rebuild in place by deleting the named
+  indices and the state directory, or rebuild under a new state directory,
+  prefix and brain. `--fresh` is refused for the same case, because it does
+  not delete those documents either. `--json` emits the same facts as
+  `xerj.autoindex.unsupported_sync_delta.v1` on stdout with exit 1.
+- **Files added after a plan was frozen are now called out on stderr.** They
+  are still not indexed by a rerun that resumes an existing plan — the plan is
+  a crash-resume boundary, not a folder-sync generation — but the run now
+  lists them, records them as skipped (exit 3, completed-with-junk) and points
+  at `--fresh`, which rebuilds the plan in place and picks them up. Adding or
+  changing files and rerunning keeps working; only removals are refused.
 - **`xerj brain` no longer turns an absent or zero node-count probe into an
   automatic reset.** Journal/server disagreement now fails with the journal,
-  URL, prefix, and brain identity plus recovery instructions. Probe transport
-  and malformed-response failures remain errors instead of being reported as
-  an empty destination.
+  URL, prefix, and brain identity plus recovery instructions, including the
+  explicit `--fresh` rerun for a genuinely wiped data directory. Probe
+  transport and malformed-response failures remain errors instead of being
+  reported as an empty destination.
 
 ## [1.0.0-rc.10] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — fail-closed autoindex restart semantics
+
+- **`autoindex --fresh` no longer discards a durable resume plan.** A durable
+  plan contains the alias, path, graph, and stale-record knowledge needed for
+  safe reconciliation. `--fresh` is accepted only when the selected state
+  directory has no durable plan and never cleans the destination. An
+  independent rebuild must use a new state directory, new prefix, and new brain
+  namespace when graph detection is enabled (or disable graph writes), be
+  validated, and only then replace the old reader target. The shared catalog
+  and old target require explicit, validated cleanup. Membership additions and
+  removals are refused; same-path replacement remains supported.
+- **`xerj brain` no longer turns an absent or zero node-count probe into an
+  automatic reset.** Journal/server disagreement now fails with the journal,
+  URL, prefix, and brain identity plus recovery instructions. Probe transport
+  and malformed-response failures remain errors instead of being reported as
+  an empty destination.
+
 ## [1.0.0-rc.10] - 2026-08-03
 
 ### Security
@@ -82,7 +99,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reaching the HNSW graph. Each arrived with a standalone harness and honest
   caveats. They are tracked for the following release rather than rushed into
   this one.
-
 
 ### Changed — runtime-field types (can break existing mappings)
 

--- a/demo/usecases/autoindex/RECIPE_DRAFT.md
+++ b/demo/usecases/autoindex/RECIPE_DRAFT.md
@@ -203,13 +203,11 @@ done in 0.1s — 3 datasets, 5801 records live, 0 junk records, 1 junk/skipped f
 just polite re-runs: in the robustness evaluation, a `kill -9` at 18 s into a
 200 MB file followed by a re-run converged to **byte-identical counts across
 all 9 datasets** — no duplicates. `xerj autoindex status` shows the journal
-and live index counts. `--fresh` starts without resume state only when the
-selected state directory has no durable plan; it never removes stale
-destination records. For an independent rebuild, use a new `--state-dir`, new
-`--prefix`, and new `--brain` when graph detection is enabled (or add
-`--no-graph`). Validate before switching readers. The shared
-`autoindex-catalog` and old target require explicit, validated cleanup. Added
-or removed content groups are refused; same-path replacement remains supported.
+and live index counts; `--fresh` ignores the journal and rebuilds the plan in
+place (ids stay idempotent), which is how a rerun picks up files added since
+the last one. Deleting an indexed file is refused before any destination
+change — nothing here removes the documents it already published — and the
+error names what is gone plus the recovery routes.
 
 ## Reproduce it yourself
 

--- a/demo/usecases/autoindex/RECIPE_DRAFT.md
+++ b/demo/usecases/autoindex/RECIPE_DRAFT.md
@@ -203,8 +203,13 @@ done in 0.1s — 3 datasets, 5801 records live, 0 junk records, 1 junk/skipped f
 just polite re-runs: in the robustness evaluation, a `kill -9` at 18 s into a
 200 MB file followed by a re-run converged to **byte-identical counts across
 all 9 datasets** — no duplicates. `xerj autoindex status` shows the journal
-and live index counts; `--fresh` ignores the journal and restarts (ids stay
-idempotent).
+and live index counts. `--fresh` starts without resume state only when the
+selected state directory has no durable plan; it never removes stale
+destination records. For an independent rebuild, use a new `--state-dir`, new
+`--prefix`, and new `--brain` when graph detection is enabled (or add
+`--no-graph`). Validate before switching readers. The shared
+`autoindex-catalog` and old target require explicit, validated cleanup. Added
+or removed content groups are refused; same-path replacement remains supported.
 
 ## Reproduce it yourself
 

--- a/demo/usecases/autoindex/run-eval.sh
+++ b/demo/usecases/autoindex/run-eval.sh
@@ -2,9 +2,11 @@
 # End-to-end eval of `xerj autoindex` against a corpus folder.
 #
 # Boots a dedicated server on es_compat $PORT (rest PORT+100, grpc PORT+101),
-# runs autoindex over $CORPUS, proves same-state resume, then performs an
-# isolated data/graph rebuild under a new state directory, prefix, and brain.
-# The global autoindex-catalog remains shared and is excluded from comparison.
+# runs autoindex over $CORPUS, then re-runs twice to prove idempotency — the
+# resume path (all files done) and a full --fresh re-extract — and requires the
+# per-index doc counts to be byte-identical to run 1. Ends with the data map.
+# The shared autoindex-catalog is excluded from the comparison: every run
+# appends its own run record, so a growing catalog is the design, not drift.
 #
 # Nothing here is bound to one machine: every path is an env override with a
 # default under the repo or $TMPDIR, so the same script gates CI and drives a
@@ -33,20 +35,11 @@ CFG="$WORK/server-$PORT.toml"
 LOG="$WORK/server-$PORT.log"
 URL="http://localhost:$PORT"
 STATE="$WORK/state"
-REBUILD_STATE="$WORK/rebuild-state"
-PREFIX="ax-eval-a"
-REBUILD_PREFIX="ax-eval-b"
-BRAIN="eval-a"
-REBUILD_BRAIN="eval-b"
+PREFIX="ax-eval"
+BRAIN="eval"
 
 [ -x "$BIN" ] || { echo "xerj binary not found at $BIN"; exit 1; }
 [ -d "$CORPUS" ] || { echo "corpus folder not found at $CORPUS"; exit 1; }
-[ ! -e "$DATA" ] && [ ! -e "$STATE" ] && [ ! -e "$REBUILD_STATE" ] || {
-  echo "work directory already contains eval state: $WORK"
-  echo "choose a new XERJ_AUTOINDEX_WORK or explicitly remove the old isolated eval directory"
-  exit 1
-}
-
 mkdir -p "$WORK"
 cat >"$CFG" <<EOF
 [server]
@@ -85,10 +78,10 @@ if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
   FAIL=1
 fi
 
-# Name + doc count only. The _cat row also carries on-disk size, which an
-# isolated data/graph rebuild legitimately changes (segments are rewritten).
-# The shared global catalog is excluded because every run appends its own run
-# record — a growing catalog is the design, not drift. Columns of the _cat row:
+# Name + doc count only. The _cat row also carries on-disk size, which a
+# --fresh re-extract legitimately changes (segments are rewritten), and the
+# catalog is excluded outright because every run appends its own run record —
+# a growing catalog is the design, not drift. Columns of the _cat row:
 # green(1) open(2) name(3) uuid(4) pri(5) rep(6) docs(7).
 counts() { curl -s "$URL/_cat/indices" | awk -v prefix="$1-" '$3 ~ ("^" prefix) {sub("^" prefix, "", $3); print $3, $7}' | sort; }
 
@@ -104,16 +97,16 @@ if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
   FAIL=1
 fi
 
-echo "=== isolated data/graph rebuild reproducibility (new state, prefix, and brain; shared catalog excluded) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$REBUILD_STATE" --prefix "$REBUILD_PREFIX" --brain "$REBUILD_BRAIN"
+echo "=== idempotency: re-run with --fresh (full re-extract, idempotent ids) ==="
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --prefix "$PREFIX" --brain "$BRAIN" --fresh
 RC=$?
 if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
-  echo "isolated data/graph rebuild exited $RC (expected 0 or 3)"
+  echo "--fresh re-extract exited $RC (expected 0 or 3)"
   FAIL=1
 fi
 
-counts "$REBUILD_PREFIX" > "$WORK/counts-run3.txt"
-echo "=== normalized data-index count diff original vs isolated data/graph rebuild (shared catalog excluded; must be empty) ==="
+counts "$PREFIX" > "$WORK/counts-run3.txt"
+echo "=== doc-count diff run1 vs run3 (must be empty) ==="
 cat "$WORK/counts-run3.txt"
 if diff "$WORK/counts-run1.txt" "$WORK/counts-run3.txt"; then
   echo "IDENTICAL COUNTS ✓"

--- a/demo/usecases/autoindex/run-eval.sh
+++ b/demo/usecases/autoindex/run-eval.sh
@@ -2,9 +2,9 @@
 # End-to-end eval of `xerj autoindex` against a corpus folder.
 #
 # Boots a dedicated server on es_compat $PORT (rest PORT+100, grpc PORT+101),
-# runs autoindex over $CORPUS, then re-runs twice to prove idempotency — the
-# resume path (all files done) and a full --fresh re-extract — and requires the
-# per-index doc counts to be byte-identical to run 1. Ends with the data map.
+# runs autoindex over $CORPUS, proves same-state resume, then performs an
+# isolated data/graph rebuild under a new state directory, prefix, and brain.
+# The global autoindex-catalog remains shared and is excluded from comparison.
 #
 # Nothing here is bound to one machine: every path is an env override with a
 # default under the repo or $TMPDIR, so the same script gates CI and drives a
@@ -33,9 +33,19 @@ CFG="$WORK/server-$PORT.toml"
 LOG="$WORK/server-$PORT.log"
 URL="http://localhost:$PORT"
 STATE="$WORK/state"
+REBUILD_STATE="$WORK/rebuild-state"
+PREFIX="ax-eval-a"
+REBUILD_PREFIX="ax-eval-b"
+BRAIN="eval-a"
+REBUILD_BRAIN="eval-b"
 
 [ -x "$BIN" ] || { echo "xerj binary not found at $BIN"; exit 1; }
 [ -d "$CORPUS" ] || { echo "corpus folder not found at $CORPUS"; exit 1; }
+[ ! -e "$DATA" ] && [ ! -e "$STATE" ] && [ ! -e "$REBUILD_STATE" ] || {
+  echo "work directory already contains eval state: $WORK"
+  echo "choose a new XERJ_AUTOINDEX_WORK or explicitly remove the old isolated eval directory"
+  exit 1
+}
 
 mkdir -p "$WORK"
 cat >"$CFG" <<EOF
@@ -66,7 +76,7 @@ curl -sf "$URL/" >/dev/null || { echo "server failed to boot"; tail -20 "$LOG"; 
 FAIL=0
 
 echo "=== autoindex run ($CORPUS) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --fresh
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --prefix "$PREFIX" --brain "$BRAIN"
 RC=$?
 echo "exit code: $RC"
 # 0 complete, 3 completed-with-junk (unreadable files recorded, never fatal).
@@ -75,25 +85,35 @@ if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
   FAIL=1
 fi
 
-# Name + doc count only. The _cat row also carries on-disk size, which a
-# --fresh re-extract legitimately changes (segments are rewritten), and the
-# catalog is excluded outright because every run appends its own run record —
-# a growing catalog is the design, not drift. Columns of the _cat row:
+# Name + doc count only. The _cat row also carries on-disk size, which an
+# isolated data/graph rebuild legitimately changes (segments are rewritten).
+# The shared global catalog is excluded because every run appends its own run
+# record — a growing catalog is the design, not drift. Columns of the _cat row:
 # green(1) open(2) name(3) uuid(4) pri(5) rep(6) docs(7).
-counts() { curl -s "$URL/_cat/indices" | awk '$3 ~ /^ax-/ {print $3, $7}' | sort; }
+counts() { curl -s "$URL/_cat/indices" | awk -v prefix="$1-" '$3 ~ ("^" prefix) {sub("^" prefix, "", $3); print $3, $7}' | sort; }
 
 echo "=== per-index counts (run 1) ==="
 curl -s "$URL/_cat/indices" | grep -E 'ax-|autoindex-catalog' | sort
-counts > "$WORK/counts-run1.txt"
+counts "$PREFIX" > "$WORK/counts-run1.txt"
 
 echo "=== idempotency: re-run (resume path — all files done) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE"
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --prefix "$PREFIX" --brain "$BRAIN"
+RC=$?
+if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
+  echo "resume run exited $RC (expected 0 or 3)"
+  FAIL=1
+fi
 
-echo "=== idempotency: re-run with --fresh (full re-extract, idempotent ids) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --fresh
+echo "=== isolated data/graph rebuild reproducibility (new state, prefix, and brain; shared catalog excluded) ==="
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$REBUILD_STATE" --prefix "$REBUILD_PREFIX" --brain "$REBUILD_BRAIN"
+RC=$?
+if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
+  echo "isolated data/graph rebuild exited $RC (expected 0 or 3)"
+  FAIL=1
+fi
 
-counts > "$WORK/counts-run3.txt"
-echo "=== doc-count diff run1 vs run3 (must be empty) ==="
+counts "$REBUILD_PREFIX" > "$WORK/counts-run3.txt"
+echo "=== normalized data-index count diff original vs isolated data/graph rebuild (shared catalog excluded; must be empty) ==="
 cat "$WORK/counts-run3.txt"
 if diff "$WORK/counts-run1.txt" "$WORK/counts-run3.txt"; then
   echo "IDENTICAL COUNTS ✓"

--- a/docs/EXPERIMENTAL_ONNX.md
+++ b/docs/EXPERIMENTAL_ONNX.md
@@ -88,7 +88,7 @@ In another terminal, index a corpus:
 target/release/xerj autoindex /path/to/corpus \
   --url http://localhost:9200 \
   --prefix finance-onnx \
-  --fresh
+  --state-dir /path/to/new-finance-onnx-state
 
 target/release/xerj autoindex map \
   --url http://localhost:9200 \
@@ -152,9 +152,11 @@ with the same assets. XERJ refuses:
 - enabling ONNX in place on a populated marker-less semantic index;
 - caller-supplied derived vectors whose identity cannot be verified.
 
-The error tells the operator to restore the original assets or re-run
-autoindex with `--fresh` and a new prefix. XERJ never silently mixes vector
-spaces.
+The error tells the operator to restore the original assets or perform an
+isolated autoindex rebuild with a new state directory, new prefix, and new
+brain when graph detection is enabled (or `--no-graph`). Validate the new
+target before switching readers; the shared catalog and old target require
+explicit, validated cleanup. XERJ never silently mixes vector spaces.
 
 The transformer-fused graph produced by the offline recipe is a different
 model identity from its source graph because its model hash differs. Do not

--- a/docs/design/second_brain_graph_wf.js
+++ b/docs/design/second_brain_graph_wf.js
@@ -99,9 +99,8 @@ heterogeneous content (code + PDFs + docs), and captured as a screencast.
   automaticPresenceSimulation:true})\`, then claim via the setup magic-link the server prints
   at first boot. A working reference script is ${REPO}/sb_capture.mjs.
 - \`xerj brain\` gotcha: a stale resume journal in \`~/.xerj/autoindex\` makes re-runs skip
-  detection. For an independent clean run, choose a new \`--state-dir\`, new
-  \`--prefix\`, and new \`--brain\` (or \`--no-graph\`); \`--fresh\` cannot
-  discard a durable plan or clean the shared catalog or old target.
+  detection. Use \`--fresh\` (or clear it) for clean runs; note that \`--fresh\` rebuilds
+  the plan in place and never removes documents for notes you deleted.
 - Commits authored \`xerj-org <git@xerj.org>\`, NO Claude co-author trailer, never mention
   ctrl-frk. Do NOT push. Commit on \`feat/second-brain\`.
 

--- a/docs/design/second_brain_graph_wf.js
+++ b/docs/design/second_brain_graph_wf.js
@@ -99,7 +99,9 @@ heterogeneous content (code + PDFs + docs), and captured as a screencast.
   automaticPresenceSimulation:true})\`, then claim via the setup magic-link the server prints
   at first boot. A working reference script is ${REPO}/sb_capture.mjs.
 - \`xerj brain\` gotcha: a stale resume journal in \`~/.xerj/autoindex\` makes re-runs skip
-  detection. Use \`--fresh\` (or clear it) for clean runs.
+  detection. For an independent clean run, choose a new \`--state-dir\`, new
+  \`--prefix\`, and new \`--brain\` (or \`--no-graph\`); \`--fresh\` cannot
+  discard a durable plan or clean the shared catalog or old target.
 - Commits authored \`xerj-org <git@xerj.org>\`, NO Claude co-author trailer, never mention
   ctrl-frk. Do NOT push. Commit on \`feat/second-brain\`.
 

--- a/docs/recipes/zero-config-indexing.md
+++ b/docs/recipes/zero-config-indexing.md
@@ -228,13 +228,17 @@ live indices at http://localhost:9280:
   autoindex-catalog                                 9 docs
 ```
 
-`--fresh` starts without resume state only when the selected state directory
-has no durable plan; it never removes stale destination records. For an
-independent rebuild, use a new `--state-dir`, new `--prefix`, and new
-`--brain` when graph detection is enabled (or add `--no-graph`). Validate
-before switching readers. The shared `autoindex-catalog` and old target require
-explicit, validated cleanup. Added or removed content groups are refused;
-same-path replacement remains supported.
+`--fresh` ignores the journal and rebuilds the plan in place (ids stay
+idempotent), which is how you pick up files added since the last run.
+
+A rerun that resumes an existing plan indexes changed files and reports added
+ones as skipped. Deleting a file is refused: nothing here removes the
+documents it already published, so the rerun stops before touching the
+destination and names what is gone. Restore the file and rerun, or rebuild —
+in place by deleting the named indices and the state directory, or isolated
+under a new `--state-dir`, `--prefix` and `--brain` (or `--no-graph`),
+validated before you switch readers. The shared `autoindex-catalog` and the
+old target require explicit cleanup.
 
 ## Reproduce it yourself
 

--- a/docs/recipes/zero-config-indexing.md
+++ b/docs/recipes/zero-config-indexing.md
@@ -228,7 +228,13 @@ live indices at http://localhost:9280:
   autoindex-catalog                                 9 docs
 ```
 
-`--fresh` ignores the journal and restarts (ids stay idempotent).
+`--fresh` starts without resume state only when the selected state directory
+has no durable plan; it never removes stale destination records. For an
+independent rebuild, use a new `--state-dir`, new `--prefix`, and new
+`--brain` when graph detection is enabled (or add `--no-graph`). Validate
+before switching readers. The shared `autoindex-catalog` and old target require
+explicit, validated cleanup. Added or removed content groups are refused;
+same-path replacement remains supported.
 
 ## Reproduce it yourself
 

--- a/docs/usecases/second-brain/README.md
+++ b/docs/usecases/second-brain/README.md
@@ -205,12 +205,13 @@ other note tools. No such numbers are claimed.
   root-caused.
 - **YAML-frontmatter markdown can sniff as YAML:** one `SKILL.md` with
   frontmatter landed in junk/skipped instead of being indexed.
-- **Stale resume journals can pollute links** after a wiped data dir;
-  `--fresh` cannot discard a durable plan and is not stale-journal recovery.
-  Restore the server data directory used by the journal. For an explicitly
-  isolated rebuild, use a new state directory, prefix, and brain namespace,
-  validate it, then switch readers. The shared `autoindex-catalog` and old
-  target require explicit, validated cleanup.
+- **Stale resume journals can pollute links** after a wiped data dir. `xerj
+  brain` no longer guesses: it reports the disagreement between the journal
+  and the server instead of resetting on its own. If the data directory really
+  was wiped, rerun with `--fresh` to rebuild the plan and republish every note
+  in place; if it was not, point at the data directory the journal was written
+  against, or rebuild under a new state directory, prefix and brain and
+  validate before switching readers.
 - **Wikilink detection was not exercised on this corpus** (real docs use
   markdown links); it is covered by the demo-corpus run (30 wikilinks) and
   the autoindex test suite.

--- a/docs/usecases/second-brain/README.md
+++ b/docs/usecases/second-brain/README.md
@@ -206,7 +206,11 @@ other note tools. No such numbers are claimed.
 - **YAML-frontmatter markdown can sniff as YAML:** one `SKILL.md` with
   frontmatter landed in junk/skipped instead of being indexed.
 - **Stale resume journals can pollute links** after a wiped data dir;
-  `--fresh` re-walks everything and is the mitigation.
+  `--fresh` cannot discard a durable plan and is not stale-journal recovery.
+  Restore the server data directory used by the journal. For an explicitly
+  isolated rebuild, use a new state directory, prefix, and brain namespace,
+  validate it, then switch readers. The shared `autoindex-catalog` and old
+  target require explicit, validated cleanup.
 - **Wikilink detection was not exercised on this corpus** (real docs use
   markdown links); it is covered by the demo-corpus run (30 wikilinks) and
   the autoindex test suite.

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -53,9 +53,8 @@ pub enum Cmd {
     Help,
 }
 
-const FRESH_HELP: &str =
-    "start without resume state only when the selected state directory has no \
-durable plan; an existing plan is refused and destination records are never reset";
+const FRESH_HELP: &str = "ignore the existing journal and rebuild the plan in place\n\
+                                  (ids stay idempotent) — see RESUME POLICY";
 
 pub fn print_help() {
     println!(
@@ -115,14 +114,16 @@ pub fn print_help() {
          \n\
          RESUME POLICY:\n\
              A durable plan supports no-op resume and same-path content replacement.\n\
-             Added or removed content groups are refused before remote mutation.\n\
-             An independent rebuild needs a new --state-dir, new --prefix, and, when\n\
-             graph detection is enabled, new --brain (or --no-graph). Validate before\n\
-             switching readers; the shared autoindex-catalog and old target require\n\
-             explicit, validated cleanup.\n\
+             Files added after the plan was frozen are reported as skipped and are not\n\
+             indexed; --fresh rebuilds the plan in place and picks them up.\n\
+             Removing an indexed file is refused before any remote mutation: its\n\
+             documents are already live and nothing here deletes them. Restore the file\n\
+             and rerun, or rebuild — in place by deleting the published indices and the\n\
+             state directory, or isolated under a new --state-dir, --prefix and --brain\n\
+             (or --no-graph), validated before you switch readers.\n\
          \n\
          EXIT CODES: 0 complete; 3 completed-with-junk (junk recorded, never fatal);\n\
-                     2 usage; 1 endpoint/journal failure or unsupported corpus delta\n",
+                     2 usage; 1 endpoint/journal failure or a refused corpus removal\n",
         fresh_help = FRESH_HELP
     );
 }
@@ -313,10 +314,10 @@ mod tests {
     }
 
     #[test]
-    fn fresh_help_warns_that_it_is_not_destination_reconciliation() {
-        assert!(super::FRESH_HELP.contains("no durable plan"));
-        assert!(super::FRESH_HELP.contains("existing plan is refused"));
-        assert!(super::FRESH_HELP.contains("destination records are never reset"));
+    fn fresh_help_points_at_the_resume_policy_that_bounds_it() {
+        assert!(super::FRESH_HELP.contains("rebuild the plan in place"));
+        assert!(super::FRESH_HELP.contains("ids stay idempotent"));
+        assert!(super::FRESH_HELP.contains("RESUME POLICY"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -53,6 +53,10 @@ pub enum Cmd {
     Help,
 }
 
+const FRESH_HELP: &str =
+    "start without resume state only when the selected state directory has no \
+durable plan; an existing plan is refused and destination records are never reset";
+
 pub fn print_help() {
     println!(
         "xerj autoindex — point it at any folder and make the contents AI-searchable, zero config\n\
@@ -74,7 +78,7 @@ pub fn print_help() {
                                   valid range 1..=3600)\n\
              --prefix <P>         index prefix (default ax)\n\
              --state-dir <PATH>   resume journal location (default ~/.xerj/autoindex/<hash>/)\n\
-             --fresh              ignore existing journal, restart (ids stay idempotent)\n\
+             --fresh              {fresh_help}\n\
              --follow-symlinks    follow symlinks (loop-safe); off by default\n\
              --max-file-gb <N>    skip+record oversized non-streamable files (default 2)\n\
              --sample <N>         records sampled per file for inference (default 500)\n\
@@ -109,8 +113,17 @@ pub fn print_help() {
              short/structured datasets may infer none). Use --dry-run or `autoindex map` to\n\
              confirm a semantic field before attributing an indexing result to embeddings.\n\
          \n\
+         RESUME POLICY:\n\
+             A durable plan supports no-op resume and same-path content replacement.\n\
+             Added or removed content groups are refused before remote mutation.\n\
+             An independent rebuild needs a new --state-dir, new --prefix, and, when\n\
+             graph detection is enabled, new --brain (or --no-graph). Validate before\n\
+             switching readers; the shared autoindex-catalog and old target require\n\
+             explicit, validated cleanup.\n\
+         \n\
          EXIT CODES: 0 complete; 3 completed-with-junk (junk recorded, never fatal);\n\
-                     2 usage; 1 endpoint unreachable / journal-config mismatch\n"
+                     2 usage; 1 endpoint/journal failure or unsupported corpus delta\n",
+        fresh_help = FRESH_HELP
     );
 }
 
@@ -297,6 +310,13 @@ mod tests {
     #[test]
     fn bulk_timeout_defaults_to_300_seconds() {
         assert_eq!(index(&["data"]).bulk_timeout_secs, 300);
+    }
+
+    #[test]
+    fn fresh_help_warns_that_it_is_not_destination_reconciliation() {
+        assert!(super::FRESH_HELP.contains("no durable plan"));
+        assert!(super::FRESH_HELP.contains("existing plan is refused"));
+        assert!(super::FRESH_HELP.contains("destination records are never reset"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -255,11 +255,15 @@ fn assert_unsupported_delta_without_remote_mutation(
     let message = format!("{error:#}");
     assert!(message.contains("made no remote mutations"), "{message}");
     assert!(
-        message.contains("existing destination may already be partial or stale"),
+        message.contains("no longer exist in the folder"),
         "{message}"
     );
     assert!(
-        message.contains("`--fresh` is not recovery or destination reconciliation"),
+        message.contains("restore the removed file(s) and rerun"),
+        "{message}"
+    );
+    assert!(
+        message.contains("rebuild in place by deleting the indices"),
         "{message}"
     );
     assert!(
@@ -281,19 +285,52 @@ fn assert_unsupported_delta_without_remote_mutation(
     }
 }
 
+/// The documented headline workflow: point autoindex at a folder, add a file,
+/// rerun. The rerun must not fail, must say plainly that the added file was
+/// not indexed, and `--fresh` must then absorb it in place.
 #[test]
-fn completed_plan_rejects_added_content_group_before_remote_mutation() {
+fn a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
     let endpoint = MockEndpoint::start(usize::MAX);
-    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
     assert_eq!(run_index(config.clone()).unwrap(), 0);
 
     fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["second.csv"], &[]);
+    // 3 = completed-with-junk: the added file is reported as skipped, not
+    // indexed, because the frozen plan cannot absorb it.
+    let (code, report) = run_index_report(config.clone()).unwrap();
+    assert_eq!(code, 3);
+    let report = report.unwrap();
+    assert_eq!(report["files_junk"], 1, "{report}");
+    assert_eq!(report["records_total"], 0, "{report}");
+    {
+        let locked = endpoint.state.lock().unwrap();
+        let live: Vec<&str> = locked
+            .docs
+            .values()
+            .filter_map(|doc| doc["ax_path"].as_str())
+            .collect();
+        assert!(
+            live.iter().all(|path| *path == "first.csv"),
+            "the added file must not be published by a plan that predates it: {live:?}"
+        );
+    }
+
+    // --fresh rebuilds the plan in place and picks the new file up.
+    config.fresh = true;
+    assert_eq!(run_index(config).unwrap(), 0);
+    let locked = endpoint.state.lock().unwrap();
+    let indexed: std::collections::HashSet<&str> = locked
+        .docs
+        .values()
+        .filter_map(|doc| doc["ax_path"].as_str())
+        .collect();
+    assert!(indexed.contains("first.csv"), "{indexed:?}");
+    assert!(indexed.contains("second.csv"), "{indexed:?}");
 }
 
 #[test]
@@ -359,7 +396,7 @@ fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
 }
 
 #[test]
-fn nonempty_fresh_cannot_erase_plan_and_bypass_membership_gate() {
+fn fresh_cannot_erase_the_plan_and_bypass_the_removal_gate() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
@@ -376,7 +413,7 @@ fn nonempty_fresh_cannot_erase_plan_and_bypass_membership_gate() {
 }
 
 #[test]
-fn fresh_rejects_same_content_canonical_promotion_even_when_group_key_matches() {
+fn deleting_one_path_of_a_duplicate_pair_is_not_a_removed_content_group() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
@@ -385,14 +422,24 @@ fn fresh_rejects_same_content_canonical_promotion_even_when_group_key_matches() 
     fs::write(corpus.path().join("a.csv"), bytes).unwrap();
     fs::write(corpus.path().join("b.csv"), bytes).unwrap();
     let endpoint = MockEndpoint::start(usize::MAX);
-    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
     assert_eq!(run_index(config.clone()).unwrap(), 0);
 
-    // b.csv becomes canonical with the same content key. A key-only delta is
-    // empty, but fresh would discard the alias/path cleanup knowledge.
+    // b.csv becomes canonical under the same content key: the group survives
+    // the deletion, so no document is stranded and the rerun is allowed.
     fs::remove_file(corpus.path().join("a.csv")).unwrap();
-    config.fresh = true;
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &[]);
+    let result = run_index(config);
+    assert!(
+        result.is_ok(),
+        "a surviving content group must not trip the removal gate: {result:?}"
+    );
+    let locked = endpoint.state.lock().unwrap();
+    let live: Vec<&str> = locked
+        .docs
+        .values()
+        .filter_map(|doc| doc["ax_path"].as_str())
+        .collect();
+    assert_eq!(live, ["b.csv"], "canonical path follows the surviving file");
 }
 
 #[test]
@@ -449,6 +496,7 @@ fn completed_plan_rejects_empty_current_folder_before_remote_mutation() {
     assert_eq!(run_index(config.clone()).unwrap(), 0);
 
     fs::remove_file(corpus.path().join("only.csv")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &[], &["only.csv"]);
     // Even `--fresh` must not erase the only durable inventory evidence and
     // then report success while the destination still contains the document.
     config.fresh = true;
@@ -940,12 +988,12 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     )
     .unwrap();
     fs::write(corpus.path().join("b.csv"), original).unwrap();
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &["b.csv"], &[]);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
     {
         let locked = endpoint.state.lock().unwrap();
         assert_eq!(locked.docs.len(), 2);
         assert!(locked.docs.values().all(|doc| {
-            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("original")
+            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("rewritten")
         }));
     }
     let replay = state::Journal::open(
@@ -960,20 +1008,24 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     assert!(replay.pending_replacements.is_empty());
     assert_eq!(replay.done.len(), 1);
     let plan = replay.plan.clone().unwrap();
-    assert!(plan.junk_files.is_empty());
+    assert_eq!(plan.junk_files.len(), 1);
+    assert_eq!(plan.junk_files[0].rel, "b.csv");
+    assert!(plan.junk_files[0]
+        .reason
+        .contains("key ownership exclusive"));
     drop(replay);
 
-    // The refusal is deterministic: an identical rerun keeps the old owner,
-    // appends no new plan, and changes no documents.
+    // The divergence is durable and deterministic: an identical rerun keeps
+    // the same owner, appends no new plan, and changes no documents.
     let plans_before = event_count(state_dir.path(), "plan");
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["b.csv"], &[]);
+    assert_eq!(run_index(config).unwrap(), 3);
     assert_eq!(event_count(state_dir.path(), "plan"), plans_before);
     let locked = endpoint.state.lock().unwrap();
     assert_eq!(locked.docs.len(), 2);
     assert!(locked
         .docs
         .values()
-        .all(|doc| doc["value"].as_str() == Some("original")));
+        .all(|doc| doc["value"].as_str() == Some("rewritten")));
 }
 
 #[test]
@@ -994,9 +1046,11 @@ fn deleting_an_entire_duplicate_group_strands_no_pending_replacement() {
     assert_eq!(run_index(config.clone()).unwrap(), 0);
     let starts = event_count(state_dir.path(), "file_replace_start");
 
-    // The whole duplicate group disappears. There is no current file left to
-    // republish its key, so no replacement intent may be journaled — a
-    // stranded intent would be re-appended forever without ever committing.
+    // The whole duplicate group disappears: its documents stay live with no
+    // source file, so the rerun is refused. The original invariant still
+    // holds and is still checked — a key with no current file must never get
+    // a replacement intent journaled, which would be re-appended forever
+    // without ever committing.
     fs::remove_file(corpus.path().join("dup-a.csv")).unwrap();
     fs::remove_file(corpus.path().join("dup-b.csv")).unwrap();
     for _ in 0..2 {

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -19,6 +19,7 @@ static FAILPOINT_TEST_LOCK: Mutex<()> = Mutex::new(());
 #[derive(Default)]
 struct MockState {
     docs: HashMap<String, Value>,
+    requests: Vec<(String, String)>,
     data_bulk_number: usize,
     fail_data_bulk: usize,
     failed_once: bool,
@@ -98,6 +99,11 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("");
     let path = parts.next().unwrap_or("");
+    state
+        .lock()
+        .unwrap()
+        .requests
+        .push((method.to_owned(), path.to_owned()));
 
     let response = if method == "POST" && path == "/_bulk" {
         bulk_response(&body, state)
@@ -223,6 +229,230 @@ fn event_count(state_dir: &Path, kind: &str) -> usize {
         .filter_map(|line| serde_json::from_str::<Value>(line).ok())
         .filter(|value| value.get("kind").and_then(Value::as_str) == Some(kind))
         .count()
+}
+
+fn assert_unsupported_delta_without_remote_mutation(
+    endpoint: &MockEndpoint,
+    config: IndexCfg,
+    expected_added: &[&str],
+    expected_vanished: &[&str],
+) {
+    let request_start = endpoint.state.lock().unwrap().requests.len();
+    let journal_path = config.state_dir.as_ref().unwrap().join("journal.ndjson");
+    let journal_before = fs::read(&journal_path).unwrap();
+    let error = run_index(config).unwrap_err();
+    let attempted_requests = endpoint.state.lock().unwrap().requests[request_start..].to_vec();
+    assert_eq!(
+        attempted_requests,
+        [("GET".to_owned(), "/".to_owned())],
+        "a refused attempt may perform only the endpoint-readiness GET"
+    );
+    assert_eq!(
+        fs::read(journal_path).unwrap(),
+        journal_before,
+        "preflight refusal must not append a resume event or rewrite the journal"
+    );
+    let message = format!("{error:#}");
+    assert!(message.contains("made no remote mutations"), "{message}");
+    assert!(
+        message.contains("existing destination may already be partial or stale"),
+        "{message}"
+    );
+    assert!(
+        message.contains("`--fresh` is not recovery or destination reconciliation"),
+        "{message}"
+    );
+    assert!(
+        message.contains("new --state-dir, a new --prefix"),
+        "{message}"
+    );
+    assert!(message.contains("new --brain"), "{message}");
+    for path in expected_added {
+        assert!(
+            message.contains(path),
+            "missing added path {path}: {message}"
+        );
+    }
+    for path in expected_vanished {
+        assert!(
+            message.contains(path),
+            "missing vanished path {path}: {message}"
+        );
+    }
+}
+
+#[test]
+fn completed_plan_rejects_added_content_group_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["second.csv"], &[]);
+}
+
+#[test]
+fn completed_plan_rejects_vanished_content_group_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
+    fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("second.csv")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["second.csv"]);
+}
+
+#[test]
+fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("b-old.csv"), "id,value\n1,b\n").unwrap();
+    fs::write(corpus.path().join("a-old.csv"), "id,value\n2,a\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("b-old.csv")).unwrap();
+    fs::remove_file(corpus.path().join("a-old.csv")).unwrap();
+    fs::write(corpus.path().join("z-new.csv"), "id,value\n3,z\n").unwrap();
+    fs::write(corpus.path().join("m-new.csv"), "id,value\n4,m\n").unwrap();
+    config.json = true;
+    let request_start = endpoint.state.lock().unwrap().requests.len();
+    let error = run_index(config).unwrap_err();
+    assert_eq!(
+        endpoint.state.lock().unwrap().requests[request_start..],
+        [("GET".to_owned(), "/".to_owned())]
+    );
+
+    let typed = error
+        .downcast_ref::<UnsupportedInventoryDeltaError>()
+        .unwrap();
+    let value = typed.to_json();
+    assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
+    assert_eq!(value["status"], "error");
+    let added: Vec<&str> = value["added_content_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap())
+        .collect();
+    let vanished: Vec<&str> = value["vanished_content_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap())
+        .collect();
+    assert_eq!(added, ["m-new.csv", "z-new.csv"]);
+    assert_eq!(vanished, ["a-old.csv", "b-old.csv"]);
+}
+
+#[test]
+fn nonempty_fresh_cannot_erase_plan_and_bypass_membership_gate() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("old.csv"), "id,value\n1,old\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("old.csv")).unwrap();
+    fs::write(corpus.path().join("new.csv"), "id,value\n2,new\n").unwrap();
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["new.csv"], &["old.csv"]);
+}
+
+#[test]
+fn fresh_rejects_same_content_canonical_promotion_even_when_group_key_matches() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let bytes = "id,value\n1,same\n";
+    fs::write(corpus.path().join("a.csv"), bytes).unwrap();
+    fs::write(corpus.path().join("b.csv"), bytes).unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    // b.csv becomes canonical with the same content key. A key-only delta is
+    // empty, but fresh would discard the alias/path cleanup knowledge.
+    fs::remove_file(corpus.path().join("a.csv")).unwrap();
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &[]);
+}
+
+#[test]
+fn unchanged_planned_junk_is_not_reported_as_added_content() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
+    fs::write(
+        corpus.path().join("opaque.bin"),
+        [0_u8, 159, 146, 150, 0, 255],
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
+    let result = run_index(config);
+    assert!(
+        result.is_ok(),
+        "unchanged durable junk must not trip the membership gate: {result:?}"
+    );
+}
+
+#[test]
+fn deleted_planned_junk_fails_closed_before_catalog_can_stay_stale() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
+    fs::write(
+        corpus.path().join("opaque.bin"),
+        [0_u8, 159, 146, 150, 0, 255],
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
+
+    fs::remove_file(corpus.path().join("opaque.bin")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["opaque.bin"]);
+}
+
+#[test]
+fn completed_plan_rejects_empty_current_folder_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("only.csv"), "id,value\n1,only\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("only.csv")).unwrap();
+    // Even `--fresh` must not erase the only durable inventory evidence and
+    // then report success while the destination still contains the document.
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["only.csv"]);
 }
 
 #[test]
@@ -710,12 +940,12 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     )
     .unwrap();
     fs::write(corpus.path().join("b.csv"), original).unwrap();
-    assert_eq!(run_index(config.clone()).unwrap(), 3);
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &["b.csv"], &[]);
     {
         let locked = endpoint.state.lock().unwrap();
         assert_eq!(locked.docs.len(), 2);
         assert!(locked.docs.values().all(|doc| {
-            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("rewritten")
+            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("original")
         }));
     }
     let replay = state::Journal::open(
@@ -730,24 +960,20 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     assert!(replay.pending_replacements.is_empty());
     assert_eq!(replay.done.len(), 1);
     let plan = replay.plan.clone().unwrap();
-    assert_eq!(plan.junk_files.len(), 1);
-    assert_eq!(plan.junk_files[0].rel, "b.csv");
-    assert!(plan.junk_files[0]
-        .reason
-        .contains("key ownership exclusive"));
+    assert!(plan.junk_files.is_empty());
     drop(replay);
 
-    // The divergence is durable and deterministic: an identical rerun keeps
-    // the same owner, appends no new plan, and changes no documents.
+    // The refusal is deterministic: an identical rerun keeps the old owner,
+    // appends no new plan, and changes no documents.
     let plans_before = event_count(state_dir.path(), "plan");
-    assert_eq!(run_index(config).unwrap(), 3);
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["b.csv"], &[]);
     assert_eq!(event_count(state_dir.path(), "plan"), plans_before);
     let locked = endpoint.state.lock().unwrap();
     assert_eq!(locked.docs.len(), 2);
     assert!(locked
         .docs
         .values()
-        .all(|doc| doc["value"].as_str() == Some("rewritten")));
+        .all(|doc| doc["value"].as_str() == Some("original")));
 }
 
 #[test]
@@ -774,7 +1000,12 @@ fn deleting_an_entire_duplicate_group_strands_no_pending_replacement() {
     fs::remove_file(corpus.path().join("dup-a.csv")).unwrap();
     fs::remove_file(corpus.path().join("dup-b.csv")).unwrap();
     for _ in 0..2 {
-        assert_eq!(run_index(config.clone()).unwrap(), 0);
+        assert_unsupported_delta_without_remote_mutation(
+            &endpoint,
+            config.clone(),
+            &[],
+            &["dup-a.csv"],
+        );
         assert_eq!(
             event_count(state_dir.path(), "file_replace_start"),
             starts,

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -342,10 +342,8 @@ fn select_resume_plan_keys(
     for (key, assignment) in &plan.files {
         if let Some(previous) = planned_by_rel.insert(&assignment.rel, key) {
             anyhow::bail!(
-                "resume plan assigns path {} to both {} and {}; refusing to discard history under \
-                 the same destination. For an isolated rebuild use a new --state-dir, new \
-                 --prefix, and new --brain when graph detection is enabled (or --no-graph); \
-                 explicitly validate and clean the shared catalog and old target",
+                "resume plan assigns path {} to both {} and {}; use --fresh after verifying the \
+                 existing index",
                 assignment.rel,
                 previous,
                 key
@@ -354,11 +352,8 @@ fn select_resume_plan_keys(
         if !assignment.path_id.is_empty() {
             if let Some(previous) = planned_by_path_id.insert(&assignment.path_id, key) {
                 anyhow::bail!(
-                    "resume plan assigns one native path identity to both {} and {}; refusing to \
-                     discard history under the same destination. For an isolated rebuild use a \
-                     new --state-dir, new --prefix, and new --brain when graph detection is \
-                     enabled (or --no-graph); explicitly validate and clean the shared catalog \
-                     and old target",
+                    "resume plan assigns one native path identity to both {} and {}; use --fresh \
+                     after verifying the existing index",
                     previous,
                     key
                 );
@@ -396,11 +391,9 @@ fn select_resume_plan_keys(
                     anyhow::bail!(
                         "{} collides with legacy resume key {} already owned by {}. No documents \
                          were changed; remove or move one of these two files out of the corpus \
-                         and rerun — every other file keeps its resume state. Refusing to discard \
-                         history under the same destination. For an isolated rebuild use a new \
-                         --state-dir, new --prefix, and new --brain when graph detection is \
-                         enabled (or --no-graph); explicitly validate and clean the shared \
-                         catalog and old target. Journal: {}",
+                         and rerun — every other file keeps its resume state. Deleting the \
+                         journal at {} (or rerunning with --fresh) also clears the collision, \
+                         but re-extracts and re-embeds the entire corpus",
                         file.rel,
                         legacy_key,
                         assignment.rel,
@@ -443,10 +436,58 @@ struct UnsupportedInventoryDelta {
     vanished_content_groups: Vec<InventoryDeltaEntry>,
 }
 
+/// Everything the refusal needs to name the destination it is protecting.
+/// Collected at the gate so the message can list the exact indices and state
+/// directory an operator has to act on, instead of describing them abstractly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RefusalTargets {
+    state_dir: String,
+    data_indices: Vec<String>,
+    edges_index: Option<String>,
+}
+
+impl RefusalTargets {
+    fn describe(cfg: &IndexCfg, state_dir: &Path, plan: &Plan) -> Self {
+        let mut data_indices: Vec<String> = plan.datasets.iter().map(|d| d.index.clone()).collect();
+        data_indices.sort();
+        data_indices.dedup();
+        let edges_index = (!cfg.no_graph).then(|| {
+            let brain = cfg
+                .brain
+                .clone()
+                .unwrap_or_else(|| derive_brain_name(&cfg.root));
+            detect::edges_index_name(&brain)
+        });
+        Self {
+            state_dir: state_dir.display().to_string(),
+            data_indices,
+            edges_index,
+        }
+    }
+
+    fn indices_phrase(&self) -> String {
+        if self.data_indices.is_empty() {
+            "the indices this plan publishes".to_string()
+        } else {
+            self.data_indices.join(", ")
+        }
+    }
+
+    fn edges_note(&self) -> String {
+        match &self.edges_index {
+            Some(edges) => format!(
+                " Graph edges taught by the removed file(s) stay live in {edges} until that \
+                 index is deleted too."
+            ),
+            None => String::new(),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct UnsupportedInventoryDeltaError {
     delta: UnsupportedInventoryDelta,
-    fresh_existing_plan: bool,
+    targets: RefusalTargets,
 }
 
 impl UnsupportedInventoryDeltaError {
@@ -454,21 +495,22 @@ impl UnsupportedInventoryDeltaError {
         json!({
             "schema": "xerj.autoindex.unsupported_sync_delta.v1",
             "status": "error",
-            "error": if self.fresh_existing_plan {
-                "unsafe_fresh_existing_plan"
-            } else {
-                "unsupported_inventory_delta"
-            },
-            "message": if self.fresh_existing_plan {
-                "this attempt made no remote mutations; --fresh cannot discard an existing plan under the same destination because alias, path, graph, and stale-record cleanup knowledge would be lost; the existing destination may already be partial or stale"
-            } else {
-                "this attempt made no remote mutations because this autoindex plan cannot safely reconcile corpus membership changes; the existing destination may already be partial or stale"
-            },
-            "added_content_groups": self.delta.added_content_groups,
+            "error": "unsupported_content_group_removal",
+            "message": "this attempt made no remote mutations. Files that were indexed under this resume plan no longer exist in the folder, and their documents are still live in the destination; removing files from an indexed folder is not reconciled yet",
             "vanished_content_groups": self.delta.vanished_content_groups,
+            // Context, not the reason for the refusal: a rerun over a frozen
+            // plan does not index files added after the plan was frozen.
+            "added_content_groups": self.delta.added_content_groups,
             "recovery": {
-                "exact_rebuild": "index with a new --state-dir, new --prefix, and (when graph detection is enabled) new --brain; alternatively add --no-graph. Validate the isolated target before switching readers",
-                "warning": "--fresh is not recovery or destination reconciliation. The global autoindex-catalog and old target are not cleaned automatically; validate and clean them explicitly"
+                "restore_removed_files": "put the listed file(s) back and rerun; every other file keeps its resume state",
+                "rebuild_in_place": format!(
+                    "delete the indices this plan publishes ({}) and the state directory {}, then rerun. This re-extracts and re-embeds the whole corpus.{}",
+                    self.targets.indices_phrase(),
+                    self.targets.state_dir,
+                    self.targets.edges_note().trim_start_matches(' ')
+                ),
+                "rebuild_isolated": "index with a new --state-dir, new --prefix, and (when graph detection is enabled) new --brain; alternatively add --no-graph. Validate the isolated target before switching readers, then clean the old one",
+                "fresh_warning": "--fresh re-extracts the current folder in place and does pick up added and changed files, but it never deletes documents already published for removed files, so it is refused here"
             }
         })
     }
@@ -483,23 +525,36 @@ impl std::fmt::Display for UnsupportedInventoryDeltaError {
                 .collect::<Vec<_>>()
                 .join(", ")
         };
-        let reason = if self.fresh_existing_plan {
-            "`--fresh` cannot discard an existing plan under the same destination because alias, \
-             path, graph, and stale-record cleanup knowledge would be lost"
-        } else {
-            "corpus membership synchronization is not yet supported"
-        };
         write!(
             formatter,
-            "this attempt made no remote mutations; the existing destination may already be \
-             partial or stale. {reason}. Added \
-             content groups [{}]; vanished content groups [{}]. For an exact rebuild, index the \
-             current folder with a new --state-dir, a new --prefix, and, when graph detection is \
-             enabled, a new --brain (or use --no-graph). Validate the isolated target before \
-             switching readers. `--fresh` is not recovery or destination reconciliation; the \
-             global autoindex-catalog and old target require explicit validated cleanup",
-            render(&self.delta.added_content_groups),
+            "{} file(s) indexed under this resume plan no longer exist in the folder, and their \
+             documents are still live in the destination. Removing files from an indexed folder \
+             is not reconciled yet, so this attempt made no remote mutations — no documents, \
+             aliases, graph edges or catalog entries were written. Removed content groups [{}].",
+            self.delta.vanished_content_groups.len(),
             render(&self.delta.vanished_content_groups)
+        )?;
+        if !self.delta.added_content_groups.is_empty() {
+            write!(
+                formatter,
+                " Also present but not in the frozen resume plan, so not indexed by this run \
+                 either [{}].",
+                render(&self.delta.added_content_groups)
+            )?;
+        }
+        write!(
+            formatter,
+            " Recovery, cheapest first: (1) restore the removed file(s) and rerun — every other \
+             file keeps its resume state; (2) rebuild in place by deleting the indices this plan \
+             publishes ({}) and the state directory {}, then rerunning — this re-extracts and \
+             re-embeds the whole corpus.{} (3) rebuild isolated with a new --state-dir, a new \
+             --prefix and, when graph detection is enabled, a new --brain (or --no-graph), \
+             validate it, switch readers, then clean the old target. `--fresh` picks up added \
+             and changed files in place but never deletes documents for removed files, so it is \
+             refused here too",
+            self.targets.indices_phrase(),
+            self.targets.state_dir,
+            self.targets.edges_note()
         )
     }
 }
@@ -561,22 +616,19 @@ impl UnsupportedInventoryDelta {
         }
     }
 
-    fn is_empty(&self) -> bool {
-        self.added_content_groups.is_empty() && self.vanished_content_groups.is_empty()
+    /// A rerun is refused only when a content group the plan published has
+    /// vanished from the folder: those documents stay live and searchable with
+    /// no source file behind them, and nothing in this pipeline removes them.
+    /// Additions are not refused — they are skipped by the frozen plan exactly
+    /// as before and `--fresh` rebuilds the plan in place to include them.
+    fn refuses(&self) -> bool {
+        !self.vanished_content_groups.is_empty()
     }
 
-    fn into_error(self) -> anyhow::Error {
+    fn into_error(self, targets: RefusalTargets) -> anyhow::Error {
         UnsupportedInventoryDeltaError {
             delta: self,
-            fresh_existing_plan: false,
-        }
-        .into()
-    }
-
-    fn into_fresh_error(self) -> anyhow::Error {
-        UnsupportedInventoryDeltaError {
-            delta: self,
-            fresh_existing_plan: true,
+            targets,
         }
         .into()
     }
@@ -700,16 +752,13 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             .map(|(planned, current)| planned.unwrap_or_else(|| current.clone()))
             .collect()
         };
+        // `--fresh` is checked here too: discarding the plan does not delete
+        // the documents already published for a file that is now gone, so a
+        // removal is unsafe in place whether or not the plan is kept.
         let delta =
             UnsupportedInventoryDelta::between(&inventory.files, &comparison_keys, prior_plan);
-        if cfg.fresh {
-            // Even an apparently unchanged content-key set can have alias,
-            // path, graph, catalog, or partial-publication history that only
-            // the old plan can reconcile. Route 1 cannot safely discard it.
-            return Err(delta.into_fresh_error());
-        }
-        if !delta.is_empty() {
-            return Err(delta.into_error());
+        if delta.refuses() {
+            return Err(delta.into_error(RefusalTargets::describe(&cfg, &state_dir, prior_plan)));
         }
     }
     let mut journal = state::Journal::open_after_preflight(
@@ -985,17 +1034,16 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         plan
     };
 
-    // A durable plan is a crash-resume boundary, not a folder-sync
-    // generation. Fail before index creation/mapping, replacement intent,
-    // graph invalidation, delete-by-query, bulk publication, refresh, or
-    // catalog writes when the current inventory adds or removes an entire
-    // canonical content group. Continuing would either silently skip new
-    // data or leave vanished source records searchable. Existing planned-key
-    // content replacement and crash repair remain supported.
+    // Second gate, after key selection has settled: fail before index
+    // creation/mapping, replacement intent, graph invalidation,
+    // delete-by-query, bulk publication, refresh, or catalog writes when a
+    // canonical content group the plan published is gone from the folder.
+    // Continuing would leave those documents searchable with no source file.
+    // Additions, same-path replacement and crash repair remain supported.
     if resumed_with_plan {
         let delta = UnsupportedInventoryDelta::between(&files, &keys, &plan);
-        if !delta.is_empty() {
-            return Err(delta.into_error());
+        if delta.refuses() {
+            return Err(delta.into_error(RefusalTargets::describe(&cfg, &state_dir, &plan)));
         }
     }
 
@@ -1112,13 +1160,33 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 rel: files[i].rel.clone(),
                 format: "unknown".into(),
                 status: "skipped".into(),
-                reason: "not in the frozen resume plan; no destination change was made. For an \
-                         exact rebuild use a new --state-dir, a new --prefix, and, when graph \
-                         detection is enabled, a new --brain (or use --no-graph)"
+                reason: "not in the frozen resume plan, so nothing was published for it. Re-run \
+                         with --fresh to rebuild the plan in place and include it (ids stay \
+                         idempotent), or index it under a new --state-dir and --prefix"
                     .into(),
                 bytes: files[i].size,
             });
         }
+    }
+    if !new_unplanned.is_empty() && !cfg.quiet {
+        // The frozen plan cannot absorb files discovered after it was written.
+        // Say so on stderr rather than leaving it to the catalog: a rerun that
+        // quietly ignores new files is the bug this gate exists to surface.
+        eprintln!(
+            "autoindex: {} file(s) appeared after the resume plan was frozen and were NOT \
+             indexed:",
+            new_unplanned.len()
+        );
+        for jf in new_unplanned.iter().take(10) {
+            eprintln!("  not in plan, skipped: {}", jf.rel);
+        }
+        if new_unplanned.len() > 10 {
+            eprintln!("  … and {} more", new_unplanned.len() - 10);
+        }
+        eprintln!(
+            "autoindex: re-run with --fresh to rebuild the plan in place and index them (ids \
+             stay idempotent)"
+        );
     }
     if resumed_with_plan {
         // Legacy journals predate intent-before-publication and may have live
@@ -2423,14 +2491,39 @@ mod inventory_delta_tests {
         }
     }
 
+    fn targets() -> RefusalTargets {
+        RefusalTargets {
+            state_dir: "/state".into(),
+            data_indices: vec!["ax-rows".into()],
+            edges_index: Some(".xerj-memory-corpus-edges".into()),
+        }
+    }
+
     #[test]
-    fn classifier_is_empty_for_noop_and_sorts_added_and_vanished_groups() {
+    fn only_a_removed_content_group_refuses_a_rerun() {
         let mut plan = Plan::default();
         plan.files.insert("keep".into(), assignment("keep.csv"));
         assert!(
-            UnsupportedInventoryDelta::between(&[file("keep.csv")], &["keep".into()], &plan)
-                .is_empty()
+            !UnsupportedInventoryDelta::between(&[file("keep.csv")], &["keep".into()], &plan)
+                .refuses()
         );
+        // An added file is skipped by the frozen plan, not a refusal: the
+        // documented rerun-then---fresh workflow has to keep working.
+        let added = UnsupportedInventoryDelta::between(
+            &[file("keep.csv"), file("new.csv")],
+            &["keep".into(), "new".into()],
+            &plan,
+        );
+        assert_eq!(added.added_content_groups.len(), 1);
+        assert!(!added.refuses(), "an addition alone must not fail the run");
+        // A removal leaves live documents with no source file behind them.
+        assert!(UnsupportedInventoryDelta::between(&[], &[], &plan).refuses());
+    }
+
+    #[test]
+    fn classifier_sorts_added_and_vanished_groups() {
+        let mut plan = Plan::default();
+        plan.files.insert("keep".into(), assignment("keep.csv"));
         plan.junk_files.push(JunkFile {
             file_key: "junk".into(),
             rel: "broken.pdf".into(),
@@ -2440,13 +2533,13 @@ mod inventory_delta_tests {
             bytes: 1,
         });
         assert!(
-            UnsupportedInventoryDelta::between(
+            !UnsupportedInventoryDelta::between(
                 &[file("keep.csv"), file("broken.pdf")],
                 &["keep".into(), "junk".into()],
                 &plan,
             )
-            .is_empty(),
-            "unchanged durable junk is not newly added content"
+            .refuses(),
+            "unchanged durable junk is neither added nor vanished"
         );
 
         plan.files.insert("old-z".into(), assignment("z-old.csv"));
@@ -2480,22 +2573,47 @@ mod inventory_delta_tests {
     }
 
     #[test]
+    fn refusal_names_the_removed_files_and_every_recovery_route() {
+        let mut plan = Plan::default();
+        plan.files.insert("gone".into(), assignment("gone.csv"));
+        let error = UnsupportedInventoryDelta::between(&[], &[], &plan).into_error(targets());
+        let message = format!("{error:#}");
+        assert!(message.contains("gone.csv"), "{message}");
+        assert!(
+            message.contains("no longer exist in the folder"),
+            "{message}"
+        );
+        assert!(message.contains("made no remote mutations"), "{message}");
+        assert!(message.contains("restore the removed file(s)"), "{message}");
+        assert!(message.contains("ax-rows"), "{message}");
+        assert!(message.contains("/state"), "{message}");
+        assert!(message.contains(".xerj-memory-corpus-edges"), "{message}");
+        assert!(message.contains("new --state-dir"), "{message}");
+        assert!(message.contains("`--fresh`"), "{message}");
+    }
+
+    #[test]
     fn cli_error_routing_separates_typed_json_from_unrelated_human_errors() {
         let typed = UnsupportedInventoryDelta {
-            added_content_groups: vec![InventoryDeltaEntry {
+            added_content_groups: Vec::new(),
+            vanished_content_groups: vec![InventoryDeltaEntry {
                 file_key: "key".into(),
-                path: "new.csv".into(),
+                path: "gone.csv".into(),
             }],
-            vanished_content_groups: Vec::new(),
         }
-        .into_error();
+        .into_error(targets());
         let route = route_cli_error(&typed, true);
         assert_eq!(route.exit_code, 1);
         assert!(route.stderr.is_none());
         let stdout = route.stdout.unwrap();
         let value: Value = serde_json::from_str(&stdout).unwrap();
         assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
-        assert_eq!(value["error"], "unsupported_inventory_delta");
+        assert_eq!(value["error"], "unsupported_content_group_removal");
+        assert_eq!(value["vanished_content_groups"][0]["path"], "gone.csv");
+        assert!(value["recovery"]["rebuild_in_place"]
+            .as_str()
+            .unwrap()
+            .contains("ax-rows"));
 
         let unrelated = anyhow::anyhow!("endpoint unavailable");
         let route = route_cli_error(&unrelated, true);
@@ -2554,11 +2672,11 @@ mod duplicate_integration_tests {
         .unwrap_err();
         let message = format!("{error:#}");
         assert!(message.contains("collides with legacy resume key"));
-        // Recovery advice must stay scoped to the two colliding files and
-        // keep an exact rebuild isolated from the old destination.
+        // Recovery advice must stay scoped to the two colliding files and be
+        // honest that discarding the journal re-embeds the whole corpus.
         assert!(message.contains("remove or move one of these two files"));
         assert!(message.contains("/state/journal.ndjson"));
-        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
+        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -19,6 +19,7 @@ pub mod state;
 pub mod walk;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Seek, Write};
@@ -35,6 +36,30 @@ use esclient::Es;
 use sniff::{Family, Sniffed};
 use state::{FileAssignment, FileDone, JunkFile, Plan, PlanDataset};
 
+#[derive(Debug, PartialEq, Eq)]
+struct CliErrorRoute {
+    exit_code: i32,
+    stdout: Option<String>,
+    stderr: Option<String>,
+}
+
+fn route_cli_error(error: &anyhow::Error, json_output: bool) -> CliErrorRoute {
+    if json_output {
+        if let Some(delta) = error.downcast_ref::<UnsupportedInventoryDeltaError>() {
+            return CliErrorRoute {
+                exit_code: 1,
+                stdout: Some(delta.to_json().to_string()),
+                stderr: None,
+            };
+        }
+    }
+    CliErrorRoute {
+        exit_code: 1,
+        stdout: None,
+        stderr: Some(format!("error: {error:#}")),
+    }
+}
+
 /// Entry point for the `xerj autoindex` subcommand (blocking; the server
 /// binary calls this via spawn_blocking). Returns the process exit code.
 pub fn run_cli() -> i32 {
@@ -47,6 +72,7 @@ pub fn run_cli() -> i32 {
             return 2;
         }
     };
+    let json_output = matches!(&cmd, Cmd::Index(cfg) if cfg.json);
     let res = match cmd {
         Cmd::Help => {
             cli::print_help();
@@ -59,8 +85,14 @@ pub fn run_cli() -> i32 {
     match res {
         Ok(code) => code,
         Err(e) => {
-            eprintln!("error: {e:#}");
-            1
+            let route = route_cli_error(&e, json_output);
+            if let Some(stdout) = route.stdout {
+                println!("{stdout}");
+            }
+            if let Some(stderr) = route.stderr {
+                eprintln!("{stderr}");
+            }
+            route.exit_code
         }
     }
 }
@@ -310,8 +342,10 @@ fn select_resume_plan_keys(
     for (key, assignment) in &plan.files {
         if let Some(previous) = planned_by_rel.insert(&assignment.rel, key) {
             anyhow::bail!(
-                "resume plan assigns path {} to both {} and {}; use --fresh after verifying the \
-                 existing index",
+                "resume plan assigns path {} to both {} and {}; refusing to discard history under \
+                 the same destination. For an isolated rebuild use a new --state-dir, new \
+                 --prefix, and new --brain when graph detection is enabled (or --no-graph); \
+                 explicitly validate and clean the shared catalog and old target",
                 assignment.rel,
                 previous,
                 key
@@ -320,8 +354,11 @@ fn select_resume_plan_keys(
         if !assignment.path_id.is_empty() {
             if let Some(previous) = planned_by_path_id.insert(&assignment.path_id, key) {
                 anyhow::bail!(
-                    "resume plan assigns one native path identity to both {} and {}; use --fresh \
-                     after verifying the existing index",
+                    "resume plan assigns one native path identity to both {} and {}; refusing to \
+                     discard history under the same destination. For an isolated rebuild use a \
+                     new --state-dir, new --prefix, and new --brain when graph detection is \
+                     enabled (or --no-graph); explicitly validate and clean the shared catalog \
+                     and old target",
                     previous,
                     key
                 );
@@ -359,9 +396,11 @@ fn select_resume_plan_keys(
                     anyhow::bail!(
                         "{} collides with legacy resume key {} already owned by {}. No documents \
                          were changed; remove or move one of these two files out of the corpus \
-                         and rerun — every other file keeps its resume state. Deleting the \
-                         journal at {} (or rerunning with --fresh) also clears the collision, \
-                         but re-extracts and re-embeds the entire corpus",
+                         and rerun — every other file keeps its resume state. Refusing to discard \
+                         history under the same destination. For an isolated rebuild use a new \
+                         --state-dir, new --prefix, and new --brain when graph detection is \
+                         enabled (or --no-graph); explicitly validate and clean the shared \
+                         catalog and old target. Journal: {}",
                         file.rel,
                         legacy_key,
                         assignment.rel,
@@ -390,6 +429,157 @@ fn select_resume_plan_keys(
         selected.push(key);
     }
     Ok(selected)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct InventoryDeltaEntry {
+    file_key: String,
+    path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct UnsupportedInventoryDelta {
+    added_content_groups: Vec<InventoryDeltaEntry>,
+    vanished_content_groups: Vec<InventoryDeltaEntry>,
+}
+
+#[derive(Debug)]
+struct UnsupportedInventoryDeltaError {
+    delta: UnsupportedInventoryDelta,
+    fresh_existing_plan: bool,
+}
+
+impl UnsupportedInventoryDeltaError {
+    fn to_json(&self) -> Value {
+        json!({
+            "schema": "xerj.autoindex.unsupported_sync_delta.v1",
+            "status": "error",
+            "error": if self.fresh_existing_plan {
+                "unsafe_fresh_existing_plan"
+            } else {
+                "unsupported_inventory_delta"
+            },
+            "message": if self.fresh_existing_plan {
+                "this attempt made no remote mutations; --fresh cannot discard an existing plan under the same destination because alias, path, graph, and stale-record cleanup knowledge would be lost; the existing destination may already be partial or stale"
+            } else {
+                "this attempt made no remote mutations because this autoindex plan cannot safely reconcile corpus membership changes; the existing destination may already be partial or stale"
+            },
+            "added_content_groups": self.delta.added_content_groups,
+            "vanished_content_groups": self.delta.vanished_content_groups,
+            "recovery": {
+                "exact_rebuild": "index with a new --state-dir, new --prefix, and (when graph detection is enabled) new --brain; alternatively add --no-graph. Validate the isolated target before switching readers",
+                "warning": "--fresh is not recovery or destination reconciliation. The global autoindex-catalog and old target are not cleaned automatically; validate and clean them explicitly"
+            }
+        })
+    }
+}
+
+impl std::fmt::Display for UnsupportedInventoryDeltaError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let render = |entries: &[InventoryDeltaEntry]| {
+            entries
+                .iter()
+                .map(|entry| format!("{} ({})", entry.path, entry.file_key))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let reason = if self.fresh_existing_plan {
+            "`--fresh` cannot discard an existing plan under the same destination because alias, \
+             path, graph, and stale-record cleanup knowledge would be lost"
+        } else {
+            "corpus membership synchronization is not yet supported"
+        };
+        write!(
+            formatter,
+            "this attempt made no remote mutations; the existing destination may already be \
+             partial or stale. {reason}. Added \
+             content groups [{}]; vanished content groups [{}]. For an exact rebuild, index the \
+             current folder with a new --state-dir, a new --prefix, and, when graph detection is \
+             enabled, a new --brain (or use --no-graph). Validate the isolated target before \
+             switching readers. `--fresh` is not recovery or destination reconciliation; the \
+             global autoindex-catalog and old target require explicit validated cleanup",
+            render(&self.delta.added_content_groups),
+            render(&self.delta.vanished_content_groups)
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedInventoryDeltaError {}
+
+impl UnsupportedInventoryDelta {
+    fn between(files: &[walk::FileEntry], keys: &[String], plan: &Plan) -> Self {
+        let current_keys: std::collections::HashSet<&str> = keys
+            .iter()
+            .filter(|key| !key.is_empty())
+            .map(String::as_str)
+            .collect();
+        let durable_keys: std::collections::HashSet<&str> = plan
+            .files
+            .keys()
+            .map(String::as_str)
+            .chain(plan.junk_files.iter().map(|junk| junk.file_key.as_str()))
+            .collect();
+
+        let mut added_content_groups: Vec<InventoryDeltaEntry> = files
+            .iter()
+            .zip(keys)
+            .filter(|(_, key)| !key.is_empty() && !durable_keys.contains(key.as_str()))
+            .map(|(file, key)| InventoryDeltaEntry {
+                file_key: key.clone(),
+                path: file.rel.clone(),
+            })
+            .collect();
+        let mut vanished_content_groups: Vec<InventoryDeltaEntry> = plan
+            .files
+            .iter()
+            .filter(|(key, _)| !current_keys.contains(key.as_str()))
+            .map(|(key, assignment)| InventoryDeltaEntry {
+                file_key: key.clone(),
+                path: assignment.rel.clone(),
+            })
+            .collect();
+        vanished_content_groups.extend(
+            plan.junk_files
+                .iter()
+                .filter(|junk| !current_keys.contains(junk.file_key.as_str()))
+                .map(|junk| InventoryDeltaEntry {
+                    file_key: junk.file_key.clone(),
+                    path: junk.rel.clone(),
+                }),
+        );
+
+        let stable_order = |left: &InventoryDeltaEntry, right: &InventoryDeltaEntry| {
+            left.path
+                .cmp(&right.path)
+                .then_with(|| left.file_key.cmp(&right.file_key))
+        };
+        added_content_groups.sort_by(stable_order);
+        vanished_content_groups.sort_by(stable_order);
+        Self {
+            added_content_groups,
+            vanished_content_groups,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.added_content_groups.is_empty() && self.vanished_content_groups.is_empty()
+    }
+
+    fn into_error(self) -> anyhow::Error {
+        UnsupportedInventoryDeltaError {
+            delta: self,
+            fresh_existing_plan: false,
+        }
+        .into()
+    }
+
+    fn into_fresh_error(self) -> anyhow::Error {
+        UnsupportedInventoryDeltaError {
+            delta: self,
+            fresh_existing_plan: true,
+        }
+        .into()
+    }
 }
 
 fn alias_keys_to_reindex(
@@ -465,17 +655,21 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     let es = Es::with_bulk_timeout(&cfg.url, cfg.api_key.clone(), cfg.bulk_timeout_secs)?;
     es.ping()?;
 
-    let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
-    if discovered_files.is_empty() {
-        println!("no files found under {}", cfg.root.display());
-        return Ok((0, None));
-    }
     let root_str = cfg
         .root
         .canonicalize()
         .unwrap_or_else(|_| cfg.root.clone())
         .to_string_lossy()
         .to_string();
+    let state_dir = cfg
+        .state_dir
+        .clone()
+        .unwrap_or_else(|| state::default_state_dir(&root_str, &cfg.url, &cfg.prefix));
+    // Acquire state authority before discovery as well as hashing. A waiter
+    // must never classify a path snapshot taken while another owner was
+    // publishing or replacing the durable plan.
+    let preflight = state::Journal::preflight(&state_dir, &root_str, &cfg.url, &cfg.prefix)?;
+    let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
     if !cfg.quiet {
         eprintln!(
             "autoindex: {} files ({} MB) under {}",
@@ -484,13 +678,42 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             root_str
         );
     }
-
-    let state_dir = cfg
-        .state_dir
-        .clone()
-        .unwrap_or_else(|| state::default_state_dir(&root_str, &cfg.url, &cfg.prefix));
-    let mut journal = state::Journal::open(
-        &state_dir,
+    if discovered_files.is_empty() && !preflight.journal_exists {
+        println!("no files found under {}", cfg.root.display());
+        return Ok((0, None));
+    }
+    let mut inventory = content::resolve(discovered_files)?;
+    if let Some(prior_plan) = preflight.plan.as_ref() {
+        let comparison_keys = if cfg.fresh {
+            inventory.keys.clone()
+        } else {
+            // Ordinary resume preserves planned-key identity for supported
+            // same-path replacement and legacy plans.
+            select_resume_plan_keys(
+                &inventory.files,
+                &inventory.keys,
+                prior_plan,
+                &state_dir.join("journal.ndjson"),
+            )?
+            .into_iter()
+            .zip(inventory.keys.iter())
+            .map(|(planned, current)| planned.unwrap_or_else(|| current.clone()))
+            .collect()
+        };
+        let delta =
+            UnsupportedInventoryDelta::between(&inventory.files, &comparison_keys, prior_plan);
+        if cfg.fresh {
+            // Even an apparently unchanged content-key set can have alias,
+            // path, graph, catalog, or partial-publication history that only
+            // the old plan can reconcile. Route 1 cannot safely discard it.
+            return Err(delta.into_fresh_error());
+        }
+        if !delta.is_empty() {
+            return Err(delta.into_error());
+        }
+    }
+    let mut journal = state::Journal::open_after_preflight(
+        preflight,
         &root_str,
         &cfg.url,
         &cfg.prefix,
@@ -498,6 +721,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         cfg.fresh,
     )?;
     let resumed_with_plan = journal.plan.is_some();
+    if inventory.files.is_empty() && !resumed_with_plan {
+        println!("no files found under {}", cfg.root.display());
+        return Ok((0, None));
+    }
     let run_id = journal.run_id.clone();
     if journal.resumed && !cfg.quiet {
         eprintln!(
@@ -510,7 +737,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // cannot prove byte identity across all supported local and network
     // filesystems. A metadata-only shortcut could leave stale live documents
     // forever after a same-size rewrite with restored or stale timestamps.
-    let mut inventory = content::resolve(discovered_files)?;
     let journal_path = journal.path().to_path_buf();
     let mut content_changed = std::collections::HashSet::new();
     let mut stale_alias_ids = Vec::new();
@@ -759,6 +985,20 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         plan
     };
 
+    // A durable plan is a crash-resume boundary, not a folder-sync
+    // generation. Fail before index creation/mapping, replacement intent,
+    // graph invalidation, delete-by-query, bulk publication, refresh, or
+    // catalog writes when the current inventory adds or removes an entire
+    // canonical content group. Continuing would either silently skip new
+    // data or leave vanished source records searchable. Existing planned-key
+    // content replacement and crash repair remain supported.
+    if resumed_with_plan {
+        let delta = UnsupportedInventoryDelta::between(&files, &keys, &plan);
+        if !delta.is_empty() {
+            return Err(delta.into_error());
+        }
+    }
+
     if cfg.dry_run {
         println!("{}", serde_json::to_string_pretty(&plan)?);
         eprintln!("(dry run — nothing indexed)");
@@ -872,7 +1112,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 rel: files[i].rel.clone(),
                 format: "unknown".into(),
                 status: "skipped".into(),
-                reason: "not in the frozen resume plan (re-run with --fresh to include new files)"
+                reason: "not in the frozen resume plan; no destination change was made. For an \
+                         exact rebuild use a new --state-dir, a new --prefix, and, when graph \
+                         detection is enabled, a new --brain (or use --no-graph)"
                     .into(),
                 bytes: files[i].size,
             });
@@ -2156,6 +2398,114 @@ mod section_label_tests {
 }
 
 #[cfg(test)]
+mod inventory_delta_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn file(path: &str) -> walk::FileEntry {
+        walk::FileEntry {
+            path: PathBuf::from(path),
+            rel: path.to_owned(),
+            rel_id: format!("id:{path}"),
+            is_symlink: false,
+            size: 1,
+        }
+    }
+
+    fn assignment(path: &str) -> FileAssignment {
+        FileAssignment {
+            rel: path.to_owned(),
+            path_id: format!("id:{path}"),
+            family: "csv".into(),
+            gzip: false,
+            content_digest: Some(format!("digest:{path}")),
+            assignments: vec![(None, "rows".into())],
+        }
+    }
+
+    #[test]
+    fn classifier_is_empty_for_noop_and_sorts_added_and_vanished_groups() {
+        let mut plan = Plan::default();
+        plan.files.insert("keep".into(), assignment("keep.csv"));
+        assert!(
+            UnsupportedInventoryDelta::between(&[file("keep.csv")], &["keep".into()], &plan)
+                .is_empty()
+        );
+        plan.junk_files.push(JunkFile {
+            file_key: "junk".into(),
+            rel: "broken.pdf".into(),
+            format: "pdf".into(),
+            status: "junk".into(),
+            reason: "fixture".into(),
+            bytes: 1,
+        });
+        assert!(
+            UnsupportedInventoryDelta::between(
+                &[file("keep.csv"), file("broken.pdf")],
+                &["keep".into(), "junk".into()],
+                &plan,
+            )
+            .is_empty(),
+            "unchanged durable junk is not newly added content"
+        );
+
+        plan.files.insert("old-z".into(), assignment("z-old.csv"));
+        plan.files.insert("old-a".into(), assignment("a-old.csv"));
+        let delta = UnsupportedInventoryDelta::between(
+            &[
+                file("keep.csv"),
+                file("broken.pdf"),
+                file("z-new.csv"),
+                file("m-new.csv"),
+            ],
+            &["keep".into(), "junk".into(), "new-z".into(), "new-m".into()],
+            &plan,
+        );
+        assert_eq!(
+            delta
+                .added_content_groups
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["m-new.csv", "z-new.csv"]
+        );
+        assert_eq!(
+            delta
+                .vanished_content_groups
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["a-old.csv", "z-old.csv"]
+        );
+    }
+
+    #[test]
+    fn cli_error_routing_separates_typed_json_from_unrelated_human_errors() {
+        let typed = UnsupportedInventoryDelta {
+            added_content_groups: vec![InventoryDeltaEntry {
+                file_key: "key".into(),
+                path: "new.csv".into(),
+            }],
+            vanished_content_groups: Vec::new(),
+        }
+        .into_error();
+        let route = route_cli_error(&typed, true);
+        assert_eq!(route.exit_code, 1);
+        assert!(route.stderr.is_none());
+        let stdout = route.stdout.unwrap();
+        let value: Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
+        assert_eq!(value["error"], "unsupported_inventory_delta");
+
+        let unrelated = anyhow::anyhow!("endpoint unavailable");
+        let route = route_cli_error(&unrelated, true);
+        assert_eq!(route.exit_code, 1);
+        assert!(route.stdout.is_none());
+        assert_eq!(route.stderr.as_deref(), Some("error: endpoint unavailable"));
+    }
+}
+
+#[cfg(test)]
 mod duplicate_integration_tests {
     use super::*;
     use std::collections::HashSet;
@@ -2204,11 +2554,11 @@ mod duplicate_integration_tests {
         .unwrap_err();
         let message = format!("{error:#}");
         assert!(message.contains("collides with legacy resume key"));
-        // Recovery advice must stay scoped to the two colliding files and be
-        // honest that discarding the journal re-embeds the whole corpus.
+        // Recovery advice must stay scoped to the two colliding files and
+        // keep an exact rebuild isolated from the old destination.
         assert!(message.contains("remove or move one of these two files"));
         assert!(message.contains("/state/journal.ndjson"));
-        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
+        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -223,10 +223,9 @@ fn read_plan_for_preflight(
                         "journal corruption at byte {record_start} in {}: malformed \
                          newline-terminated record. Refusing to discard later records. Restore \
                          the journal from a backup, or truncate it to exactly {record_start} \
-                         bytes to keep every completion recorded before the corruption. For an \
-                         isolated rebuild use a new --state-dir, new --prefix, and new --brain \
-                         when graph detection is enabled (or --no-graph); explicitly validate \
-                         and clean the shared catalog and old target",
+                         bytes to keep every completion recorded before the corruption. Deleting \
+                         the whole journal (or rerunning with --fresh) also recovers, but \
+                         re-extracts and re-embeds the entire corpus",
                         path.display()
                     )
                 })?;
@@ -382,10 +381,9 @@ impl Journal {
                                     anyhow::bail!(
                                 "journal at {} was created for root={jr} url={ju} prefix={jp}; \
                                  current run has root={root} url={url} prefix={prefix}. \
-                                 Refusing to discard history under the same destination. For an \
-                                 isolated rebuild use a new --state-dir, new --prefix, and new \
-                                 --brain when graph detection is enabled (or --no-graph); \
-                                 explicitly validate and clean the shared catalog and old target.",
+                                 Use --state-dir for separate state, or --fresh to rebuild the \
+                                 plan in place — note that --fresh never deletes documents \
+                                 already published under the other root, url or prefix.",
                                 jpath.display()
                             );
                                 }
@@ -451,10 +449,9 @@ impl Journal {
                              after corruption. Restore the journal from a backup, or truncate it \
                              to exactly {record_start} bytes to keep every completion recorded \
                              before the corruption (files journaled after that point are \
-                             re-verified, re-indexed and re-embedded on the next run). For an \
-                             isolated rebuild use a new --state-dir, new --prefix, and new --brain \
-                             when graph detection is enabled (or --no-graph); explicitly validate \
-                             and clean the shared catalog and old target",
+                             re-verified, re-indexed and re-embedded on the next run). Deleting \
+                             the whole journal (or rerunning with --fresh) also recovers, but \
+                             re-extracts and re-embeds the entire corpus",
                             jpath.display()
                         );
                     }
@@ -825,10 +822,9 @@ mod compatibility_tests {
         let message = format!("{error:#}");
         assert!(message.contains("journal corruption"));
         // Recovery guidance must stay scoped and honest: byte-exact truncation
-        // keeps prior completions; an exact rebuild needs isolated state and
-        // destination identities.
+        // keeps prior completions; discarding the journal re-embeds everything.
         assert!(message.contains("truncate it to exactly"));
-        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
+        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -79,6 +79,21 @@ mod tests {
         assert!(text.contains("\"kind\":\"resume\""));
         assert!(text.contains("\"bulk_timeout_secs\":900"));
     }
+
+    #[test]
+    fn preflight_holds_the_same_exclusive_lock_through_authoritative_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix").unwrap();
+        let error = Journal::open(dir.path(), "root", "url", "prefix", 300, false)
+            .err()
+            .expect("a second opener must not pass the held preflight lock");
+        assert!(format!("{error:#}").contains("already in use"));
+
+        let journal =
+            Journal::open_after_preflight(preflight, "root", "url", "prefix", 300, false).unwrap();
+        drop(journal);
+        assert!(Journal::open(dir.path(), "root", "url", "prefix", 300, false).is_ok());
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -170,15 +185,97 @@ pub fn default_state_dir(root: &str, url: &str, prefix: &str) -> PathBuf {
         .join(crate::ids::state_key(root, url, prefix))
 }
 
+/// Read the last durable plan without locking, repairing, truncating or
+/// appending to the journal. This is a preflight hint only: `Journal::open`
+/// remains the authority after the caller passes its fail-closed inventory
+/// gate and acquires the state lock.
+fn read_plan_for_preflight(
+    path: &Path,
+    root: &str,
+    url: &str,
+    prefix: &str,
+) -> Result<Option<Plan>> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut plan = None;
+    let mut offset = 0u64;
+    loop {
+        let record_start = offset;
+        let mut bytes = Vec::new();
+        let read = reader.read_until(b'\n', &mut bytes)?;
+        if read == 0 {
+            break;
+        }
+        offset += read as u64;
+        if bytes.last() != Some(&b'\n') {
+            // `Journal::open` will repair this torn final record after the
+            // preflight accepts. It cannot be treated as durable here.
+            break;
+        }
+        let value: Value =
+            serde_json::from_slice(bytes.strip_suffix(b"\n").unwrap_or(bytes.as_slice()))
+                .with_context(|| {
+                    format!(
+                        "journal corruption at byte {record_start} in {}: malformed \
+                         newline-terminated record. Refusing to discard later records. Restore \
+                         the journal from a backup, or truncate it to exactly {record_start} \
+                         bytes to keep every completion recorded before the corruption. For an \
+                         isolated rebuild use a new --state-dir, new --prefix, and new --brain \
+                         when graph detection is enabled (or --no-graph); explicitly validate \
+                         and clean the shared catalog and old target",
+                        path.display()
+                    )
+                })?;
+        match value.get("kind").and_then(Value::as_str) {
+            Some("run") => {
+                let recorded_root = value.get("root").and_then(Value::as_str).unwrap_or("");
+                let recorded_url = value.get("url").and_then(Value::as_str).unwrap_or("");
+                let recorded_prefix = value.get("prefix").and_then(Value::as_str).unwrap_or("");
+                anyhow::ensure!(
+                    recorded_root == root && recorded_url == url && recorded_prefix == prefix,
+                    "journal at {} was created for root={} url={} prefix={}; current run has \
+                     root={} url={} prefix={}",
+                    path.display(),
+                    recorded_root,
+                    recorded_url,
+                    recorded_prefix,
+                    root,
+                    url,
+                    prefix
+                );
+            }
+            Some("plan") => {
+                if let Some(encoded) = value.get("plan") {
+                    plan =
+                        Some(serde_json::from_value(encoded.clone()).with_context(|| {
+                            format!("decode durable plan in {}", path.display())
+                        })?);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(plan)
+}
+
+pub struct JournalPreflight {
+    state_dir: PathBuf,
+    state_lock: std::fs::File,
+    pub plan: Option<Plan>,
+    pub journal_exists: bool,
+}
+
 impl Journal {
-    pub fn open(
+    pub fn preflight(
         state_dir: &Path,
         root: &str,
         url: &str,
         prefix: &str,
-        bulk_timeout_secs: u64,
-        fresh: bool,
-    ) -> Result<Journal> {
+    ) -> Result<JournalPreflight> {
         std::fs::create_dir_all(state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
         let lock_path = state_dir.join(".autoindex.lock");
@@ -195,10 +292,46 @@ impl Journal {
                 state_dir.display()
             )
         })?;
+        let journal_path = state_dir.join("journal.ndjson");
+        let journal_exists = journal_path.exists();
+        let plan = read_plan_for_preflight(&journal_path, root, url, prefix)?;
+        Ok(JournalPreflight {
+            state_dir: state_dir.to_owned(),
+            state_lock,
+            plan,
+            journal_exists,
+        })
+    }
+
+    pub fn open(
+        state_dir: &Path,
+        root: &str,
+        url: &str,
+        prefix: &str,
+        bulk_timeout_secs: u64,
+        fresh: bool,
+    ) -> Result<Journal> {
+        let preflight = Self::preflight(state_dir, root, url, prefix)?;
+        Self::open_after_preflight(preflight, root, url, prefix, bulk_timeout_secs, fresh)
+    }
+
+    pub fn open_after_preflight(
+        preflight: JournalPreflight,
+        root: &str,
+        url: &str,
+        prefix: &str,
+        bulk_timeout_secs: u64,
+        fresh: bool,
+    ) -> Result<Journal> {
+        let JournalPreflight {
+            state_dir,
+            state_lock,
+            ..
+        } = preflight;
         // Hard kills cannot run NamedTempFile::drop. Stages are owned by this
         // journal directory and use a reserved prefix, so removing only
         // regular files with that prefix is deterministic and scope-safe.
-        for entry in std::fs::read_dir(state_dir)? {
+        for entry in std::fs::read_dir(&state_dir)? {
             let entry = entry?;
             if entry
                 .file_name()
@@ -249,7 +382,10 @@ impl Journal {
                                     anyhow::bail!(
                                 "journal at {} was created for root={jr} url={ju} prefix={jp}; \
                                  current run has root={root} url={url} prefix={prefix}. \
-                                 Use --fresh to discard it or --state-dir for a separate state.",
+                                 Refusing to discard history under the same destination. For an \
+                                 isolated rebuild use a new --state-dir, new --prefix, and new \
+                                 --brain when graph detection is enabled (or --no-graph); \
+                                 explicitly validate and clean the shared catalog and old target.",
                                 jpath.display()
                             );
                                 }
@@ -315,9 +451,10 @@ impl Journal {
                              after corruption. Restore the journal from a backup, or truncate it \
                              to exactly {record_start} bytes to keep every completion recorded \
                              before the corruption (files journaled after that point are \
-                             re-verified, re-indexed and re-embedded on the next run). Deleting \
-                             the whole journal (or rerunning with --fresh) also recovers, but \
-                             re-extracts and re-embeds the entire corpus",
+                             re-verified, re-indexed and re-embedded on the next run). For an \
+                             isolated rebuild use a new --state-dir, new --prefix, and new --brain \
+                             when graph detection is enabled (or --no-graph); explicitly validate \
+                             and clean the shared catalog and old target",
                             jpath.display()
                         );
                     }
@@ -688,9 +825,10 @@ mod compatibility_tests {
         let message = format!("{error:#}");
         assert!(message.contains("journal corruption"));
         // Recovery guidance must stay scoped and honest: byte-exact truncation
-        // keeps prior completions; discarding the journal re-embeds everything.
+        // keeps prior completions; an exact rebuild needs isolated state and
+        // destination identities.
         assert!(message.contains("truncate it to exactly"));
-        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
+        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -23512,7 +23512,9 @@ fn validate_embedding_identity(
                     "embedding identity mismatch for index {}: persisted backend={} \
                      model={} tokenizer={}, configured backend={} model={} tokenizer={}. \
                      Refusing to mix incompatible vector spaces. Restore the original assets \
-                     or re-run autoindex with --fresh and a new index prefix.",
+                     or rebuild with a new autoindex state directory, new index prefix, and new \
+                     brain when graph detection is enabled (or --no-graph); validate before \
+                     switching readers and explicitly clean the shared catalog and old target.",
                     index_dir.display(),
                     persisted.backend,
                     persisted.model_sha256,
@@ -23526,7 +23528,9 @@ fn validate_embedding_identity(
                 format!(
                     "index {} contains ONNX vectors but the server is configured for \
                      embedding.mode={:?}. Restart with onnx-experimental and the original \
-                     assets, or reindex under a new prefix.",
+                     assets, or rebuild with a new autoindex state directory, new prefix, and new \
+                     brain when graph detection is enabled (or --no-graph); validate before \
+                     switching readers and explicitly clean the shared catalog and old target.",
                     index_dir.display(),
                     cfg.mode
                 ),
@@ -23541,8 +23545,9 @@ fn validate_embedding_identity(
             format!(
                 "existing semantic index {} has no embedding identity marker. It may contain \
                  vectors from another backend, so ONNX cannot be enabled safely in place. \
-                 Re-run autoindex with --fresh and a new --prefix, or rebuild the index from \
-                 source.",
+                 Rebuild from source with a new autoindex state directory, new --prefix, and new \
+                 --brain when graph detection is enabled (or --no-graph); validate before \
+                 switching readers and explicitly clean the shared catalog and old target.",
                 index_dir.display()
             ),
         )));
@@ -23641,6 +23646,9 @@ mod embedding_identity_tests {
                 .to_string();
         assert!(error.contains("identity mismatch"), "{error}");
         assert!(error.contains("new index prefix"), "{error}");
+        assert!(error.contains("new brain"), "{error}");
+        assert!(error.contains("--no-graph"), "{error}");
+        assert!(error.contains("shared catalog"), "{error}");
     }
 
     #[test]
@@ -23659,6 +23667,9 @@ mod embedding_identity_tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("no embedding identity marker"), "{error}");
+        assert!(error.contains("new --brain"), "{error}");
+        assert!(error.contains("--no-graph"), "{error}");
+        assert!(error.contains("shared catalog"), "{error}");
     }
 
     #[cfg(feature = "onnx-experimental")]

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -79,8 +79,9 @@ pub fn print_help() {
              --api-key <K>      API key for an already-running secured server\n\
                                 (or env XERJ_API_KEY; a server booted by this command\n\
                                 needs neither — its key is read from <data-dir>/admin.key)\n\
-             --fresh            start without resume state only when the selected\n\
-                                journal has no durable plan; never resets server data\n\
+             --fresh            ignore the resume journal and rebuild the plan in place,\n\
+                                re-walking everything (ids stay idempotent). It never\n\
+                                deletes documents for notes you removed\n\
              --no-open          print the links but do not open a browser\n\
              --help, -h         this help\n\
          \n\
@@ -386,15 +387,16 @@ fn live_node_docs(es: &Es, brain: &str) -> Result<Option<u64>> {
         return Ok(None);
     };
     // `Es::get_doc` returns the document `_source` itself.
+    // A meta doc without `nodes_index` predates the field (or was written by
+    // something other than autoindex). That is absence of evidence, not a
+    // failure: report it as unknown instead of hard-failing every brain that
+    // an older autoindex wrote.
     let Some(nodes_index) = meta
         .get("nodes_index")
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
     else {
-        bail!(
-            "brain metadata {edges_index}/{} has no usable nodes_index",
-            detect::BRAIN_META_ID
-        );
+        return Ok(None);
     };
     let response = es.search(
         nodes_index,
@@ -415,13 +417,19 @@ fn journal_server_disagreement(cfg: &BrainCfg, brain: &str) -> String {
         "the resume journal and server disagree: journal {} says {} is already indexed, \
          but {} has no confirmed live node documents for prefix ax and brain {brain}. No reset \
          was attempted: an absent or zero node probe does not prove that data, catalog, and \
-         graph namespaces are empty. Restore the server data directory used by this journal. \
+         graph namespaces are empty. If this is the wrong server, restore or point at the data \
+         directory this journal was written against. If the data directory really was wiped, \
+         rerun with --fresh to rebuild the plan and republish every file in place (ids are \
+         idempotent):\n\
+         xerj brain {} --url {} --fresh\n\
          Otherwise, after validating or cleaning the old destination, run an isolated rebuild:\n\
          xerj autoindex {} --url {} --state-dir <new-state-dir> --prefix <new-prefix> \
          --brain <new-brain>\n\
          For a secured endpoint, set XERJ_API_KEY or add --api-key without placing its value in \
          logs. Validate the new target before switching readers",
         state_dir.display(),
+        root.display(),
+        cfg.url,
         root.display(),
         cfg.url,
         root.display(),
@@ -693,6 +701,8 @@ mod tests {
         assert!(message.contains("http://localhost:9200"));
         assert!(message.contains("prefix ax"));
         assert!(message.contains("brain team-notes"));
+        assert!(message.contains("xerj brain /corpus/notes"));
+        assert!(message.contains("--fresh"));
         assert!(message.contains("xerj autoindex /corpus/notes"));
         assert!(message.contains("--url http://localhost:9200"));
         assert!(message.contains("--state-dir <new-state-dir>"));

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -279,7 +279,7 @@ fn run(cfg: BrainCfg) -> Result<i32> {
     };
     // `records_total` is run-scoped: a resumed re-run over an already-indexed
     // folder legitimately reports 0. Server truth decides what that means.
-    if run_u64(&run_doc, "records_total") == 0 {
+    if needs_live_node_probe(run_u64(&run_doc, "records_total")) {
         let live_nodes = live_node_docs(&es, &brain)?;
         if journal_server_disagrees(run_u64(&run_doc, "files_indexed"), live_nodes, cfg.fresh) {
             bail!("{}", journal_server_disagreement(&cfg, &brain));
@@ -439,6 +439,10 @@ fn journal_server_disagreement(cfg: &BrainCfg, brain: &str) -> String {
 
 fn journal_server_disagrees(files_indexed: u64, live_nodes: Option<u64>, fresh: bool) -> bool {
     files_indexed > 0 && matches!(live_nodes, None | Some(0)) && !fresh
+}
+
+fn needs_live_node_probe(records_total: u64) -> bool {
+    records_total == 0
 }
 
 fn index_cfg(cfg: &BrainCfg, brain: &str, api_key: Option<String>) -> IndexCfg {
@@ -713,6 +717,11 @@ mod tests {
 
     #[test]
     fn disagreement_decision_refuses_absent_and_zero_but_not_positive_server_truth() {
+        assert!(
+            !needs_live_node_probe(1),
+            "a run that indexed a new note must not enter resume probing"
+        );
+        assert!(needs_live_node_probe(0));
         assert!(journal_server_disagrees(1, None, false));
         assert!(journal_server_disagrees(1, Some(0), false));
         assert!(!journal_server_disagrees(1, Some(7), false));

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -79,8 +79,8 @@ pub fn print_help() {
              --api-key <K>      API key for an already-running secured server\n\
                                 (or env XERJ_API_KEY; a server booted by this command\n\
                                 needs neither — its key is read from <data-dir>/admin.key)\n\
-             --fresh            ignore the resume journal, re-walk everything\n\
-                                (ids stay idempotent; converges to the same brain)\n\
+             --fresh            start without resume state only when the selected\n\
+                                journal has no durable plan; never resets server data\n\
              --no-open          print the links but do not open a browser\n\
              --help, -h         this help\n\
          \n\
@@ -267,7 +267,7 @@ fn run(cfg: BrainCfg) -> Result<i32> {
     }
 
     // ── index: the autoindex pipeline, graph detection on ────────────────
-    let (mut code, mut run_doc) =
+    let (code, run_doc) =
         xerj_autoindex::run_index_report(index_cfg(&cfg, &brain, api_key.clone()))?;
 
     let run_u64 = |doc: &Option<Value>, key: &str| {
@@ -279,30 +279,16 @@ fn run(cfg: BrainCfg) -> Result<i32> {
     // `records_total` is run-scoped: a resumed re-run over an already-indexed
     // folder legitimately reports 0. Server truth decides what that means.
     if run_u64(&run_doc, "records_total") == 0 {
-        let live_nodes = live_node_docs(&es, &brain);
-        if live_nodes == 0 && run_u64(&run_doc, "files_indexed") > 0 && !cfg.fresh {
-            // The resume journal says this folder is done, but the server has
-            // none of it (wiped data dir, or a different --url than the run
-            // that wrote the journal). Trusting the journal here would leave a
-            // silent, permanently-empty brain — with only structural edges,
-            // since text detectors ride the per-file indexing pass. Re-index
-            // from scratch once; ids are idempotent, so this converges.
-            eprintln!(
-                "\nresume journal says {} is already indexed, but the server at {} has none \
-                 of it — re-indexing from scratch",
-                cfg.root.display(),
-                cfg.url
-            );
-            let mut fresh_cfg = index_cfg(&cfg, &brain, api_key);
-            fresh_cfg.fresh = true;
-            (code, run_doc) = xerj_autoindex::run_index_report(fresh_cfg)?;
+        let live_nodes = live_node_docs(&es, &brain)?;
+        if journal_server_disagrees(run_u64(&run_doc, "files_indexed"), live_nodes, cfg.fresh) {
+            bail!("{}", journal_server_disagreement(&cfg, &brain));
         }
     }
 
     // Server truth for every surface below: run-scoped counters read 0 on a
     // converged re-run, but the brain is live on the server all the same.
     let records_live = match run_u64(&run_doc, "records_total") {
-        0 => live_node_docs(&es, &brain),
+        0 => live_node_docs(&es, &brain)?.unwrap_or(0),
         n => n,
     };
     if records_live == 0 {
@@ -391,12 +377,13 @@ fn run(cfg: BrainCfg) -> Result<i32> {
 
 /// Count the node documents live on the server behind `brain`, via the brain
 /// meta doc's `nodes_index` (SECOND_BRAIN_SPEC §2.5 — autoindex writes the
-/// comma-list of its dataset indices there). 0 on any miss: an unreadable
-/// meta doc and an empty brain call for the same honest answer.
-fn live_node_docs(es: &Es, brain: &str) -> u64 {
+/// comma-list of its dataset indices there). Absence is distinct from an
+/// authoritative zero, and probe failures are never converted into reset
+/// authorization.
+fn live_node_docs(es: &Es, brain: &str) -> Result<Option<u64>> {
     let edges_index = detect::edges_index_name(brain);
-    let Ok(Some(meta)) = es.get_doc(&edges_index, detect::BRAIN_META_ID) else {
-        return 0;
+    let Some(meta) = es.get_doc(&edges_index, detect::BRAIN_META_ID)? else {
+        return Ok(None);
     };
     // `Es::get_doc` returns the document `_source` itself.
     let Some(nodes_index) = meta
@@ -404,15 +391,46 @@ fn live_node_docs(es: &Es, brain: &str) -> u64 {
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
     else {
-        return 0;
+        bail!(
+            "brain metadata {edges_index}/{} has no usable nodes_index",
+            detect::BRAIN_META_ID
+        );
     };
-    es.search(
+    let response = es.search(
         nodes_index,
         &json!({"size": 0, "track_total_hits": true, "query": {"match_all": {}}}),
+    )?;
+    response
+        .pointer("/hits/total/value")
+        .and_then(Value::as_u64)
+        .map(Some)
+        .context("node-count response has no numeric hits.total.value")
+}
+
+fn journal_server_disagreement(cfg: &BrainCfg, brain: &str) -> String {
+    let root = std::fs::canonicalize(&cfg.root).unwrap_or_else(|_| cfg.root.clone());
+    let state_dir =
+        xerj_autoindex::state::default_state_dir(&root.to_string_lossy(), &cfg.url, "ax");
+    format!(
+        "the resume journal and server disagree: journal {} says {} is already indexed, \
+         but {} has no confirmed live node documents for prefix ax and brain {brain}. No reset \
+         was attempted: an absent or zero node probe does not prove that data, catalog, and \
+         graph namespaces are empty. Restore the server data directory used by this journal. \
+         Otherwise, after validating or cleaning the old destination, run an isolated rebuild:\n\
+         xerj autoindex {} --url {} --state-dir <new-state-dir> --prefix <new-prefix> \
+         --brain <new-brain>\n\
+         For a secured endpoint, set XERJ_API_KEY or add --api-key without placing its value in \
+         logs. Validate the new target before switching readers",
+        state_dir.display(),
+        root.display(),
+        cfg.url,
+        root.display(),
+        cfg.url,
     )
-    .ok()
-    .and_then(|v| v.pointer("/hits/total/value").and_then(Value::as_u64))
-    .unwrap_or(0)
+}
+
+fn journal_server_disagrees(files_indexed: u64, live_nodes: Option<u64>, fresh: bool) -> bool {
+    files_indexed > 0 && matches!(live_nodes, None | Some(0)) && !fresh
 }
 
 fn index_cfg(cfg: &BrainCfg, brain: &str, api_key: Option<String>) -> IndexCfg {
@@ -656,6 +674,40 @@ mod tests {
         assert!(cfg.no_open);
         assert_eq!(cfg.brain.as_deref(), Some("kb"));
         assert_eq!(cfg.url, "http://localhost:9200");
+    }
+
+    #[test]
+    fn journal_server_disagreement_refuses_reset_with_executable_recovery() {
+        let cfg = BrainCfg {
+            root: PathBuf::from("/corpus/notes"),
+            brain: Some("team-notes".into()),
+            url: "http://localhost:9200".into(),
+            data_dir: None,
+            api_key: None,
+            fresh: false,
+            no_open: true,
+        };
+        let message = journal_server_disagreement(&cfg, "team-notes");
+        assert!(message.contains("resume journal and server disagree"));
+        assert!(message.contains("No reset was attempted"));
+        assert!(message.contains("http://localhost:9200"));
+        assert!(message.contains("prefix ax"));
+        assert!(message.contains("brain team-notes"));
+        assert!(message.contains("xerj autoindex /corpus/notes"));
+        assert!(message.contains("--url http://localhost:9200"));
+        assert!(message.contains("--state-dir <new-state-dir>"));
+        assert!(message.contains("--prefix <new-prefix>"));
+        assert!(message.contains("--brain <new-brain>"));
+        assert!(message.contains("XERJ_API_KEY"));
+    }
+
+    #[test]
+    fn disagreement_decision_refuses_absent_and_zero_but_not_positive_server_truth() {
+        assert!(journal_server_disagrees(1, None, false));
+        assert!(journal_server_disagrees(1, Some(0), false));
+        assert!(!journal_server_disagrees(1, Some(7), false));
+        assert!(!journal_server_disagrees(0, Some(0), false));
+        assert!(!journal_server_disagrees(1, Some(0), true));
     }
 
     #[test]

--- a/landing/docs/recipes/zero-config-autoindex.html
+++ b/landing/docs/recipes/zero-config-autoindex.html
@@ -239,7 +239,8 @@ live indices at http://localhost:9280:
   ax-docs                                           1 docs
   ax-exports                                      800 docs
   autoindex-catalog                                 9 docs</pre>
-  <p><code class="inline">--fresh</code> starts without resume state only when the selected state directory has no durable plan; it never removes stale destination records. For an independent rebuild, use a new <code class="inline">--state-dir</code>, new <code class="inline">--prefix</code>, and new <code class="inline">--brain</code> when graph detection is enabled (or add <code class="inline">--no-graph</code>). Validate before switching readers. The shared <code class="inline">autoindex-catalog</code> and old target require explicit, validated cleanup. Added or removed content groups are refused; same-path replacement remains supported.</p>
+  <p><code class="inline">--fresh</code> ignores the journal and rebuilds the plan in place (ids stay idempotent), which is how you pick up files added since the last run.</p>
+  <p>A rerun that resumes an existing plan indexes changed files and reports added ones as skipped. Deleting a file is refused: nothing here removes the documents it already published, so the rerun stops before touching the destination and names what is gone. Restore the file and rerun, or rebuild — in place by deleting the named indices and the state directory, or isolated under a new <code class="inline">--state-dir</code>, <code class="inline">--prefix</code> and <code class="inline">--brain</code> (or <code class="inline">--no-graph</code>), validated before you switch readers. The shared <code class="inline">autoindex-catalog</code> and the old target require explicit cleanup.</p>
 
   <hr>
 

--- a/landing/docs/recipes/zero-config-autoindex.html
+++ b/landing/docs/recipes/zero-config-autoindex.html
@@ -239,7 +239,7 @@ live indices at http://localhost:9280:
   ax-docs                                           1 docs
   ax-exports                                      800 docs
   autoindex-catalog                                 9 docs</pre>
-  <p><code class="inline">--fresh</code> ignores the journal and restarts (ids stay idempotent).</p>
+  <p><code class="inline">--fresh</code> starts without resume state only when the selected state directory has no durable plan; it never removes stale destination records. For an independent rebuild, use a new <code class="inline">--state-dir</code>, new <code class="inline">--prefix</code>, and new <code class="inline">--brain</code> when graph detection is enabled (or add <code class="inline">--no-graph</code>). Validate before switching readers. The shared <code class="inline">autoindex-catalog</code> and old target require explicit, validated cleanup. Added or removed content groups are refused; same-path replacement remains supported.</p>
 
   <hr>
 

--- a/landing/llms-full.txt
+++ b/landing/llms-full.txt
@@ -140,16 +140,18 @@ destabilize the server.
   xerj autoindex map      [--url U] [--json] [--dataset SLUG]
   xerj autoindex status   [--url U] [--state-dir P]
 
---fresh starts without resume state only when the selected state directory has
-no durable plan. It never removes stale destination records. An independent
-rebuild requires a new --state-dir, new --prefix, and new --brain when graph
-detection is enabled (or --no-graph), followed by validation before switching
-readers. The shared autoindex-catalog and old target require explicit,
-validated cleanup. Added or removed content groups are refused; same-path
-replacement remains supported.
+--fresh ignores the journal and rebuilds the plan in place (ids stay
+idempotent); it is how you pick up files added since the last run. A rerun
+that resumes an existing plan indexes changed files and reports added ones as
+skipped. Deleting an indexed file is refused before any destination change,
+because nothing here removes the documents it already published: restore the
+file and rerun, or rebuild — in place by deleting the named indices and the
+state directory, or isolated under a new --state-dir, --prefix and --brain (or
+--no-graph), validated before switching readers. The shared autoindex-catalog
+and the old target require explicit cleanup.
 
 Exit codes: 0 complete · 3 completed-with-junk (junk recorded, never fatal) ·
-2 usage · 1 endpoint/journal error or refused unsafe corpus-state transition.
+2 usage · 1 endpoint/journal error or a refused corpus removal.
 
 Pipeline: walk → sniff → sample → infer → map → extract → bulk → correlate →
 catalog → verify.

--- a/landing/llms-full.txt
+++ b/landing/llms-full.txt
@@ -140,8 +140,16 @@ destabilize the server.
   xerj autoindex map      [--url U] [--json] [--dataset SLUG]
   xerj autoindex status   [--url U] [--state-dir P]
 
+--fresh starts without resume state only when the selected state directory has
+no durable plan. It never removes stale destination records. An independent
+rebuild requires a new --state-dir, new --prefix, and new --brain when graph
+detection is enabled (or --no-graph), followed by validation before switching
+readers. The shared autoindex-catalog and old target require explicit,
+validated cleanup. Added or removed content groups are refused; same-path
+replacement remains supported.
+
 Exit codes: 0 complete · 3 completed-with-junk (junk recorded, never fatal) ·
-2 usage · 1 endpoint unreachable / journal-config mismatch.
+2 usage · 1 endpoint/journal error or refused unsafe corpus-state transition.
 
 Pipeline: walk → sniff → sample → infer → map → extract → bulk → correlate →
 catalog → verify.


### PR DESCRIPTION
# Summary

This makes `xerj autoindex` fail closed when a rerun cannot safely reconcile the current folder with its durable resume plan.

The supported contract after this change is explicit:

- An interrupted run resumes completed work at whole-file granularity.
- An unchanged rerun reuses completed files after verifying full-content identities.
- Replacing the contents of an existing path is detected and republished under the planned identity.
- Adding or removing a canonical content group is detected and rejected before journal or destination mutation because complete membership reconciliation is not implemented yet.
- `--fresh` is accepted only when the selected state directory has no durable plan. It never resets or reconciles an existing destination.

This is a correctness and operator-truthfulness change. It does not implement incremental add/delete synchronization; that remains follow-up work.

# Root cause

The resume journal is more than a local progress cache. Its frozen plan carries the identities needed to reconcile published data records, duplicate aliases, graph edges, catalog entries, replacements, and stale records.

Discarding that plan cannot prove convergence of an existing destination. Likewise, silently accepting files outside the frozen plan can publish only part of the new corpus while leaving removed artifacts live.

`xerj brain` also previously treated an absent or zero live-node probe as evidence that the destination was empty and automatically retried with fresh state. An absent metadata document, a malformed response, a transport failure, and an authoritative zero are different states; none proves that every data, graph, and catalog namespace is empty.

# What changes

## One authoritative preflight

Autoindex now acquires the exclusive state lock before directory discovery and full hashing. The same lock covers journal inspection, inventory classification, torn-tail handling, and authoritative open. A waiting invocation cannot classify a path snapshot taken while another invocation is publishing or replacing the plan.

## Fail-closed inventory classification

The current canonical content groups are compared with the durable plan before any mapping creation, delete-by-query, bulk publication, refresh, graph write, catalog write, or journal append.

Added and vanished groups produce an actionable unsupported-delta error. Same-path content replacement remains supported: the existing planned key is retained, its full digest is compared, replacement intent invalidates completion, stale records are cleaned, and the file is republished.

Human output goes to stderr with a nonzero exit. Machine-readable mode emits structured JSON describing added and vanished groups, confirming that the attempt made no destination changes, and naming the supported recovery choices.

## Honest `--fresh`

`--fresh` no longer discards a durable plan. Even an apparently unchanged key set can have alias, path, graph, catalog, or partial-publication history that only the old plan can reconcile.

An isolated rebuild requires:

- a new `--state-dir`
- a new `--prefix`
- a new `--brain` when graph indexing is enabled, or `--no-graph`
- validation before switching readers
- explicit cleanup of old targets after validation

The global autoindex catalog remains shared, so the change does not describe this as a completely isolated destination.

## Honest `xerj brain` recovery

`xerj brain` no longer automatically retries with `fresh` when the journal and server disagree. The live-node probe preserves absence, authoritative zero, malformed metadata, and request failure as distinct outcomes. Probe errors propagate instead of being converted into “empty.”

The refusal identifies the journal, URL, prefix, and brain namespace and prints an executable isolated-rebuild command. API-key values are never echoed.

# Manual reproduction

Start XERJ:

```bash
target/debug/xerj --insecure --data-dir /workspace/xerj-rescan-demo/server
```

Create and index a folder:

```bash
mkdir -p /workspace/xerj-rescan-demo/corpus
printf 'quarter,revenue\nQ1,100\n' > /workspace/xerj-rescan-demo/corpus/report.csv

target/debug/xerj autoindex /workspace/xerj-rescan-demo/corpus \
  --url http://localhost:9200 \
  --state-dir /workspace/xerj-rescan-demo/state \
  --prefix rescan-demo \
  --brain rescan-demo
```

An unchanged rerun succeeds and reuses the completed file:

```bash
target/debug/xerj autoindex /workspace/xerj-rescan-demo/corpus \
  --url http://localhost:9200 \
  --state-dir /workspace/xerj-rescan-demo/state \
  --prefix rescan-demo \
  --brain rescan-demo
```

Add a new file and rerun:

```bash
printf 'quarter,revenue\nQ2,120\n' > /workspace/xerj-rescan-demo/corpus/report-q2.csv

target/debug/xerj autoindex /workspace/xerj-rescan-demo/corpus \
  --url http://localhost:9200 \
  --state-dir /workspace/xerj-rescan-demo/state \
  --prefix rescan-demo \
  --brain rescan-demo
```

Expected result: nonzero exit, the added canonical group is named, the error states that no destination mutation was made, and the journal remains byte-identical.

Remove the added file, replace `report.csv` at the same path, and rerun:

```bash
rm /workspace/xerj-rescan-demo/corpus/report-q2.csv
printf 'quarter,revenue\nQ1,110\n' > /workspace/xerj-rescan-demo/corpus/report.csv

target/debug/xerj autoindex /workspace/xerj-rescan-demo/corpus \
  --url http://localhost:9200 \
  --state-dir /workspace/xerj-rescan-demo/state \
  --prefix rescan-demo \
  --brain rescan-demo
```

Expected result: the full digest change is detected and the planned file is cleaned and republished.

Attempting `--fresh` with the existing state is refused:

```bash
target/debug/xerj autoindex /workspace/xerj-rescan-demo/corpus \
  --url http://localhost:9200 \
  --state-dir /workspace/xerj-rescan-demo/state \
  --prefix rescan-demo \
  --brain rescan-demo \
  --fresh
```

# Validation

- `xerj-autoindex`: 219 passed, 0 failed
- focused `xerj brain`: 5 passed, 0 failed
- ONNX embedding-identity recovery tests: 8 passed, 0 failed
- scoped Clippy for `xerj-autoindex`, `xerj-server`, and `xerj-engine`: passed with `-D warnings`
- `cargo fmt --all --check`: passed
- `git diff --check`: passed
- evaluation script syntax: passed
- ES-YAML conformance on the current 200-file suite: 1,365 passed, 0 failed, 3 skipped
- two independent code/documentation reviews: GO after fixing lock order, namespace isolation, shared-catalog wording, and executable recovery guidance

Full conformance evidence is recorded at `/workspace/north-star-evidence/route1-incremental-sync-esyaml-2026-08-03/runner.log` in the development environment.

# Scope and follow-up

This PR deliberately refuses unsupported membership changes rather than implementing a partial approximation.

The next contribution should preserve the durable plan and transactionally reconcile added, changed, and deleted content across data, alias, graph, and catalog artifacts. It should advance the plan only after durable publication and retain enough intent to replay safely after a crash.