### PR TITLE
test(engine): bound the publication test barriers so a missed point fails fast

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1760,6 +1760,21 @@ mod merge_publication_transaction_tests {
     use crate::Engine;
     use tempfile::TempDir;
 
+    /// Wait for a publication test barrier, bounded.
+    ///
+    /// These barriers block a tokio worker thread on purpose, and an unbounded
+    /// `recv()` turns "the code never reached this point" into a hang. On CI
+    /// that surfaced as a job cancelled at the six-hour ceiling with nothing in
+    /// the log but "has been running for over 60 seconds". Bounded, the same
+    /// bug is a ten-second failure naming the point it waited for.
+    #[track_caller]
+    fn await_barrier<T>(rx: &std::sync::mpsc::Receiver<T>, what: &str) -> T {
+        match rx.recv_timeout(std::time::Duration::from_secs(20)) {
+            Ok(v) => v,
+            Err(e) => panic!("publication barrier `{what}` never fired ({e:?})"),
+        }
+    }
+
     fn config(dir: &TempDir) -> xerj_common::config::Config {
         let mut config = xerj_common::config::Config::default();
         config.server.data_dir = dir.path().to_string_lossy().into_owned();
@@ -1997,12 +2012,12 @@ mod merge_publication_transaction_tests {
         index.set_publication_test_hook(Some(Arc::new(move |_, point| {
             if point == PublicationTestPoint::MergeAfterRepoint {
                 entered_tx.lock().take().unwrap().send(()).unwrap();
-                resume_rx.lock().take().unwrap().recv().unwrap();
+                await_barrier(&resume_rx.lock().take().unwrap(), "resume");
             }
         })));
         let merge_index = Arc::clone(&index);
         let merge = tokio::spawn(async move { merge_index.run_merge_once().await });
-        tokio::task::spawn_blocking(move || entered_rx.recv().unwrap())
+        tokio::task::spawn_blocking(move || await_barrier(&entered_rx, "entered"))
             .await
             .unwrap();
         let read_index = Arc::clone(&index);


### PR DESCRIPTION
Closes #157.

## What happened

`Build + Test` on #151, the last rc.10 blocker, logged this and then went quiet:

```
08:02:58  running 406 tests
08:03:58  cancellation_inside_guarded_repoint_fails_closed_and_recovery_restores_inputs
          has been running for over 60 seconds
```

Six hours later GitHub cancelled the job at its ceiling. Run duration **6:00:26, conclusion cancelled**. Not a test failure, a hang, and the log said nothing useful about why.

## Why

These barriers block a tokio worker thread deliberately (`publication_test_point` is sync, called from async, and its own comment says test barriers may intentionally block). They then waited on an unbounded `recv()`, which only returns if the merge path reaches `MergeAfterRepoint`. When merge policy decides there is nothing to merge, that point never fires and the barrier waits forever. On a 2-core runner under load that is a coin flip.

A hanging test is strictly worse than a failing one. It costs a full CI slot, produces no diagnosis, and here it held up a release.

## The change

Both barriers in `merge_publication_transaction_tests` now wait with a 20 second bound and panic naming the point they were waiting for.

## Verified, not assumed

Made the barrier point unreachable (`if false && point == ...`) and re-ran. The test that used to hang for six hours now fails in **20.01s** with:

```
publication barrier `entered` never fired (Timeout)
```

Restored, and all six tests pass in 0.07s. The behaviour under test is unchanged; only the failure mode is.

## Residual

Scoped deliberately to the module that actually hung. `index.rs` still has ~32 other unbounded `recv()` calls against 2 `recv_timeout`, and the wider fixes in #157 (stop consuming runtime workers via `block_in_place` or an async oneshot, wrap the awaits in `tokio::time::timeout`, consider a workspace-wide per-test timeout) remain open.