### PR TITLE
chore(release): bump the workspace version to 1.0.0-rc.10

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-ai"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -6370,7 +6370,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-api"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-autoindex"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-cluster"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6466,7 +6466,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-common"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-compress"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "byteorder",
  "bytes",
@@ -6497,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-console-api"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-engine"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-fts"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "bitpacking",
@@ -6598,7 +6598,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-logs"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-mcp"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-query"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-server"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "axum",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-storage"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6717,7 +6717,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-vector"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-wasm"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "anyhow",
  "bytes",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["xerj Contributors"]


### PR DESCRIPTION
## The problem

`v1.0.0-rc.10` is published with all 16 assets, and the installer works: correct target detected, SHA-256 verified, server boots green, ingest and query round-trip fine. But:

```
$ XERJ_INSTALL_DIR=/tmp/rc10 sh -c "$(curl -fsSL https://xerj.org/get)"
==> downloading xerj-1.0.0-rc.10-x86_64-unknown-linux-musl.tar.gz…
 ok  sha256 verified
xerj v1.0.0-rc.10 is ready.

$ /tmp/rc10/xerj --help
xerj v1.0.0-rc.9 — the unified search engine for AI
```

Asset names come from the git tag; the banner comes from `env!("CARGO_PKG_VERSION")`. `engine/Cargo.toml` still said `1.0.0-rc.9` because the workspace version was never bumped (`git log v1.0.0-rc.9..HEAD -- engine/Cargo.toml` is empty).

Not cosmetic: anyone who installs rc.10 and checks their version is told rc.9, so bug reports get attributed to the wrong release.

## The change

Workspace version to `1.0.0-rc.10`, 16 lockfile entries follow.

## Verified

Rebuilt `-p xerj-server --release` and ran it:

```
xerj v1.0.0-rc.10 — the unified search engine for AI (Elasticsearch wire-compatible)
```

## Follow-up needed

The published rc.10 artifacts were built before this, so they still carry the wrong banner. For the release to describe itself correctly the tag and its assets need re-cutting on top of this commit. That is a destructive change to a published release, so it is left as an explicit decision rather than done here.

Worth adding a release-time guard afterwards: fail the workflow when the tag and `CARGO_PKG_VERSION` disagree, so this cannot ship again.