### PR TITLE
fix(engine): skip tombstone-only segments in agg corpus

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -15830,6 +15830,17 @@ impl Index {
                 .collect();
             let snap_bg = self.store.snapshot();
             for seg in &snap_bg.segments {
+                // A tombstone-only segment is an intentional delete journal:
+                // it has `doc_count == 0` and no Stored section to hydrate.
+                // Its deletions are already represented in the version map,
+                // while this pass only assembles source documents for the
+                // aggregation corpus. Trying to load it makes the valid
+                // absence of Stored look like an unreadable segment and turns
+                // every fallback aggregation after a persisted delete into a
+                // 500 response.
+                if seg.doc_count == 0 {
+                    continue;
+                }
                 // Cooperative deadline: the full-corpus assembly is the
                 // most expensive path in the engine (decompress + parse
                 // EVERY stored doc).  Stop pulling further segments once

--- a/engine/crates/xerj-engine/tests/tombstone_only_segment_search.rs
+++ b/engine/crates/xerj-engine/tests/tombstone_only_segment_search.rs
@@ -1,0 +1,115 @@
+//! Search regressions for delete-only (`doc_count == 0`) segments.
+//!
+//! A persisted delete has no stored documents. Its segment intentionally
+//! contains only the tombstone section, so query paths must not try to hydrate
+//! a `Stored` section from it.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+use xerj_engine::{Engine, Index};
+use xerj_query::parse_request;
+
+fn make_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    Engine::new(config).expect("engine::new")
+}
+
+async fn seed_delete_only_segment(engine: &Engine, name: &str) {
+    engine.create_index(name, Schema::empty()).unwrap();
+    let index = engine.get_index(name).unwrap();
+
+    index
+        .index_document(Some("live".into()), json!({"group": "kept", "amount": 10}))
+        .await
+        .unwrap();
+    index
+        .index_document(
+            Some("deleted".into()),
+            json!({"group": "kept", "amount": 999}),
+        )
+        .await
+        .unwrap();
+    index.flush().await.unwrap();
+
+    assert!(index.delete_document("deleted").await.unwrap());
+    index.flush().await.unwrap();
+
+    assert!(
+        index
+            .store_snapshot()
+            .segments
+            .iter()
+            .any(|segment| segment.doc_count == 0 && segment.has_tombstones),
+        "test setup must publish a tombstone-only segment"
+    );
+}
+
+async fn assert_filtered_aggregation_works(index: &Index) {
+    let unfiltered = parse_request(&json!({
+        "query": {"match_all": {}},
+        "track_total_hits": true
+    }))
+    .unwrap();
+    let result = index
+        .search(&unfiltered)
+        .await
+        .expect("unfiltered search must succeed");
+    assert_eq!(result.total.value, 1);
+    assert_eq!(result.hits.len(), 1);
+    assert_eq!(result.hits[0].id, "live");
+
+    // A filtered aggregation enters the JSON full-corpus fallback before the
+    // later doc-values fallback can answer. Before the fix that corpus walk
+    // attempted to hydrate the tombstone-only segment and returned
+    // `segment ... unreadable during corpus assembly`.
+    let request = parse_request(&json!({
+        "size": 0,
+        "track_total_hits": true,
+        "query": {"terms": {"group": ["kept"]}},
+        "aggs": {
+            "amount_min": {"min": {"field": "amount"}},
+            "amount_max": {"max": {"field": "amount"}}
+        }
+    }))
+    .unwrap();
+
+    let result = index.search(&request).await.expect("search must succeed");
+    assert_eq!(result.total.value, 1);
+    let aggs = result.aggs.expect("aggregations");
+    assert_eq!(aggs["amount_min"]["value"], json!(10.0));
+    assert_eq!(aggs["amount_max"]["value"], json!(10.0));
+}
+
+#[tokio::test]
+async fn filtered_aggregation_skips_live_tombstone_only_segment() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    seed_delete_only_segment(&engine, "live-delete").await;
+
+    let index = engine.get_index("live-delete").unwrap();
+    assert_filtered_aggregation_works(&index).await;
+}
+
+#[tokio::test]
+async fn filtered_aggregation_skips_reopened_tombstone_only_segment() {
+    let dir = TempDir::new().unwrap();
+    {
+        let engine = make_engine(&dir);
+        seed_delete_only_segment(&engine, "reopened-delete").await;
+    }
+
+    let reopened = make_engine(&dir);
+    let index = reopened.get_index("reopened-delete").unwrap();
+    assert!(
+        index
+            .store_snapshot()
+            .segments
+            .iter()
+            .any(|segment| segment.doc_count == 0 && segment.has_tombstones),
+        "restart must retain the tombstone-only segment"
+    );
+    assert_filtered_aggregation_works(&index).await;
+}


### PR DESCRIPTION
## Summary

Fix searches that returned HTTP 500 after a delete was made segment-durable.

XERJ persists an acknowledged delete in a tombstone-only segment. That segment correctly has `doc_count == 0` and a Tombstones section, but no Stored section because it contains no source documents. The JSON aggregation fallback previously tried to hydrate Stored data from every segment in the snapshot. It therefore interpreted a valid tombstone-only segment as unreadable and returned `segment ... unreadable during corpus assembly`.

The corpus walker now skips segments whose authoritative row count is zero. Tombstones are already applied through the version map, and a zero-document segment cannot contribute a source document to an aggregation corpus. Non-empty segments retain the existing fail-closed behavior: a genuinely missing or unreadable Stored section still produces an error rather than silently dropping documents.

## User-visible failure

The failure affected aggregation requests after a persisted delete, including the validation query used by incremental `autoindex` reconciliation. It reproduced both in the live process and after restart.

Example request:

```http
POST /reports/_search
Content-Type: application/json

{
  "size": 0,
  "track_total_hits": true,
  "query": {
    "terms": {
      "group": ["kept"]
    }
  },
  "aggs": {
    "amount_min": {
      "min": {
        "field": "amount"
      }
    },
    "amount_max": {
      "max": {
        "field": "amount"
      }
    }
  }
}
```

Before this change, once `_refresh` had published a tombstone-only segment, that request returned HTTP 500 with `segment <id> unreadable during corpus assembly`. After this change it returns the one surviving document in `hits.total` and the correct minimum and maximum values.

## Tests

The new deterministic regression creates only two documents, flushes them, deletes one, and flushes again. It asserts that the setup published a real `doc_count == 0 && has_tombstones` segment, then proves:

- An unfiltered query returns only the surviving document.
- The filtered min/max aggregation succeeds and excludes the deleted sentinel value.
- The same results hold after dropping and reopening the engine.

Validation completed on commit `672560f5fe88975d13bb29f3683bb7bb34e3947e`:

- `cargo fmt --all --check`
- `git diff --check`
- Tombstone-only regression: 2 passed, 0 failed
- RC4 storage hardening regression: 2 passed, 0 failed
- `cargo clippy -p xerj-engine --tests -- -D warnings`
- ES-YAML conformance: 1365 passed, 0 failed, 3 skipped
- Independent semantic review: GO

For transparency, a broader `cargo test -p xerj-engine` sweep reached the unrelated pre-existing stack overflow in `painless_script_limits::script_failure_is_not_cached_or_replayed`. This patch does not touch the script engine or that execution path.