### PR TITLE
feat(autoindex): reconcile generated non-graph corpora incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — fail-closed autoindex restart semantics
+
+- **`autoindex --fresh` no longer discards a durable resume plan.** A durable
+  plan contains the alias, path, graph, and stale-record knowledge needed for
+  safe reconciliation. `--fresh` is accepted only when the selected state
+  directory has no durable plan and never cleans the destination. An
+  independent rebuild must use a new state directory, new prefix, and new brain
+  namespace when graph detection is enabled (or disable graph writes), be
+  validated, and only then replace the old reader target. The shared catalog
+  and old target require explicit, validated cleanup. Generated journals with
+  `--no-graph` reconcile additions, changes, deletions, renames, and no-op
+  reruns. Legacy journals and graph-enabled generations refuse membership
+  changes before remote mutation.
+
 ## [1.0.0-rc.10] - 2026-08-03
 
 ### Security
@@ -82,7 +96,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reaching the HNSW graph. Each arrived with a standalone harness and honest
   caveats. They are tracked for the following release rather than rushed into
   this one.
-
 
 ### Changed — runtime-field types (can break existing mappings)
 

--- a/demo/usecases/autoindex/RECIPE_DRAFT.md
+++ b/demo/usecases/autoindex/RECIPE_DRAFT.md
@@ -203,8 +203,15 @@ done in 0.1s — 3 datasets, 5801 records live, 0 junk records, 1 junk/skipped f
 just polite re-runs: in the robustness evaluation, a `kill -9` at 18 s into a
 200 MB file followed by a re-run converged to **byte-identical counts across
 all 9 datasets** — no duplicates. `xerj autoindex status` shows the journal
-and live index counts; `--fresh` ignores the journal and restarts (ids stay
-idempotent).
+and live index counts. `--fresh` starts without resume state only when the
+selected state directory has no durable plan; it never removes stale
+destination records. For an independent rebuild, use a new `--state-dir`, new
+`--prefix`, and new `--brain` when graph detection is enabled (or add
+`--no-graph`). Validate before switching readers. The shared
+`autoindex-catalog` and old target require explicit, validated cleanup.
+Generated journals with `--no-graph` reconcile additions, changes, deletions,
+renames, and no-op reruns. Legacy journals and graph-enabled generations refuse
+membership changes before remote mutation.
 
 ## Reproduce it yourself
 

--- a/docs/EXPERIMENTAL_ONNX.md
+++ b/docs/EXPERIMENTAL_ONNX.md
@@ -88,7 +88,7 @@ In another terminal, index a corpus:
 target/release/xerj autoindex /path/to/corpus \
   --url http://localhost:9200 \
   --prefix finance-onnx \
-  --fresh
+  --state-dir /path/to/new-finance-onnx-state
 
 target/release/xerj autoindex map \
   --url http://localhost:9200 \
@@ -152,9 +152,11 @@ with the same assets. XERJ refuses:
 - enabling ONNX in place on a populated marker-less semantic index;
 - caller-supplied derived vectors whose identity cannot be verified.
 
-The error tells the operator to restore the original assets or re-run
-autoindex with `--fresh` and a new prefix. XERJ never silently mixes vector
-spaces.
+The error tells the operator to restore the original assets or perform an
+isolated autoindex rebuild with a new state directory, new prefix, and new
+brain when graph detection is enabled (or `--no-graph`). Validate the new
+target before switching readers; the shared catalog and old target require
+explicit, validated cleanup. XERJ never silently mixes vector spaces.
 
 The transformer-fused graph produced by the offline recipe is a different
 model identity from its source graph because its model hash differs. Do not

--- a/docs/recipes/zero-config-indexing.md
+++ b/docs/recipes/zero-config-indexing.md
@@ -228,7 +228,14 @@ live indices at http://localhost:9280:
   autoindex-catalog                                 9 docs
 ```
 
-`--fresh` ignores the journal and restarts (ids stay idempotent).
+`--fresh` starts without resume state only when the selected state directory
+has no durable plan; it never removes stale destination records. For an
+independent rebuild, use a new `--state-dir`, new `--prefix`, and new
+`--brain` when graph detection is enabled (or add `--no-graph`). Validate
+before switching readers. The shared `autoindex-catalog` and old target require
+explicit, validated cleanup. Generated journals with `--no-graph` reconcile
+additions, changes, deletions, renames, and no-op reruns. Legacy journals and
+graph-enabled generations refuse membership changes before remote mutation.
 
 ## Reproduce it yourself
 

--- a/engine/crates/xerj-ai/src/embed.rs
+++ b/engine/crates/xerj-ai/src/embed.rs
@@ -139,6 +139,13 @@ pub struct EmbeddingProxy {
 impl EmbeddingProxy {
     /// Create a new proxy with the given config.
     pub fn new(config: EmbeddingProxyConfig) -> Result<Self> {
+        let endpoint = reqwest::Url::parse(&config.endpoint)
+            .map_err(|e| XerjError::embedding(format!("invalid embedding endpoint: {e}")))?;
+        if !matches!(endpoint.scheme(), "http" | "https") {
+            return Err(XerjError::embedding(
+                "embedding endpoint must use http or https",
+            ));
+        }
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
             .build()
@@ -311,6 +318,14 @@ mod tests {
     fn config_with_api_key() {
         let cfg = EmbeddingProxyConfig::new("http://localhost", "model").with_api_key("sk-test");
         assert_eq!(cfg.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn proxy_rejects_invalid_or_non_http_endpoints_at_construction() {
+        for endpoint in ["not a url", "file:///private/model"] {
+            let cfg = EmbeddingProxyConfig::new(endpoint, "model");
+            assert!(EmbeddingProxy::new(cfg).is_err(), "{endpoint} was accepted");
+        }
     }
 
     #[tokio::test]

--- a/engine/crates/xerj-ai/src/embedder.rs
+++ b/engine/crates/xerj-ai/src/embedder.rs
@@ -313,37 +313,6 @@ impl std::fmt::Debug for OnnxConfig {
 }
 
 #[cfg(feature = "onnx-experimental")]
-impl PartialEq for OnnxConfig {
-    fn eq(&self, other: &Self) -> bool {
-        self.model_sha256 == other.model_sha256
-            && self.tokenizer_sha256 == other.tokenizer_sha256
-            && self.intra_threads == other.intra_threads
-            && self.session_pool_size == other.session_pool_size
-            && self.microbatch == other.microbatch
-            && self.max_inflight_calls == other.max_inflight_calls
-            && self.max_input_bytes_per_call == other.max_input_bytes_per_call
-            && self.max_inflight_input_bytes == other.max_inflight_input_bytes
-    }
-}
-
-#[cfg(feature = "onnx-experimental")]
-impl Eq for OnnxConfig {}
-
-#[cfg(feature = "onnx-experimental")]
-impl std::hash::Hash for OnnxConfig {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.model_sha256.hash(state);
-        self.tokenizer_sha256.hash(state);
-        self.intra_threads.hash(state);
-        self.session_pool_size.hash(state);
-        self.microbatch.hash(state);
-        self.max_inflight_calls.hash(state);
-        self.max_input_bytes_per_call.hash(state);
-        self.max_inflight_input_bytes.hash(state);
-    }
-}
-
-#[cfg(feature = "onnx-experimental")]
 #[derive(Debug, thiserror::Error)]
 #[error("{reason}")]
 pub struct OnnxAdmissionError {
@@ -540,7 +509,7 @@ mod onnx_handle_tests {
 
     fn cfg(model_sha256: &str) -> OnnxConfig {
         OnnxConfig {
-            model_bytes: Arc::from(b"model bytes".as_slice()),
+            model_bytes: Arc::from(format!("model bytes for {model_sha256}").into_bytes()),
             tokenizer_bytes: Arc::from(b"tokenizer bytes".as_slice()),
             model_sha256: model_sha256.into(),
             tokenizer_sha256: "tokenizer-hash".into(),
@@ -554,10 +523,24 @@ mod onnx_handle_tests {
     }
 
     #[test]
-    fn same_paths_with_different_content_hashes_never_share_session_cell() {
-        let first = OnnxHandle::new(cfg("model-a"));
-        let second = OnnxHandle::new(cfg("model-b"));
+    fn different_actual_bytes_never_share_session_cell() {
+        let first = cfg("model-a");
+        let mut second = cfg("model-b");
+        second.model_bytes = Arc::from(b"different model bytes".as_slice());
+        let first = OnnxHandle::new(first);
+        let second = OnnxHandle::new(second);
         assert!(!Arc::ptr_eq(&first.shared, &second.shared));
+    }
+
+    #[test]
+    fn identical_bytes_share_even_when_descriptive_hash_fields_differ() {
+        let first_cfg = cfg("descriptive-a");
+        let mut second_cfg = cfg("descriptive-b");
+        second_cfg.model_bytes = first_cfg.model_bytes.clone();
+        second_cfg.tokenizer_bytes = first_cfg.tokenizer_bytes.clone();
+        let first = OnnxHandle::new(first_cfg);
+        let second = OnnxHandle::new(second_cfg);
+        assert!(Arc::ptr_eq(&first.shared, &second.shared));
     }
 
     #[test]

--- a/engine/crates/xerj-ai/src/embedder.rs
+++ b/engine/crates/xerj-ai/src/embedder.rs
@@ -357,16 +357,46 @@ pub struct OnnxHandle {
 }
 
 #[cfg(feature = "onnx-experimental")]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct OnnxCacheKey {
+    model_sha256: String,
+    tokenizer_sha256: String,
+    intra_threads: usize,
+    session_pool_size: usize,
+    microbatch: crate::onnx::MicrobatchConfig,
+    max_inflight_calls: usize,
+    max_input_bytes_per_call: usize,
+    max_inflight_input_bytes: usize,
+}
+
+#[cfg(feature = "onnx-experimental")]
+impl From<&OnnxConfig> for OnnxCacheKey {
+    fn from(cfg: &OnnxConfig) -> Self {
+        Self {
+            model_sha256: cfg.model_sha256.clone(),
+            tokenizer_sha256: cfg.tokenizer_sha256.clone(),
+            intra_threads: cfg.intra_threads,
+            session_pool_size: cfg.session_pool_size,
+            microbatch: cfg.microbatch,
+            max_inflight_calls: cfg.max_inflight_calls,
+            max_input_bytes_per_call: cfg.max_input_bytes_per_call,
+            max_inflight_input_bytes: cfg.max_inflight_input_bytes,
+        }
+    }
+}
+
+#[cfg(feature = "onnx-experimental")]
 impl OnnxHandle {
     fn new(cfg: OnnxConfig) -> Self {
         use std::collections::HashMap;
         use std::sync::{Mutex, OnceLock, Weak};
-        static CELLS: OnceLock<Mutex<HashMap<OnnxConfig, Weak<OnnxShared>>>> = OnceLock::new();
+        static CELLS: OnceLock<Mutex<HashMap<OnnxCacheKey, Weak<OnnxShared>>>> = OnceLock::new();
+        let key = OnnxCacheKey::from(&cfg);
         let mut cells = CELLS
             .get_or_init(|| Mutex::new(HashMap::new()))
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(shared) = cells.get(&cfg).and_then(Weak::upgrade) {
+        if let Some(shared) = cells.get(&key).and_then(Weak::upgrade) {
             return Self { cfg, shared };
         }
         cells.retain(|_, shared| shared.strong_count() > 0);
@@ -377,7 +407,7 @@ impl OnnxHandle {
                 cfg.max_inflight_input_bytes.max(1),
             )),
         });
-        cells.insert(cfg.clone(), std::sync::Arc::downgrade(&shared));
+        cells.insert(key, std::sync::Arc::downgrade(&shared));
         Self { cfg, shared }
     }
 
@@ -523,6 +553,17 @@ mod onnx_handle_tests {
         let first = OnnxHandle::new(cfg("model-a"));
         let second = OnnxHandle::new(cfg("model-b"));
         assert!(!Arc::ptr_eq(&first.shared, &second.shared));
+    }
+
+    #[test]
+    fn session_registry_key_does_not_retain_asset_bytes_after_handle_drop() {
+        let config = cfg("releasable-assets");
+        let weak_model = Arc::downgrade(&config.model_bytes);
+        let weak_tokenizer = Arc::downgrade(&config.tokenizer_bytes);
+        let handle = OnnxHandle::new(config);
+        drop(handle);
+        assert!(weak_model.upgrade().is_none());
+        assert!(weak_tokenizer.upgrade().is_none());
     }
 
     #[test]

--- a/engine/crates/xerj-ai/src/embedder.rs
+++ b/engine/crates/xerj-ai/src/embedder.rs
@@ -283,12 +283,12 @@ impl Embedder {
 }
 
 #[cfg(feature = "onnx-experimental")]
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct OnnxConfig {
-    pub model_path: std::path::PathBuf,
-    pub tokenizer_path: std::path::PathBuf,
-    /// Content fingerprints are part of the shared-session cache key and are
-    /// rechecked immediately before load, preventing same-path asset swaps.
+    /// Immutable byte snapshots are shared by identity reporting and lazy
+    /// loading. A later same-path replacement cannot change the loaded space.
+    pub model_bytes: std::sync::Arc<[u8]>,
+    pub tokenizer_bytes: std::sync::Arc<[u8]>,
     pub model_sha256: String,
     pub tokenizer_sha256: String,
     pub intra_threads: usize,
@@ -298,6 +298,49 @@ pub struct OnnxConfig {
     pub max_inflight_calls: usize,
     pub max_input_bytes_per_call: usize,
     pub max_inflight_input_bytes: usize,
+}
+
+#[cfg(feature = "onnx-experimental")]
+impl std::fmt::Debug for OnnxConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OnnxConfig")
+            .field("model_sha256", &self.model_sha256)
+            .field("tokenizer_sha256", &self.tokenizer_sha256)
+            .field("intra_threads", &self.intra_threads)
+            .field("session_pool_size", &self.session_pool_size)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "onnx-experimental")]
+impl PartialEq for OnnxConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.model_sha256 == other.model_sha256
+            && self.tokenizer_sha256 == other.tokenizer_sha256
+            && self.intra_threads == other.intra_threads
+            && self.session_pool_size == other.session_pool_size
+            && self.microbatch == other.microbatch
+            && self.max_inflight_calls == other.max_inflight_calls
+            && self.max_input_bytes_per_call == other.max_input_bytes_per_call
+            && self.max_inflight_input_bytes == other.max_inflight_input_bytes
+    }
+}
+
+#[cfg(feature = "onnx-experimental")]
+impl Eq for OnnxConfig {}
+
+#[cfg(feature = "onnx-experimental")]
+impl std::hash::Hash for OnnxConfig {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.model_sha256.hash(state);
+        self.tokenizer_sha256.hash(state);
+        self.intra_threads.hash(state);
+        self.session_pool_size.hash(state);
+        self.microbatch.hash(state);
+        self.max_inflight_calls.hash(state);
+        self.max_input_bytes_per_call.hash(state);
+        self.max_inflight_input_bytes.hash(state);
+    }
 }
 
 #[cfg(feature = "onnx-experimental")]
@@ -343,30 +386,9 @@ impl OnnxHandle {
         self.shared
             .init
             .get_or_spawn("xerj-onnx-init", move || {
-                    let model_bytes = std::fs::read(&cfg.model_path).map_err(|e| {
-                        anyhow!("read ONNX model {}: {e}", cfg.model_path.display())
-                    })?;
-                    let tokenizer_bytes = std::fs::read(&cfg.tokenizer_path).map_err(|e| {
-                        anyhow!("read ONNX tokenizer {}: {e}", cfg.tokenizer_path.display())
-                    })?;
-                    let actual_model = sha256_bytes(&model_bytes);
-                    let actual_tokenizer = sha256_bytes(&tokenizer_bytes);
-                    if actual_model != cfg.model_sha256 || actual_tokenizer != cfg.tokenizer_sha256
-                    {
-                        return Err(anyhow!(
-                            "ONNX assets changed after configuration; refusing to load a \
-                             different vector space from the same path (model expected {}, \
-                             actual {}; tokenizer expected {}, actual {}). Restart with the \
-                             intended assets or reindex under a new prefix",
-                            cfg.model_sha256,
-                            actual_model,
-                            cfg.tokenizer_sha256,
-                            actual_tokenizer
-                        ));
-                    }
                     let embedder = crate::onnx::OnnxPool::load_bytes(
-                        &model_bytes,
-                        &tokenizer_bytes,
+                        &cfg.model_bytes,
+                        &cfg.tokenizer_bytes,
                         cfg.intra_threads,
                         cfg.session_pool_size,
                     )?;
@@ -474,26 +496,17 @@ impl OnnxHandle {
     }
 }
 
-#[cfg(feature = "onnx-experimental")]
-fn sha256_bytes(bytes: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
-}
-
 #[cfg(all(test, feature = "onnx-experimental"))]
 mod onnx_handle_tests {
     use super::{CancellationSafeInit, OnnxConfig, OnnxHandle};
     use crate::onnx::MicrobatchConfig;
-    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
     fn cfg(model_sha256: &str) -> OnnxConfig {
         OnnxConfig {
-            model_path: PathBuf::from("/tmp/model.onnx"),
-            tokenizer_path: PathBuf::from("/tmp/tokenizer.json"),
+            model_bytes: Arc::from(b"model bytes".as_slice()),
+            tokenizer_bytes: Arc::from(b"tokenizer bytes".as_slice()),
             model_sha256: model_sha256.into(),
             tokenizer_sha256: "tokenizer-hash".into(),
             intra_threads: 4,

--- a/engine/crates/xerj-ai/src/embedder.rs
+++ b/engine/crates/xerj-ai/src/embedder.rs
@@ -372,9 +372,14 @@ struct OnnxCacheKey {
 #[cfg(feature = "onnx-experimental")]
 impl From<&OnnxConfig> for OnnxCacheKey {
     fn from(cfg: &OnnxConfig) -> Self {
+        use sha2::{Digest, Sha256};
+
         Self {
-            model_sha256: cfg.model_sha256.clone(),
-            tokenizer_sha256: cfg.tokenizer_sha256.clone(),
+            // OnnxConfig is public, so its descriptive hash fields are not a
+            // construction invariant. Session sharing must be keyed from the
+            // bytes the runtime will actually load.
+            model_sha256: format!("{:x}", Sha256::digest(&cfg.model_bytes)),
+            tokenizer_sha256: format!("{:x}", Sha256::digest(&cfg.tokenizer_bytes)),
             intra_threads: cfg.intra_threads,
             session_pool_size: cfg.session_pool_size,
             microbatch: cfg.microbatch,
@@ -552,6 +557,17 @@ mod onnx_handle_tests {
     fn same_paths_with_different_content_hashes_never_share_session_cell() {
         let first = OnnxHandle::new(cfg("model-a"));
         let second = OnnxHandle::new(cfg("model-b"));
+        assert!(!Arc::ptr_eq(&first.shared, &second.shared));
+    }
+
+    #[test]
+    fn forged_equal_hash_fields_cannot_share_sessions_for_different_bytes() {
+        let first = cfg("forged");
+        let mut second = cfg("forged");
+        second.model_bytes = Arc::from(b"different model bytes".as_slice());
+        second.tokenizer_bytes = Arc::from(b"different tokenizer bytes".as_slice());
+        let first = OnnxHandle::new(first);
+        let second = OnnxHandle::new(second);
         assert!(!Arc::ptr_eq(&first.shared, &second.shared));
     }
 

--- a/engine/crates/xerj-api/Cargo.toml
+++ b/engine/crates/xerj-api/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+onnx-experimental = ["xerj-engine/onnx-experimental"]
+
 [dependencies]
 xerj-common  = { path = "../xerj-common" }
 xerj-engine  = { path = "../xerj-engine" }

--- a/engine/crates/xerj-api/src/authz.rs
+++ b/engine/crates/xerj-api/src/authz.rs
@@ -2418,6 +2418,10 @@ mod tests {
             assert!(check(p, Method::GET, "/_cat/indices", ""), "cat");
             assert!(check(p, Method::GET, "/v1/health", ""), "native health");
             assert!(
+                check(p, Method::GET, "/v1/embedding/identity", ""),
+                "embedding identity"
+            );
+            assert!(
                 check(p, Method::GET, "/_resolve/index/logs-*", ""),
                 "resolve"
             );

--- a/engine/crates/xerj-api/src/native.rs
+++ b/engine/crates/xerj-api/src/native.rs
@@ -655,6 +655,26 @@ pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
     Json(resp).into_response()
 }
 
+/// Machine-readable, privacy-safe embedding identity for resumable ingestion.
+pub async fn embedding_execution_identity(State(state): State<AppState>) -> impl IntoResponse {
+    let started = Instant::now();
+    let request_id = Uuid::new_v4().to_string();
+    match state.engine.embedding_execution_identity() {
+        Ok(identity) => Json(NativeResponse::new(
+            identity,
+            started.elapsed().as_millis() as u64,
+            &request_id,
+        ))
+        .into_response(),
+        Err(error) => native_error(
+            error.into(),
+            Some(&request_id),
+            started.elapsed().as_millis() as u64,
+        )
+        .into_response(),
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // k8s probes — v0.8 8-P4
 //

--- a/engine/crates/xerj-api/src/native.rs
+++ b/engine/crates/xerj-api/src/native.rs
@@ -659,19 +659,34 @@ pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
 pub async fn embedding_execution_identity(State(state): State<AppState>) -> impl IntoResponse {
     let started = Instant::now();
     let request_id = Uuid::new_v4().to_string();
-    match state.engine.embedding_execution_identity() {
-        Ok(identity) => Json(NativeResponse::new(
+    let engine = state.engine.clone();
+    let result = tokio::task::spawn_blocking(move || engine.embedding_execution_identity()).await;
+    match result {
+        Ok(Ok(identity)) => Json(NativeResponse::new(
             identity,
             started.elapsed().as_millis() as u64,
             &request_id,
         ))
         .into_response(),
-        Err(error) => {
+        Ok(Err(error)) => {
             tracing::warn!(error = %error, "embedding execution identity is unavailable");
             native_error(
                 xerj_common::XerjError::embedding(
                     "embedding execution identity is unavailable; verify the configured embedding \
-                 backend and local assets in the server logs",
+                     backend and local assets in the server logs. Asset-read failures are cached \
+                     for this server lifetime; restart the server after fixing the assets",
+                ),
+                Some(&request_id),
+                started.elapsed().as_millis() as u64,
+            )
+            .into_response()
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "embedding identity worker failed");
+            native_error(
+                xerj_common::XerjError::embedding(
+                    "embedding execution identity worker failed; inspect the server logs and \
+                     restart the server before retrying",
                 ),
                 Some(&request_id),
                 started.elapsed().as_millis() as u64,

--- a/engine/crates/xerj-api/src/native.rs
+++ b/engine/crates/xerj-api/src/native.rs
@@ -666,12 +666,18 @@ pub async fn embedding_execution_identity(State(state): State<AppState>) -> impl
             &request_id,
         ))
         .into_response(),
-        Err(error) => native_error(
-            error.into(),
-            Some(&request_id),
-            started.elapsed().as_millis() as u64,
-        )
-        .into_response(),
+        Err(error) => {
+            tracing::warn!(error = %error, "embedding execution identity is unavailable");
+            native_error(
+                xerj_common::XerjError::embedding(
+                    "embedding execution identity is unavailable; verify the configured embedding \
+                 backend and local assets in the server logs",
+                ),
+                Some(&request_id),
+                started.elapsed().as_millis() as u64,
+            )
+            .into_response()
+        }
     }
 }
 

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -1190,6 +1190,7 @@ mod tests {
                 .unwrap();
             let encoded = String::from_utf8(bytes.to_vec()).unwrap();
             assert!(encoded.contains("verify the configured embedding backend"));
+            assert!(encoded.contains("restart the server after fixing the assets"));
             for private in [
                 MODEL,
                 TOKENIZER,

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -1056,11 +1056,19 @@ mod tests {
     }
 
     fn test_state(distribution: &str) -> AppState {
+        test_state_with(distribution, |_| {})
+    }
+
+    fn test_state_with(
+        distribution: &str,
+        configure: impl FnOnce(&mut xerj_common::config::Config),
+    ) -> AppState {
         let dir = tempfile::tempdir().expect("tempdir").keep();
         let mut config = xerj_common::config::Config::default();
         config.server.data_dir = dir.to_string_lossy().into_owned();
         config.storage.wal_sync = xerj_common::config::WalSync::Async;
         config.compat.distribution = distribution.to_string();
+        configure(&mut config);
         let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
         let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
         AppState::new(config, engine, metrics)
@@ -1146,6 +1154,51 @@ mod tests {
             let encoded = String::from_utf8(bytes.to_vec()).unwrap();
             for secret_field in ["api_key", "endpoint", "model_path", "tokenizer_path"] {
                 assert!(!encoded.contains(secret_field), "{secret_field} leaked");
+            }
+        }
+    }
+
+    #[cfg(feature = "onnx-experimental")]
+    #[tokio::test]
+    async fn embedding_identity_asset_failures_do_not_leak_local_paths() {
+        const MODEL: &str = "/private/customer-a/models/missing-model.onnx";
+        const TOKENIZER: &str = "/private/customer-a/models/missing-tokenizer.json";
+        for app in [
+            build_native_router(test_state_with("elasticsearch", |config| {
+                config.embedding.mode = "onnx-experimental".into();
+                config.embedding.onnx_model_path = MODEL.into();
+                config.embedding.onnx_tokenizer_path = TOKENIZER.into();
+            })),
+            build_es_compat_router(test_state_with("elasticsearch", |config| {
+                config.embedding.mode = "onnx-experimental".into();
+                config.embedding.onnx_model_path = MODEL.into();
+                config.embedding.onnx_tokenizer_path = TOKENIZER.into();
+            })),
+        ] {
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/v1/embedding/identity")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert!(!response.status().is_success());
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let encoded = String::from_utf8(bytes.to_vec()).unwrap();
+            assert!(encoded.contains("verify the configured embedding backend"));
+            for private in [
+                MODEL,
+                TOKENIZER,
+                "missing-model.onnx",
+                "missing-tokenizer.json",
+                "No such file",
+                "os error",
+            ] {
+                assert!(!encoded.contains(private), "{private} leaked: {encoded}");
             }
         }
     }

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -104,6 +104,10 @@ pub fn build_native_router(state: AppState) -> Router {
         .route("/v1/health", get(native::health))
         .route("/v1/health/ready", get(native::readiness))
         .route("/v1/cluster/health", get(native::cluster_health))
+        .route(
+            "/v1/embedding/identity",
+            get(native::embedding_execution_identity),
+        )
         // k8s probes — v0.8 8-P4 — see comment in `native.rs::liveness`.
         .route("/health/live", get(native::liveness))
         .route("/health/ready", get(native::readiness))
@@ -225,6 +229,13 @@ pub fn build_es_compat_router(state: AppState) -> Router {
         // firewalled off) can still scrape metrics. Same handler as the native
         // router; gated by the optional read-only `auth.metrics_token`.
         .route("/v1/metrics", get(native::metrics))
+        // Autoindex defaults to the ES-compatible listener, so the native
+        // embedding identity contract must be available here as well as on
+        // the dedicated native listener.
+        .route(
+            "/v1/embedding/identity",
+            get(native::embedding_execution_identity),
+        )
         // ── Cluster-level ──────────────────────────────────────────────────
         .route("/", get(es_compat::es_info))
         .route("/_cluster/health", get(es_compat::cluster_health))
@@ -1105,5 +1116,37 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("Elasticsearch")
         );
+    }
+
+    #[tokio::test]
+    async fn embedding_identity_is_sanitized_machine_readable_native_data() {
+        for app in [
+            build_native_router(test_state("elasticsearch")),
+            build_es_compat_router(test_state("elasticsearch")),
+        ] {
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/v1/embedding/identity")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            let data = value["data"].as_object().unwrap();
+            assert_eq!(data["backend"], "lexical");
+            assert_eq!(data["dimensions"], 384);
+            assert_eq!(data["resumable"], true);
+            assert_eq!(data["identity_sha256"].as_str().unwrap().len(), 64);
+            let encoded = String::from_utf8(bytes.to_vec()).unwrap();
+            for secret_field in ["api_key", "endpoint", "model_path", "tokenizer_path"] {
+                assert!(!encoded.contains(secret_field), "{secret_field} leaked");
+            }
+        }
     }
 }

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -12,6 +12,7 @@ pub struct IndexCfg {
     pub pdf_timeout_secs: u64,
     pub bulk_mb: usize,
     pub bulk_timeout_secs: u64,
+    pub snapshot_max_bytes: u64,
     pub prefix: String,
     pub state_dir: Option<PathBuf>,
     pub fresh: bool,
@@ -56,6 +57,9 @@ pub enum Cmd {
 const FRESH_HELP: &str =
     "start without resume state only when the selected state directory has no \
 durable plan; an existing plan is refused and destination records are never reset";
+const RESUME_POLICY_HELP: &str =
+    "generated --no-graph journals reconcile add, change, delete, rename, and no-op runs; \
+legacy journals and graph-enabled generations refuse membership changes before remote mutation";
 
 pub fn print_help() {
     println!(
@@ -78,6 +82,8 @@ pub fn print_help() {
                                   valid range 1..=3600)\n\
              --prefix <P>         index prefix (default ax)\n\
              --state-dir <PATH>   resume journal location (default ~/.xerj/autoindex/<hash>/)\n\
+             --snapshot-max-gb <N> logical payload cap for sealed source+prepared records\n\
+                                  bytes (default 64); excludes filesystem/manifest overhead\n\
              --fresh              {fresh_help}\n\
              --follow-symlinks    follow symlinks (loop-safe); off by default\n\
              --max-file-gb <N>    skip+record oversized non-streamable files (default 2)\n\
@@ -104,6 +110,14 @@ pub fn print_help() {
              phase-B indexing parses it again. A framed, early-stop protocol is planned;\n\
              use fewer --pdf-workers when parent memory is constrained.\n\
          \n\
+         INCREMENTAL RECONCILIATION:\n\
+             Generated journals with --no-graph reconcile added, removed, moved, and changed\n\
+             files. Legacy journals and graph-enabled generations remain fail-closed. Each\n\
+             changed generation currently copies and prepares the full corpus (O(N)); the\n\
+             latest full snapshot remains retained, and cleanup re-reads protected artifacts\n\
+             to verify them. --snapshot-max-gb limits logical staged payload bytes before each\n\
+             write; it is not a physical disk-space or peak-allocation guarantee.\n\
+         \n\
          EMBEDDINGS:\n\
              autoindex sends semantic_text to the running server; it does not choose the\n\
              server's embedding backend. The default is lexical (not neural). For the\n\
@@ -114,16 +128,17 @@ pub fn print_help() {
              confirm a semantic field before attributing an indexing result to embeddings.\n\
          \n\
          RESUME POLICY:\n\
-             A durable plan supports no-op resume and same-path content replacement.\n\
-             Added or removed content groups are refused before remote mutation.\n\
-             An independent rebuild needs a new --state-dir, new --prefix, and, when\n\
-             graph detection is enabled, new --brain (or --no-graph). Validate before\n\
-             switching readers; the shared autoindex-catalog and old target require\n\
-             explicit, validated cleanup.\n\
+             {resume_policy_help}.\n\
+             If a legacy or graph-enabled journal refuses a change, do not use --fresh as\n\
+             cleanup. Restore its original destination, or rebuild with a new --state-dir and\n\
+             new --prefix plus a new --brain when graph is enabled (or use --no-graph).\n\
+             Validate before switching readers; explicitly clean the shared\n\
+             autoindex-catalog and old target only after validation.\n\
          \n\
          EXIT CODES: 0 complete; 3 completed-with-junk (junk recorded, never fatal);\n\
                      2 usage; 1 endpoint/journal failure or unsupported corpus delta\n",
-        fresh_help = FRESH_HELP
+        fresh_help = FRESH_HELP,
+        resume_policy_help = RESUME_POLICY_HELP
     );
 }
 
@@ -145,6 +160,7 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
     let mut pdf_timeout_secs = 120u64;
     let mut bulk_mb = 8usize;
     let mut bulk_timeout_secs = 300u64;
+    let mut snapshot_max_bytes = 64u64 << 30;
     let mut bulk_timeout_explicit = false;
     let mut prefix = "ax".to_string();
     let mut state_dir: Option<PathBuf> = None;
@@ -200,6 +216,17 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
                 if !(1..=3_600).contains(&bulk_timeout_secs) {
                     return Err("--bulk-timeout-secs must be in the range 1..=3600 seconds".into());
                 }
+            }
+            "--snapshot-max-gb" => {
+                let gib: u64 = it
+                    .next()
+                    .ok_or("--snapshot-max-gb needs a positive integer")?
+                    .parse()
+                    .map_err(|_| "--snapshot-max-gb needs a positive integer")?;
+                snapshot_max_bytes = gib
+                    .checked_mul(1u64 << 30)
+                    .filter(|bytes| *bytes > 0)
+                    .ok_or("--snapshot-max-gb is too large")?;
             }
             "--in-flight" => {
                 let _ = it.next(); // reserved (bulks are worker-synchronous in v1)
@@ -279,6 +306,7 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
             pdf_timeout_secs,
             bulk_mb: bulk_mb.clamp(1, 24),
             bulk_timeout_secs,
+            snapshot_max_bytes,
             prefix,
             state_dir,
             fresh,
@@ -313,10 +341,42 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_budget_defaults_and_accepts_gibibytes() {
+        assert_eq!(index(&["data"]).snapshot_max_bytes, 64u64 << 30);
+        assert_eq!(
+            index(&["data", "--snapshot-max-gb", "7"]).snapshot_max_bytes,
+            7u64 << 30
+        );
+        for value in ["0", "nope", "18446744073709551615"] {
+            assert!(super::parse(
+                ["data", "--snapshot-max-gb", value]
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect()
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
     fn fresh_help_warns_that_it_is_not_destination_reconciliation() {
         assert!(super::FRESH_HELP.contains("no durable plan"));
         assert!(super::FRESH_HELP.contains("existing plan is refused"));
         assert!(super::FRESH_HELP.contains("destination records are never reset"));
+    }
+
+    #[test]
+    fn resume_policy_help_distinguishes_supported_and_refused_state() {
+        let help = super::RESUME_POLICY_HELP;
+        for claim in [
+            "generated --no-graph journals",
+            "add, change, delete, rename, and no-op",
+            "legacy journals",
+            "graph-enabled generations",
+            "before remote mutation",
+        ] {
+            assert!(help.contains(claim), "missing resume-policy claim: {claim}");
+        }
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -53,6 +53,10 @@ pub enum Cmd {
     Help,
 }
 
+const FRESH_HELP: &str =
+    "start without resume state only when the selected state directory has no \
+durable plan; an existing plan is refused and destination records are never reset";
+
 pub fn print_help() {
     println!(
         "xerj autoindex — point it at any folder and make the contents AI-searchable, zero config\n\
@@ -74,7 +78,7 @@ pub fn print_help() {
                                   valid range 1..=3600)\n\
              --prefix <P>         index prefix (default ax)\n\
              --state-dir <PATH>   resume journal location (default ~/.xerj/autoindex/<hash>/)\n\
-             --fresh              ignore existing journal, restart (ids stay idempotent)\n\
+             --fresh              {fresh_help}\n\
              --follow-symlinks    follow symlinks (loop-safe); off by default\n\
              --max-file-gb <N>    skip+record oversized non-streamable files (default 2)\n\
              --sample <N>         records sampled per file for inference (default 500)\n\
@@ -109,8 +113,17 @@ pub fn print_help() {
              short/structured datasets may infer none). Use --dry-run or `autoindex map` to\n\
              confirm a semantic field before attributing an indexing result to embeddings.\n\
          \n\
+         RESUME POLICY:\n\
+             A durable plan supports no-op resume and same-path content replacement.\n\
+             Added or removed content groups are refused before remote mutation.\n\
+             An independent rebuild needs a new --state-dir, new --prefix, and, when\n\
+             graph detection is enabled, new --brain (or --no-graph). Validate before\n\
+             switching readers; the shared autoindex-catalog and old target require\n\
+             explicit, validated cleanup.\n\
+         \n\
          EXIT CODES: 0 complete; 3 completed-with-junk (junk recorded, never fatal);\n\
-                     2 usage; 1 endpoint unreachable / journal-config mismatch\n"
+                     2 usage; 1 endpoint/journal failure or unsupported corpus delta\n",
+        fresh_help = FRESH_HELP
     );
 }
 
@@ -297,6 +310,13 @@ mod tests {
     #[test]
     fn bulk_timeout_defaults_to_300_seconds() {
         assert_eq!(index(&["data"]).bulk_timeout_secs, 300);
+    }
+
+    #[test]
+    fn fresh_help_warns_that_it_is_not_destination_reconciliation() {
+        assert!(super::FRESH_HELP.contains("no durable plan"));
+        assert!(super::FRESH_HELP.contains("existing plan is refused"));
+        assert!(super::FRESH_HELP.contains("destination records are never reset"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/content.rs
+++ b/engine/crates/xerj-autoindex/src/content.rs
@@ -61,6 +61,7 @@ fn resolve_with_digests(files: Vec<FileEntry>, digests: Vec<String>) -> Result<I
                     file_key: resolved_keys[canonical].clone(),
                     rel: files[index].rel.clone(),
                     path_id: files[index].rel_id.clone(),
+                    is_symlink: Some(files[index].is_symlink),
                     duplicate_of: files[canonical].rel.clone(),
                     bytes: files[index].size,
                 });
@@ -245,6 +246,7 @@ mod tests {
         let inv = resolve(crate::walk::walk(dir.path(), false).unwrap()).unwrap();
         assert_eq!(inv.files.len(), 1);
         assert_eq!(inv.duplicates.len(), 1);
+        assert_eq!(inv.duplicates[0].is_symlink, Some(false));
     }
 
     #[cfg(unix)]
@@ -281,5 +283,6 @@ mod tests {
         let inv = resolve(crate::walk::walk(dir.path(), true).unwrap()).unwrap();
         assert_eq!(inv.files[0].rel, "z-real");
         assert_eq!(inv.duplicates[0].rel, "a-link");
+        assert_eq!(inv.duplicates[0].is_symlink, Some(true));
     }
 }

--- a/engine/crates/xerj-autoindex/src/detect/e2e.rs
+++ b/engine/crates/xerj-autoindex/src/detect/e2e.rs
@@ -261,6 +261,7 @@ fn cfg(root: &Path, state_dir: &Path, url: &str) -> IndexCfg {
         pdf_timeout_secs: 30,
         bulk_mb: 8,
         bulk_timeout_secs: 300,
+        snapshot_max_bytes: 64 << 30,
         prefix: "ax".into(),
         state_dir: Some(state_dir.to_owned()),
         fresh: false,

--- a/engine/crates/xerj-autoindex/src/esclient.rs
+++ b/engine/crates/xerj-autoindex/src/esclient.rs
@@ -2,6 +2,7 @@
 //! backoff on 429/5xx/transport errors; parses per-item bulk errors.
 
 use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 
@@ -22,6 +23,18 @@ pub struct BulkOutcome {
     pub server_errors: u64,
     pub first_error: Option<String>,
     pub first_server_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingExecutionIdentity {
+    pub version: u32,
+    pub backend: String,
+    pub identity_sha256: String,
+    pub dimensions: usize,
+    pub semantic_contract: String,
+    pub resumable: bool,
+    #[serde(default)]
+    pub non_resumable_reason: Option<String>,
 }
 
 /// Ensure an autoindex index-create body pins the index to a single WAL shard.
@@ -104,6 +117,46 @@ impl Es {
             .send()
             .with_context(|| format!("endpoint unreachable: {}", self.base))?;
         Ok(resp.json().unwrap_or(Value::Null))
+    }
+
+    pub fn embedding_execution_identity(&self) -> Result<EmbeddingExecutionIdentity> {
+        let response = self
+            .req(reqwest::Method::GET, "/v1/embedding/identity")
+            .send()
+            .context("GET /v1/embedding/identity")?;
+        let status = response.status();
+        if !status.is_success() {
+            anyhow::bail!(
+                "GET /v1/embedding/identity failed: HTTP {status}; semantic autoindex requires \
+                 a XERJ server that exposes a resumable embedding identity"
+            );
+        }
+        let value: Value = response
+            .json()
+            .context("parse embedding identity response")?;
+        let identity: EmbeddingExecutionIdentity = serde_json::from_value(
+            value
+                .get("data")
+                .cloned()
+                .ok_or_else(|| anyhow!("embedding identity response has no data object"))?,
+        )
+        .context("parse embedding identity")?;
+        if identity.version != 1
+            || identity.identity_sha256.len() != 64
+            || !identity
+                .identity_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+            || identity.dimensions == 0
+            || identity.semantic_contract != "semantic_text-derived-vector.v1"
+            || !matches!(
+                identity.backend.as_str(),
+                "lexical" | "neural" | "proxy" | "onnx-experimental"
+            )
+        {
+            anyhow::bail!("server returned an unsupported embedding execution identity");
+        }
+        Ok(identity)
     }
 
     /// GET an arbitrary path and return only the HTTP status code.
@@ -483,6 +536,32 @@ mod tests {
         )
         .unwrap();
         stream.write_all(body).unwrap();
+    }
+
+    #[test]
+    fn embedding_identity_uses_native_endpoint_and_parses_sanitized_data() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_request(&mut stream);
+            assert!(
+                String::from_utf8_lossy(&request)
+                    .starts_with("GET /v1/embedding/identity HTTP/1.1"),
+                "{}",
+                String::from_utf8_lossy(&request)
+            );
+            respond_json(
+                &mut stream,
+                br#"{"data":{"version":1,"backend":"lexical","identity_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","dimensions":384,"semantic_contract":"semantic_text-derived-vector.v1","resumable":true},"took_ms":0,"request_id":"test"}"#,
+            );
+        });
+        let es = Es::new(&format!("http://{address}"), None).unwrap();
+        let identity = es.embedding_execution_identity().unwrap();
+        assert_eq!(identity.backend, "lexical");
+        assert!(identity.resumable);
+        assert_eq!(identity.dimensions, 384);
+        server.join().unwrap();
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -19,6 +19,7 @@ static FAILPOINT_TEST_LOCK: Mutex<()> = Mutex::new(());
 #[derive(Default)]
 struct MockState {
     docs: HashMap<String, Value>,
+    catalog_docs: HashMap<String, Value>,
     requests: Vec<(String, String)>,
     data_bulk_number: usize,
     fail_data_bulk: usize,
@@ -49,7 +50,11 @@ impl MockEndpoint {
             match listener.accept() {
                 Ok((stream, _)) => handle(stream, &server_state),
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                    if server_state.lock().unwrap().stop {
+                    if server_state
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .stop
+                    {
                         break;
                     }
                     thread::yield_now();
@@ -67,10 +72,13 @@ impl MockEndpoint {
 
 impl Drop for MockEndpoint {
     fn drop(&mut self) {
-        self.state.lock().unwrap().stop = true;
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .stop = true;
         // Wake the nonblocking listener even on heavily loaded test hosts.
         let _ = TcpStream::connect(self.url.trim_start_matches("http://"));
-        self.join.take().unwrap().join().unwrap();
+        let _ = self.join.take().unwrap().join();
     }
 }
 
@@ -125,6 +133,10 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
             .pointer("/query/term/ax_file")
             .and_then(Value::as_str)
             .map(str::to_owned);
+        let file_key = query
+            .pointer("/query/term/file_key")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         let mut locked = state.lock().unwrap();
         locked.delete_calls += 1;
         if let Some(key) = ax_file {
@@ -132,11 +144,38 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
                 .docs
                 .retain(|_, doc| doc.get("ax_file").and_then(Value::as_str) != Some(key.as_str()));
         }
+        if let Some(key) = file_key {
+            locked
+                .catalog_docs
+                .retain(|_, doc| doc.get("file_key").and_then(Value::as_str) != Some(key.as_str()));
+        }
         json!({"deleted": 0, "failures": []})
     } else if method == "GET" && path.ends_with("/_count") {
         json!({"count": state.lock().unwrap().docs.len()})
     } else if method == "POST" && path.ends_with("/_search") {
-        json!({"hits":{"total":{"value":0},"hits":[]},"aggregations":{}})
+        let query: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+        let ax_file = query
+            .pointer("/query/term/ax_file")
+            .or_else(|| query.pointer("/query/bool/must/0/term/ax_file"))
+            .and_then(Value::as_str);
+        let file_key = query
+            .pointer("/query/term/file_key")
+            .and_then(Value::as_str);
+        let locked = state.lock().unwrap();
+        let documents = if file_key.is_some() {
+            &locked.catalog_docs
+        } else {
+            &locked.docs
+        };
+        let count = documents
+            .values()
+            .filter(|doc| {
+                ax_file.is_none_or(|key| doc.get("ax_file").and_then(Value::as_str) == Some(key))
+                    && file_key
+                        .is_none_or(|key| doc.get("file_key").and_then(Value::as_str) == Some(key))
+            })
+            .count();
+        json!({"hits":{"total":{"value":count},"hits":[]},"aggregations":{}})
     } else {
         // ping, index creation/mapping, refresh, and catalog operations
         json!({"acknowledged": true})
@@ -162,11 +201,30 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
         .and_then(|action| action.pointer("/index/_index").cloned())
         .and_then(|index| index.as_str().map(str::to_owned))
         .is_some_and(|index| index != catalog::CATALOG_INDEX);
-    if !is_data {
+    let is_graph = lines
+        .first()
+        .and_then(|line| serde_json::from_slice::<Value>(line).ok())
+        .and_then(|action| action.pointer("/index/_index").cloned())
+        .and_then(|index| index.as_str().map(str::to_owned))
+        .is_some_and(|index| index.ends_with("-edges"));
+    let mut locked = state.lock().unwrap();
+    if !is_data || is_graph {
+        if is_graph {
+            return json!({"errors": false, "items": []});
+        }
+        for pair in lines.chunks_exact(2) {
+            let action: Value = serde_json::from_slice(pair[0]).unwrap();
+            let doc: Value = serde_json::from_slice(pair[1]).unwrap();
+            let id = action
+                .as_object()
+                .and_then(|action| action.values().next())
+                .and_then(|metadata| metadata.get("_id"))
+                .and_then(Value::as_str)
+                .unwrap();
+            locked.catalog_docs.insert(id.to_owned(), doc);
+        }
         return json!({"errors": false, "items": []});
     }
-
-    let mut locked = state.lock().unwrap();
     locked.data_bulk_number += 1;
     let fail = !locked.failed_once && locked.data_bulk_number == locked.fail_data_bulk;
     let pairs = lines.chunks_exact(2);
@@ -201,6 +259,7 @@ fn cfg(root: &Path, state_dir: &Path, url: &str) -> IndexCfg {
         pdf_timeout_secs: 30,
         bulk_mb: 64,
         bulk_timeout_secs: 3_600,
+        snapshot_max_bytes: 64 << 30,
         prefix: "failure-test".into(),
         state_dir: Some(state_dir.to_owned()),
         fresh: false,
@@ -208,11 +267,10 @@ fn cfg(root: &Path, state_dir: &Path, url: &str) -> IndexCfg {
         max_file_gb: 1,
         sample: 50,
         no_semantic: true,
-        // These tests count data bulks to place injected failures; graph
-        // edge bulks would shift that numbering, so keep detection off here
-        // (the graph pipeline has its own e2e suite in detect::e2e).
+        // This module preserves legacy graph-enabled failure behavior;
+        // incremental non-graph behavior has its own HTTP suite.
         brain: None,
-        no_graph: true,
+        no_graph: false,
         dry_run: false,
         json: false,
         quiet: true,
@@ -745,25 +803,44 @@ fn existing_completion_is_invalidated_and_partial_visibility_is_deleted_on_resum
         {
             let locked = endpoint.state.lock().unwrap();
             assert!(locked.failed_once);
-            assert!(locked.docs.len() < rows);
+            assert!(
+                locked
+                    .docs
+                    .values()
+                    .filter(|doc| doc.get("value").is_some())
+                    .count()
+                    < rows
+            );
         }
 
         assert_eq!(run_index(config).unwrap(), 0);
         assert_eq!(file_done_count(state_dir.path()), 2);
         let locked = endpoint.state.lock().unwrap();
-        assert_eq!(locked.docs.len(), rows);
+        assert_eq!(
+            locked
+                .docs
+                .values()
+                .filter(|doc| doc.get("value").is_some())
+                .count(),
+            rows
+        );
         assert_eq!(
             locked.delete_calls, 2,
             "fresh publication skips delete; replacement and repair each clean once"
         );
-        assert!(locked.docs.values().all(|doc| {
-            doc["value"]
-                .as_str()
-                .is_some_and(|value| value.starts_with("replacement-"))
-        }));
+        assert!(locked
+            .docs
+            .values()
+            .filter(|doc| doc.get("value").is_some())
+            .all(|doc| {
+                doc["value"]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("replacement-"))
+            }));
         let mut locators: Vec<usize> = locked
             .docs
             .values()
+            .filter(|doc| doc.get("value").is_some())
             .map(|doc| {
                 doc["ax_locator"]
                     .as_str()
@@ -822,12 +899,24 @@ fn resume_repairs_kills_after_plan_delete_and_final_bulk_before_file_done() {
 
         assert_eq!(run_index(config).unwrap(), 0);
         let locked = endpoint.state.lock().unwrap();
-        assert_eq!(locked.docs.len(), rows, "boundary {boundary}");
-        assert!(locked.docs.values().all(|doc| {
-            doc["value"]
-                .as_str()
-                .is_some_and(|value| value.starts_with("new-"))
-        }));
+        assert_eq!(
+            locked
+                .docs
+                .values()
+                .filter(|doc| doc.get("value").is_some())
+                .count(),
+            rows,
+            "boundary {boundary}"
+        );
+        assert!(locked
+            .docs
+            .values()
+            .filter(|doc| doc.get("value").is_some())
+            .all(|doc| {
+                doc["value"]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("new-"))
+            }));
     }
 }
 
@@ -845,7 +934,7 @@ fn file_done_append_and_fsync_failures_are_fatal_and_resume_repairs() {
         assert_eq!(run_index(config.clone()).unwrap(), 0);
         fs::write(&path, "id,value\n0,new\n1,new\n").unwrap();
 
-        state::fail_next_file_done_io(io_boundary);
+        state::fail_next_file_done_io(io_boundary, &state_dir.path().join("journal.ndjson"));
         let error = run_index(config.clone()).unwrap_err();
         let message = format!("{error:#}");
         assert!(
@@ -877,10 +966,18 @@ fn file_done_append_and_fsync_failures_are_fatal_and_resume_repairs() {
 
         assert_eq!(run_index(config).unwrap(), 0);
         let locked = endpoint.state.lock().unwrap();
-        assert_eq!(locked.docs.len(), 2);
+        assert_eq!(
+            locked
+                .docs
+                .values()
+                .filter(|doc| doc.get("value").is_some())
+                .count(),
+            2
+        );
         assert!(locked
             .docs
             .values()
+            .filter(|doc| doc.get("value").is_some())
             .all(|doc| doc["value"].as_str() == Some("new")));
     }
 }
@@ -948,10 +1045,18 @@ fn pending_generation_b_is_superseded_when_source_changes_to_c() {
     assert_eq!(starts.last().copied(), Some(committed_generation));
     drop(replay_c);
     let locked = endpoint.state.lock().unwrap();
-    assert_eq!(locked.docs.len(), 2);
+    assert_eq!(
+        locked
+            .docs
+            .values()
+            .filter(|doc| doc.get("value").is_some())
+            .count(),
+        2
+    );
     assert!(locked
         .docs
         .values()
+        .filter(|doc| doc.get("value").is_some())
         .all(|doc| doc["value"].as_str() == Some("generation-c")));
 }
 
@@ -984,9 +1089,12 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &["b.csv"], &[]);
     {
         let locked = endpoint.state.lock().unwrap();
-        assert_eq!(locked.docs.len(), 2);
+        assert_eq!(locked.docs.len(), 3);
         assert!(locked.docs.values().all(|doc| {
-            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("original")
+            doc["ax_path"].as_str() == Some("a.csv")
+                && doc
+                    .get("value")
+                    .is_none_or(|value| value.as_str() == Some("original"))
         }));
     }
     let replay = state::Journal::open(
@@ -1010,11 +1118,10 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["b.csv"], &[]);
     assert_eq!(event_count(state_dir.path(), "plan"), plans_before);
     let locked = endpoint.state.lock().unwrap();
-    assert_eq!(locked.docs.len(), 2);
-    assert!(locked
-        .docs
-        .values()
-        .all(|doc| doc["value"].as_str() == Some("original")));
+    assert_eq!(locked.docs.len(), 3);
+    assert!(locked.docs.values().all(|doc| doc
+        .get("value")
+        .is_none_or(|value| value.as_str() == Some("original"))));
 }
 
 #[test]
@@ -1080,7 +1187,7 @@ fn partial_file_done_is_rolled_back_before_another_worker_commits() {
 
     fs::write(corpus.path().join("a.csv"), "id,value\n0,a-new\n1,a-new\n").unwrap();
     fs::write(corpus.path().join("b.csv"), "id,value\n2,b-new\n3,b-new\n").unwrap();
-    state::fail_next_file_done_io(3);
+    state::fail_next_file_done_io(3, &state_dir.path().join("journal.ndjson"));
     let error = run_index(config.clone()).unwrap_err();
     assert!(format!("{error:#}").contains("partial file_done write"));
 
@@ -1102,10 +1209,21 @@ fn partial_file_done_is_rolled_back_before_another_worker_commits() {
 
     assert_eq!(run_index(config).unwrap(), 0);
     let locked = endpoint.state.lock().unwrap();
-    assert_eq!(locked.docs.len(), 4);
-    assert!(locked.docs.values().all(|doc| {
-        doc["value"]
-            .as_str()
-            .is_some_and(|value| value.ends_with("-new"))
-    }));
+    assert_eq!(
+        locked
+            .docs
+            .values()
+            .filter(|doc| doc.get("value").is_some())
+            .count(),
+        4
+    );
+    assert!(locked
+        .docs
+        .values()
+        .filter(|doc| doc.get("value").is_some())
+        .all(|doc| {
+            doc["value"]
+                .as_str()
+                .is_some_and(|value| value.ends_with("-new"))
+        }));
 }

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -19,6 +19,7 @@ static FAILPOINT_TEST_LOCK: Mutex<()> = Mutex::new(());
 #[derive(Default)]
 struct MockState {
     docs: HashMap<String, Value>,
+    requests: Vec<(String, String)>,
     data_bulk_number: usize,
     fail_data_bulk: usize,
     failed_once: bool,
@@ -100,6 +101,11 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("");
     let path = parts.next().unwrap_or("");
+    state
+        .lock()
+        .unwrap()
+        .requests
+        .push((method.to_owned(), path.to_owned()));
 
     let response = if method == "GET" && path == "/v1/embedding/identity" {
         let identity = state.lock().unwrap().embedding_identity_sha256.clone();
@@ -235,6 +241,230 @@ fn event_count(state_dir: &Path, kind: &str) -> usize {
         .filter_map(|line| serde_json::from_str::<Value>(line).ok())
         .filter(|value| value.get("kind").and_then(Value::as_str) == Some(kind))
         .count()
+}
+
+fn assert_unsupported_delta_without_remote_mutation(
+    endpoint: &MockEndpoint,
+    config: IndexCfg,
+    expected_added: &[&str],
+    expected_vanished: &[&str],
+) {
+    let request_start = endpoint.state.lock().unwrap().requests.len();
+    let journal_path = config.state_dir.as_ref().unwrap().join("journal.ndjson");
+    let journal_before = fs::read(&journal_path).unwrap();
+    let error = run_index(config).unwrap_err();
+    let attempted_requests = endpoint.state.lock().unwrap().requests[request_start..].to_vec();
+    assert_eq!(
+        attempted_requests,
+        [("GET".to_owned(), "/".to_owned())],
+        "a refused attempt may perform only the endpoint-readiness GET"
+    );
+    assert_eq!(
+        fs::read(journal_path).unwrap(),
+        journal_before,
+        "preflight refusal must not append a resume event or rewrite the journal"
+    );
+    let message = format!("{error:#}");
+    assert!(message.contains("made no remote mutations"), "{message}");
+    assert!(
+        message.contains("existing destination may already be partial or stale"),
+        "{message}"
+    );
+    assert!(
+        message.contains("`--fresh` is not recovery or destination reconciliation"),
+        "{message}"
+    );
+    assert!(
+        message.contains("new --state-dir, a new --prefix"),
+        "{message}"
+    );
+    assert!(message.contains("new --brain"), "{message}");
+    for path in expected_added {
+        assert!(
+            message.contains(path),
+            "missing added path {path}: {message}"
+        );
+    }
+    for path in expected_vanished {
+        assert!(
+            message.contains(path),
+            "missing vanished path {path}: {message}"
+        );
+    }
+}
+
+#[test]
+fn completed_plan_rejects_added_content_group_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["second.csv"], &[]);
+}
+
+#[test]
+fn completed_plan_rejects_vanished_content_group_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
+    fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("second.csv")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["second.csv"]);
+}
+
+#[test]
+fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("b-old.csv"), "id,value\n1,b\n").unwrap();
+    fs::write(corpus.path().join("a-old.csv"), "id,value\n2,a\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("b-old.csv")).unwrap();
+    fs::remove_file(corpus.path().join("a-old.csv")).unwrap();
+    fs::write(corpus.path().join("z-new.csv"), "id,value\n3,z\n").unwrap();
+    fs::write(corpus.path().join("m-new.csv"), "id,value\n4,m\n").unwrap();
+    config.json = true;
+    let request_start = endpoint.state.lock().unwrap().requests.len();
+    let error = run_index(config).unwrap_err();
+    assert_eq!(
+        endpoint.state.lock().unwrap().requests[request_start..],
+        [("GET".to_owned(), "/".to_owned())]
+    );
+
+    let typed = error
+        .downcast_ref::<UnsupportedInventoryDeltaError>()
+        .unwrap();
+    let value = typed.to_json();
+    assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
+    assert_eq!(value["status"], "error");
+    let added: Vec<&str> = value["added_content_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap())
+        .collect();
+    let vanished: Vec<&str> = value["vanished_content_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap())
+        .collect();
+    assert_eq!(added, ["m-new.csv", "z-new.csv"]);
+    assert_eq!(vanished, ["a-old.csv", "b-old.csv"]);
+}
+
+#[test]
+fn nonempty_fresh_cannot_erase_plan_and_bypass_membership_gate() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("old.csv"), "id,value\n1,old\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("old.csv")).unwrap();
+    fs::write(corpus.path().join("new.csv"), "id,value\n2,new\n").unwrap();
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["new.csv"], &["old.csv"]);
+}
+
+#[test]
+fn fresh_rejects_same_content_canonical_promotion_even_when_group_key_matches() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let bytes = "id,value\n1,same\n";
+    fs::write(corpus.path().join("a.csv"), bytes).unwrap();
+    fs::write(corpus.path().join("b.csv"), bytes).unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    // b.csv becomes canonical with the same content key. A key-only delta is
+    // empty, but fresh would discard the alias/path cleanup knowledge.
+    fs::remove_file(corpus.path().join("a.csv")).unwrap();
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &[]);
+}
+
+#[test]
+fn unchanged_planned_junk_is_not_reported_as_added_content() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
+    fs::write(
+        corpus.path().join("opaque.bin"),
+        [0_u8, 159, 146, 150, 0, 255],
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
+    let result = run_index(config);
+    assert!(
+        result.is_ok(),
+        "unchanged durable junk must not trip the membership gate: {result:?}"
+    );
+}
+
+#[test]
+fn deleted_planned_junk_fails_closed_before_catalog_can_stay_stale() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
+    fs::write(
+        corpus.path().join("opaque.bin"),
+        [0_u8, 159, 146, 150, 0, 255],
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
+
+    fs::remove_file(corpus.path().join("opaque.bin")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["opaque.bin"]);
+}
+
+#[test]
+fn completed_plan_rejects_empty_current_folder_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("only.csv"), "id,value\n1,only\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("only.csv")).unwrap();
+    // Even `--fresh` must not erase the only durable inventory evidence and
+    // then report success while the destination still contains the document.
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["only.csv"]);
 }
 
 #[test]
@@ -751,12 +981,12 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     )
     .unwrap();
     fs::write(corpus.path().join("b.csv"), original).unwrap();
-    assert_eq!(run_index(config.clone()).unwrap(), 3);
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &["b.csv"], &[]);
     {
         let locked = endpoint.state.lock().unwrap();
         assert_eq!(locked.docs.len(), 2);
         assert!(locked.docs.values().all(|doc| {
-            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("rewritten")
+            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("original")
         }));
     }
     let replay = state::Journal::open(
@@ -771,24 +1001,20 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     assert!(replay.pending_replacements.is_empty());
     assert_eq!(replay.done.len(), 1);
     let plan = replay.plan.clone().unwrap();
-    assert_eq!(plan.junk_files.len(), 1);
-    assert_eq!(plan.junk_files[0].rel, "b.csv");
-    assert!(plan.junk_files[0]
-        .reason
-        .contains("key ownership exclusive"));
+    assert!(plan.junk_files.is_empty());
     drop(replay);
 
-    // The divergence is durable and deterministic: an identical rerun keeps
-    // the same owner, appends no new plan, and changes no documents.
+    // The refusal is deterministic: an identical rerun keeps the old owner,
+    // appends no new plan, and changes no documents.
     let plans_before = event_count(state_dir.path(), "plan");
-    assert_eq!(run_index(config).unwrap(), 3);
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["b.csv"], &[]);
     assert_eq!(event_count(state_dir.path(), "plan"), plans_before);
     let locked = endpoint.state.lock().unwrap();
     assert_eq!(locked.docs.len(), 2);
     assert!(locked
         .docs
         .values()
-        .all(|doc| doc["value"].as_str() == Some("rewritten")));
+        .all(|doc| doc["value"].as_str() == Some("original")));
 }
 
 #[test]
@@ -815,7 +1041,12 @@ fn deleting_an_entire_duplicate_group_strands_no_pending_replacement() {
     fs::remove_file(corpus.path().join("dup-a.csv")).unwrap();
     fs::remove_file(corpus.path().join("dup-b.csv")).unwrap();
     for _ in 0..2 {
-        assert_eq!(run_index(config.clone()).unwrap(), 0);
+        assert_unsupported_delta_without_remote_mutation(
+            &endpoint,
+            config.clone(),
+            &[],
+            &["dup-a.csv"],
+        );
         assert_eq!(
             event_count(state_dir.path(), "file_replace_start"),
             starts,

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -24,6 +24,7 @@ struct MockState {
     failed_once: bool,
     delete_calls: usize,
     stop: bool,
+    embedding_identity_sha256: String,
 }
 
 struct MockEndpoint {
@@ -39,6 +40,7 @@ impl MockEndpoint {
         let url = format!("http://{}", listener.local_addr().unwrap());
         let state = Arc::new(Mutex::new(MockState {
             fail_data_bulk,
+            embedding_identity_sha256: "a".repeat(64),
             ..MockState::default()
         }));
         let server_state = Arc::clone(&state);
@@ -99,7 +101,17 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
     let method = parts.next().unwrap_or("");
     let path = parts.next().unwrap_or("");
 
-    let response = if method == "POST" && path == "/_bulk" {
+    let response = if method == "GET" && path == "/v1/embedding/identity" {
+        let identity = state.lock().unwrap().embedding_identity_sha256.clone();
+        json!({"data": {
+            "version": 1,
+            "backend": "lexical",
+            "identity_sha256": identity,
+            "dimensions": 384,
+            "semantic_contract": "semantic_text-derived-vector.v1",
+            "resumable": true
+        }, "took_ms": 0, "request_id": "test"})
+    } else if method == "POST" && path == "/_bulk" {
         bulk_response(&body, state)
     } else if method == "POST" && path.contains("/_delete_by_query") {
         let query: Value = serde_json::from_slice(&body).unwrap();
@@ -223,6 +235,35 @@ fn event_count(state_dir: &Path, kind: &str) -> usize {
         .filter_map(|line| serde_json::from_str::<Value>(line).ok())
         .filter(|value| value.get("kind").and_then(Value::as_str) == Some(kind))
         .count()
+}
+
+#[test]
+fn semantic_resume_rejects_embedding_identity_drift_before_another_bulk() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("report.txt"),
+        "Quarterly operating income improved materially after stronger subscription renewals. \
+         Management expects durable demand across the next reporting period.",
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    config.no_semantic = false;
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    assert_eq!(event_count(state_dir.path(), "embedding_identity"), 1);
+    let bulks_before = endpoint.state.lock().unwrap().data_bulk_number;
+    endpoint.state.lock().unwrap().embedding_identity_sha256 = "b".repeat(64);
+    let error = run_index(config).unwrap_err().to_string();
+    assert!(error.contains("refusing to mix vector spaces"), "{error}");
+    assert!(error.contains("--fresh"), "{error}");
+    assert_eq!(
+        endpoint.state.lock().unwrap().data_bulk_number,
+        bulks_before,
+        "identity drift must fail before another data bulk"
+    );
 }
 
 #[test]

--- a/engine/crates/xerj-autoindex/src/generation_catalog.rs
+++ b/engine/crates/xerj-autoindex/src/generation_catalog.rs
@@ -1,0 +1,608 @@
+//! Exact catalog projection for one committed corpus generation.
+//!
+//! Data-group operations are intentionally not catalog authority. A generation
+//! which only adds junk, removes an alias, or changes one of many files still
+//! has to publish a complete agent-facing data map. This module builds that
+//! complete, retry-stable projection without performing HTTP I/O.
+
+use crate::catalog;
+use crate::sync::{CommittedManifest, GenerationManifest, SyncOperationKind};
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DatasetCatalogStats {
+    pub record_count: u64,
+    pub junk_records: u64,
+    pub bytes: u64,
+    pub formats: Vec<String>,
+    pub time_min: Option<String>,
+    pub time_max: Option<String>,
+    pub sample_queries: Vec<Value>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenerationCatalogMetadata {
+    /// Stable ID sealed into the pending generation. This is the `run_id`
+    /// attached to every catalog document in this projection.
+    pub generation_id: String,
+    /// Stable timestamp sealed before publication. Retries must reuse it.
+    pub started: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CatalogProjection {
+    pub generation_id: String,
+    /// Complete desired managed document set, keyed by catalog `_id`.
+    pub documents: BTreeMap<String, Value>,
+    /// IDs managed by the previous generation which no longer exist.
+    pub stale_ids: BTreeSet<String>,
+}
+
+impl CatalogProjection {
+    /// Validate an exact read-back of all desired managed documents.
+    ///
+    /// The HTTP backend should fetch these IDs after refresh and pass the
+    /// resulting `_source` values here. Extra unrelated catalog documents are
+    /// outside this corpus projection and therefore are not accepted through
+    /// this API.
+    pub fn validate_observed(&self, observed: &BTreeMap<String, Value>) -> Result<()> {
+        anyhow::ensure!(
+            observed.len() == self.documents.len(),
+            "catalog read-back contains {} documents; expected {}",
+            observed.len(),
+            self.documents.len()
+        );
+        for (id, expected) in &self.documents {
+            let actual = observed
+                .get(id)
+                .with_context(|| format!("catalog read-back is missing {id}"))?;
+            anyhow::ensure!(
+                actual == expected,
+                "catalog read-back for {id} disagrees with the sealed generation projection"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Build the complete catalog projection for `desired`.
+///
+/// `dataset_stats` must be exact, generation-bound values obtained from the
+/// sealed prepared artifacts or from a refreshed exact read-back. Supplying
+/// sampled estimates here would make the data map lie.
+///
+/// `prior_managed_ids` is the exact set observed through the authenticated
+/// catalog endpoint for the prior committed catalog generation. The manifest
+/// cannot derive correlation IDs, so callers must query or durably persist
+/// this set.
+pub fn project_generation(
+    _base: &CommittedManifest,
+    desired: &GenerationManifest,
+    metadata: &GenerationCatalogMetadata,
+    dataset_stats: &BTreeMap<String, DatasetCatalogStats>,
+    correlations: &BTreeMap<String, Value>,
+    prior_managed_ids: &BTreeSet<String>,
+) -> Result<CatalogProjection> {
+    anyhow::ensure!(
+        !metadata.generation_id.is_empty() && !metadata.started.is_empty(),
+        "catalog generation metadata is incomplete"
+    );
+    let execution = desired
+        .execution
+        .as_ref()
+        .context("catalog generation has no execution identity")?;
+    let mut documents = BTreeMap::new();
+
+    for group in &desired.groups {
+        let assignment = desired.plan.files.get(&group.content_id).with_context(|| {
+            format!(
+                "catalog group {} has no desired file assignment",
+                group.group_id
+            )
+        })?;
+        let format = assignment_format(assignment.family.as_str(), assignment.gzip);
+        let (id, doc) = catalog::file_doc(
+            &group.content_id,
+            &group.canonical.rel,
+            &format,
+            "indexed",
+            None,
+            group.expected_records,
+            0,
+            group.content_size,
+            &metadata.generation_id,
+        );
+        insert_unique(&mut documents, id, doc)?;
+        for alias in &group.aliases {
+            let (id, doc) = catalog::duplicate_file_doc(
+                &group.content_id,
+                &alias.rel,
+                &alias.path_id,
+                &group.canonical.rel,
+                group.content_size,
+                &metadata.generation_id,
+            );
+            insert_unique(&mut documents, id, doc)?;
+        }
+    }
+
+    for junk in &desired.plan.junk_files {
+        let (id, doc) = catalog::file_doc(
+            &junk.file_key,
+            &junk.rel,
+            &junk.format,
+            &junk.status,
+            Some(&junk.reason),
+            0,
+            0,
+            junk.bytes,
+            &metadata.generation_id,
+        );
+        insert_unique(&mut documents, id, doc)?;
+    }
+
+    let mut total_records = 0u64;
+    let mut total_junk_records = 0u64;
+    for dataset in &desired.plan.datasets {
+        let stats = dataset_stats.get(&dataset.slug).with_context(|| {
+            format!(
+                "catalog generation has no exact statistics for dataset {}",
+                dataset.slug
+            )
+        })?;
+        total_records = total_records
+            .checked_add(stats.record_count)
+            .context("catalog total record count overflow")?;
+        total_junk_records = total_junk_records
+            .checked_add(stats.junk_records)
+            .context("catalog total junk-record count overflow")?;
+        let mut formats = stats.formats.clone();
+        formats.sort();
+        formats.dedup();
+        let (id, doc) = catalog::dataset_doc(&catalog::DatasetDocInput {
+            pd: dataset,
+            record_count: stats.record_count,
+            junk_records: stats.junk_records,
+            bytes: stats.bytes,
+            file_count: dataset.file_count,
+            formats,
+            time_min: stats.time_min.clone(),
+            time_max: stats.time_max.clone(),
+            sample_queries: stats.sample_queries.clone(),
+            notes: stats.notes.clone(),
+            run_id: &metadata.generation_id,
+        });
+        insert_unique(&mut documents, id, doc)?;
+    }
+
+    for (id, correlation) in correlations {
+        let mut correlation = correlation.clone();
+        anyhow::ensure!(
+            correlation.get("doc_kind").and_then(Value::as_str) == Some("correlation"),
+            "catalog correlation {id} has the wrong doc_kind"
+        );
+        correlation["run_id"] = Value::String(metadata.generation_id.clone());
+        insert_unique(&mut documents, id.clone(), correlation)?;
+    }
+
+    let files_total = desired
+        .groups
+        .iter()
+        .map(|group| 1usize + group.aliases.len())
+        .sum::<usize>()
+        .checked_add(desired.plan.junk_files.len())
+        .context("catalog file count overflow")?;
+    let run_doc = json!({
+        "doc_kind": "run",
+        "run_id": metadata.generation_id,
+        "root": execution.root_identity,
+        "url": execution.url,
+        "prefix": execution.prefix,
+        "started": metadata.started,
+        "generation": desired.generation,
+        "files_total": files_total,
+        "unique_content_files": desired.groups.len(),
+        "files_indexed": desired.groups.len(),
+        "duplicate_files": desired.plan.duplicate_files.len(),
+        "files_junk": desired.plan.junk_files.len(),
+        "records_total": total_records,
+        "junk_records_total": total_junk_records,
+        "semantic": desired
+            .plan
+            .datasets
+            .iter()
+            .any(|dataset| dataset.semantic_field.is_some()),
+    });
+    insert_unique(
+        &mut documents,
+        format!("run:{}", metadata.generation_id),
+        run_doc,
+    )?;
+
+    anyhow::ensure!(
+        documents.values().all(|doc| {
+            doc.get("run_id").and_then(Value::as_str) == Some(metadata.generation_id.as_str())
+        }),
+        "every desired catalog document must carry the current generation run_id"
+    );
+
+    let desired_ids: BTreeSet<String> = documents.keys().cloned().collect();
+    let stale_ids = prior_managed_ids
+        .difference(&desired_ids)
+        .filter(|id| !desired_ids.contains(*id))
+        .cloned()
+        .collect();
+
+    Ok(CatalogProjection {
+        generation_id: metadata.generation_id.clone(),
+        documents,
+        stale_ids,
+    })
+}
+
+/// Provenance rule used by the publication backend.
+///
+/// Upserts publish newly prepared bytes and therefore must carry the desired
+/// generation ID. Metadata-only operations must preserve the existing
+/// document `ax_run`; deletes leave no live provenance value.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn expected_ax_run<'a>(
+    kind: &SyncOperationKind,
+    desired_generation_id: &'a str,
+    existing_ax_run: Option<&'a str>,
+) -> Result<Option<&'a str>> {
+    match kind {
+        SyncOperationKind::Upsert => Ok(Some(desired_generation_id)),
+        SyncOperationKind::Metadata => existing_ax_run
+            .map(Some)
+            .context("metadata-only publication has no existing ax_run to preserve"),
+        SyncOperationKind::Delete => Ok(None),
+    }
+}
+
+#[cfg(test)]
+fn managed_non_run_ids(plan: &crate::state::Plan) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    ids.extend(plan.files.keys().map(|key| format!("file:{key}")));
+    ids.extend(
+        plan.junk_files
+            .iter()
+            .map(|junk| format!("file:{}", junk.file_key)),
+    );
+    ids.extend(
+        plan.duplicate_files
+            .iter()
+            .map(|alias| catalog::duplicate_file_id(&alias.file_key, &alias.rel, &alias.path_id)),
+    );
+    ids.extend(
+        plan.datasets
+            .iter()
+            .map(|dataset| format!("ds:{}", dataset.slug)),
+    );
+    ids
+}
+
+fn assignment_format(family: &str, gzip: bool) -> String {
+    if gzip {
+        format!("{family}(gzip)")
+    } else {
+        family.to_owned()
+    }
+}
+
+fn insert_unique(documents: &mut BTreeMap<String, Value>, id: String, doc: Value) -> Result<()> {
+    anyhow::ensure!(
+        documents.insert(id.clone(), doc).is_none(),
+        "catalog projection contains duplicate document ID {id}"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{DuplicateFile, FileAssignment, JunkFile, Plan, PlanDataset};
+    use crate::sync::{
+        ExecutionIdentity, ManifestGroup, ManifestPath, SourceExecutionPolicy,
+        EXECUTION_IDENTITY_VERSION,
+    };
+    fn unix_path_id(path: &str) -> String {
+        let encoded = path
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        format!("unix:{encoded}")
+    }
+
+    fn dataset() -> PlanDataset {
+        PlanDataset {
+            slug: "reports".into(),
+            index: "ax-reports".into(),
+            family: "csv".into(),
+            group: None,
+            specs: Vec::new(),
+            time_field: None,
+            semantic_field: None,
+            sampled_records: 2,
+            file_count: 1,
+        }
+    }
+
+    fn assignment(path: &str) -> FileAssignment {
+        FileAssignment {
+            rel: path.into(),
+            path_id: unix_path_id(path),
+            is_symlink: Some(false),
+            family: "csv".into(),
+            gzip: false,
+            content_digest: Some("digest".into()),
+            assignments: vec![(None, "reports".into())],
+        }
+    }
+
+    fn group(key: &str, path: &str, aliases: Vec<ManifestPath>) -> ManifestGroup {
+        ManifestGroup {
+            group_id: format!("group-{key}"),
+            content_id: key.into(),
+            content_digest: "digest".into(),
+            content_size: 10,
+            canonical: ManifestPath {
+                path_id: unix_path_id(path),
+                rel: path.into(),
+                is_symlink: false,
+            },
+            aliases,
+            dataset_slugs: vec!["reports".into()],
+            expected_records: 2,
+            expected_passages: 0,
+            expected_vectors: 0,
+        }
+    }
+
+    fn execution(generation_id: &str) -> ExecutionIdentity {
+        ExecutionIdentity {
+            version: EXECUTION_IDENTITY_VERSION,
+            root_identity: "/corpus".into(),
+            url: "http://engine".into(),
+            prefix: "ax".into(),
+            follow_symlinks: false,
+            chunker_identity: "prepared-records-v1".into(),
+            embedding_identity_sha256: "a".repeat(64),
+            embedding_backend: "lexical".into(),
+            embedding_dimension: 384,
+            embedding_semantic_contract: "semantic_text-derived-vector.v1".into(),
+            embedding_resumable: true,
+            graph_enabled: false,
+            brain: "none".into(),
+            detector_identity: "disabled".into(),
+            schema_identity: "schema".into(),
+            index_identity: "index".into(),
+            source_policy: SourceExecutionPolicy::DurableSnapshot {
+                reference: format!("sync-snapshots/{generation_id}"),
+                snapshot_digest: "snapshot".into(),
+            },
+        }
+    }
+
+    fn manifest(
+        generation: u64,
+        id: &str,
+        plan: Plan,
+        groups: Vec<ManifestGroup>,
+    ) -> GenerationManifest {
+        GenerationManifest {
+            generation,
+            execution: Some(execution(id)),
+            plan,
+            groups,
+        }
+    }
+
+    fn committed(generation: GenerationManifest) -> CommittedManifest {
+        CommittedManifest {
+            generation: generation.generation,
+            manifest_digest: "base".into(),
+            plan: generation.plan,
+            groups: generation.groups,
+            execution: generation.execution,
+        }
+    }
+
+    fn stats() -> BTreeMap<String, DatasetCatalogStats> {
+        BTreeMap::from([(
+            "reports".into(),
+            DatasetCatalogStats {
+                record_count: 2,
+                junk_records: 0,
+                bytes: 10,
+                formats: vec!["csv".into()],
+                time_min: None,
+                time_max: None,
+                sample_queries: Vec::new(),
+                notes: Vec::new(),
+            },
+        )])
+    }
+
+    fn metadata(id: &str) -> GenerationCatalogMetadata {
+        GenerationCatalogMetadata {
+            generation_id: id.into(),
+            started: "2026-08-03T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn every_current_document_moves_to_latest_catalog_generation() {
+        let mut base_plan = Plan {
+            datasets: vec![dataset()],
+            ..Plan::default()
+        };
+        base_plan
+            .files
+            .insert("keep".into(), assignment("keep.csv"));
+        base_plan
+            .files
+            .insert("change".into(), assignment("change.csv"));
+        let base_generation = manifest(
+            1,
+            "generation-1",
+            base_plan.clone(),
+            vec![
+                group("keep", "keep.csv", vec![]),
+                group("change", "change.csv", vec![]),
+            ],
+        );
+        let base = committed(base_generation);
+
+        let desired = manifest(
+            2,
+            "generation-2",
+            base_plan,
+            vec![
+                group("keep", "keep.csv", vec![]),
+                group("change", "change.csv", vec![]),
+            ],
+        );
+        let projection = project_generation(
+            &base,
+            &desired,
+            &metadata("generation-2"),
+            &stats(),
+            &BTreeMap::new(),
+            &managed_non_run_ids(&base.plan),
+        )
+        .unwrap();
+
+        assert!(projection.documents.len() >= 4);
+        assert!(projection
+            .documents
+            .values()
+            .all(|doc| { doc.get("run_id").and_then(Value::as_str) == Some("generation-2") }));
+        assert_eq!(
+            projection.documents["file:keep"]["run_id"], "generation-2",
+            "an unchanged peer remains visible in the latest data map"
+        );
+    }
+
+    #[test]
+    fn junk_transitions_and_removed_aliases_have_exact_stale_ids() {
+        let alias = ManifestPath {
+            path_id: unix_path_id("alias.csv"),
+            rel: "alias.csv".into(),
+            is_symlink: false,
+        };
+        let duplicate = DuplicateFile {
+            file_key: "indexed".into(),
+            rel: alias.rel.clone(),
+            path_id: alias.path_id.clone(),
+            is_symlink: Some(false),
+            duplicate_of: "indexed.csv".into(),
+            bytes: 10,
+        };
+        let mut base_plan = Plan {
+            datasets: vec![dataset()],
+            duplicate_files: vec![duplicate.clone()],
+            ..Plan::default()
+        };
+        base_plan
+            .files
+            .insert("indexed".into(), assignment("indexed.csv"));
+        base_plan.junk_files.push(JunkFile {
+            file_key: "old-junk".into(),
+            rel: "old.bin".into(),
+            format: "binary".into(),
+            status: "junk".into(),
+            reason: "binary".into(),
+            bytes: 10,
+        });
+        let base = committed(manifest(
+            1,
+            "generation-1",
+            base_plan,
+            vec![group("indexed", "indexed.csv", vec![alias])],
+        ));
+
+        let mut desired_plan = Plan {
+            datasets: vec![dataset()],
+            ..Plan::default()
+        };
+        desired_plan.junk_files.push(JunkFile {
+            file_key: "indexed".into(),
+            rel: "indexed.csv".into(),
+            format: "binary".into(),
+            status: "junk".into(),
+            reason: "became binary".into(),
+            bytes: 10,
+        });
+        let desired = manifest(2, "generation-2", desired_plan, Vec::new());
+        let mut no_dataset_stats = stats();
+        no_dataset_stats.get_mut("reports").unwrap().record_count = 0;
+        let projection = project_generation(
+            &base,
+            &desired,
+            &metadata("generation-2"),
+            &no_dataset_stats,
+            &BTreeMap::new(),
+            &managed_non_run_ids(&base.plan),
+        )
+        .unwrap();
+
+        assert_eq!(projection.documents["file:indexed"]["status"], "junk");
+        assert!(projection.stale_ids.contains("file:old-junk"));
+        assert!(projection.stale_ids.contains(&catalog::duplicate_file_id(
+            &duplicate.file_key,
+            &duplicate.rel,
+            &duplicate.path_id
+        )));
+        assert!(!projection.stale_ids.contains("file:indexed"));
+    }
+
+    #[test]
+    fn provenance_contract_changes_only_upsert_ax_run() {
+        assert_eq!(
+            expected_ax_run(&SyncOperationKind::Upsert, "g2", Some("g1")).unwrap(),
+            Some("g2")
+        );
+        assert_eq!(
+            expected_ax_run(&SyncOperationKind::Metadata, "g2", Some("g1")).unwrap(),
+            Some("g1")
+        );
+        assert_eq!(
+            expected_ax_run(&SyncOperationKind::Delete, "g2", Some("g1")).unwrap(),
+            None
+        );
+        assert!(expected_ax_run(&SyncOperationKind::Metadata, "g2", None).is_err());
+    }
+
+    #[test]
+    fn exact_readback_rejects_missing_or_different_documents() {
+        let plan = Plan {
+            datasets: vec![dataset()],
+            ..Plan::default()
+        };
+        let base = committed(manifest(1, "g1", plan.clone(), Vec::new()));
+        let desired = manifest(2, "g2", plan, Vec::new());
+        let projection = project_generation(
+            &base,
+            &desired,
+            &metadata("g2"),
+            &stats(),
+            &BTreeMap::new(),
+            &managed_non_run_ids(&base.plan),
+        )
+        .unwrap();
+        projection.validate_observed(&projection.documents).unwrap();
+
+        let mut missing = projection.documents.clone();
+        missing.pop_first();
+        assert!(projection.validate_observed(&missing).is_err());
+
+        let mut changed = projection.documents.clone();
+        changed.get_mut("ds:reports").unwrap()["record_count"] = json!(999);
+        assert!(projection.validate_observed(&changed).is_err());
+    }
+}

--- a/engine/crates/xerj-autoindex/src/generation_catalog_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/generation_catalog_http_tests.rs
@@ -1,0 +1,519 @@
+//! Backend-contract tests for whole-generation catalog publication.
+//!
+//! The in-memory endpoint models the observable HTTP contract: a bulk response
+//! may be accepted remotely and lost locally, so applying one exact projection
+//! twice must converge. Correlation IDs are supplied as independently observed
+//! prior-generation IDs because the current committed manifest does not persist
+//! them; a real backend must query them by the prior `run_id`.
+
+use crate::catalog;
+use crate::generation_catalog::{
+    expected_ax_run, project_generation, CatalogProjection, DatasetCatalogStats,
+    GenerationCatalogMetadata,
+};
+use crate::state::{DuplicateFile, FileAssignment, JunkFile, Plan, PlanDataset};
+use crate::sync::{
+    CommittedManifest, ExecutionIdentity, GenerationManifest, ManifestGroup, ManifestPath,
+    SourceExecutionPolicy, SyncOperationKind, EXECUTION_IDENTITY_VERSION,
+};
+use anyhow::Result;
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Default)]
+struct CatalogEndpoint {
+    documents: BTreeMap<String, Value>,
+    fail_after_accept_once: bool,
+}
+
+impl CatalogEndpoint {
+    fn publish(
+        &mut self,
+        projection: &CatalogProjection,
+        independently_observed_stale: &BTreeSet<String>,
+    ) -> Result<()> {
+        for id in projection
+            .stale_ids
+            .iter()
+            .chain(independently_observed_stale)
+        {
+            self.documents.remove(id);
+        }
+        self.documents.extend(projection.documents.clone());
+        if std::mem::take(&mut self.fail_after_accept_once) {
+            anyhow::bail!("response lost after the endpoint accepted the publication");
+        }
+        Ok(())
+    }
+
+    fn desired_readback(&self, projection: &CatalogProjection) -> BTreeMap<String, Value> {
+        projection
+            .documents
+            .keys()
+            .filter_map(|id| self.documents.get(id).cloned().map(|doc| (id.clone(), doc)))
+            .collect()
+    }
+}
+
+fn path_id(path: &str) -> String {
+    let encoded = path
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("unix:{encoded}")
+}
+
+fn dataset() -> PlanDataset {
+    PlanDataset {
+        slug: "reports".into(),
+        index: "ax-reports".into(),
+        family: "csv".into(),
+        group: None,
+        specs: Vec::new(),
+        time_field: None,
+        semantic_field: None,
+        sampled_records: 2,
+        file_count: 0,
+    }
+}
+
+fn assignment(path: &str) -> FileAssignment {
+    FileAssignment {
+        rel: path.into(),
+        path_id: path_id(path),
+        is_symlink: Some(false),
+        family: "csv".into(),
+        gzip: false,
+        content_digest: Some(format!("digest-{path}")),
+        assignments: vec![(None, "reports".into())],
+    }
+}
+
+fn group(key: &str, path: &str, aliases: &[&str]) -> ManifestGroup {
+    ManifestGroup {
+        group_id: format!("group-{key}"),
+        content_id: key.into(),
+        content_digest: format!("digest-{path}"),
+        content_size: 20,
+        canonical: ManifestPath {
+            path_id: path_id(path),
+            rel: path.into(),
+            is_symlink: false,
+        },
+        aliases: aliases
+            .iter()
+            .map(|alias| ManifestPath {
+                path_id: path_id(alias),
+                rel: (*alias).into(),
+                is_symlink: false,
+            })
+            .collect(),
+        dataset_slugs: vec!["reports".into()],
+        expected_records: 2,
+        expected_passages: 0,
+        expected_vectors: 0,
+    }
+}
+
+fn junk(key: &str, path: &str, reason: &str) -> JunkFile {
+    JunkFile {
+        file_key: key.into(),
+        rel: path.into(),
+        format: "binary".into(),
+        status: "junk".into(),
+        reason: reason.into(),
+        bytes: 9,
+    }
+}
+
+fn execution(generation_id: &str) -> ExecutionIdentity {
+    ExecutionIdentity {
+        version: EXECUTION_IDENTITY_VERSION,
+        root_identity: "/finance".into(),
+        url: "http://engine".into(),
+        prefix: "ax".into(),
+        follow_symlinks: false,
+        chunker_identity: "prepared-records-v1".into(),
+        embedding_identity_sha256: "a".repeat(64),
+        embedding_backend: "lexical".into(),
+        embedding_dimension: 384,
+        embedding_semantic_contract: "semantic_text-derived-vector.v1".into(),
+        embedding_resumable: true,
+        graph_enabled: false,
+        brain: "none".into(),
+        detector_identity: "disabled".into(),
+        schema_identity: "schema".into(),
+        index_identity: "index".into(),
+        source_policy: SourceExecutionPolicy::DurableSnapshot {
+            reference: format!("sync-snapshots/{generation_id}"),
+            snapshot_digest: format!("snapshot-{generation_id}"),
+        },
+    }
+}
+
+fn generation(
+    number: u64,
+    generation_id: &str,
+    mut plan: Plan,
+    groups: Vec<ManifestGroup>,
+) -> GenerationManifest {
+    for dataset in &mut plan.datasets {
+        dataset.file_count = groups
+            .iter()
+            .filter(|group| group.dataset_slugs.contains(&dataset.slug))
+            .count();
+    }
+    GenerationManifest {
+        generation: number,
+        execution: Some(execution(generation_id)),
+        plan,
+        groups,
+    }
+}
+
+fn committed(generation: GenerationManifest) -> CommittedManifest {
+    CommittedManifest {
+        generation: generation.generation,
+        manifest_digest: format!("manifest-{}", generation.generation),
+        plan: generation.plan,
+        groups: generation.groups,
+        execution: generation.execution,
+    }
+}
+
+fn metadata(id: &str) -> GenerationCatalogMetadata {
+    GenerationCatalogMetadata {
+        generation_id: id.into(),
+        started: "2026-08-03T12:00:00Z".into(),
+    }
+}
+
+fn stats(records: u64, bytes: u64) -> BTreeMap<String, DatasetCatalogStats> {
+    BTreeMap::from([(
+        "reports".into(),
+        DatasetCatalogStats {
+            record_count: records,
+            junk_records: 0,
+            bytes,
+            formats: vec!["csv".into()],
+            time_min: None,
+            time_max: None,
+            sample_queries: vec![json!({"class": "full_text"})],
+            notes: Vec::new(),
+        },
+    )])
+}
+
+fn plan(indexed: &[(&str, &str)], junk_files: Vec<JunkFile>) -> Plan {
+    let mut plan = Plan {
+        datasets: vec![dataset()],
+        junk_files,
+        ..Plan::default()
+    };
+    for (key, path) in indexed {
+        plan.files.insert((*key).into(), assignment(path));
+    }
+    plan
+}
+
+fn prior_managed_ids(base: &CommittedManifest) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    ids.extend(base.plan.files.keys().map(|key| format!("file:{key}")));
+    ids.extend(
+        base.plan
+            .junk_files
+            .iter()
+            .map(|junk| format!("file:{}", junk.file_key)),
+    );
+    ids.extend(
+        base.plan
+            .duplicate_files
+            .iter()
+            .map(|alias| catalog::duplicate_file_id(&alias.file_key, &alias.rel, &alias.path_id)),
+    );
+    ids.extend(
+        base.plan
+            .datasets
+            .iter()
+            .map(|dataset| format!("ds:{}", dataset.slug)),
+    );
+    ids
+}
+
+#[test]
+fn junk_only_add_change_and_delete_converge_without_hiding_unchanged_data() {
+    let base_generation = generation(
+        1,
+        "g1",
+        plan(&[("keep", "keep.csv")], vec![]),
+        vec![group("keep", "keep.csv", &[])],
+    );
+    let base = committed(base_generation);
+    let mut endpoint = CatalogEndpoint::default();
+
+    let added = generation(
+        2,
+        "g2",
+        plan(
+            &[("keep", "keep.csv")],
+            vec![junk("junk-a", "opaque.bin", "binary")],
+        ),
+        vec![group("keep", "keep.csv", &[])],
+    );
+    let projection = project_generation(
+        &base,
+        &added,
+        &metadata("g2"),
+        &stats(2, 20),
+        &BTreeMap::new(),
+        &prior_managed_ids(&base),
+    )
+    .unwrap();
+    endpoint.publish(&projection, &BTreeSet::new()).unwrap();
+    assert_eq!(endpoint.documents["file:junk-a"]["status"], "junk");
+    assert_eq!(endpoint.documents["file:keep"]["run_id"], "g2");
+
+    let base = committed(added);
+    let changed = generation(
+        3,
+        "g3",
+        plan(
+            &[("keep", "keep.csv")],
+            vec![junk("junk-a", "opaque.bin", "unsupported archive")],
+        ),
+        vec![group("keep", "keep.csv", &[])],
+    );
+    let projection = project_generation(
+        &base,
+        &changed,
+        &metadata("g3"),
+        &stats(2, 20),
+        &BTreeMap::new(),
+        &prior_managed_ids(&base),
+    )
+    .unwrap();
+    endpoint.publish(&projection, &BTreeSet::new()).unwrap();
+    assert_eq!(
+        endpoint.documents["file:junk-a"]["reason"],
+        "unsupported archive"
+    );
+
+    let base = committed(changed);
+    let deleted = generation(
+        4,
+        "g4",
+        plan(&[("keep", "keep.csv")], vec![]),
+        vec![group("keep", "keep.csv", &[])],
+    );
+    let projection = project_generation(
+        &base,
+        &deleted,
+        &metadata("g4"),
+        &stats(2, 20),
+        &BTreeMap::new(),
+        &prior_managed_ids(&base),
+    )
+    .unwrap();
+    assert!(projection.stale_ids.contains("file:junk-a"));
+    endpoint.publish(&projection, &BTreeSet::new()).unwrap();
+    assert!(!endpoint.documents.contains_key("file:junk-a"));
+    assert_eq!(endpoint.documents["file:keep"]["run_id"], "g4");
+}
+
+#[test]
+fn indexed_and_junk_transitions_replace_the_same_catalog_identity() {
+    let indexed = generation(
+        1,
+        "g1",
+        plan(&[("same", "report.csv")], vec![]),
+        vec![group("same", "report.csv", &[])],
+    );
+    let base = committed(indexed);
+    let became_junk = generation(
+        2,
+        "g2",
+        plan(
+            &[],
+            vec![junk("same", "report.csv", "no records extracted")],
+        ),
+        Vec::new(),
+    );
+    let mut empty_stats = stats(0, 0);
+    empty_stats.get_mut("reports").unwrap().formats.clear();
+    let junk_projection = project_generation(
+        &base,
+        &became_junk,
+        &metadata("g2"),
+        &empty_stats,
+        &BTreeMap::new(),
+        &prior_managed_ids(&base),
+    )
+    .unwrap();
+    assert_eq!(junk_projection.documents["file:same"]["status"], "junk");
+    assert!(!junk_projection.stale_ids.contains("file:same"));
+
+    let base = committed(became_junk);
+    let indexed_again = generation(
+        3,
+        "g3",
+        plan(&[("same", "report.csv")], vec![]),
+        vec![group("same", "report.csv", &[])],
+    );
+    let projection = project_generation(
+        &base,
+        &indexed_again,
+        &metadata("g3"),
+        &stats(2, 20),
+        &BTreeMap::new(),
+        &prior_managed_ids(&base),
+    )
+    .unwrap();
+    assert_eq!(projection.documents["file:same"]["status"], "indexed");
+    assert!(!projection.stale_ids.contains("file:same"));
+}
+
+#[test]
+fn accepted_response_retry_is_idempotent_and_exactly_validated() {
+    let base = committed(generation(
+        1,
+        "g1",
+        plan(&[("a", "a.csv")], vec![]),
+        vec![group("a", "a.csv", &[])],
+    ));
+    let desired = generation(
+        2,
+        "g2",
+        plan(&[("a", "a.csv"), ("b", "b.csv")], vec![]),
+        vec![group("a", "a.csv", &[]), group("b", "b.csv", &[])],
+    );
+    let projection = project_generation(
+        &base,
+        &desired,
+        &metadata("g2"),
+        &stats(4, 40),
+        &BTreeMap::new(),
+        &prior_managed_ids(&base),
+    )
+    .unwrap();
+    let mut endpoint = CatalogEndpoint {
+        fail_after_accept_once: true,
+        ..CatalogEndpoint::default()
+    };
+    assert!(endpoint.publish(&projection, &BTreeSet::new()).is_err());
+    endpoint.publish(&projection, &BTreeSet::new()).unwrap();
+    projection
+        .validate_observed(&endpoint.desired_readback(&projection))
+        .unwrap();
+}
+
+#[test]
+fn exact_run_dataset_file_ids_and_payloads_are_generation_bound() {
+    let base = committed(generation(1, "g1", plan(&[], vec![]), Vec::new()));
+    let desired = generation(
+        2,
+        "g2",
+        plan(&[("report", "report.csv")], vec![]),
+        vec![group("report", "report.csv", &[])],
+    );
+    let projection = project_generation(
+        &base,
+        &desired,
+        &metadata("g2"),
+        &stats(2, 20),
+        &BTreeMap::new(),
+        &prior_managed_ids(&base),
+    )
+    .unwrap();
+
+    assert_eq!(
+        projection
+            .documents
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["ds:reports".into(), "file:report".into(), "run:g2".into()])
+    );
+    assert_eq!(projection.documents["run:g2"]["records_total"], 2);
+    assert_eq!(projection.documents["run:g2"]["files_total"], 1);
+    assert_eq!(projection.documents["ds:reports"]["record_count"], 2);
+    assert_eq!(projection.documents["file:report"]["records"], 2);
+    assert!(projection
+        .documents
+        .values()
+        .all(|doc| doc["run_id"] == "g2"));
+}
+
+#[test]
+fn stale_alias_and_independently_observed_correlation_are_deleted() {
+    let alias = DuplicateFile {
+        file_key: "report".into(),
+        rel: "copy.csv".into(),
+        path_id: path_id("copy.csv"),
+        is_symlink: Some(false),
+        duplicate_of: "report.csv".into(),
+        bytes: 20,
+    };
+    let mut base_plan = plan(&[("report", "report.csv")], vec![]);
+    base_plan.duplicate_files.push(alias.clone());
+    let base = committed(generation(
+        1,
+        "g1",
+        base_plan,
+        vec![group("report", "report.csv", &["copy.csv"])],
+    ));
+    let desired = generation(
+        2,
+        "g2",
+        plan(&[("report", "report.csv")], vec![]),
+        vec![group("report", "report.csv", &[])],
+    );
+    let stale_correlation = "corr:reports:old".to_string();
+    let mut observed_prior = prior_managed_ids(&base);
+    observed_prior.insert(stale_correlation.clone());
+    let projection = project_generation(
+        &base,
+        &desired,
+        &metadata("g2"),
+        &stats(2, 20),
+        &BTreeMap::new(),
+        &observed_prior,
+    )
+    .unwrap();
+    let alias_id = catalog::duplicate_file_id(&alias.file_key, &alias.rel, &alias.path_id);
+    assert!(projection.stale_ids.contains(&alias_id));
+
+    let mut endpoint = CatalogEndpoint::default();
+    endpoint
+        .documents
+        .insert(alias_id.clone(), json!({"doc_kind": "file"}));
+    endpoint.documents.insert(
+        stale_correlation.clone(),
+        json!({"doc_kind": "correlation", "run_id": "g1"}),
+    );
+    endpoint.publish(&projection, &BTreeSet::new()).unwrap();
+    assert!(!endpoint.documents.contains_key(&alias_id));
+    assert!(!endpoint.documents.contains_key(&stale_correlation));
+}
+
+#[test]
+fn metadata_publication_preserves_ax_run_while_upsert_changes_it() {
+    let mut live_document = json!({"ax_path": "old.csv", "ax_run": "g1"});
+    let preserved = expected_ax_run(
+        &SyncOperationKind::Metadata,
+        "g2",
+        live_document.get("ax_run").and_then(Value::as_str),
+    )
+    .unwrap()
+    .unwrap()
+    .to_owned();
+    live_document["ax_path"] = Value::String("renamed.csv".into());
+    live_document["ax_run"] = Value::String(preserved);
+    assert_eq!(live_document["ax_run"], "g1");
+
+    let replacement = expected_ax_run(&SyncOperationKind::Upsert, "g3", Some("g1"))
+        .unwrap()
+        .unwrap();
+    live_document["ax_run"] = Value::String(replacement.into());
+    assert_eq!(live_document["ax_run"], "g3");
+}

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -692,6 +692,51 @@ fn fresh_cannot_destroy_a_committed_generation() {
     assert_eq!(journal_events(state_dir.path(), "sync_commit"), 2);
 }
 
+/// Every refusal on the generated path now sends the operator to an isolated
+/// rebuild, so that recipe has to work. `--fresh` is no longer a rebuild-in-
+/// place escape hatch, and a new `--prefix` alone is not enough when the state
+/// directory was named explicitly: `preflight` refuses a journal recorded for a
+/// different prefix before the run reaches anything else.
+#[test]
+fn the_isolated_rebuild_the_refusals_recommend_is_followable() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let committed_state = tempfile::tempdir().unwrap();
+    let rebuild_state = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), committed_state.path(), &endpoint.url, false);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    // A new --prefix on its own cannot rebuild: the recorded journal owns it.
+    let mut prefix_only = config.clone();
+    prefix_only.prefix = "incremental-http-rebuild".into();
+    let message = format!("{:#}", run_index(prefix_only).unwrap_err());
+    assert!(message.contains("was created for root="), "{message}");
+
+    // A new --state-dir and a new --prefix together do rebuild, and leave the
+    // original generation and its sealed snapshot untouched.
+    let journal_before = fs::read(committed_state.path().join("journal.ndjson")).unwrap();
+    let snapshots_before = snapshot_names(committed_state.path());
+    let mut rebuild = cfg(corpus.path(), rebuild_state.path(), &endpoint.url, false);
+    rebuild.prefix = "incremental-http-rebuild".into();
+    let (code, summary) = run_index_report(rebuild).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(summary.unwrap()["generation"], 1);
+    assert_eq!(journal_events(rebuild_state.path(), "sync_commit"), 1);
+    assert_eq!(
+        fs::read(committed_state.path().join("journal.ndjson")).unwrap(),
+        journal_before,
+        "an isolated rebuild must not touch the original journal"
+    );
+    assert_eq!(
+        snapshot_names(committed_state.path()),
+        snapshots_before,
+        "an isolated rebuild must not touch the original sealed snapshots"
+    );
+}
+
 /// The same refusal on a crashed generation, where the journal additionally
 /// holds the only record of the pending transaction and its sealed source.
 #[test]

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -750,3 +750,50 @@ fn fresh_cannot_destroy_a_pending_generation() {
     assert!(rendered.contains("sealed-pending"), "{rendered}");
     assert!(rendered.contains("sealed-second"), "{rendered}");
 }
+
+/// Two runs started in the same process and the same UTC second must not share
+/// a `run_id`.
+///
+/// The generation catalog keys its managed documents on `run_id`, so a
+/// collision makes the second run read the first run's documents back as its
+/// own generation. `xerj brain` calls `run_index_report` more than once per
+/// process, so this is reachable without any concurrency.
+#[test]
+fn same_second_runs_in_one_process_do_not_share_a_generation_identity() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let first_state = tempfile::tempdir().unwrap();
+    let second_state = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+
+    assert_eq!(
+        run_index(cfg(corpus.path(), first_state.path(), &endpoint.url, false)).unwrap(),
+        0
+    );
+    let second = run_index_report(cfg(
+        corpus.path(),
+        second_state.path(),
+        &endpoint.url,
+        false,
+    ));
+    let (code, summary) = second.expect("a second run in the same second must commit");
+    assert_eq!(code, 0);
+    assert_eq!(summary.unwrap()["generation"], 1);
+
+    let run_id = |state_dir: &Path| -> String {
+        fs::read_to_string(state_dir.join("journal.ndjson"))
+            .unwrap()
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .find_map(|event| {
+                event
+                    .get("run_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
+            .expect("journal records a run_id")
+    };
+    assert_ne!(run_id(first_state.path()), run_id(second_state.path()));
+}

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -797,3 +797,76 @@ fn same_second_runs_in_one_process_do_not_share_a_generation_identity() {
     };
     assert_ne!(run_id(first_state.path()), run_id(second_state.path()));
 }
+
+/// An upsert must clear the desired content identity as well as the committed
+/// one before it replays.
+///
+/// A byte-identical retry of the same prepared stream is idempotent on its own,
+/// because `ids::doc_id` is derived from dataset slug, content id and locator.
+/// The guard earns its keep when a prior aborted attempt left documents under
+/// the desired `ax_file` whose ids the current stream does not overwrite — an
+/// earlier generation of the same content under a different dataset
+/// assignment, or a partially rolled-back attempt. This test models that
+/// survivor directly, because the exact record validation at the commit
+/// barrier is what turns such a leftover into a hard, unrecoverable failure.
+#[test]
+fn upsert_clears_a_survivor_under_the_desired_content_identity() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let source = corpus.path().join("a.csv");
+    let original = "id,value\n1,alpha\n";
+    fs::write(&source, original).unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    let (index, content_id) = {
+        let locked = endpoint.state.lock().unwrap();
+        let ((index, _), doc) = locked
+            .docs
+            .iter()
+            .find(|((index, _), _)| index != catalog::CATALOG_INDEX)
+            .expect("the first generation published a data document");
+        (
+            index.clone(),
+            doc.get("ax_file")
+                .and_then(Value::as_str)
+                .expect("data documents carry ax_file")
+                .to_owned(),
+        )
+    };
+
+    // Replace the content, then restore it, so the third generation upserts the
+    // original content identity again.
+    fs::write(&source, "id,value\n2,bravo\n").unwrap();
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    fs::write(&source, original).unwrap();
+
+    // A document from an aborted earlier attempt at exactly this content, under
+    // an id the prepared stream will not overwrite.
+    endpoint.state.lock().unwrap().docs.insert(
+        (index.clone(), "aborted-attempt-survivor".to_owned()),
+        json!({
+            "id": 1,
+            "value": "alpha",
+            "ax_file": content_id,
+            "ax_path": "a.csv",
+            "ax_locator": "aborted-attempt-survivor"
+        }),
+    );
+
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert!(
+        !endpoint
+            .state
+            .lock()
+            .unwrap()
+            .docs
+            .contains_key(&(index, "aborted-attempt-survivor".to_owned())),
+        "the upsert must delete the desired content identity before replaying it"
+    );
+    assert_eq!(paths(&endpoint.data_docs()), ["a.csv"]);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 3);
+}

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -399,6 +399,23 @@ fn paths(docs: &[Value]) -> Vec<String> {
     paths
 }
 
+fn snapshot_names(state_dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = fs::read_dir(state_dir.join("sync-snapshots"))
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter(|entry| {
+                    entry.file_type().is_ok_and(|kind| kind.is_dir())
+                        && !entry.file_name().to_string_lossy().starts_with('.')
+                })
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+    names.sort();
+    names
+}
+
 fn final_snapshot_count(state_dir: &Path) -> usize {
     fs::read_dir(state_dir.join("sync-snapshots"))
         .map(|entries| {
@@ -609,4 +626,127 @@ fn pending_semantic_identity_drift_rejects_before_any_further_bulk() {
         "identity drift must be rejected before another data bulk"
     );
     assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+}
+
+/// `--fresh` must be refused before it can destroy generation authority.
+///
+/// `Journal::open_after_preflight` deletes `journal.ndjson` whenever `fresh` is
+/// set, and `gc_snapshots` then sees an empty protected set and removes every
+/// sealed snapshot. Both run inside the generated branches, ahead of the legacy
+/// plan gate, so without the preflight refusal a single `--fresh` erases the
+/// committed manifest and every sealed source the next run needs.
+#[test]
+fn fresh_cannot_destroy_a_committed_generation() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
+    fs::write(corpus.path().join("b.csv"), "id,value\n2,bravo\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let committed_docs = endpoint.data_docs();
+    assert_eq!(paths(&committed_docs), ["a.csv", "b.csv"]);
+
+    let journal_path = state_dir.path().join("journal.ndjson");
+    let journal_before = fs::read(&journal_path).unwrap();
+    let snapshots_before = snapshot_names(state_dir.path());
+    assert_eq!(snapshots_before.len(), 1, "{snapshots_before:?}");
+    let requests_before = endpoint.state.lock().unwrap().requests.len();
+
+    // The folder also changed, which is exactly when a user reaches for
+    // --fresh.
+    fs::remove_file(corpus.path().join("b.csv")).unwrap();
+    config.fresh = true;
+    let error = run_index(config.clone()).unwrap_err();
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("`--fresh` cannot discard an existing plan under the same destination"),
+        "{message}"
+    );
+
+    assert_eq!(
+        fs::read(&journal_path).unwrap(),
+        journal_before,
+        "a refused --fresh must not rewrite the journal"
+    );
+    assert_eq!(
+        snapshot_names(state_dir.path()),
+        snapshots_before,
+        "a refused --fresh must not garbage-collect sealed snapshots"
+    );
+    let attempted = endpoint.state.lock().unwrap().requests[requests_before..].to_vec();
+    assert_eq!(
+        attempted,
+        [("GET".to_owned(), "/".to_owned())],
+        "a refused --fresh may perform only the endpoint-readiness GET"
+    );
+
+    // The surviving authority still reconciles the real folder change.
+    config.fresh = false;
+    let (code, summary) = run_index_report(config).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(summary.unwrap()["generation"], 2);
+    assert_eq!(paths(&endpoint.data_docs()), ["a.csv"]);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 2);
+}
+
+/// The same refusal on a crashed generation, where the journal additionally
+/// holds the only record of the pending transaction and its sealed source.
+#[test]
+fn fresh_cannot_destroy_a_pending_generation() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let source = corpus.path().join("a.csv");
+    fs::write(&source, "id,value\n1,committed\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(&source, "id,value\n1,sealed-pending\n2,sealed-second\n").unwrap();
+    endpoint.state.lock().unwrap().fail_next_data_bulk = true;
+    assert!(run_index(config.clone()).is_err());
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 2);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+
+    let journal_path = state_dir.path().join("journal.ndjson");
+    let journal_before = fs::read(&journal_path).unwrap();
+    let snapshots_before = snapshot_names(state_dir.path());
+    assert_eq!(snapshots_before.len(), 2, "{snapshots_before:?}");
+    let requests_before = endpoint.state.lock().unwrap().requests.len();
+
+    config.fresh = true;
+    let error = run_index(config.clone()).unwrap_err();
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("`--fresh` cannot discard an existing plan under the same destination"),
+        "{message}"
+    );
+    assert_eq!(
+        fs::read(&journal_path).unwrap(),
+        journal_before,
+        "a refused --fresh must not rewrite a pending journal"
+    );
+    assert_eq!(
+        snapshot_names(state_dir.path()),
+        snapshots_before,
+        "a refused --fresh must not delete the pending sealed source"
+    );
+    let attempted = endpoint.state.lock().unwrap().requests[requests_before..].to_vec();
+    assert_eq!(
+        attempted,
+        [("GET".to_owned(), "/".to_owned())],
+        "a refused --fresh may perform only the endpoint-readiness GET"
+    );
+
+    // The pending transaction is still resumable from its sealed source.
+    config.fresh = false;
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 2);
+    let rendered = serde_json::to_string(&endpoint.data_docs()).unwrap();
+    assert!(rendered.contains("sealed-pending"), "{rendered}");
+    assert!(rendered.contains("sealed-second"), "{rendered}");
 }

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -1,0 +1,612 @@
+//! Real-HTTP end-to-end coverage for incremental corpus generations.
+//!
+//! The endpoint below is deliberately stateful. It applies bulk index/update
+//! actions, delete-by-query, and exact count searches so `run_index` traverses
+//! the same HTTP client and validation barriers as a real server.
+
+use super::*;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+static HTTP_E2E_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Default)]
+struct HttpState {
+    docs: HashMap<(String, String), Value>,
+    requests: Vec<(String, String)>,
+    data_bulk_requests: usize,
+    fail_next_data_bulk: bool,
+    fail_embedding_identity: bool,
+    stop: bool,
+    embedding_identity_sha256: String,
+    saw_dataset_mapping_update: bool,
+    saw_catalog_mapping_update: bool,
+}
+
+struct HttpEndpoint {
+    url: String,
+    state: Arc<Mutex<HttpState>>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl HttpEndpoint {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let state = Arc::new(Mutex::new(HttpState {
+            embedding_identity_sha256: "a".repeat(64),
+            ..HttpState::default()
+        }));
+        let server_state = Arc::clone(&state);
+        let join = thread::spawn(move || loop {
+            match listener.accept() {
+                Ok((stream, _)) => handle_http(stream, &server_state),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if server_state.lock().unwrap().stop {
+                        break;
+                    }
+                    thread::yield_now();
+                }
+                Err(error) => panic!("HTTP test endpoint accept failed: {error}"),
+            }
+        });
+        Self {
+            url,
+            state,
+            join: Some(join),
+        }
+    }
+
+    fn data_docs(&self) -> Vec<Value> {
+        self.state
+            .lock()
+            .unwrap()
+            .docs
+            .iter()
+            .filter(|((index, _), _)| index != catalog::CATALOG_INDEX)
+            .map(|(_, doc)| doc.clone())
+            .collect()
+    }
+
+    fn data_bulk_requests(&self) -> usize {
+        self.state.lock().unwrap().data_bulk_requests
+    }
+}
+
+impl Drop for HttpEndpoint {
+    fn drop(&mut self) {
+        self.state.lock().unwrap().stop = true;
+        let _ = TcpStream::connect(self.url.trim_start_matches("http://"));
+        self.join.take().unwrap().join().unwrap();
+    }
+}
+
+fn handle_http(mut stream: TcpStream, state: &Arc<Mutex<HttpState>>) {
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).unwrap() == 0 {
+        return;
+    }
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        if line == "\r\n" || line.is_empty() {
+            break;
+        }
+        if let Some(value) = line
+            .to_ascii_lowercase()
+            .strip_prefix("content-length:")
+            .map(str::trim)
+        {
+            content_length = value.parse().unwrap();
+        }
+    }
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body).unwrap();
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("");
+    state
+        .lock()
+        .unwrap()
+        .requests
+        .push((method.to_owned(), path.to_owned()));
+
+    let (status, response) = if method == "GET" && path == "/v1/embedding/identity" {
+        let locked = state.lock().unwrap();
+        if locked.fail_embedding_identity {
+            (
+                500,
+                json!({"error": {
+                    "type": "injected_identity_failure",
+                    "reason": "genesis recovery boundary"
+                }}),
+            )
+        } else {
+            (
+                200,
+                json!({"data": {
+                    "version": 1,
+                    "backend": "lexical",
+                    "identity_sha256": locked.embedding_identity_sha256.clone(),
+                    "dimensions": 384,
+                    "semantic_contract": "semantic_text-derived-vector.v1",
+                    "resumable": true
+                }, "took_ms": 0, "request_id": "incremental-http-test"}),
+            )
+        }
+    } else if method == "POST" && path == "/_bulk" {
+        let locked = state.lock().unwrap();
+        assert!(
+            locked.saw_dataset_mapping_update && locked.saw_catalog_mapping_update,
+            "bulk publication preceded exact generation mapping updates"
+        );
+        drop(locked);
+        bulk_http(&body, state)
+    } else if method == "POST" && path.contains("/_delete_by_query") {
+        let deleted = delete_http(path, &body, state);
+        (200, json!({"deleted": deleted, "failures": []}))
+    } else if method == "POST" && path.ends_with("/_search") {
+        (200, search_http(path, &body, state))
+    } else if method == "GET" && path.ends_with("/_count") {
+        let index = path.trim_start_matches('/').trim_end_matches("/_count");
+        let count = state
+            .lock()
+            .unwrap()
+            .docs
+            .keys()
+            .filter(|(candidate, _)| candidate == index)
+            .count();
+        (200, json!({"count": count}))
+    } else if method == "PUT" {
+        let value: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+        let mut locked = state.lock().unwrap();
+        if path.ends_with("/_mapping") {
+            assert!(value.get("properties").is_some());
+            assert!(value.get("mappings").is_none());
+            if path.starts_with(&format!("/{}/", catalog::CATALOG_INDEX)) {
+                locked.saw_catalog_mapping_update = true;
+            } else {
+                locked.saw_dataset_mapping_update = true;
+            }
+        } else {
+            assert!(value.pointer("/mappings/properties").is_some());
+            assert!(value.get("properties").is_none());
+        }
+        (200, json!({"acknowledged": true}))
+    } else {
+        // Readiness, index creation/mapping, and refresh.
+        (200, json!({"acknowledged": true}))
+    };
+    let bytes = response.to_string();
+    write!(
+        stream,
+        "HTTP/1.1 {status} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        if status == 200 {
+            "OK"
+        } else {
+            "Internal Server Error"
+        },
+        bytes.len(),
+        bytes
+    )
+    .unwrap();
+}
+
+fn bulk_http(body: &[u8], state: &Arc<Mutex<HttpState>>) -> (u16, Value) {
+    let lines: Vec<&[u8]> = body
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .collect();
+    let is_data = lines.iter().step_by(2).any(|line| {
+        serde_json::from_slice::<Value>(line)
+            .ok()
+            .and_then(|action| {
+                action
+                    .pointer("/index/_index")
+                    .or_else(|| action.pointer("/update/_index"))
+                    .and_then(Value::as_str)
+                    .map(|index| index != catalog::CATALOG_INDEX)
+            })
+            .unwrap_or(false)
+    });
+    let mut locked = state.lock().unwrap();
+    if is_data {
+        locked.data_bulk_requests += 1;
+        if std::mem::take(&mut locked.fail_next_data_bulk) {
+            return (
+                200,
+                json!({
+                    "errors": true,
+                    "items": [{"index": {
+                        "status": 500,
+                        "error": {
+                            "type": "injected_failure",
+                            "reason": "leave durable generation pending"
+                        }
+                    }}]
+                }),
+            );
+        }
+    }
+    let mut cursor = 0;
+    while cursor < lines.len() {
+        let action: Value = serde_json::from_slice(lines[cursor]).unwrap();
+        cursor += 1;
+        if let Some(meta) = action.get("delete") {
+            let index = meta["_index"].as_str().unwrap().to_owned();
+            let id = meta["_id"].as_str().unwrap().to_owned();
+            locked.docs.remove(&(index, id));
+            continue;
+        }
+        let payload: Value = serde_json::from_slice(lines[cursor]).unwrap();
+        cursor += 1;
+        if let Some(meta) = action.get("index") {
+            let index = meta["_index"].as_str().unwrap().to_owned();
+            let id = meta["_id"].as_str().unwrap().to_owned();
+            locked.docs.insert((index, id), payload);
+        } else if let Some(meta) = action.get("update") {
+            let index = meta["_index"].as_str().unwrap().to_owned();
+            let id = meta["_id"].as_str().unwrap().to_owned();
+            let patch = payload["doc"].as_object().unwrap();
+            let target = locked.docs.get_mut(&(index, id)).unwrap();
+            let target = target.as_object_mut().unwrap();
+            target.extend(patch.clone());
+        }
+    }
+    (200, json!({"errors": false, "items": []}))
+}
+
+fn delete_http(path: &str, body: &[u8], state: &Arc<Mutex<HttpState>>) -> usize {
+    let index = path
+        .trim_start_matches('/')
+        .split("/_delete_by_query")
+        .next()
+        .unwrap();
+    let query: Value = serde_json::from_slice(body).unwrap();
+    let term = query
+        .pointer("/query/term")
+        .and_then(Value::as_object)
+        .and_then(|term| term.iter().next())
+        .map(|(field, value)| (field.clone(), value.clone()));
+    let mut locked = state.lock().unwrap();
+    let before = locked.docs.len();
+    locked.docs.retain(|(candidate, _), doc| {
+        if candidate != index {
+            return true;
+        }
+        let Some((field, expected)) = &term else {
+            return false;
+        };
+        doc.get(field) != Some(expected)
+    });
+    before - locked.docs.len()
+}
+
+fn search_http(path: &str, body: &[u8], state: &Arc<Mutex<HttpState>>) -> Value {
+    let indices = path
+        .trim_start_matches('/')
+        .trim_end_matches("/_search")
+        .split(',')
+        .collect::<Vec<_>>();
+    let query: Value = serde_json::from_slice(body).unwrap();
+    let term = query
+        .pointer("/query/term")
+        .or_else(|| query.pointer("/query/bool/must/0/term"))
+        .and_then(Value::as_object)
+        .and_then(|term| term.iter().next());
+    let terms = query
+        .pointer("/query/terms")
+        .and_then(Value::as_object)
+        .and_then(|terms| terms.iter().next());
+    let filters = query
+        .pointer("/query/bool/filter")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let exists = query
+        .pointer("/query/bool/must/1/exists/field")
+        .and_then(Value::as_str);
+    let locked = state.lock().unwrap();
+    let matching: Vec<_> = locked
+        .docs
+        .iter()
+        .filter(|((index, _), doc)| {
+            indices.contains(&index.as_str())
+                && term
+                    .map(|(field, value)| doc.get(field) == Some(value))
+                    .unwrap_or(true)
+                && terms
+                    .map(|(field, values)| {
+                        values.as_array().is_some_and(|values| {
+                            values.iter().any(|value| doc.get(field) == Some(value))
+                        })
+                    })
+                    .unwrap_or(true)
+                && filters.iter().all(|filter| {
+                    filter
+                        .get("term")
+                        .and_then(Value::as_object)
+                        .and_then(|term| term.iter().next())
+                        .is_none_or(|(field, value)| doc.get(field) == Some(value))
+                })
+                && exists.map(|field| doc.get(field).is_some()).unwrap_or(true)
+        })
+        .collect();
+    let hits = matching
+        .iter()
+        .map(|((_, id), source)| json!({"_id": id, "_source": source}))
+        .collect::<Vec<_>>();
+    json!({
+        "hits": {
+            "total": {"value": matching.len(), "relation": "eq"},
+            "hits": hits
+        },
+        "aggregations": {}
+    })
+}
+
+fn cfg(root: &Path, state_dir: &Path, url: &str, semantic: bool) -> IndexCfg {
+    IndexCfg {
+        root: root.to_owned(),
+        url: url.to_owned(),
+        api_key: None,
+        workers: 1,
+        pdf_workers: 1,
+        pdf_timeout_secs: 30,
+        bulk_mb: 1,
+        bulk_timeout_secs: 30,
+        snapshot_max_bytes: 64 << 30,
+        prefix: "incremental-http".into(),
+        state_dir: Some(state_dir.to_owned()),
+        fresh: false,
+        follow_symlinks: false,
+        max_file_gb: 1,
+        sample: 50,
+        no_semantic: !semantic,
+        brain: None,
+        no_graph: true,
+        dry_run: false,
+        json: false,
+        quiet: true,
+    }
+}
+
+fn journal_events(state_dir: &Path, kind: &str) -> usize {
+    fs::read_to_string(state_dir.join("journal.ndjson"))
+        .unwrap()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| event.get("kind").and_then(Value::as_str) == Some(kind))
+        .count()
+}
+
+fn paths(docs: &[Value]) -> Vec<String> {
+    let mut paths: Vec<_> = docs
+        .iter()
+        .filter_map(|doc| doc.get("ax_path").and_then(Value::as_str))
+        .map(str::to_owned)
+        .collect();
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn final_snapshot_count(state_dir: &Path) -> usize {
+    fs::read_dir(state_dir.join("sync-snapshots"))
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter(|entry| {
+                    entry.file_type().is_ok_and(|kind| kind.is_dir())
+                        && !entry.file_name().to_string_lossy().starts_with('.')
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+#[test]
+fn genesis_recovers_after_snapshot_budget_failure_before_sync_begin() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    config.snapshot_max_bytes = 1;
+
+    let error = run_index(config.clone()).unwrap_err();
+    assert!(format!("{error:#}").contains("snapshot source footprint"));
+    assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 0);
+    assert_eq!(endpoint.data_bulk_requests(), 0);
+
+    config.snapshot_max_bytes = 64 << 30;
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+    assert_eq!(endpoint.data_docs().len(), 1);
+}
+
+#[test]
+fn no_semantic_generation_does_not_require_embedding_identity_endpoint() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    endpoint.state.lock().unwrap().fail_embedding_identity = true;
+
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+    assert_eq!(journal_events(state_dir.path(), "finish"), 1);
+    assert_eq!(final_snapshot_count(state_dir.path()), 1);
+    assert_eq!(endpoint.data_docs().len(), 1);
+}
+
+#[test]
+fn initial_generation_and_noop_are_end_to_end_idempotent() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n2,beta\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+
+    let (code, summary) = run_index_report(config.clone()).unwrap();
+    assert_eq!(code, 0);
+    let summary = summary.expect("generated run must return its committed run projection");
+    assert_eq!(summary["generation"], 1);
+    assert_eq!(summary["records_total"], 2);
+    let first_docs = endpoint.data_docs();
+    assert_eq!(first_docs.len(), 2);
+    assert_eq!(paths(&first_docs), ["a.csv"]);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+    let root = corpus.path().canonicalize().unwrap();
+    let preflight = state::Journal::preflight(
+        state_dir.path(),
+        &root.to_string_lossy(),
+        &endpoint.url,
+        "incremental-http",
+    )
+    .unwrap();
+    assert!(
+        preflight.committed_manifest.is_some(),
+        "sync_commit must be visible to the next preflight"
+    );
+    drop(preflight);
+
+    let bulks = endpoint.data_bulk_requests();
+    let (_, noop_summary) = run_index_report(config).unwrap();
+    assert_eq!(noop_summary.unwrap()["generation"], 1);
+    assert_eq!(endpoint.data_docs(), first_docs);
+    assert_eq!(endpoint.data_bulk_requests(), bulks);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+    assert_eq!(journal_events(state_dir.path(), "finish"), 2);
+}
+
+#[test]
+fn add_change_delete_and_rename_converge_over_real_http() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(corpus.path().join("b.csv"), "id,value\n2,bravo\n").unwrap();
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    assert_eq!(paths(&endpoint.data_docs()), ["a.csv", "b.csv"]);
+
+    fs::write(
+        corpus.path().join("a.csv"),
+        "id,value\n1,alpha-new\n3,charlie\n",
+    )
+    .unwrap();
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    assert_eq!(endpoint.data_docs().len(), 3);
+
+    fs::remove_file(corpus.path().join("b.csv")).unwrap();
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    assert_eq!(paths(&endpoint.data_docs()), ["a.csv"]);
+
+    fs::rename(
+        corpus.path().join("a.csv"),
+        corpus.path().join("renamed.csv"),
+    )
+    .unwrap();
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(paths(&endpoint.data_docs()), ["renamed.csv"]);
+    assert_eq!(endpoint.data_docs().len(), 2);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 5);
+}
+
+#[test]
+fn pending_generation_replays_sealed_source_after_live_source_mutates() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let source = corpus.path().join("a.csv");
+    fs::write(&source, "id,value\n1,committed\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(&source, "id,value\n1,sealed-pending\n2,sealed-second\n").unwrap();
+    endpoint.state.lock().unwrap().fail_next_data_bulk = true;
+    assert!(run_index(config.clone()).is_err());
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 2);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+
+    fs::write(&source, "id,value\n9,mutated-after-sync-begin\n").unwrap();
+    assert_eq!(run_index(config).unwrap(), 0);
+    let docs = endpoint.data_docs();
+    assert_eq!(docs.len(), 2);
+    let rendered = serde_json::to_string(&docs).unwrap();
+    assert!(rendered.contains("sealed-pending"), "{rendered}");
+    assert!(rendered.contains("sealed-second"), "{rendered}");
+    assert!(!rendered.contains("mutated-after-sync-begin"), "{rendered}");
+}
+
+#[test]
+fn pending_semantic_identity_drift_rejects_before_any_further_bulk() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let source = corpus.path().join("report.txt");
+    fs::write(
+        &source,
+        "Initial quarterly report discusses durable subscription revenue and operating income.",
+    )
+    .unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, true);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(
+        &source,
+        "Updated quarterly report discusses materially stronger subscription revenue and margin.",
+    )
+    .unwrap();
+    endpoint.state.lock().unwrap().fail_next_data_bulk = true;
+    assert!(run_index(config.clone()).is_err());
+    let bulks_before = endpoint.data_bulk_requests();
+    endpoint.state.lock().unwrap().embedding_identity_sha256 = "b".repeat(64);
+
+    let error = run_index(config).unwrap_err();
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("different embedding execution identity"),
+        "{message}"
+    );
+    assert!(
+        message.contains("no remote mutation was attempted"),
+        "{message}"
+    );
+    assert_eq!(
+        endpoint.data_bulk_requests(),
+        bulks_before,
+        "identity drift must be rejected before another data bulk"
+    );
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+}

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -16,9 +16,11 @@ pub mod ids;
 pub mod infer;
 pub mod sniff;
 pub mod state;
+mod sync;
 pub mod walk;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Seek, Write};
@@ -35,6 +37,30 @@ use esclient::Es;
 use sniff::{Family, Sniffed};
 use state::{FileAssignment, FileDone, JunkFile, Plan, PlanDataset};
 
+#[derive(Debug, PartialEq, Eq)]
+struct CliErrorRoute {
+    exit_code: i32,
+    stdout: Option<String>,
+    stderr: Option<String>,
+}
+
+fn route_cli_error(error: &anyhow::Error, json_output: bool) -> CliErrorRoute {
+    if json_output {
+        if let Some(delta) = error.downcast_ref::<UnsupportedInventoryDeltaError>() {
+            return CliErrorRoute {
+                exit_code: 1,
+                stdout: Some(delta.to_json().to_string()),
+                stderr: None,
+            };
+        }
+    }
+    CliErrorRoute {
+        exit_code: 1,
+        stdout: None,
+        stderr: Some(format!("error: {error:#}")),
+    }
+}
+
 /// Entry point for the `xerj autoindex` subcommand (blocking; the server
 /// binary calls this via spawn_blocking). Returns the process exit code.
 pub fn run_cli() -> i32 {
@@ -47,6 +73,7 @@ pub fn run_cli() -> i32 {
             return 2;
         }
     };
+    let json_output = matches!(&cmd, Cmd::Index(cfg) if cfg.json);
     let res = match cmd {
         Cmd::Help => {
             cli::print_help();
@@ -59,8 +86,14 @@ pub fn run_cli() -> i32 {
     match res {
         Ok(code) => code,
         Err(e) => {
-            eprintln!("error: {e:#}");
-            1
+            let route = route_cli_error(&e, json_output);
+            if let Some(stdout) = route.stdout {
+                println!("{stdout}");
+            }
+            if let Some(stderr) = route.stderr {
+                eprintln!("{stderr}");
+            }
+            route.exit_code
         }
     }
 }
@@ -310,8 +343,10 @@ fn select_resume_plan_keys(
     for (key, assignment) in &plan.files {
         if let Some(previous) = planned_by_rel.insert(&assignment.rel, key) {
             anyhow::bail!(
-                "resume plan assigns path {} to both {} and {}; use --fresh after verifying the \
-                 existing index",
+                "resume plan assigns path {} to both {} and {}; refusing to discard history under \
+                 the same destination. For an isolated rebuild use a new --state-dir, new \
+                 --prefix, and new --brain when graph detection is enabled (or --no-graph); \
+                 explicitly validate and clean the shared catalog and old target",
                 assignment.rel,
                 previous,
                 key
@@ -320,8 +355,11 @@ fn select_resume_plan_keys(
         if !assignment.path_id.is_empty() {
             if let Some(previous) = planned_by_path_id.insert(&assignment.path_id, key) {
                 anyhow::bail!(
-                    "resume plan assigns one native path identity to both {} and {}; use --fresh \
-                     after verifying the existing index",
+                    "resume plan assigns one native path identity to both {} and {}; refusing to \
+                     discard history under the same destination. For an isolated rebuild use a \
+                     new --state-dir, new --prefix, and new --brain when graph detection is \
+                     enabled (or --no-graph); explicitly validate and clean the shared catalog \
+                     and old target",
                     previous,
                     key
                 );
@@ -359,9 +397,11 @@ fn select_resume_plan_keys(
                     anyhow::bail!(
                         "{} collides with legacy resume key {} already owned by {}. No documents \
                          were changed; remove or move one of these two files out of the corpus \
-                         and rerun — every other file keeps its resume state. Deleting the \
-                         journal at {} (or rerunning with --fresh) also clears the collision, \
-                         but re-extracts and re-embeds the entire corpus",
+                         and rerun — every other file keeps its resume state. Refusing to discard \
+                         history under the same destination. For an isolated rebuild use a new \
+                         --state-dir, new --prefix, and new --brain when graph detection is \
+                         enabled (or --no-graph); explicitly validate and clean the shared \
+                         catalog and old target. Journal: {}",
                         file.rel,
                         legacy_key,
                         assignment.rel,
@@ -390,6 +430,157 @@ fn select_resume_plan_keys(
         selected.push(key);
     }
     Ok(selected)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct InventoryDeltaEntry {
+    file_key: String,
+    path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct UnsupportedInventoryDelta {
+    added_content_groups: Vec<InventoryDeltaEntry>,
+    vanished_content_groups: Vec<InventoryDeltaEntry>,
+}
+
+#[derive(Debug)]
+struct UnsupportedInventoryDeltaError {
+    delta: UnsupportedInventoryDelta,
+    fresh_existing_plan: bool,
+}
+
+impl UnsupportedInventoryDeltaError {
+    fn to_json(&self) -> Value {
+        json!({
+            "schema": "xerj.autoindex.unsupported_sync_delta.v1",
+            "status": "error",
+            "error": if self.fresh_existing_plan {
+                "unsafe_fresh_existing_plan"
+            } else {
+                "unsupported_inventory_delta"
+            },
+            "message": if self.fresh_existing_plan {
+                "this attempt made no remote mutations; --fresh cannot discard an existing plan under the same destination because alias, path, graph, and stale-record cleanup knowledge would be lost; the existing destination may already be partial or stale"
+            } else {
+                "this attempt made no remote mutations because this autoindex plan cannot safely reconcile corpus membership changes; the existing destination may already be partial or stale"
+            },
+            "added_content_groups": self.delta.added_content_groups,
+            "vanished_content_groups": self.delta.vanished_content_groups,
+            "recovery": {
+                "exact_rebuild": "index with a new --state-dir, new --prefix, and (when graph detection is enabled) new --brain; alternatively add --no-graph. Validate the isolated target before switching readers",
+                "warning": "--fresh is not recovery or destination reconciliation. The global autoindex-catalog and old target are not cleaned automatically; validate and clean them explicitly"
+            }
+        })
+    }
+}
+
+impl std::fmt::Display for UnsupportedInventoryDeltaError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let render = |entries: &[InventoryDeltaEntry]| {
+            entries
+                .iter()
+                .map(|entry| format!("{} ({})", entry.path, entry.file_key))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let reason = if self.fresh_existing_plan {
+            "`--fresh` cannot discard an existing plan under the same destination because alias, \
+             path, graph, and stale-record cleanup knowledge would be lost"
+        } else {
+            "corpus membership synchronization is not yet supported"
+        };
+        write!(
+            formatter,
+            "this attempt made no remote mutations; the existing destination may already be \
+             partial or stale. {reason}. Added \
+             content groups [{}]; vanished content groups [{}]. For an exact rebuild, index the \
+             current folder with a new --state-dir, a new --prefix, and, when graph detection is \
+             enabled, a new --brain (or use --no-graph). Validate the isolated target before \
+             switching readers. `--fresh` is not recovery or destination reconciliation; the \
+             global autoindex-catalog and old target require explicit validated cleanup",
+            render(&self.delta.added_content_groups),
+            render(&self.delta.vanished_content_groups)
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedInventoryDeltaError {}
+
+impl UnsupportedInventoryDelta {
+    fn between(files: &[walk::FileEntry], keys: &[String], plan: &Plan) -> Self {
+        let current_keys: std::collections::HashSet<&str> = keys
+            .iter()
+            .filter(|key| !key.is_empty())
+            .map(String::as_str)
+            .collect();
+        let durable_keys: std::collections::HashSet<&str> = plan
+            .files
+            .keys()
+            .map(String::as_str)
+            .chain(plan.junk_files.iter().map(|junk| junk.file_key.as_str()))
+            .collect();
+
+        let mut added_content_groups: Vec<InventoryDeltaEntry> = files
+            .iter()
+            .zip(keys)
+            .filter(|(_, key)| !key.is_empty() && !durable_keys.contains(key.as_str()))
+            .map(|(file, key)| InventoryDeltaEntry {
+                file_key: key.clone(),
+                path: file.rel.clone(),
+            })
+            .collect();
+        let mut vanished_content_groups: Vec<InventoryDeltaEntry> = plan
+            .files
+            .iter()
+            .filter(|(key, _)| !current_keys.contains(key.as_str()))
+            .map(|(key, assignment)| InventoryDeltaEntry {
+                file_key: key.clone(),
+                path: assignment.rel.clone(),
+            })
+            .collect();
+        vanished_content_groups.extend(
+            plan.junk_files
+                .iter()
+                .filter(|junk| !current_keys.contains(junk.file_key.as_str()))
+                .map(|junk| InventoryDeltaEntry {
+                    file_key: junk.file_key.clone(),
+                    path: junk.rel.clone(),
+                }),
+        );
+
+        let stable_order = |left: &InventoryDeltaEntry, right: &InventoryDeltaEntry| {
+            left.path
+                .cmp(&right.path)
+                .then_with(|| left.file_key.cmp(&right.file_key))
+        };
+        added_content_groups.sort_by(stable_order);
+        vanished_content_groups.sort_by(stable_order);
+        Self {
+            added_content_groups,
+            vanished_content_groups,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.added_content_groups.is_empty() && self.vanished_content_groups.is_empty()
+    }
+
+    fn into_error(self) -> anyhow::Error {
+        UnsupportedInventoryDeltaError {
+            delta: self,
+            fresh_existing_plan: false,
+        }
+        .into()
+    }
+
+    fn into_fresh_error(self) -> anyhow::Error {
+        UnsupportedInventoryDeltaError {
+            delta: self,
+            fresh_existing_plan: true,
+        }
+        .into()
+    }
 }
 
 fn alias_keys_to_reindex(
@@ -465,17 +656,21 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     let es = Es::with_bulk_timeout(&cfg.url, cfg.api_key.clone(), cfg.bulk_timeout_secs)?;
     es.ping()?;
 
-    let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
-    if discovered_files.is_empty() {
-        println!("no files found under {}", cfg.root.display());
-        return Ok((0, None));
-    }
     let root_str = cfg
         .root
         .canonicalize()
         .unwrap_or_else(|_| cfg.root.clone())
         .to_string_lossy()
         .to_string();
+    let state_dir = cfg
+        .state_dir
+        .clone()
+        .unwrap_or_else(|| state::default_state_dir(&root_str, &cfg.url, &cfg.prefix));
+    // Acquire state authority before discovery as well as hashing. A waiter
+    // must never classify a path snapshot taken while another owner was
+    // publishing or replacing the durable plan.
+    let preflight = state::Journal::preflight(&state_dir, &root_str, &cfg.url, &cfg.prefix)?;
+    let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
     if !cfg.quiet {
         eprintln!(
             "autoindex: {} files ({} MB) under {}",
@@ -484,13 +679,42 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             root_str
         );
     }
-
-    let state_dir = cfg
-        .state_dir
-        .clone()
-        .unwrap_or_else(|| state::default_state_dir(&root_str, &cfg.url, &cfg.prefix));
-    let mut journal = state::Journal::open(
-        &state_dir,
+    if discovered_files.is_empty() && !preflight.journal_exists {
+        println!("no files found under {}", cfg.root.display());
+        return Ok((0, None));
+    }
+    let mut inventory = content::resolve(discovered_files)?;
+    if let Some(prior_plan) = preflight.plan.as_ref() {
+        let comparison_keys = if cfg.fresh {
+            inventory.keys.clone()
+        } else {
+            // Ordinary resume preserves planned-key identity for supported
+            // same-path replacement and legacy plans.
+            select_resume_plan_keys(
+                &inventory.files,
+                &inventory.keys,
+                prior_plan,
+                &state_dir.join("journal.ndjson"),
+            )?
+            .into_iter()
+            .zip(inventory.keys.iter())
+            .map(|(planned, current)| planned.unwrap_or_else(|| current.clone()))
+            .collect()
+        };
+        let delta =
+            UnsupportedInventoryDelta::between(&inventory.files, &comparison_keys, prior_plan);
+        if cfg.fresh {
+            // Even an apparently unchanged content-key set can have alias,
+            // path, graph, catalog, or partial-publication history that only
+            // the old plan can reconcile. Route 1 cannot safely discard it.
+            return Err(delta.into_fresh_error());
+        }
+        if !delta.is_empty() {
+            return Err(delta.into_error());
+        }
+    }
+    let mut journal = state::Journal::open_after_preflight(
+        preflight,
         &root_str,
         &cfg.url,
         &cfg.prefix,
@@ -498,6 +722,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         cfg.fresh,
     )?;
     let resumed_with_plan = journal.plan.is_some();
+    if inventory.files.is_empty() && !resumed_with_plan {
+        println!("no files found under {}", cfg.root.display());
+        return Ok((0, None));
+    }
     let run_id = journal.run_id.clone();
     if journal.resumed && !cfg.quiet {
         eprintln!(
@@ -510,7 +738,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // cannot prove byte identity across all supported local and network
     // filesystems. A metadata-only shortcut could leave stale live documents
     // forever after a same-size rewrite with restored or stale timestamps.
-    let mut inventory = content::resolve(discovered_files)?;
     let journal_path = journal.path().to_path_buf();
     let mut content_changed = std::collections::HashSet::new();
     let mut stale_alias_ids = Vec::new();
@@ -759,6 +986,20 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         plan
     };
 
+    // A durable plan is a crash-resume boundary, not a folder-sync
+    // generation. Fail before index creation/mapping, replacement intent,
+    // graph invalidation, delete-by-query, bulk publication, refresh, or
+    // catalog writes when the current inventory adds or removes an entire
+    // canonical content group. Continuing would either silently skip new
+    // data or leave vanished source records searchable. Existing planned-key
+    // content replacement and crash repair remain supported.
+    if resumed_with_plan {
+        let delta = UnsupportedInventoryDelta::between(&files, &keys, &plan);
+        if !delta.is_empty() {
+            return Err(delta.into_error());
+        }
+    }
+
     if cfg.dry_run {
         println!("{}", serde_json::to_string_pretty(&plan)?);
         eprintln!("(dry run — nothing indexed)");
@@ -887,7 +1128,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 rel: files[i].rel.clone(),
                 format: "unknown".into(),
                 status: "skipped".into(),
-                reason: "not in the frozen resume plan (re-run with --fresh to include new files)"
+                reason: "not in the frozen resume plan; no destination change was made. For an \
+                         exact rebuild use a new --state-dir, a new --prefix, and, when graph \
+                         detection is enabled, a new --brain (or use --no-graph)"
                     .into(),
                 bytes: files[i].size,
             });
@@ -2171,6 +2414,114 @@ mod section_label_tests {
 }
 
 #[cfg(test)]
+mod inventory_delta_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn file(path: &str) -> walk::FileEntry {
+        walk::FileEntry {
+            path: PathBuf::from(path),
+            rel: path.to_owned(),
+            rel_id: format!("id:{path}"),
+            is_symlink: false,
+            size: 1,
+        }
+    }
+
+    fn assignment(path: &str) -> FileAssignment {
+        FileAssignment {
+            rel: path.to_owned(),
+            path_id: format!("id:{path}"),
+            family: "csv".into(),
+            gzip: false,
+            content_digest: Some(format!("digest:{path}")),
+            assignments: vec![(None, "rows".into())],
+        }
+    }
+
+    #[test]
+    fn classifier_is_empty_for_noop_and_sorts_added_and_vanished_groups() {
+        let mut plan = Plan::default();
+        plan.files.insert("keep".into(), assignment("keep.csv"));
+        assert!(
+            UnsupportedInventoryDelta::between(&[file("keep.csv")], &["keep".into()], &plan)
+                .is_empty()
+        );
+        plan.junk_files.push(JunkFile {
+            file_key: "junk".into(),
+            rel: "broken.pdf".into(),
+            format: "pdf".into(),
+            status: "junk".into(),
+            reason: "fixture".into(),
+            bytes: 1,
+        });
+        assert!(
+            UnsupportedInventoryDelta::between(
+                &[file("keep.csv"), file("broken.pdf")],
+                &["keep".into(), "junk".into()],
+                &plan,
+            )
+            .is_empty(),
+            "unchanged durable junk is not newly added content"
+        );
+
+        plan.files.insert("old-z".into(), assignment("z-old.csv"));
+        plan.files.insert("old-a".into(), assignment("a-old.csv"));
+        let delta = UnsupportedInventoryDelta::between(
+            &[
+                file("keep.csv"),
+                file("broken.pdf"),
+                file("z-new.csv"),
+                file("m-new.csv"),
+            ],
+            &["keep".into(), "junk".into(), "new-z".into(), "new-m".into()],
+            &plan,
+        );
+        assert_eq!(
+            delta
+                .added_content_groups
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["m-new.csv", "z-new.csv"]
+        );
+        assert_eq!(
+            delta
+                .vanished_content_groups
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["a-old.csv", "z-old.csv"]
+        );
+    }
+
+    #[test]
+    fn cli_error_routing_separates_typed_json_from_unrelated_human_errors() {
+        let typed = UnsupportedInventoryDelta {
+            added_content_groups: vec![InventoryDeltaEntry {
+                file_key: "key".into(),
+                path: "new.csv".into(),
+            }],
+            vanished_content_groups: Vec::new(),
+        }
+        .into_error();
+        let route = route_cli_error(&typed, true);
+        assert_eq!(route.exit_code, 1);
+        assert!(route.stderr.is_none());
+        let stdout = route.stdout.unwrap();
+        let value: Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
+        assert_eq!(value["error"], "unsupported_inventory_delta");
+
+        let unrelated = anyhow::anyhow!("endpoint unavailable");
+        let route = route_cli_error(&unrelated, true);
+        assert_eq!(route.exit_code, 1);
+        assert!(route.stdout.is_none());
+        assert_eq!(route.stderr.as_deref(), Some("error: endpoint unavailable"));
+    }
+}
+
+#[cfg(test)]
 mod duplicate_integration_tests {
     use super::*;
     use std::collections::HashSet;
@@ -2219,11 +2570,11 @@ mod duplicate_integration_tests {
         .unwrap_err();
         let message = format!("{error:#}");
         assert!(message.contains("collides with legacy resume key"));
-        // Recovery advice must stay scoped to the two colliding files and be
-        // honest that discarding the journal re-embeds the whole corpus.
+        // Recovery advice must stay scoped to the two colliding files and
+        // keep an exact rebuild isolated from the old destination.
         assert!(message.contains("remove or move one of these two files"));
         assert!(message.contains("/state/journal.ndjson"));
-        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
+        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -922,7 +922,8 @@ fn pin_pending_embedding_identity(
     anyhow::ensure!(
         current.resumable,
         "pending semantic generation cannot resume because the current embedding backend is not \
-         resumable: {}; restore the original backend or rebuild with --fresh and a new --prefix",
+         resumable: {}; restore the original backend, or rebuild with a new --state-dir and a new \
+         --prefix",
         current
             .non_resumable_reason
             .as_deref()
@@ -935,8 +936,8 @@ fn pin_pending_embedding_identity(
             && current.semantic_contract == expected.embedding_semantic_contract
             && current.resumable == expected.embedding_resumable,
         "pending semantic generation was prepared for a different embedding execution identity; \
-         no remote mutation was attempted. Restore the original embedding backend, or discard the \
-         pending generation and rebuild with --fresh and a new --prefix"
+         no remote mutation was attempted. Restore the original embedding backend, or rebuild with \
+         a new --state-dir and a new --prefix. --fresh cannot discard this pending generation"
     );
     journal.pin_embedding_identity(
         &current.identity_sha256,
@@ -1147,7 +1148,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                         && expected.schema_identity == schema_identity
                         && expected.index_identity == index_identity,
                     "autoindex execution configuration changed since the committed generation; \
-                     rebuild with --fresh and a new --prefix"
+                     rebuild with a new --state-dir and a new --prefix"
                 );
                 if plan
                     .datasets
@@ -1163,7 +1164,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             && current.semantic_contract == expected.embedding_semantic_contract,
                         "embedding execution identity changed since this autoindex journal was \
                          created; refusing to mix vector spaces. No remote mutation was attempted. \
-                         Restore the original identity or rebuild with --fresh and a new --prefix"
+                         Restore the original identity, or rebuild with a new --state-dir and a \
+                         new --prefix"
                     );
                 }
             }

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -12,8 +12,12 @@ pub mod dataset;
 pub mod detect;
 pub mod esclient;
 pub mod extract;
+mod generation_catalog;
+#[cfg(test)]
+mod generation_catalog_http_tests;
 pub mod ids;
 pub mod infer;
+mod reconcile_plan;
 pub mod sniff;
 pub mod state;
 mod sync;
@@ -37,6 +41,267 @@ use detect::EdgeDetector as _;
 use esclient::Es;
 use sniff::{Family, Sniffed};
 use state::{FileAssignment, FileDone, JunkFile, Plan, PlanDataset};
+
+const PREPARED_RECORDS_IDENTITY: &str = "prepared-records-v1";
+const DOCUMENT_IDS_IDENTITY: &str = "document-ids-v1";
+const DETECTOR_DISABLED_IDENTITY: &str = "disabled";
+
+fn prepared_records_identity(cfg: &IndexCfg) -> Result<String> {
+    let value = json!({
+        "contract": PREPARED_RECORDS_IDENTITY,
+        "sample": cfg.sample,
+        "max_file_gb": cfg.max_file_gb,
+        "no_semantic": cfg.no_semantic,
+        // Worker counts are operational only. The timeout can change whether
+        // a PDF yields records, so it is part of the semantic contract.
+        "pdf_timeout_secs": cfg.pdf_timeout_secs,
+    });
+    Ok(format!(
+        "{}-{:032x}",
+        PREPARED_RECORDS_IDENTITY,
+        xxhash_rust::xxh3::xxh3_128(&serde_json::to_vec(&value)?)
+    ))
+}
+
+fn preparation_contract_digest(cfg: &IndexCfg, plan: &Plan) -> Result<String> {
+    let (schema_identity, index_identity) = generation_contract_identities(plan)?;
+    let encoded = serde_json::to_vec(&json!({
+        "prepared_records": prepared_records_identity(cfg)?,
+        "document_ids": DOCUMENT_IDS_IDENTITY,
+        "schema_identity": schema_identity,
+        "index_identity": index_identity,
+        "plan": plan,
+    }))?;
+    Ok(format!(
+        "axpc1-{:032x}",
+        xxhash_rust::xxh3::xxh3_128(&encoded)
+    ))
+}
+
+pub(crate) fn generation_contract_identities(plan: &Plan) -> Result<(String, String)> {
+    let mut datasets = plan.datasets.iter().collect::<Vec<_>>();
+    datasets.sort_by(|left, right| {
+        left.slug
+            .cmp(&right.slug)
+            .then_with(|| left.index.cmp(&right.index))
+    });
+    let schema = datasets
+        .iter()
+        .map(|dataset| {
+            json!({
+                "slug": dataset.slug,
+                "family": dataset.family,
+                "group": dataset.group,
+                "specs": dataset.specs,
+                "time_field": dataset.time_field,
+                "semantic_field": dataset.semantic_field,
+            })
+        })
+        .collect::<Vec<_>>();
+    let indices = datasets
+        .iter()
+        .map(|dataset| {
+            json!({
+                "index": dataset.index,
+                "mapping": build_mapping(&dataset.specs),
+            })
+        })
+        .collect::<Vec<_>>();
+    let digest = |label: &str, value: Value| -> Result<String> {
+        let bytes = serde_json::to_vec(&json!({"contract": label, "value": value}))?;
+        Ok(format!("{:032x}", xxhash_rust::xxh3::xxh3_128(&bytes)))
+    };
+    Ok((
+        digest(PREPARED_RECORDS_IDENTITY, Value::Array(schema))?,
+        digest(
+            DOCUMENT_IDS_IDENTITY,
+            json!({
+                "datasets": indices,
+                "catalog_index": catalog::CATALOG_INDEX,
+                "catalog_mapping": catalog::catalog_mapping(),
+                "document_ids": DOCUMENT_IDS_IDENTITY,
+            }),
+        )?,
+    ))
+}
+
+pub(crate) fn ensure_generation_mappings(es: &Es, plan: &Plan) -> Result<()> {
+    for dataset in &plan.datasets {
+        let mut create_body = build_mapping(&dataset.specs);
+        create_body["mappings"]["properties"]["ax_paths"] = json!({"type": "keyword"});
+        let update_body = json!({
+            "properties": create_body["mappings"]["properties"].clone()
+        });
+        es.ensure_index(&dataset.index, &create_body)
+            .with_context(|| format!("create generation index {}", dataset.index))?;
+        es.update_mapping(&dataset.index, &update_body)
+            .with_context(|| format!("install generation mapping for {}", dataset.index))?;
+    }
+    let mut catalog_create_body = catalog::catalog_mapping();
+    catalog_create_body["mappings"]["properties"]["duplicate_of"] = json!({"type": "keyword"});
+    let catalog_update_body = json!({
+        "properties": catalog_create_body["mappings"]["properties"].clone()
+    });
+    es.ensure_index(catalog::CATALOG_INDEX, &catalog_create_body)?;
+    es.update_mapping(catalog::CATALOG_INDEX, &catalog_update_body)
+        .context("install generation catalog mapping")
+}
+
+fn begin_non_graph_generation(
+    es: &Es,
+    journal: &mut state::Journal,
+    state_dir: &Path,
+    cfg: &IndexCfg,
+    root_identity: &str,
+    inventory: &content::Inventory,
+    plan: Plan,
+) -> Result<()> {
+    anyhow::ensure!(
+        cfg.no_graph,
+        "non-graph generation cutover requires --no-graph"
+    );
+    anyhow::ensure!(
+        journal.pending_sync.is_none(),
+        "cannot prepare over an existing pending generation"
+    );
+    if journal.committed_manifest.is_none() {
+        journal.sync_bootstrap_genesis()?;
+    }
+    let base = journal
+        .committed_manifest
+        .as_ref()
+        .context("generation cutover has no committed base")?
+        .clone();
+    let tx_id = format!("{}-g{}", journal.run_id, base.generation + 1);
+    let preparation_contract = preparation_contract_digest(cfg, &plan)?;
+    let snapshot = sync_executor::create_prepared_snapshot(
+        state_dir,
+        &tx_id,
+        inventory,
+        &plan,
+        &preparation_contract,
+        cfg.snapshot_max_bytes,
+    )?;
+    let chunker_identity = prepared_records_identity(cfg)?;
+    let semantic = plan
+        .datasets
+        .iter()
+        .any(|dataset| dataset.semantic_field.is_some());
+    let identity = if semantic {
+        let identity = es
+            .embedding_execution_identity()
+            .context("generation cutover could not pin the server embedding execution identity")?;
+        anyhow::ensure!(
+            identity.resumable,
+            "generation cutover requires a resumable embedding execution identity: {}",
+            identity
+                .non_resumable_reason
+                .as_deref()
+                .unwrap_or("the server did not provide an immutable identity")
+        );
+        journal.pin_embedding_identity(
+            &identity.identity_sha256,
+            identity.resumable,
+            identity.non_resumable_reason.as_deref(),
+        )?;
+        identity
+    } else {
+        crate::esclient::EmbeddingExecutionIdentity {
+            version: 1,
+            backend: "disabled".into(),
+            identity_sha256: "0".repeat(64),
+            dimensions: 1,
+            semantic_contract: "disabled-no-semantic-fields-v1".into(),
+            resumable: true,
+            non_resumable_reason: None,
+        }
+    };
+
+    let aliases_by_content = plan.duplicate_files.iter().fold(
+        HashMap::<&str, Vec<sync::ManifestPath>>::new(),
+        |mut aliases, alias| {
+            aliases
+                .entry(alias.file_key.as_str())
+                .or_default()
+                .push(sync::ManifestPath {
+                    path_id: alias.path_id.clone(),
+                    rel: alias.rel.clone(),
+                    is_symlink: alias.is_symlink.unwrap_or(false),
+                });
+            aliases
+        },
+    );
+    let file_by_content = inventory
+        .keys
+        .iter()
+        .zip(&inventory.files)
+        .zip(&inventory.digests)
+        .map(|((key, file), digest)| (key.as_str(), (file, digest)))
+        .collect::<HashMap<_, _>>();
+    let mut candidates = Vec::with_capacity(plan.files.len());
+    for (content_id, assignment) in &plan.files {
+        let (file, digest) = file_by_content
+            .get(content_id.as_str())
+            .with_context(|| format!("planned content {content_id} is absent from inventory"))?;
+        let mut paths = vec![sync::ManifestPath {
+            path_id: assignment.path_id.clone(),
+            rel: assignment.rel.clone(),
+            is_symlink: assignment.is_symlink.unwrap_or(file.is_symlink),
+        }];
+        paths.extend(
+            aliases_by_content
+                .get(content_id.as_str())
+                .cloned()
+                .unwrap_or_default(),
+        );
+        candidates.push(sync::DesiredContentGroup {
+            content_id: content_id.clone(),
+            content_digest: (*digest).clone(),
+            content_size: file.size,
+            dataset_slugs: assignment
+                .assignments
+                .iter()
+                .map(|(_, slug)| slug.clone())
+                .collect(),
+            paths,
+            expected_records: 0,
+            expected_passages: 0,
+            expected_vectors: 0,
+        });
+    }
+    let mut groups = sync::reconcile_groups(&base.groups, candidates)?;
+    sync_executor::bind_prepared_counts(&mut groups, &snapshot, &inventory.keys)?;
+    let (schema_identity, index_identity) = generation_contract_identities(&plan)?;
+    let desired = sync::GenerationManifest {
+        generation: base.generation + 1,
+        execution: Some(sync::ExecutionIdentity {
+            version: sync::EXECUTION_IDENTITY_VERSION,
+            root_identity: root_identity.to_owned(),
+            url: cfg.url.clone(),
+            prefix: cfg.prefix.clone(),
+            follow_symlinks: cfg.follow_symlinks,
+            chunker_identity,
+            embedding_identity_sha256: identity.identity_sha256,
+            embedding_backend: identity.backend,
+            embedding_dimension: identity.dimensions,
+            embedding_semantic_contract: identity.semantic_contract,
+            embedding_resumable: identity.resumable,
+            graph_enabled: false,
+            brain: "disabled".into(),
+            detector_identity: DETECTOR_DISABLED_IDENTITY.into(),
+            schema_identity,
+            index_identity,
+            source_policy: sync::SourceExecutionPolicy::DurableSnapshot {
+                reference: format!("sync-snapshots/{tx_id}"),
+                snapshot_digest: snapshot.snapshot_digest,
+            },
+        }),
+        plan,
+        groups,
+    };
+    let pending = sync::PendingSync::new(tx_id, &base, desired)?;
+    journal.sync_begin(&pending)
+}
 
 #[derive(Debug, PartialEq, Eq)]
 struct CliErrorRoute {
@@ -632,6 +897,117 @@ pub fn derive_brain_name(root: &Path) -> String {
     }
 }
 
+fn pin_pending_embedding_identity(
+    es: &Es,
+    journal: &mut state::Journal,
+    pending: &sync::PendingSync,
+) -> Result<()> {
+    if !pending
+        .desired
+        .plan
+        .datasets
+        .iter()
+        .any(|dataset| dataset.semantic_field.is_some())
+    {
+        return Ok(());
+    }
+    let expected = pending
+        .desired
+        .execution
+        .as_ref()
+        .context("pending semantic generation has no execution identity")?;
+    let current = es.embedding_execution_identity().context(
+        "pending semantic generation cannot verify the server embedding execution identity",
+    )?;
+    anyhow::ensure!(
+        current.resumable,
+        "pending semantic generation cannot resume because the current embedding backend is not \
+         resumable: {}; restore the original backend or rebuild with --fresh and a new --prefix",
+        current
+            .non_resumable_reason
+            .as_deref()
+            .unwrap_or("the server did not provide a stable execution identity")
+    );
+    anyhow::ensure!(
+        current.identity_sha256 == expected.embedding_identity_sha256
+            && current.backend == expected.embedding_backend
+            && current.dimensions == expected.embedding_dimension
+            && current.semantic_contract == expected.embedding_semantic_contract
+            && current.resumable == expected.embedding_resumable,
+        "pending semantic generation was prepared for a different embedding execution identity; \
+         no remote mutation was attempted. Restore the original embedding backend, or discard the \
+         pending generation and rebuild with --fresh and a new --prefix"
+    );
+    journal.pin_embedding_identity(
+        &current.identity_sha256,
+        current.resumable,
+        current.non_resumable_reason.as_deref(),
+    )
+}
+
+fn finish_generated_run(es: &Es, journal: &mut state::Journal, cfg: &IndexCfg) -> Result<Value> {
+    let committed = journal
+        .committed_manifest
+        .as_ref()
+        .context("generated run finished without committed generation authority")?;
+    let execution = committed
+        .execution
+        .as_ref()
+        .context("generated run finished without execution identity")?;
+    let generation = committed.generation;
+    let dataset_count = committed.plan.datasets.len();
+    let sync::SourceExecutionPolicy::DurableSnapshot { reference, .. } = &execution.source_policy
+    else {
+        anyhow::bail!("generated run does not reference a durable snapshot");
+    };
+    let run_id = reference
+        .strip_prefix("sync-snapshots/")
+        .context("generated run snapshot reference is not state-relative")?
+        .to_owned();
+    let response = es.search(
+        catalog::CATALOG_INDEX,
+        &json!({
+            "size": 2,
+            "query": {"bool": {"filter": [
+                {"term": {"run_id": &run_id}},
+                {"term": {"doc_kind": "run"}}
+            ]}}
+        }),
+    )?;
+    let hits = response
+        .pointer("/hits/hits")
+        .and_then(Value::as_array)
+        .context("generated run summary query has no hits")?;
+    anyhow::ensure!(
+        hits.len() == 1,
+        "generated run summary query returned {} documents; expected exactly one",
+        hits.len()
+    );
+    let summary = hits[0]
+        .get("_source")
+        .cloned()
+        .context("generated run summary hit has no _source")?;
+    anyhow::ensure!(
+        summary.get("generation").and_then(Value::as_u64) == Some(generation),
+        "generated run summary generation disagrees with committed authority"
+    );
+    journal.finish(&summary)?;
+    if cfg.json {
+        println!("{summary}");
+    } else if !cfg.quiet {
+        println!(
+            "generation {} committed — {} datasets, {} records live",
+            generation,
+            dataset_count,
+            summary
+                .get("records_total")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        );
+    }
+    Ok(summary)
+}
+
 fn run_index(cfg: IndexCfg) -> Result<i32> {
     run_index_report(cfg).map(|(code, _)| code)
 }
@@ -671,6 +1047,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // must never classify a path snapshot taken while another owner was
     // publishing or replacing the durable plan.
     let preflight = state::Journal::preflight(&state_dir, &root_str, &cfg.url, &cfg.prefix)?;
+    let genesis_recovery = preflight
+        .committed_manifest
+        .as_ref()
+        .is_some_and(|manifest| manifest.generation == 0 && manifest.groups.is_empty());
     // A durable sync_begin owns the desired generation. Never rediscover and
     // replan from a mutable source tree while that transaction is pending.
     // Operation handlers are deliberately not enabled by this foundation
@@ -685,6 +1065,13 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             cfg.bulk_timeout_secs,
             cfg.fresh,
         )?;
+        sync_executor::gc_snapshots(&state_dir, &journal)?;
+        let pending = journal
+            .pending_sync
+            .as_ref()
+            .context("preflight reported a pending generation but authoritative replay did not")?
+            .clone();
+        pin_pending_embedding_identity(&es, &mut journal, &pending)?;
         let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);
         sync_executor::replay_pending_operations(&state_dir, &mut journal, &mut backend)?;
         if !cfg.quiet {
@@ -692,7 +1079,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 "autoindex: resumed and committed pending corpus generation from durable source"
             );
         }
-        return Ok((0, None));
+        let summary = finish_generated_run(&es, &mut journal, &cfg)?;
+        return Ok((0, Some(summary)));
     }
     let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
     if !cfg.quiet {
@@ -708,33 +1096,158 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         return Ok((0, None));
     }
     let mut inventory = content::resolve(discovered_files)?;
-    if let Some(prior_plan) = preflight.plan.as_ref() {
-        let comparison_keys = if cfg.fresh {
-            inventory.keys.clone()
-        } else {
-            // Ordinary resume preserves planned-key identity for supported
-            // same-path replacement and legacy plans.
-            select_resume_plan_keys(
-                &inventory.files,
-                &inventory.keys,
-                prior_plan,
-                &state_dir.join("journal.ndjson"),
-            )?
-            .into_iter()
-            .zip(inventory.keys.iter())
-            .map(|(planned, current)| planned.unwrap_or_else(|| current.clone()))
-            .collect()
-        };
-        let delta =
-            UnsupportedInventoryDelta::between(&inventory.files, &comparison_keys, prior_plan);
-        if cfg.fresh {
-            // Even an apparently unchanged content-key set can have alias,
-            // path, graph, catalog, or partial-publication history that only
-            // the old plan can reconcile. Route 1 cannot safely discard it.
-            return Err(delta.into_fresh_error());
+    if cfg.no_graph && preflight.committed_manifest.is_some() && !genesis_recovery {
+        let mut journal = state::Journal::open_after_preflight(
+            preflight,
+            &root_str,
+            &cfg.url,
+            &cfg.prefix,
+            cfg.bulk_timeout_secs,
+            cfg.fresh,
+        )?;
+        sync_executor::gc_snapshots(&state_dir, &journal)?;
+        let base = journal
+            .committed_manifest
+            .as_ref()
+            .context("generated journal lost its committed manifest")?
+            .clone();
+        let scans: Vec<FileScan> = inventory
+            .files
+            .par_iter()
+            .map(|file| scan_file(&file.path, file.size, cfg.sample, cfg.max_file_gb))
+            .collect();
+        let plan = reconcile_plan::reconcile_plan(&inventory, &base.plan, scans)?;
+        if serde_json::to_value(&plan)? == serde_json::to_value(&base.plan)? {
+            if let Some(expected) = &base.execution {
+                let (schema_identity, index_identity) = generation_contract_identities(&plan)?;
+                anyhow::ensure!(
+                    expected.root_identity == root_str
+                        && expected.url == cfg.url
+                        && expected.prefix == cfg.prefix
+                        && expected.follow_symlinks == cfg.follow_symlinks
+                        && expected.chunker_identity == prepared_records_identity(&cfg)?
+                        && !expected.graph_enabled
+                        && expected.brain == "disabled"
+                        && expected.detector_identity == DETECTOR_DISABLED_IDENTITY
+                        && expected.schema_identity == schema_identity
+                        && expected.index_identity == index_identity,
+                    "autoindex execution configuration changed since the committed generation; \
+                     rebuild with --fresh and a new --prefix"
+                );
+                if plan
+                    .datasets
+                    .iter()
+                    .any(|dataset| dataset.semantic_field.is_some())
+                {
+                    let current = es.embedding_execution_identity()?;
+                    anyhow::ensure!(
+                        current.resumable
+                            && current.identity_sha256 == expected.embedding_identity_sha256
+                            && current.backend == expected.embedding_backend
+                            && current.dimensions == expected.embedding_dimension
+                            && current.semantic_contract == expected.embedding_semantic_contract,
+                        "embedding execution identity changed since this autoindex journal was \
+                         created; refusing to mix vector spaces. No remote mutation was attempted. \
+                         Restore the original identity or rebuild with --fresh and a new --prefix"
+                    );
+                }
+            }
+            let summary = finish_generated_run(&es, &mut journal, &cfg)?;
+            return Ok((0, Some(summary)));
         }
-        if !delta.is_empty() {
-            return Err(delta.into_error());
+        begin_non_graph_generation(
+            &es,
+            &mut journal,
+            &state_dir,
+            &cfg,
+            &root_str,
+            &inventory,
+            plan,
+        )?;
+        let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);
+        sync_executor::replay_pending_operations(&state_dir, &mut journal, &mut backend)?;
+        let summary = finish_generated_run(&es, &mut journal, &cfg)?;
+        return Ok((0, Some(summary)));
+    }
+    if cfg.no_graph && preflight.plan.is_some() && !genesis_recovery {
+        let replacement_state = state_dir.with_extension("generation-v1");
+        let replacement_prefix = format!("{}-generation-v1", cfg.prefix);
+        let reasons = if preflight.legacy_migration_reasons.is_empty() {
+            "legacy journal has no complete generated-manifest authority".to_owned()
+        } else {
+            preflight.legacy_migration_reasons.join("; ")
+        };
+        let mut rebuild_argv = vec![
+            "xerj".to_owned(),
+            "autoindex".to_owned(),
+            cfg.root.to_string_lossy().into_owned(),
+            "--no-graph".to_owned(),
+            "--url".to_owned(),
+            cfg.url.clone(),
+            "--state-dir".to_owned(),
+            replacement_state.to_string_lossy().into_owned(),
+            "--prefix".to_owned(),
+            replacement_prefix,
+            "--workers".to_owned(),
+            cfg.workers.to_string(),
+            "--pdf-workers".to_owned(),
+            cfg.pdf_workers.to_string(),
+            "--pdf-timeout-secs".to_owned(),
+            cfg.pdf_timeout_secs.to_string(),
+            "--bulk-mb".to_owned(),
+            cfg.bulk_mb.to_string(),
+            "--bulk-timeout-secs".to_owned(),
+            cfg.bulk_timeout_secs.to_string(),
+            "--snapshot-max-gb".to_owned(),
+            (cfg.snapshot_max_bytes >> 30).to_string(),
+            "--max-file-gb".to_owned(),
+            cfg.max_file_gb.to_string(),
+            "--sample".to_owned(),
+            cfg.sample.to_string(),
+        ];
+        if cfg.no_semantic {
+            rebuild_argv.push("--no-semantic".to_owned());
+        }
+        if cfg.follow_symlinks {
+            rebuild_argv.push("--follow-symlinks".to_owned());
+        }
+        anyhow::bail!(
+            "this state directory contains a legacy nonempty plan that cannot become generation \
+             authority: {reasons}. Start an independent rebuild using this argv JSON (no shell \
+             quoting required): {:?}. Keep XERJ_API_KEY set when the endpoint requires \
+             authentication",
+            rebuild_argv
+        );
+    }
+    if !genesis_recovery {
+        if let Some(prior_plan) = preflight.plan.as_ref() {
+            let comparison_keys = if cfg.fresh {
+                inventory.keys.clone()
+            } else {
+                // Ordinary resume preserves planned-key identity for supported
+                // same-path replacement and legacy plans.
+                select_resume_plan_keys(
+                    &inventory.files,
+                    &inventory.keys,
+                    prior_plan,
+                    &state_dir.join("journal.ndjson"),
+                )?
+                .into_iter()
+                .zip(inventory.keys.iter())
+                .map(|(planned, current)| planned.unwrap_or_else(|| current.clone()))
+                .collect()
+            };
+            let delta =
+                UnsupportedInventoryDelta::between(&inventory.files, &comparison_keys, prior_plan);
+            if cfg.fresh {
+                // Even an apparently unchanged content-key set can have alias,
+                // path, graph, catalog, or partial-publication history that only
+                // the old plan can reconcile. Route 1 cannot safely discard it.
+                return Err(delta.into_fresh_error());
+            }
+            if !delta.is_empty() {
+                return Err(delta.into_error());
+            }
         }
     }
     let mut journal = state::Journal::open_after_preflight(
@@ -745,7 +1258,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         cfg.bulk_timeout_secs,
         cfg.fresh,
     )?;
-    let resumed_with_plan = journal.plan.is_some();
+    sync_executor::gc_snapshots(&state_dir, &journal)?;
+    let resumed_with_plan = journal.plan.is_some() && !genesis_recovery;
     if inventory.files.is_empty() && !resumed_with_plan {
         println!("no files found under {}", cfg.root.display());
         return Ok((0, None));
@@ -885,10 +1399,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         plan.duplicate_files = inventory.duplicates.clone();
     }
     alias_paths_to_replace.extend(inventory.duplicates.iter().map(|alias| alias.rel.clone()));
-    let files = inventory.files;
-    let keys = inventory.keys;
-    let digests = inventory.digests;
-    let duplicate_files = inventory.duplicates;
+    let files = inventory.files.clone();
+    let keys = inventory.keys.clone();
+    let digests = inventory.digests.clone();
+    let duplicate_files = inventory.duplicates.clone();
     let paths_discovered = files.len() + duplicate_files.len();
     if !duplicate_files.is_empty() && !cfg.quiet {
         eprintln!(
@@ -908,7 +1422,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     // ── Phase A: inference (skipped when a frozen plan exists) ──────────
     let mut clusters_rt: Option<Vec<dataset::Cluster>> = None;
-    let plan: Plan = if let Some(p) = journal.plan.clone() {
+    let plan: Plan = if let Some(p) = journal.plan.clone().filter(|_| !genesis_recovery) {
         p
     } else {
         if !cfg.quiet {
@@ -1029,6 +1543,22 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         println!("{}", serde_json::to_string_pretty(&plan)?);
         eprintln!("(dry run — nothing indexed)");
         return Ok((0, None));
+    }
+
+    if cfg.no_graph && !resumed_with_plan {
+        begin_non_graph_generation(
+            &es,
+            &mut journal,
+            &state_dir,
+            &cfg,
+            &root_str,
+            &inventory,
+            plan,
+        )?;
+        let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);
+        sync_executor::replay_pending_operations(&state_dir, &mut journal, &mut backend)?;
+        let summary = finish_generated_run(&es, &mut journal, &cfg)?;
+        return Ok((0, Some(summary)));
     }
 
     if plan
@@ -2354,6 +2884,9 @@ fn run_status(cfg: StatusCfg) -> Result<i32> {
         let mut done = 0u64;
         let mut records = 0u64;
         let mut finished = false;
+        let mut generation: Option<u64> = None;
+        let mut generation_files: Option<u64> = None;
+        let mut generation_records: Option<u64> = None;
         let mut graph_line: Option<String> = None;
         if let Ok(f) = std::fs::File::open(&jp) {
             use std::io::BufRead;
@@ -2369,10 +2902,17 @@ fn run_status(cfg: StatusCfg) -> Result<i32> {
                         }
                         Some("finish") => {
                             finished = true;
+                            generation = v.pointer("/summary/generation").and_then(Value::as_u64);
+                            generation_files =
+                                v.pointer("/summary/files_indexed").and_then(Value::as_u64);
+                            generation_records =
+                                v.pointer("/summary/records_total").and_then(Value::as_u64);
                             // Latest finish wins — the summary embeds the run
                             // doc, whose `graph` block is the edge count of
                             // record for this journal.
-                            if let Some(g) = v.pointer("/summary/graph") {
+                            if let Some(g) =
+                                v.pointer("/summary/graph").filter(|graph| !graph.is_null())
+                            {
                                 graph_line = Some(format!(
                                     "graph: {} edges written to {} (brain {})",
                                     g.get("edges_written").and_then(Value::as_u64).unwrap_or(0),
@@ -2387,12 +2927,15 @@ fn run_status(cfg: StatusCfg) -> Result<i32> {
             }
         }
         println!(
-            "journal {} — root {} — {} files done, {} records, {}",
+            "journal {} — root {} — {} files done, {} records, {}{}",
             jp.display(),
             root,
-            done,
-            records,
-            if finished { "FINISHED" } else { "in progress" }
+            generation_files.unwrap_or(done),
+            generation_records.unwrap_or(records),
+            if finished { "FINISHED" } else { "in progress" },
+            generation
+                .map(|generation| format!(" (generation {generation})"))
+                .unwrap_or_default()
         );
         if let Some(line) = graph_line {
             println!("  {line}");
@@ -2801,4 +3344,56 @@ mod duplicate_integration_tests {
 }
 
 #[cfg(test)]
+mod generation_contract_identity_tests {
+    use super::*;
+
+    fn dataset(slug: &str, index: &str, family: &str) -> PlanDataset {
+        PlanDataset {
+            slug: slug.into(),
+            index: index.into(),
+            family: family.into(),
+            group: None,
+            specs: Vec::new(),
+            time_field: None,
+            semantic_field: None,
+            sampled_records: 0,
+            file_count: 0,
+        }
+    }
+
+    #[test]
+    fn contract_identities_are_order_independent_and_change_with_contracts() {
+        let mut first = Plan {
+            datasets: vec![
+                dataset("b", "prefix-b", "csv"),
+                dataset("a", "prefix-a", "json"),
+            ],
+            ..Plan::default()
+        };
+        let expected = generation_contract_identities(&first).unwrap();
+        first.datasets.reverse();
+        assert_eq!(generation_contract_identities(&first).unwrap(), expected);
+
+        first.datasets[0].family = "text".into();
+        let schema_changed = generation_contract_identities(&first).unwrap();
+        assert_ne!(schema_changed.0, expected.0);
+
+        first.datasets[0].family = "json".into();
+        first.datasets[0].index = "different-a".into();
+        let index_changed = generation_contract_identities(&first).unwrap();
+        assert_eq!(index_changed.0, expected.0);
+        assert_ne!(index_changed.1, expected.1);
+    }
+
+    #[test]
+    fn internal_contract_versions_are_explicit() {
+        assert_eq!(PREPARED_RECORDS_IDENTITY, "prepared-records-v1");
+        assert_eq!(DOCUMENT_IDS_IDENTITY, "document-ids-v1");
+        assert_eq!(DETECTOR_DISABLED_IDENTITY, "disabled");
+    }
+}
+
+#[cfg(test)]
 mod failure_resume_http_tests;
+#[cfg(test)]
+mod incremental_reconcile_http_tests;

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -17,6 +17,7 @@ pub mod infer;
 pub mod sniff;
 pub mod state;
 mod sync;
+mod sync_executor;
 pub mod walk;
 
 use anyhow::{Context, Result};
@@ -670,6 +671,29 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // must never classify a path snapshot taken while another owner was
     // publishing or replacing the durable plan.
     let preflight = state::Journal::preflight(&state_dir, &root_str, &cfg.url, &cfg.prefix)?;
+    // A durable sync_begin owns the desired generation. Never rediscover and
+    // replan from a mutable source tree while that transaction is pending.
+    // Operation handlers are deliberately not enabled by this foundation
+    // slice; fail with the exact durable transaction rather than accidentally
+    // executing a different folder snapshot.
+    if preflight.pending_sync.is_some() {
+        let mut journal = state::Journal::open_after_preflight(
+            preflight,
+            &root_str,
+            &cfg.url,
+            &cfg.prefix,
+            cfg.bulk_timeout_secs,
+            cfg.fresh,
+        )?;
+        let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);
+        sync_executor::replay_pending_operations(&state_dir, &mut journal, &mut backend)?;
+        if !cfg.quiet {
+            eprintln!(
+                "autoindex: resumed and committed pending corpus generation from durable source"
+            );
+        }
+        return Ok((0, None));
+    }
     let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
     if !cfg.quiet {
         eprintln!(
@@ -945,6 +969,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     .or_insert_with(|| FileAssignment {
                         rel: files[m].rel.clone(),
                         path_id: files[m].rel_id.clone(),
+                        is_symlink: Some(files[m].is_symlink),
                         family: c.family.as_str().to_string(),
                         gzip: sn.map(|s| s.gzip).unwrap_or(false),
                         content_digest: Some(digests[m].clone()),
@@ -2432,6 +2457,7 @@ mod inventory_delta_tests {
         FileAssignment {
             rel: path.to_owned(),
             path_id: format!("id:{path}"),
+            is_symlink: Some(false),
             family: "csv".into(),
             gzip: false,
             content_digest: Some(format!("digest:{path}")),
@@ -2532,6 +2558,7 @@ mod duplicate_integration_tests {
         FileAssignment {
             rel: rel.to_string(),
             path_id: String::new(),
+            is_symlink: None,
             family: "txt".to_string(),
             gzip: false,
             content_digest: None,
@@ -2620,6 +2647,7 @@ mod duplicate_integration_tests {
             file_key: file_key.to_string(),
             rel: rel.to_string(),
             path_id: format!("id:{rel}"),
+            is_symlink: Some(false),
             duplicate_of: format!("{file_key}.txt"),
             bytes: 10,
         };

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -704,7 +704,7 @@ struct InventoryDeltaEntry {
     path: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 struct UnsupportedInventoryDelta {
     added_content_groups: Vec<InventoryDeltaEntry>,
     vanished_content_groups: Vec<InventoryDeltaEntry>,
@@ -1051,6 +1051,21 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         .committed_manifest
         .as_ref()
         .is_some_and(|manifest| manifest.generation == 0 && manifest.groups.is_empty());
+    // `--fresh` must be refused before the journal is opened. `open_after_
+    // preflight` deletes journal.ndjson whenever `fresh` is set, and the
+    // `gc_snapshots` call that follows every open then sees an empty protected
+    // set and removes every sealed snapshot directory. The legacy plan gate
+    // further down cannot save a generated corpus: both generated branches are
+    // evaluated before it, so the committed manifest and any pending replay
+    // evidence would already be gone. Fail here, before anything is touched, so
+    // that `--fresh` really is "accepted only when the selected state directory
+    // has no durable plan" as the CLI help and docs state.
+    if cfg.fresh
+        && (preflight.pending_sync.is_some()
+            || (preflight.committed_manifest.is_some() && !genesis_recovery))
+    {
+        return Err(UnsupportedInventoryDelta::default().into_fresh_error());
+    }
     // A durable sync_begin owns the desired generation. Never rediscover and
     // replan from a mutable source tree while that transaction is pending.
     // Operation handlers are deliberately not enabled by this foundation

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -765,6 +765,21 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         return Ok((0, None));
     }
 
+    if plan
+        .datasets
+        .iter()
+        .any(|dataset| dataset.semantic_field.is_some())
+    {
+        let identity = es
+            .embedding_execution_identity()
+            .context("semantic autoindex could not pin the server embedding execution identity")?;
+        journal.pin_embedding_identity(
+            &identity.identity_sha256,
+            identity.resumable,
+            identity.non_resumable_reason.as_deref(),
+        )?;
+    }
+
     // ── create indices with explicit mappings ────────────────────────────
     for d in &plan.datasets {
         es.ensure_index(&d.index, &build_mapping(&d.specs))

--- a/engine/crates/xerj-autoindex/src/reconcile_plan.rs
+++ b/engine/crates/xerj-autoindex/src/reconcile_plan.rs
@@ -1,0 +1,587 @@
+//! Deterministic projection of a changed inventory onto a frozen typed plan.
+//!
+//! Fresh-run clustering is intentionally not reused here: cluster formation
+//! and slug election depend on corpus order and membership. Incremental runs
+//! must preserve the committed dataset/schema identity and fail closed when a
+//! file would require a new dataset or mapping.
+
+use crate::content::Inventory;
+use crate::infer::{FieldAcc, FieldSpec};
+use crate::state::{FileAssignment, JunkFile, Plan, PlanDataset};
+use crate::FileScan;
+use anyhow::{Context, Result};
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+/// Project the current, byte-verified inventory onto committed dataset schemas.
+///
+/// Assignment precedence is stable content identity, then stable native path
+/// identity, then deterministic schema matching. Dataset definitions are
+/// copied byte-for-byte except for their derived `file_count`.
+pub(crate) fn reconcile_plan(
+    inventory: &Inventory,
+    previous: &Plan,
+    scans: Vec<FileScan>,
+) -> Result<Plan> {
+    anyhow::ensure!(
+        inventory.files.len() == inventory.keys.len()
+            && inventory.files.len() == inventory.digests.len()
+            && inventory.files.len() == scans.len(),
+        "inventory and scan cardinalities disagree"
+    );
+
+    let datasets: HashMap<&str, &PlanDataset> = previous
+        .datasets
+        .iter()
+        .map(|dataset| (dataset.slug.as_str(), dataset))
+        .collect();
+    anyhow::ensure!(
+        datasets.len() == previous.datasets.len(),
+        "frozen plan has duplicate dataset slugs"
+    );
+
+    let mut prior_path_owner: HashMap<&str, (&str, &FileAssignment)> = HashMap::new();
+    for (content_id, assignment) in &previous.files {
+        anyhow::ensure!(
+            !assignment.path_id.is_empty(),
+            "frozen assignment {} has no native path identity",
+            assignment.rel
+        );
+        anyhow::ensure!(
+            prior_path_owner
+                .insert(&assignment.path_id, (content_id, assignment))
+                .is_none(),
+            "frozen plan assigns one native path identity more than once"
+        );
+    }
+    for alias in &previous.duplicate_files {
+        let assignment = previous
+            .files
+            .get(&alias.file_key)
+            .with_context(|| format!("frozen alias {} has no canonical assignment", alias.rel))?;
+        anyhow::ensure!(
+            !alias.path_id.is_empty(),
+            "frozen alias {} has no native path identity",
+            alias.rel
+        );
+        anyhow::ensure!(
+            prior_path_owner
+                .insert(&alias.path_id, (&alias.file_key, assignment))
+                .is_none(),
+            "frozen plan assigns one native path identity more than once"
+        );
+    }
+
+    let mut files = HashMap::new();
+    let mut junk_files = Vec::new();
+    for (((file, content_id), content_digest), scan) in inventory
+        .files
+        .iter()
+        .zip(&inventory.keys)
+        .zip(&inventory.digests)
+        .zip(scans)
+    {
+        if let Some((status, reason)) = scan.junk {
+            junk_files.push(JunkFile {
+                file_key: content_id.clone(),
+                rel: file.rel.clone(),
+                format: crate::format_str(scan.sniffed.as_ref()),
+                status,
+                reason,
+                bytes: file.size,
+            });
+            continue;
+        }
+        let sniffed = scan
+            .sniffed
+            .as_ref()
+            .with_context(|| format!("{} has sketches but no detected family", file.rel))?;
+        anyhow::ensure!(
+            !scan.sketches.is_empty(),
+            "{} has no dataset sketches and was not classified as junk",
+            file.rel
+        );
+
+        let content_owner = previous.files.get(content_id);
+        let path_owner = prior_path_owner.get(file.rel_id.as_str()).copied();
+        if let (Some(content), Some((path_content_id, path))) = (content_owner, path_owner) {
+            anyhow::ensure!(
+                std::ptr::eq(content, path)
+                    || previous
+                        .files
+                        .get(path_content_id)
+                        .is_some_and(|candidate| std::ptr::eq(candidate, content)),
+                "{} has conflicting committed content and path owners",
+                file.rel
+            );
+        }
+        let retained = content_owner.or_else(|| path_owner.map(|(_, assignment)| assignment));
+
+        let mut assignments = Vec::with_capacity(scan.sketches.len());
+        for (group, fields, _records) in &scan.sketches {
+            let slug = if let Some(owner) = retained {
+                retained_slug(owner, group, sniffed.family.as_str(), fields, &datasets)
+                    .with_context(|| format!("project retained file {}", file.rel))?
+            } else {
+                classify_new(group, sniffed.family.as_str(), fields, &previous.datasets)
+                    .with_context(|| format!("project new file {}", file.rel))?
+            };
+            assignments.push((group.clone(), slug));
+        }
+        assignments.sort();
+        assignments.dedup();
+        anyhow::ensure!(
+            assignments.len() == scan.sketches.len(),
+            "{} has duplicate dataset groups",
+            file.rel
+        );
+        let replaced = files.insert(
+            content_id.clone(),
+            FileAssignment {
+                rel: file.rel.clone(),
+                path_id: file.rel_id.clone(),
+                is_symlink: Some(file.is_symlink),
+                family: sniffed.family.as_str().to_owned(),
+                gzip: sniffed.gzip,
+                content_digest: Some(content_digest.clone()),
+                assignments,
+            },
+        );
+        anyhow::ensure!(
+            replaced.is_none(),
+            "byte-verified inventory contains duplicate content identity {content_id}"
+        );
+    }
+
+    let live_content: HashSet<&str> = files.keys().map(String::as_str).collect();
+    let mut duplicate_files = inventory
+        .duplicates
+        .iter()
+        .filter(|alias| live_content.contains(alias.file_key.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    duplicate_files.sort_by(|left, right| {
+        left.file_key
+            .cmp(&right.file_key)
+            .then_with(|| left.path_id.cmp(&right.path_id))
+            .then_with(|| left.rel.cmp(&right.rel))
+    });
+    junk_files.sort_by(|left, right| {
+        left.file_key
+            .cmp(&right.file_key)
+            .then_with(|| left.rel.cmp(&right.rel))
+    });
+
+    let mut frozen_datasets = previous.datasets.clone();
+    for dataset in &mut frozen_datasets {
+        dataset.file_count = files
+            .values()
+            .filter(|assignment| {
+                assignment
+                    .assignments
+                    .iter()
+                    .any(|(_, slug)| slug == &dataset.slug)
+            })
+            .count();
+    }
+
+    Ok(Plan {
+        datasets: frozen_datasets,
+        files,
+        junk_files,
+        duplicate_files,
+        alias_paths_indexed: previous.alias_paths_indexed,
+    })
+}
+
+fn retained_slug(
+    owner: &FileAssignment,
+    group: &Option<String>,
+    family: &str,
+    fields: &HashMap<String, FieldAcc>,
+    datasets: &HashMap<&str, &PlanDataset>,
+) -> Result<String> {
+    anyhow::ensure!(
+        owner.family == family,
+        "detected family changed from {} to {family}",
+        owner.family
+    );
+    let matches = owner
+        .assignments
+        .iter()
+        .filter(|(assigned_group, _)| assigned_group == group)
+        .collect::<Vec<_>>();
+    anyhow::ensure!(
+        matches.len() == 1,
+        "frozen assignment has {} matches for group {:?}",
+        matches.len(),
+        group
+    );
+    let slug = &matches[0].1;
+    let dataset = datasets
+        .get(slug.as_str())
+        .with_context(|| format!("frozen assignment references absent dataset {slug}"))?;
+    ensure_compatible(fields, dataset)?;
+    Ok(slug.clone())
+}
+
+fn classify_new(
+    group: &Option<String>,
+    family: &str,
+    fields: &HashMap<String, FieldAcc>,
+    datasets: &[PlanDataset],
+) -> Result<String> {
+    let mut candidates = Vec::new();
+    for dataset in datasets
+        .iter()
+        .filter(|dataset| dataset.family == family && &dataset.group == group)
+    {
+        if ensure_compatible(fields, dataset).is_err() {
+            continue;
+        }
+        let (intersection, union) = field_overlap(fields, &dataset.specs);
+        let threshold_met = if group.is_some() {
+            intersection * 2 >= union // 0.5
+        } else {
+            intersection * 10 >= union * 7 // 0.7
+        };
+        if threshold_met {
+            candidates.push((dataset, intersection, union));
+        }
+    }
+    candidates.sort_by(|(left, li, lu), (right, ri, ru)| {
+        ratio_cmp(*ri, *ru, *li, *lu).then_with(|| left.slug.cmp(&right.slug))
+    });
+    candidates
+        .first()
+        .map(|(dataset, _, _)| dataset.slug.clone())
+        .with_context(|| {
+            format!(
+                "no frozen dataset accepts family {family}, group {:?}, and fields {:?}; \
+                 this requires unsupported dataset/schema evolution (use a new prefix)",
+                group,
+                sorted_field_names(fields)
+            )
+        })
+}
+
+fn field_overlap(fields: &HashMap<String, FieldAcc>, specs: &[FieldSpec]) -> (usize, usize) {
+    // Keep null-only and object-shaped fields in the schema fingerprint too.
+    // FieldAcc deliberately does not count those as scalar observations, but
+    // allowing an unknown one through would let the server create a dynamic
+    // mapping outside the frozen plan.
+    let observed: HashSet<&str> = fields.keys().map(String::as_str).collect();
+    let frozen: HashSet<&str> = specs.iter().map(|spec| spec.name.as_str()).collect();
+    (
+        observed.intersection(&frozen).count(),
+        observed.union(&frozen).count().max(1),
+    )
+}
+
+fn ratio_cmp(left_n: usize, left_d: usize, right_n: usize, right_d: usize) -> Ordering {
+    (left_n * right_d).cmp(&(right_n * left_d))
+}
+
+fn ensure_compatible(fields: &HashMap<String, FieldAcc>, dataset: &PlanDataset) -> Result<()> {
+    let specs: HashMap<&str, &FieldSpec> = dataset
+        .specs
+        .iter()
+        .map(|spec| (spec.name.as_str(), spec))
+        .collect();
+    for (name, acc) in fields {
+        let spec = specs.get(name.as_str()).with_context(|| {
+            format!(
+                "field {name} is absent from frozen dataset {}",
+                dataset.slug
+            )
+        })?;
+        anyhow::ensure!(
+            compatible_with_spec(acc, spec),
+            "field {name} is incompatible with frozen {} mapping in dataset {}",
+            spec.es_type,
+            dataset.slug
+        );
+    }
+    Ok(())
+}
+
+fn compatible_with_spec(acc: &FieldAcc, spec: &FieldSpec) -> bool {
+    if acc.n == 0 {
+        return true;
+    }
+    let at_least_95 = |accepted: u64| accepted.saturating_mul(100) >= acc.n.saturating_mul(95);
+    match spec.es_type.as_str() {
+        "boolean" => at_least_95(acc.bool_ok),
+        "long" => at_least_95(acc.long_ok),
+        "double" => at_least_95(acc.double_ok),
+        "date" => {
+            let string_dates = acc.date_hits.values().copied().sum::<u64>();
+            let numeric_dates = match spec.date_enc.as_deref() {
+                Some("epoch_millis" | "epoch_seconds") => acc.long_ok,
+                _ => 0,
+            };
+            at_least_95(string_dates.saturating_add(numeric_dates).min(acc.n))
+        }
+        "keyword" | "text" | "semantic_text" => true,
+        _ => false,
+    }
+}
+
+fn sorted_field_names(fields: &HashMap<String, FieldAcc>) -> Vec<&str> {
+    let mut names = fields.keys().map(String::as_str).collect::<Vec<_>>();
+    names.sort_unstable();
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sniff::{Family, Sniffed};
+    use crate::state::{DuplicateFile, PlanDataset};
+    use crate::walk::FileEntry;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn acc(values: &[serde_json::Value]) -> FieldAcc {
+        let mut acc = FieldAcc::default();
+        for value in values {
+            acc.add(value);
+        }
+        acc
+    }
+
+    fn spec(name: &str, es_type: &str) -> FieldSpec {
+        FieldSpec {
+            name: name.into(),
+            es_type: es_type.into(),
+            date_enc: None,
+            semantic: None,
+            cardinality_est: 0,
+            cardinality_overflow: false,
+            null_ratio: 0.0,
+            avg_len: 0.0,
+            coverage: 1.0,
+            examples: vec![],
+            notes: vec![],
+            date_min: None,
+            date_max: None,
+            date_evidence: vec![],
+        }
+    }
+
+    fn dataset(slug: &str, specs: Vec<FieldSpec>) -> PlanDataset {
+        PlanDataset {
+            slug: slug.into(),
+            index: format!("ax-{slug}"),
+            family: "jsonl".into(),
+            group: None,
+            specs,
+            time_field: None,
+            semantic_field: None,
+            sampled_records: 1,
+            file_count: 1,
+        }
+    }
+
+    fn file(rel: &str, path_id: &str) -> FileEntry {
+        FileEntry {
+            path: PathBuf::from(rel),
+            rel: rel.into(),
+            rel_id: path_id.into(),
+            is_symlink: false,
+            size: 10,
+        }
+    }
+
+    fn scan(fields: HashMap<String, FieldAcc>) -> FileScan {
+        FileScan {
+            sniffed: Some(Sniffed {
+                family: Family::Jsonl,
+                gzip: false,
+                binary_kind: None,
+                csv: None,
+                encoding: "utf-8",
+            }),
+            sketches: vec![(None, fields, 1)],
+            junk: None,
+        }
+    }
+
+    fn inventory(rel: &str, path_id: &str, key: &str) -> Inventory {
+        Inventory {
+            files: vec![file(rel, path_id)],
+            keys: vec![key.into()],
+            digests: vec![format!("digest-{key}")],
+            duplicates: vec![],
+        }
+    }
+
+    fn assignment(rel: &str, path_id: &str, slug: &str) -> FileAssignment {
+        FileAssignment {
+            rel: rel.into(),
+            path_id: path_id.into(),
+            is_symlink: Some(false),
+            family: "jsonl".into(),
+            gzip: false,
+            content_digest: Some("old-digest".into()),
+            assignments: vec![(None, slug.into())],
+        }
+    }
+
+    #[test]
+    fn same_path_replacement_retains_dataset_and_never_re_elects_slug() {
+        let mut previous = Plan {
+            datasets: vec![
+                dataset("z-owner", vec![spec("id", "long"), spec("body", "text")]),
+                dataset("a-other", vec![spec("id", "long"), spec("body", "text")]),
+            ],
+            ..Plan::default()
+        };
+        previous
+            .files
+            .insert("old".into(), assignment("a.jsonl", "unix:61", "z-owner"));
+        let fields = HashMap::from([
+            ("id".into(), acc(&[json!(7)])),
+            ("body".into(), acc(&[json!("hello world")])),
+        ]);
+        let plan = reconcile_plan(
+            &inventory("a.jsonl", "unix:61", "new"),
+            &previous,
+            vec![scan(fields)],
+        )
+        .unwrap();
+        assert_eq!(
+            plan.files["new"].assignments,
+            vec![(None, "z-owner".into())]
+        );
+    }
+
+    #[test]
+    fn new_file_uses_highest_jaccard_then_stable_slug_tie_break() {
+        let previous = Plan {
+            datasets: vec![
+                dataset("z-tie", vec![spec("id", "long"), spec("body", "text")]),
+                dataset("a-tie", vec![spec("id", "long"), spec("body", "text")]),
+                dataset(
+                    "lower",
+                    vec![
+                        spec("id", "long"),
+                        spec("body", "text"),
+                        spec("extra", "keyword"),
+                    ],
+                ),
+            ],
+            ..Plan::default()
+        };
+        let fields = HashMap::from([
+            ("id".into(), acc(&[json!(7)])),
+            ("body".into(), acc(&[json!("hello")])),
+        ]);
+        let plan = reconcile_plan(
+            &inventory("new.jsonl", "unix:6e", "new"),
+            &previous,
+            vec![scan(fields)],
+        )
+        .unwrap();
+        assert_eq!(plan.files["new"].assignments, vec![(None, "a-tie".into())]);
+        assert_eq!(plan.datasets[0].file_count, 0);
+        assert_eq!(plan.datasets[1].file_count, 1);
+    }
+
+    #[test]
+    fn new_field_and_incompatible_type_fail_before_plan_changes() {
+        let previous = Plan {
+            datasets: vec![dataset("rows", vec![spec("id", "long")])],
+            ..Plan::default()
+        };
+        let unknown = HashMap::from([
+            ("id".into(), acc(&[json!(7)])),
+            ("surprise".into(), acc(&[json!("new mapping")])),
+        ]);
+        let error = reconcile_plan(
+            &inventory("new.jsonl", "unix:6e", "new"),
+            &previous,
+            vec![scan(unknown)],
+        )
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("unsupported dataset/schema evolution"));
+
+        // Object-shaped values are not counted as scalar FieldAcc evidence,
+        // but their field name must still be rejected rather than dynamically
+        // mapped by the server.
+        let object_field = HashMap::from([
+            ("id".into(), acc(&[json!(7)])),
+            ("object".into(), acc(&[json!({"nested": true})])),
+        ]);
+        let error = reconcile_plan(
+            &inventory("new.jsonl", "unix:6e", "new"),
+            &previous,
+            vec![scan(object_field)],
+        )
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("unsupported dataset/schema evolution"));
+
+        let wrong_type = HashMap::from([("id".into(), acc(&[json!("not-a-number")]))]);
+        let error = reconcile_plan(
+            &inventory("new.jsonl", "unix:6e", "new"),
+            &previous,
+            vec![scan(wrong_type)],
+        )
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("unsupported dataset/schema evolution"));
+    }
+
+    #[test]
+    fn rename_by_content_retains_assignment_and_rebuilds_aliases_and_counts() {
+        let mut previous = Plan {
+            datasets: vec![dataset("rows", vec![spec("id", "long")])],
+            ..Plan::default()
+        };
+        previous
+            .files
+            .insert("same".into(), assignment("old.jsonl", "unix:6f", "rows"));
+        let mut current = inventory("renamed.jsonl", "unix:72", "same");
+        current.duplicates.push(DuplicateFile {
+            file_key: "same".into(),
+            rel: "alias.jsonl".into(),
+            path_id: "unix:61".into(),
+            is_symlink: Some(false),
+            duplicate_of: "renamed.jsonl".into(),
+            bytes: 10,
+        });
+        let fields = HashMap::from([("id".into(), acc(&[json!(7)]))]);
+        let plan = reconcile_plan(&current, &previous, vec![scan(fields)]).unwrap();
+        assert_eq!(plan.files["same"].rel, "renamed.jsonl");
+        assert_eq!(plan.datasets[0].file_count, 1);
+        assert_eq!(plan.duplicate_files.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_content_identity_and_conflicting_owners_fail_closed() {
+        let mut previous = Plan {
+            datasets: vec![dataset("rows", vec![spec("id", "long")])],
+            ..Plan::default()
+        };
+        previous
+            .files
+            .insert("content-a".into(), assignment("a.jsonl", "unix:61", "rows"));
+        previous
+            .files
+            .insert("content-b".into(), assignment("b.jsonl", "unix:62", "rows"));
+        let fields = || HashMap::from([("id".into(), acc(&[json!(7)]))]);
+
+        let conflict = inventory("a.jsonl", "unix:62", "content-a");
+        let error = reconcile_plan(&conflict, &previous, vec![scan(fields())]).unwrap_err();
+        assert!(format!("{error:#}").contains("conflicting committed content and path owners"));
+
+        let duplicate = Inventory {
+            files: vec![file("c.jsonl", "unix:63"), file("d.jsonl", "unix:64")],
+            keys: vec!["same-key".into(), "same-key".into()],
+            digests: vec!["digest".into(), "digest".into()],
+            duplicates: vec![],
+        };
+        let error = reconcile_plan(&duplicate, &previous, vec![scan(fields()), scan(fields())])
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("duplicate content identity"));
+    }
+}

--- a/engine/crates/xerj-autoindex/src/reconcile_plan.rs
+++ b/engine/crates/xerj-autoindex/src/reconcile_plan.rs
@@ -252,17 +252,31 @@ fn classify_new(
     candidates.sort_by(|(left, li, lu), (right, ri, ru)| {
         ratio_cmp(*ri, *ru, *li, *lu).then_with(|| left.slug.cmp(&right.slug))
     });
-    candidates
-        .first()
-        .map(|(dataset, _, _)| dataset.slug.clone())
-        .with_context(|| {
-            format!(
-                "no frozen dataset accepts family {family}, group {:?}, and fields {:?}; \
-                 this requires unsupported dataset/schema evolution (use a new prefix)",
-                group,
-                sorted_field_names(fields)
-            )
-        })
+    let Some((winner, winner_intersection, winner_union)) = candidates.first() else {
+        anyhow::bail!(
+            "no frozen dataset accepts family {family}, group {:?}, and fields {:?}; \
+             this requires unsupported dataset/schema evolution (use a new prefix)",
+            group,
+            sorted_field_names(fields)
+        );
+    };
+    if let Some((runner_up, runner_up_intersection, runner_up_union)) = candidates.get(1) {
+        anyhow::ensure!(
+            ratio_cmp(
+                *winner_intersection,
+                *winner_union,
+                *runner_up_intersection,
+                *runner_up_union
+            ) != Ordering::Equal,
+            "new file matches frozen datasets {} and {} equally for family {family}, group {:?}, \
+             and fields {:?}; refusing ambiguous assignment (use a new prefix)",
+            winner.slug,
+            runner_up.slug,
+            group,
+            sorted_field_names(fields)
+        );
+    }
+    Ok(winner.slug.clone())
 }
 
 fn field_overlap(fields: &HashMap<String, FieldAcc>, specs: &[FieldSpec]) -> (usize, usize) {
@@ -457,11 +471,10 @@ mod tests {
     }
 
     #[test]
-    fn new_file_uses_highest_jaccard_then_stable_slug_tie_break() {
+    fn new_file_uses_unique_highest_jaccard_match() {
         let previous = Plan {
             datasets: vec![
-                dataset("z-tie", vec![spec("id", "long"), spec("body", "text")]),
-                dataset("a-tie", vec![spec("id", "long"), spec("body", "text")]),
+                dataset("winner", vec![spec("id", "long"), spec("body", "text")]),
                 dataset(
                     "lower",
                     vec![
@@ -483,9 +496,37 @@ mod tests {
             vec![scan(fields)],
         )
         .unwrap();
-        assert_eq!(plan.files["new"].assignments, vec![(None, "a-tie".into())]);
-        assert_eq!(plan.datasets[0].file_count, 0);
-        assert_eq!(plan.datasets[1].file_count, 1);
+        assert_eq!(plan.files["new"].assignments, vec![(None, "winner".into())]);
+        assert_eq!(plan.datasets[0].file_count, 1);
+        assert_eq!(plan.datasets[1].file_count, 0);
+    }
+
+    #[test]
+    fn new_file_with_equal_best_schema_matches_fails_closed() {
+        let previous = Plan {
+            datasets: vec![
+                dataset("z-tie", vec![spec("id", "long"), spec("body", "text")]),
+                dataset("a-tie", vec![spec("id", "long"), spec("body", "text")]),
+            ],
+            ..Plan::default()
+        };
+        let fields = HashMap::from([
+            ("id".into(), acc(&[json!(7)])),
+            ("body".into(), acc(&[json!("hello")])),
+        ]);
+        let error = reconcile_plan(
+            &inventory("new.jsonl", "unix:6e", "new"),
+            &previous,
+            vec![scan(fields)],
+        )
+        .unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("refusing ambiguous assignment"),
+            "{message}"
+        );
+        assert!(message.contains("a-tie"), "{message}");
+        assert!(message.contains("z-tie"), "{message}");
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -85,15 +85,30 @@ fn read_prefix(path: &Path, gzip: bool, n: usize) -> Result<Vec<u8>> {
 }
 
 pub fn sniff(path: &Path) -> Result<Sniffed> {
-    let head = read_prefix(path, false, 8)?;
+    sniff_with_name(path, path)
+}
+
+/// Classify bytes from `content_path` while retaining the logical filename
+/// signals (currently source-code extensions) from `logical_path`.
+///
+/// Durable preparation uses this to classify an immutable snapshot blob
+/// without losing the original name merely because the blob itself is named
+/// by an ordinal.
+pub fn sniff_with_name(content_path: &Path, logical_path: &Path) -> Result<Sniffed> {
+    let head = read_prefix(content_path, false, 8)?;
     let gzip = head.len() >= 2 && head[0] == 0x1f && head[1] == 0x8b;
-    let prefix = read_prefix(path, gzip, 8192)?;
-    let mut s = sniff_bytes(&prefix, path, gzip)?;
+    let prefix = read_prefix(content_path, gzip, 8192)?;
+    let mut s = sniff_bytes(&prefix, content_path, logical_path, gzip)?;
     s.gzip = gzip;
     Ok(s)
 }
 
-fn sniff_bytes(prefix: &[u8], path: &Path, gzip: bool) -> Result<Sniffed> {
+fn sniff_bytes(
+    prefix: &[u8],
+    content_path: &Path,
+    logical_path: &Path,
+    gzip: bool,
+) -> Result<Sniffed> {
     let mk = |family: Family| Sniffed {
         family,
         gzip: false,
@@ -117,7 +132,7 @@ fn sniff_bytes(prefix: &[u8], path: &Path, gzip: bool) -> Result<Sniffed> {
     if prefix.starts_with(b"PK\x03\x04") {
         // zip container: DOCX iff it holds word/document.xml
         if !gzip {
-            if let Ok(f) = std::fs::File::open(path) {
+            if let Ok(f) = std::fs::File::open(content_path) {
                 if let Ok(mut z) = zip::ZipArchive::new(f) {
                     let is_docx = (0..z.len()).any(|i| {
                         z.by_index_raw(i)
@@ -172,7 +187,7 @@ fn sniff_bytes(prefix: &[u8], path: &Path, gzip: bool) -> Result<Sniffed> {
     // reach here after the binary guards above, so a text `.py`/`.rs`/`.go`/…
     // routes to the tree-sitter AST extractor (crate::extract::code). Extension
     // is the right signal — code vs prose is not reliably content-sniffable.
-    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+    if let Some(ext) = logical_path.extension().and_then(|e| e.to_str()) {
         if crate::extract::code::is_code_ext(ext) {
             let mut s = mk(Family::Code);
             s.encoding = encoding;

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -12,9 +12,10 @@ use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]
-static FILE_DONE_IO_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+static FILE_DONE_IO_FAILPOINT: std::sync::Mutex<Option<(u8, PathBuf)>> =
+    std::sync::Mutex::new(None);
 #[cfg(test)]
-static SYNC_IO_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+static SYNC_IO_FAILPOINT: std::sync::Mutex<Option<(u8, PathBuf)>> = std::sync::Mutex::new(None);
 #[cfg(test)]
 pub(crate) static FILE_DONE_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> =
     std::sync::Mutex::new(());
@@ -22,13 +23,13 @@ pub(crate) static FILE_DONE_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> =
 pub(crate) static SYNC_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
-pub(crate) fn fail_next_file_done_io(boundary: u8) {
-    FILE_DONE_IO_FAILPOINT.store(boundary, std::sync::atomic::Ordering::SeqCst);
+pub(crate) fn fail_next_file_done_io(boundary: u8, journal_path: &Path) {
+    *FILE_DONE_IO_FAILPOINT.lock().unwrap() = Some((boundary, journal_path.to_path_buf()));
 }
 
 #[cfg(test)]
-fn fail_next_sync_io(boundary: u8) {
-    SYNC_IO_FAILPOINT.store(boundary, std::sync::atomic::Ordering::SeqCst);
+fn fail_next_sync_io(boundary: u8, journal_path: &Path) {
+    *SYNC_IO_FAILPOINT.lock().unwrap() = Some((boundary, journal_path.to_path_buf()));
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -186,6 +187,8 @@ mod tests {
                 "{tail}"
             );
         }
+    }
+
     #[test]
     fn preflight_holds_the_same_exclusive_lock_through_authoritative_open() {
         let dir = tempfile::tempdir().unwrap();
@@ -330,7 +333,7 @@ fn apply_legacy_plan(
 }
 
 #[cfg(test)]
-fn consume_io_failpoint(what: &str, boundary: u8) -> bool {
+fn consume_io_failpoint(what: &str, boundary: u8, journal_path: &Path) -> bool {
     let failpoint = if what == "file_done" {
         &FILE_DONE_IO_FAILPOINT
     } else if what.starts_with("sync_") {
@@ -338,14 +341,18 @@ fn consume_io_failpoint(what: &str, boundary: u8) -> bool {
     } else {
         return false;
     };
-    failpoint
-        .compare_exchange(
-            boundary,
-            0,
-            std::sync::atomic::Ordering::SeqCst,
-            std::sync::atomic::Ordering::SeqCst,
-        )
-        .is_ok()
+    let mut armed = failpoint.lock().unwrap();
+    if armed
+        .as_ref()
+        .is_some_and(|(expected_boundary, expected_path)| {
+            *expected_boundary == boundary && expected_path == journal_path
+        })
+    {
+        *armed = None;
+        true
+    } else {
+        false
+    }
 }
 
 type PreflightReplay = (
@@ -441,10 +448,13 @@ fn read_plan_for_preflight(
             }
             Some(kind) if crate::sync::is_sync_record_kind(kind) => {
                 crate::sync::replay_record(&value, &mut committed_manifest, &mut pending_sync)?;
-                if kind == "sync_commit" {
+                if matches!(kind, "sync_bootstrap" | "sync_commit") {
                     plan = committed_manifest
                         .as_ref()
                         .map(|manifest| manifest.plan.clone());
+                }
+                if kind == "sync_bootstrap" {
+                    legacy_migration_reasons.clear();
                 }
             }
             Some(kind) if kind.starts_with("sync_") => {
@@ -686,10 +696,13 @@ impl Journal {
                                     &mut committed_manifest,
                                     &mut pending_sync,
                                 )?;
-                                if kind == "sync_commit" {
+                                if matches!(kind, "sync_bootstrap" | "sync_commit") {
                                     plan = committed_manifest
                                         .as_ref()
                                         .map(|manifest| manifest.plan.clone());
+                                }
+                                if kind == "sync_bootstrap" {
+                                    legacy_migration_reasons.clear();
                                 }
                             }
                             Some(kind) if kind.starts_with("sync_") => {
@@ -864,11 +877,11 @@ impl Journal {
         line.push('\n');
         let start = self.file.metadata()?.len();
         #[cfg(test)]
-        if consume_io_failpoint(what, 1) {
+        if consume_io_failpoint(what, 1, &self.path) {
             anyhow::bail!("injected {what} append failure before any bytes");
         }
         #[cfg(test)]
-        let partial_write = consume_io_failpoint(what, 3);
+        let partial_write = consume_io_failpoint(what, 3, &self.path);
         #[cfg(not(test))]
         let partial_write = false;
         let write_result = if partial_write {
@@ -887,7 +900,7 @@ impl Journal {
             return self.rollback_transaction(start, what, "append", error);
         }
         #[cfg(test)]
-        let injected_sync_failure = consume_io_failpoint(what, 2);
+        let injected_sync_failure = consume_io_failpoint(what, 2, &self.path);
         #[cfg(not(test))]
         let injected_sync_failure = false;
         let sync_result = if injected_sync_failure {
@@ -964,6 +977,32 @@ impl Journal {
         value["kind"] = Value::String("sync_begin".into());
         self.append_transaction(&value, "sync_begin")?;
         self.pending_sync = pending;
+        Ok(())
+    }
+
+    pub fn sync_bootstrap_genesis(&mut self) -> Result<()> {
+        anyhow::ensure!(
+            self.pending_sync.is_none()
+                && self.committed_manifest.is_none()
+                && self.plan.is_none()
+                && self.done.is_empty()
+                && self.pending_replacements.is_empty(),
+            "generation-zero bootstrap is only valid for an empty new journal"
+        );
+        let manifest = crate::sync::CommittedManifest::genesis()?;
+        let mut committed = None;
+        crate::sync::replay_record(
+            &serde_json::json!({"kind": "sync_bootstrap", "manifest": manifest}),
+            &mut committed,
+            &mut None,
+        )?;
+        self.append_transaction(
+            &serde_json::json!({"kind": "sync_bootstrap", "manifest": manifest}),
+            "sync_bootstrap",
+        )?;
+        self.plan = Some(Plan::default());
+        self.committed_manifest = committed;
+        self.legacy_migration_reasons.clear();
         Ok(())
     }
 
@@ -1131,14 +1170,28 @@ mod sync_journal_tests {
             sampled_records: 1,
             file_count: 0,
         });
-        journal.write_plan(&plan).unwrap();
+        journal.sync_bootstrap_genesis().unwrap();
         journal
     }
 
     fn pending(journal: &Journal) -> PendingSync {
         let base = journal.committed_manifest.as_ref().unwrap();
         let mut plan = base.plan.clone();
-        plan.datasets[0].file_count = 1;
+        if plan.datasets.is_empty() {
+            plan.datasets.push(PlanDataset {
+                slug: "reports".into(),
+                index: "prefix-reports".into(),
+                family: "pdf".into(),
+                group: None,
+                specs: Vec::new(),
+                time_field: None,
+                semantic_field: None,
+                sampled_records: 1,
+                file_count: 1,
+            });
+        } else {
+            plan.datasets[0].file_count = 1;
+        }
         plan.files.insert(
             "content-a".into(),
             FileAssignment {
@@ -1163,13 +1216,14 @@ mod sync_journal_tests {
                     prefix: "prefix".into(),
                     follow_symlinks: false,
                     chunker_identity: "chunker-v1".into(),
+                    embedding_identity_sha256: "a".repeat(64),
                     embedding_backend: "lexical".into(),
-                    embedding_model: "feature-hash".into(),
-                    embedding_tokenizer: "builtin".into(),
                     embedding_dimension: 384,
+                    embedding_semantic_contract: "semantic_text-derived-vector.v1".into(),
+                    embedding_resumable: true,
                     graph_enabled: false,
-                    brain: "none".into(),
-                    detector_identity: "detectors-v1".into(),
+                    brain: "disabled".into(),
+                    detector_identity: "disabled".into(),
                     schema_identity: "schema-v1".into(),
                     index_identity: "index-v1".into(),
                     source_policy: SourceExecutionPolicy::AbortOnSourceChange {
@@ -1219,6 +1273,29 @@ mod sync_journal_tests {
         assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 0);
         assert!(!reopened.plan.as_ref().unwrap().alias_paths_indexed);
         assert_eq!(reopened.pending_sync.as_ref().unwrap().tx_id, "sync-1");
+    }
+
+    #[test]
+    fn new_journal_can_bootstrap_empty_generation_authority_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        journal.sync_bootstrap_genesis().unwrap();
+        let committed = journal.committed_manifest.as_ref().unwrap();
+        assert_eq!(committed.generation, 0);
+        assert!(committed.groups.is_empty());
+        assert_eq!(
+            serde_json::to_value(journal.plan.as_ref().unwrap()).unwrap(),
+            serde_json::to_value(Plan::default()).unwrap()
+        );
+        assert!(journal.sync_bootstrap_genesis().is_err());
+        drop(journal);
+
+        let reopened = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        assert_eq!(reopened.committed_manifest.unwrap().generation, 0);
+        assert_eq!(
+            serde_json::to_value(reopened.plan.unwrap()).unwrap(),
+            serde_json::to_value(Plan::default()).unwrap()
+        );
     }
 
     #[test]
@@ -1445,7 +1522,7 @@ mod sync_journal_tests {
             let mut journal = journal_with_plan(dir.path());
             let desired = pending(&journal);
             let before = std::fs::read(dir.path().join("journal.ndjson")).unwrap();
-            fail_next_sync_io(boundary);
+            fail_next_sync_io(boundary, journal.path());
             assert!(journal.sync_begin(&desired).is_err());
             assert!(journal.pending_sync.is_none());
             drop(journal);
@@ -1479,7 +1556,7 @@ mod sync_journal_tests {
                     journal.sync_validated().unwrap();
                 }
                 let before = std::fs::read(dir.path().join("journal.ndjson")).unwrap();
-                fail_next_sync_io(boundary);
+                fail_next_sync_io(boundary, journal.path());
                 let result = match stage {
                     "operation" => {
                         journal.sync_operation_state("upsert:group-a", SyncOperationState::Started)
@@ -1716,7 +1793,7 @@ mod compatibility_tests {
             let mut journal =
                 Journal::open(dir.path(), "root", "http://engine", "ax", 300, false).unwrap();
             journal.file_replace_start("file-key", "new").unwrap();
-            fail_next_file_done_io(boundary);
+            fail_next_file_done_io(boundary, journal.path());
             let error = journal
                 .file_done(&FileDone {
                     file_key: "file-key".into(),
@@ -1753,7 +1830,7 @@ mod compatibility_tests {
         journal
             .file_replace_start("file-c", "generation-c")
             .unwrap();
-        fail_next_file_done_io(3);
+        fail_next_file_done_io(3, journal.path());
         let error = journal
             .file_done(&FileDone {
                 file_key: "file-c".into(),

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -50,7 +50,7 @@ pub struct PlanDataset {
 
 #[cfg(test)]
 mod tests {
-    use super::Journal;
+    use super::{run_id_in_second, Journal};
 
     #[test]
     fn legacy_journal_can_resume_with_a_custom_operational_timeout() {
@@ -69,6 +69,19 @@ mod tests {
         let text = std::fs::read_to_string(dir.path().join("journal.ndjson")).unwrap();
         assert!(text.contains("\"kind\":\"resume\""));
         assert!(text.contains("\"bulk_timeout_secs\":3600"));
+    }
+
+    /// Run identity must stay unique inside one process even when the
+    /// one-second timestamp component cannot distinguish two runs. The
+    /// generation catalog keys managed documents on `run_id`, so a duplicate
+    /// makes a run read another run's documents back as its own generation.
+    #[test]
+    fn run_ids_minted_in_the_same_second_and_process_are_distinct() {
+        let second = "20260804T000000Z";
+        let first = run_id_in_second(second);
+        let next = run_id_in_second(second);
+        assert_ne!(first, next);
+        assert!(first.starts_with(&format!("run-{second}-")), "{first}");
     }
 
     #[test]
@@ -298,6 +311,32 @@ pub struct Journal {
     pub committed_manifest: Option<crate::sync::CommittedManifest>,
     pub pending_sync: Option<crate::sync::PendingSync>,
     pub legacy_migration_reasons: Vec<String>,
+}
+
+/// Per-process monotonic suffix for [`new_run_id`].
+///
+/// The timestamp component only has one-second resolution, so two runs started
+/// in the same second by the same process used to produce the same `run_id`.
+/// That is reachable from library consumers — `xerj brain` calls
+/// `run_index_report` more than once in one process — and a collision is not
+/// benign: the generation catalog keys managed documents on `run_id`, so the
+/// second run inherits the first run's documents as its own generation.
+static RUN_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Identity for a brand-new run: UTC second, process id, and a monotonic
+/// per-process sequence number that makes same-second runs distinct.
+fn new_run_id() -> String {
+    run_id_in_second(&chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string())
+}
+
+/// Split out of [`new_run_id`] so the same-second case is testable without
+/// depending on where a test happens to land inside a wall-clock second.
+fn run_id_in_second(second: &str) -> String {
+    format!(
+        "run-{second}-{:04x}-{:04x}",
+        std::process::id() & 0xffff,
+        RUN_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed) & 0xffff
+    )
 }
 
 pub fn default_state_dir(root: &str, url: &str, prefix: &str) -> PathBuf {
@@ -770,13 +809,7 @@ impl Journal {
             }
         }
         let is_new = run_id.is_none();
-        let run_id = run_id.unwrap_or_else(|| {
-            format!(
-                "run-{}-{:04x}",
-                chrono::Utc::now().format("%Y%m%dT%H%M%SZ"),
-                std::process::id() & 0xffff
-            )
-        });
+        let run_id = run_id.unwrap_or_else(new_run_id);
         let file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -14,12 +14,21 @@ use std::path::{Path, PathBuf};
 #[cfg(test)]
 static FILE_DONE_IO_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 #[cfg(test)]
+static SYNC_IO_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+#[cfg(test)]
 pub(crate) static FILE_DONE_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> =
     std::sync::Mutex::new(());
+#[cfg(test)]
+static SYNC_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 pub(crate) fn fail_next_file_done_io(boundary: u8) {
     FILE_DONE_IO_FAILPOINT.store(boundary, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn fail_next_sync_io(boundary: u8) {
+    SYNC_IO_FAILPOINT.store(boundary, std::sync::atomic::Ordering::SeqCst);
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -177,6 +186,19 @@ mod tests {
                 "{tail}"
             );
         }
+    #[test]
+    fn preflight_holds_the_same_exclusive_lock_through_authoritative_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix").unwrap();
+        let error = Journal::open(dir.path(), "root", "url", "prefix", 300, false)
+            .err()
+            .expect("a second opener must not pass the held preflight lock");
+        assert!(format!("{error:#}").contains("already in use"));
+
+        let journal =
+            Journal::open_after_preflight(preflight, "root", "url", "prefix", 300, false).unwrap();
+        drop(journal);
+        assert!(Journal::open(dir.path(), "root", "url", "prefix", 300, false).is_ok());
     }
 }
 
@@ -261,6 +283,11 @@ pub struct Journal {
     pub plan: Option<Plan>,
     pub embedding_identity_sha256: Option<String>,
     pub embedding_identity_resumable: Option<bool>,
+    /// Newest corpus reconciliation transaction without a durable
+    /// `sync_commit`. Its desired plan is deliberately not authoritative yet.
+    pub committed_manifest: Option<crate::sync::CommittedManifest>,
+    pub pending_sync: Option<crate::sync::PendingSync>,
+    pub legacy_migration_reasons: Vec<String>,
 }
 
 pub fn default_state_dir(root: &str, url: &str, prefix: &str) -> PathBuf {
@@ -271,15 +298,179 @@ pub fn default_state_dir(root: &str, url: &str, prefix: &str) -> PathBuf {
         .join(crate::ids::state_key(root, url, prefix))
 }
 
+fn apply_legacy_plan(
+    plan: Plan,
+    committed: &mut Option<crate::sync::CommittedManifest>,
+    migration_reasons: &mut Vec<String>,
+) -> Result<()> {
+    anyhow::ensure!(
+        committed
+            .as_ref()
+            .is_none_or(|manifest| manifest.generation == 0),
+        "legacy plan record cannot follow a committed generated manifest"
+    );
+    match crate::sync::CommittedManifest::bootstrap_legacy(plan)? {
+        crate::sync::LegacyBootstrap::Ready(manifest) => {
+            *committed = Some(*manifest);
+            migration_reasons.clear();
+        }
+        crate::sync::LegacyBootstrap::MigrationRequired { reasons } => {
+            *committed = None;
+            *migration_reasons = reasons;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn consume_io_failpoint(what: &str, boundary: u8) -> bool {
+    let failpoint = if what == "file_done" {
+        &FILE_DONE_IO_FAILPOINT
+    } else if what.starts_with("sync_") {
+        &SYNC_IO_FAILPOINT
+    } else {
+        return false;
+    };
+    failpoint
+        .compare_exchange(
+            boundary,
+            0,
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+        )
+        .is_ok()
+}
+
+type PreflightReplay = (
+    Option<Plan>,
+    Option<crate::sync::CommittedManifest>,
+    Option<crate::sync::PendingSync>,
+    Vec<String>,
+);
+
+/// Read the last durable plan without locking, repairing, truncating or
+/// appending to the journal. This is a preflight hint only: `Journal::open`
+/// remains the authority after the caller passes its fail-closed inventory
+/// gate and acquires the state lock.
+fn read_plan_for_preflight(
+    path: &Path,
+    root: &str,
+    url: &str,
+    prefix: &str,
+) -> Result<PreflightReplay> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((None, None, None, Vec::new()));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut plan = None;
+    let mut committed_manifest: Option<crate::sync::CommittedManifest> = None;
+    let mut pending_sync: Option<crate::sync::PendingSync> = None;
+    let mut legacy_migration_reasons = Vec::new();
+    let mut offset = 0u64;
+    loop {
+        let record_start = offset;
+        let mut bytes = Vec::new();
+        let read = reader.read_until(b'\n', &mut bytes)?;
+        if read == 0 {
+            break;
+        }
+        offset += read as u64;
+        if bytes.last() != Some(&b'\n') {
+            // `Journal::open` will repair this torn final record after the
+            // preflight accepts. It cannot be treated as durable here.
+            break;
+        }
+        let value: Value =
+            serde_json::from_slice(bytes.strip_suffix(b"\n").unwrap_or(bytes.as_slice()))
+                .with_context(|| {
+                    format!(
+                        "journal corruption at byte {record_start} in {}: malformed \
+                         newline-terminated record. Refusing to discard later records. Restore \
+                         the journal from a backup, or truncate it to exactly {record_start} \
+                         bytes to keep every completion recorded before the corruption. For an \
+                         isolated rebuild use a new --state-dir, new --prefix, and new --brain \
+                         when graph detection is enabled (or --no-graph); explicitly validate \
+                         and clean the shared catalog and old target",
+                        path.display()
+                    )
+                })?;
+        match value.get("kind").and_then(Value::as_str) {
+            Some("run") => {
+                let recorded_root = value.get("root").and_then(Value::as_str).unwrap_or("");
+                let recorded_url = value.get("url").and_then(Value::as_str).unwrap_or("");
+                let recorded_prefix = value.get("prefix").and_then(Value::as_str).unwrap_or("");
+                anyhow::ensure!(
+                    recorded_root == root && recorded_url == url && recorded_prefix == prefix,
+                    "journal at {} was created for root={} url={} prefix={}; current run has \
+                     root={} url={} prefix={}",
+                    path.display(),
+                    recorded_root,
+                    recorded_url,
+                    recorded_prefix,
+                    root,
+                    url,
+                    prefix
+                );
+            }
+            Some("plan") => {
+                anyhow::ensure!(
+                    pending_sync.is_none(),
+                    "legacy plan record cannot appear while a sync is pending"
+                );
+                if let Some(encoded) = value.get("plan") {
+                    let decoded: Plan = serde_json::from_value(encoded.clone())
+                        .with_context(|| format!("decode durable plan in {}", path.display()))?;
+                    plan = Some(decoded.clone());
+                    apply_legacy_plan(
+                        decoded,
+                        &mut committed_manifest,
+                        &mut legacy_migration_reasons,
+                    )?;
+                }
+            }
+            Some(kind) if crate::sync::is_sync_record_kind(kind) => {
+                crate::sync::replay_record(&value, &mut committed_manifest, &mut pending_sync)?;
+                if kind == "sync_commit" {
+                    plan = committed_manifest
+                        .as_ref()
+                        .map(|manifest| manifest.plan.clone());
+                }
+            }
+            Some(kind) if kind.starts_with("sync_") => {
+                anyhow::bail!("unknown durable sync record kind {kind}");
+            }
+            _ => {}
+        }
+    }
+    Ok((
+        plan,
+        committed_manifest,
+        pending_sync,
+        legacy_migration_reasons,
+    ))
+}
+
+pub struct JournalPreflight {
+    state_dir: PathBuf,
+    state_lock: std::fs::File,
+    pub plan: Option<Plan>,
+    pub committed_manifest: Option<crate::sync::CommittedManifest>,
+    pub pending_sync: Option<crate::sync::PendingSync>,
+    pub legacy_migration_reasons: Vec<String>,
+    pub journal_exists: bool,
+}
+
 impl Journal {
-    pub fn open(
+    pub fn preflight(
         state_dir: &Path,
         root: &str,
         url: &str,
         prefix: &str,
-        bulk_timeout_secs: u64,
-        fresh: bool,
-    ) -> Result<Journal> {
+    ) -> Result<JournalPreflight> {
         std::fs::create_dir_all(state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
         let lock_path = state_dir.join(".autoindex.lock");
@@ -296,10 +487,50 @@ impl Journal {
                 state_dir.display()
             )
         })?;
+        let journal_path = state_dir.join("journal.ndjson");
+        let journal_exists = journal_path.exists();
+        let (plan, committed_manifest, pending_sync, legacy_migration_reasons) =
+            read_plan_for_preflight(&journal_path, root, url, prefix)?;
+        Ok(JournalPreflight {
+            state_dir: state_dir.to_owned(),
+            state_lock,
+            plan,
+            committed_manifest,
+            pending_sync,
+            legacy_migration_reasons,
+            journal_exists,
+        })
+    }
+
+    pub fn open(
+        state_dir: &Path,
+        root: &str,
+        url: &str,
+        prefix: &str,
+        bulk_timeout_secs: u64,
+        fresh: bool,
+    ) -> Result<Journal> {
+        let preflight = Self::preflight(state_dir, root, url, prefix)?;
+        Self::open_after_preflight(preflight, root, url, prefix, bulk_timeout_secs, fresh)
+    }
+
+    pub fn open_after_preflight(
+        preflight: JournalPreflight,
+        root: &str,
+        url: &str,
+        prefix: &str,
+        bulk_timeout_secs: u64,
+        fresh: bool,
+    ) -> Result<Journal> {
+        let JournalPreflight {
+            state_dir,
+            state_lock,
+            ..
+        } = preflight;
         // Hard kills cannot run NamedTempFile::drop. Stages are owned by this
         // journal directory and use a reserved prefix, so removing only
         // regular files with that prefix is deterministic and scope-safe.
-        for entry in std::fs::read_dir(state_dir)? {
+        for entry in std::fs::read_dir(&state_dir)? {
             let entry = entry?;
             if entry
                 .file_name()
@@ -321,6 +552,9 @@ impl Journal {
         let mut plan = None;
         let mut embedding_identity_sha256 = None;
         let mut embedding_identity_resumable = None;
+        let mut committed_manifest: Option<crate::sync::CommittedManifest> = None;
+        let mut pending_sync: Option<crate::sync::PendingSync> = None;
+        let mut legacy_migration_reasons = Vec::new();
         let mut run_id = None;
         let mut resumed = false;
         if jpath.exists() {
@@ -352,7 +586,10 @@ impl Journal {
                                     anyhow::bail!(
                                 "journal at {} was created for root={jr} url={ju} prefix={jp}; \
                                  current run has root={root} url={url} prefix={prefix}. \
-                                 Use --fresh to discard it or --state-dir for a separate state.",
+                                 Refusing to discard history under the same destination. For an \
+                                 isolated rebuild use a new --state-dir, new --prefix, and new \
+                                 --brain when graph detection is enabled (or --no-graph); \
+                                 explicitly validate and clean the shared catalog and old target.",
                                 jpath.display()
                             );
                                 }
@@ -365,10 +602,32 @@ impl Journal {
                                 resumed = true;
                             }
                             Some("plan") => {
+                                anyhow::ensure!(
+                                    pending_sync.is_none(),
+                                    "legacy plan record at byte {record_start} cannot appear while \
+                                     a sync is pending"
+                                );
                                 if let Some(p) = v.get("plan") {
-                                    if let Ok(p) = serde_json::from_value::<Plan>(p.clone()) {
-                                        plan = Some(p);
-                                    }
+                                    let decoded: Plan = serde_json::from_value(p.clone())
+                                        .with_context(|| {
+                                            format!(
+                                                "decode durable plan record at byte {record_start} \
+                                                 in {}",
+                                                jpath.display()
+                                            )
+                                        })?;
+                                    plan = Some(decoded.clone());
+                                    apply_legacy_plan(
+                                        decoded,
+                                        &mut committed_manifest,
+                                        &mut legacy_migration_reasons,
+                                    )?;
+                                } else {
+                                    anyhow::bail!(
+                                        "durable plan record at byte {record_start} in {} has no \
+                                         plan payload",
+                                        jpath.display()
+                                    );
                                 }
                             }
                             Some("embedding_identity") => {
@@ -413,6 +672,25 @@ impl Journal {
                                 }
                                 embedding_identity_sha256 = digest.map(str::to_owned);
                                 embedding_identity_resumable = resumable;
+                            }
+                            Some(kind) if crate::sync::is_sync_record_kind(kind) => {
+                                crate::sync::replay_record(
+                                    &v,
+                                    &mut committed_manifest,
+                                    &mut pending_sync,
+                                )?;
+                                if kind == "sync_commit" {
+                                    plan = committed_manifest
+                                        .as_ref()
+                                        .map(|manifest| manifest.plan.clone());
+                                }
+                            }
+                            Some(kind) if kind.starts_with("sync_") => {
+                                anyhow::bail!(
+                                    "unknown durable sync record kind {kind} at byte \
+                                     {record_start} in {}",
+                                    jpath.display()
+                                );
                             }
                             Some("file_done") => {
                                 if let Ok(fd) = serde_json::from_value::<FileDone>(v.clone()) {
@@ -461,9 +739,10 @@ impl Journal {
                              after corruption. Restore the journal from a backup, or truncate it \
                              to exactly {record_start} bytes to keep every completion recorded \
                              before the corruption (files journaled after that point are \
-                             re-verified, re-indexed and re-embedded on the next run). Deleting \
-                             the whole journal (or rerunning with --fresh) also recovers, but \
-                             re-extracts and re-embeds the entire corpus",
+                             re-verified, re-indexed and re-embedded on the next run). For an \
+                             isolated rebuild use a new --state-dir, new --prefix, and new --brain \
+                             when graph detection is enabled (or --no-graph); explicitly validate \
+                             and clean the shared catalog and old target",
                             jpath.display()
                         );
                     }
@@ -493,6 +772,9 @@ impl Journal {
             plan,
             embedding_identity_sha256,
             embedding_identity_resumable,
+            committed_manifest,
+            pending_sync,
+            legacy_migration_reasons,
         };
         if is_new {
             j.append_transaction(
@@ -575,28 +857,11 @@ impl Journal {
         line.push('\n');
         let start = self.file.metadata()?.len();
         #[cfg(test)]
-        if what == "file_done"
-            && FILE_DONE_IO_FAILPOINT
-                .compare_exchange(
-                    1,
-                    0,
-                    std::sync::atomic::Ordering::SeqCst,
-                    std::sync::atomic::Ordering::SeqCst,
-                )
-                .is_ok()
-        {
-            anyhow::bail!("injected file_done append failure before any bytes");
+        if consume_io_failpoint(what, 1) {
+            anyhow::bail!("injected {what} append failure before any bytes");
         }
         #[cfg(test)]
-        let partial_write = what == "file_done"
-            && FILE_DONE_IO_FAILPOINT
-                .compare_exchange(
-                    3,
-                    0,
-                    std::sync::atomic::Ordering::SeqCst,
-                    std::sync::atomic::Ordering::SeqCst,
-                )
-                .is_ok();
+        let partial_write = consume_io_failpoint(what, 3);
         #[cfg(not(test))]
         let partial_write = false;
         let write_result = if partial_write {
@@ -605,7 +870,7 @@ impl Journal {
                 .write_all(&line.as_bytes()[..written])
                 .and_then(|_| {
                     Err(std::io::Error::other(format!(
-                        "injected partial file_done write after {written} bytes"
+                        "injected partial {what} write after {written} bytes"
                     )))
                 })
         } else {
@@ -615,19 +880,13 @@ impl Journal {
             return self.rollback_transaction(start, what, "append", error);
         }
         #[cfg(test)]
-        let injected_sync_failure = what == "file_done"
-            && FILE_DONE_IO_FAILPOINT
-                .compare_exchange(
-                    2,
-                    0,
-                    std::sync::atomic::Ordering::SeqCst,
-                    std::sync::atomic::Ordering::SeqCst,
-                )
-                .is_ok();
+        let injected_sync_failure = consume_io_failpoint(what, 2);
         #[cfg(not(test))]
         let injected_sync_failure = false;
         let sync_result = if injected_sync_failure {
-            Err(std::io::Error::other("injected file_done fsync failure"))
+            Err(std::io::Error::other(format!(
+                "injected {what} fsync failure"
+            )))
         } else {
             self.file.sync_data()
         };
@@ -658,8 +917,134 @@ impl Journal {
     }
 
     pub fn write_plan(&mut self, plan: &Plan) -> Result<()> {
+        anyhow::ensure!(
+            self.pending_sync.is_none(),
+            "legacy plan write cannot occur while a sync is pending"
+        );
+        anyhow::ensure!(
+            self.committed_manifest
+                .as_ref()
+                .is_none_or(|manifest| manifest.generation == 0),
+            "legacy plan write cannot follow a committed generated manifest"
+        );
+        let mut committed = self.committed_manifest.clone();
+        let mut migration_reasons = self.legacy_migration_reasons.clone();
+        apply_legacy_plan(plan.clone(), &mut committed, &mut migration_reasons)?;
         self.append_transaction(&serde_json::json!({"kind": "plan", "plan": plan}), "plan")?;
         self.plan = Some(plan.clone());
+        self.committed_manifest = committed;
+        self.legacy_migration_reasons = migration_reasons;
+        Ok(())
+    }
+
+    pub fn sync_begin(&mut self, sync: &crate::sync::PendingSync) -> Result<()> {
+        anyhow::ensure!(
+            self.pending_sync.is_none(),
+            "cannot begin sync {} while {} is still pending",
+            sync.tx_id,
+            self.pending_sync
+                .as_ref()
+                .map(|pending| pending.tx_id.as_str())
+                .unwrap_or("another sync")
+        );
+        let committed = self
+            .committed_manifest
+            .as_ref()
+            .context("cannot begin sync before a committed plan exists")?;
+        let mut pending = None;
+        crate::sync::apply_begin(committed, &mut pending, sync.clone())?;
+        let mut value = serde_json::to_value(sync)?;
+        value["kind"] = Value::String("sync_begin".into());
+        self.append_transaction(&value, "sync_begin")?;
+        self.pending_sync = pending;
+        Ok(())
+    }
+
+    pub fn sync_operation_state(
+        &mut self,
+        operation_id: &str,
+        state: crate::sync::SyncOperationState,
+    ) -> Result<()> {
+        let pending = self
+            .pending_sync
+            .as_ref()
+            .context("cannot record operation state without sync_begin")?;
+        let tx_id = pending.tx_id.clone();
+        let mut candidate = pending.clone();
+        candidate.apply_operation_state(&tx_id, operation_id, state.clone())?;
+        self.append_transaction(
+            &serde_json::json!({
+                "kind": "sync_operation_state",
+                "tx_id": tx_id,
+                "operation_id": operation_id,
+                "state": state,
+            }),
+            "sync_operation_state",
+        )?;
+        self.pending_sync = Some(candidate);
+        Ok(())
+    }
+
+    pub fn sync_validated(&mut self) -> Result<()> {
+        let pending = self
+            .pending_sync
+            .as_ref()
+            .context("cannot validate sync without sync_begin")?;
+        let tx_id = pending.tx_id.clone();
+        let digest = pending.desired_manifest_digest.clone();
+        let mut candidate = pending.clone();
+        candidate.apply_validated(&tx_id, &digest)?;
+        self.append_transaction(
+            &serde_json::json!({
+                "kind": "sync_validated",
+                "tx_id": tx_id,
+                "desired_manifest_digest": digest,
+            }),
+            "sync_validated",
+        )?;
+        self.pending_sync = Some(candidate);
+        Ok(())
+    }
+
+    pub fn sync_commit(&mut self) -> Result<()> {
+        let pending = self
+            .pending_sync
+            .as_ref()
+            .context("cannot commit sync without sync_begin")?;
+        let tx_id = pending.tx_id.clone();
+        let digest = pending.desired_manifest_digest.clone();
+        let committed = pending.clone().apply_commit(&tx_id, &digest)?;
+        self.append_transaction(
+            &serde_json::json!({
+                "kind": "sync_commit",
+                "tx_id": tx_id,
+                "desired_manifest_digest": digest,
+            }),
+            "sync_commit",
+        )?;
+        self.pending_sync = None;
+        self.plan = Some(committed.plan.clone());
+        self.committed_manifest = Some(committed);
+        Ok(())
+    }
+
+    pub fn sync_abort(&mut self, reason: &str) -> Result<()> {
+        let pending = self
+            .pending_sync
+            .as_ref()
+            .context("cannot abort without pending sync")?;
+        let tx_id = pending.tx_id.clone();
+        let digest = pending.desired_manifest_digest.clone();
+        self.append_transaction(
+            &serde_json::json!({
+                "kind": "sync_abort",
+                "tx_id": tx_id,
+                "desired_manifest_digest": digest,
+                "reason": reason,
+            }),
+            "sync_abort",
+        )?;
+        self.pending_sync = None;
         Ok(())
     }
 
@@ -714,6 +1099,401 @@ impl Journal {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+}
+
+#[cfg(test)]
+mod sync_journal_tests {
+    use super::*;
+    use crate::sync::{
+        ExecutionIdentity, GenerationManifest, ManifestGroup, ManifestPath, PendingSync,
+        SourceExecutionPolicy, SyncOperationState, EXECUTION_IDENTITY_VERSION,
+    };
+
+    fn journal_with_plan(dir: &Path) -> Journal {
+        let mut journal = Journal::open(dir, "root", "url", "prefix", 300, false).unwrap();
+        let mut plan = Plan::default();
+        plan.datasets.push(PlanDataset {
+            slug: "reports".into(),
+            index: "prefix-reports".into(),
+            family: "pdf".into(),
+            group: None,
+            specs: Vec::new(),
+            time_field: None,
+            semantic_field: None,
+            sampled_records: 1,
+            file_count: 0,
+        });
+        journal.write_plan(&plan).unwrap();
+        journal
+    }
+
+    fn pending(journal: &Journal) -> PendingSync {
+        let base = journal.committed_manifest.as_ref().unwrap();
+        let mut plan = base.plan.clone();
+        plan.datasets[0].file_count = 1;
+        plan.files.insert(
+            "content-a".into(),
+            FileAssignment {
+                rel: "a.pdf".into(),
+                path_id: "unix:61".into(),
+                family: "pdf".into(),
+                gzip: false,
+                content_digest: Some("digest-a".into()),
+                assignments: vec![(None, "reports".into())],
+            },
+        );
+        PendingSync::new(
+            "sync-1".into(),
+            base,
+            GenerationManifest {
+                generation: base.generation + 1,
+                execution: Some(ExecutionIdentity {
+                    version: EXECUTION_IDENTITY_VERSION,
+                    root_identity: "unix:root".into(),
+                    url: "url".into(),
+                    prefix: "prefix".into(),
+                    follow_symlinks: false,
+                    chunker_identity: "chunker-v1".into(),
+                    embedding_backend: "lexical".into(),
+                    embedding_model: "feature-hash".into(),
+                    embedding_tokenizer: "builtin".into(),
+                    embedding_dimension: 384,
+                    graph_enabled: false,
+                    brain: "none".into(),
+                    detector_identity: "detectors-v1".into(),
+                    schema_identity: "schema-v1".into(),
+                    index_identity: "index-v1".into(),
+                    source_policy: SourceExecutionPolicy::AbortOnSourceChange {
+                        inventory_digest: "inventory-v1".into(),
+                    },
+                }),
+                plan,
+                groups: vec![ManifestGroup {
+                    group_id: "group-a".into(),
+                    content_id: "content-a".into(),
+                    content_digest: "digest-a".into(),
+                    content_size: 10,
+                    canonical: ManifestPath {
+                        path_id: "unix:61".into(),
+                        rel: "a.pdf".into(),
+                        is_symlink: false,
+                    },
+                    aliases: Vec::new(),
+                    dataset_slugs: vec!["reports".into()],
+                    expected_records: 1,
+                    expected_passages: 1,
+                    expected_vectors: 1,
+                }],
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn sync_begin_is_pending_and_never_promotes_the_committed_manifest() {
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal_with_plan(dir.path());
+        let desired = pending(&journal);
+        journal.sync_begin(&desired).unwrap();
+        let before = std::fs::read(dir.path().join("journal.ndjson")).unwrap();
+        assert!(journal.write_plan(&Plan::default()).is_err());
+        assert_eq!(
+            std::fs::read(dir.path().join("journal.ndjson")).unwrap(),
+            before
+        );
+        assert_eq!(journal.committed_manifest.as_ref().unwrap().generation, 0);
+        assert!(!journal.plan.as_ref().unwrap().alias_paths_indexed);
+        drop(journal);
+
+        let reopened = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 0);
+        assert!(!reopened.plan.as_ref().unwrap().alias_paths_indexed);
+        assert_eq!(reopened.pending_sync.as_ref().unwrap().tx_id, "sync-1");
+    }
+
+    #[test]
+    fn replay_rejects_sync_begin_followed_by_legacy_plan_without_changing_authority() {
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal_with_plan(dir.path());
+        journal.sync_begin(&pending(&journal)).unwrap();
+        let committed_digest = journal
+            .committed_manifest
+            .as_ref()
+            .unwrap()
+            .manifest_digest
+            .clone();
+        drop(journal);
+        let path = dir.path().join("journal.ndjson");
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(
+            format!(
+                "{}\n",
+                serde_json::json!({"kind": "plan", "plan": Plan::default()})
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+        file.sync_data().unwrap();
+        drop(file);
+        let error = Journal::open(dir.path(), "root", "url", "prefix", 300, false)
+            .err()
+            .unwrap();
+        assert!(format!("{error:#}").contains("while a sync is pending"));
+        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix")
+            .err()
+            .unwrap();
+        assert!(format!("{preflight:#}").contains("while a sync is pending"));
+        // The rejected record cannot manufacture a sync_commit; the durable
+        // committed digest remains present only in the earlier sync_begin base.
+        let text = std::fs::read_to_string(dir.path().join("journal.ndjson")).unwrap();
+        assert!(text.contains(&committed_digest));
+        assert!(!text.contains("\"kind\":\"sync_commit\""));
+    }
+
+    #[test]
+    fn only_validated_all_committed_sync_advances_authority_after_restart() {
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal_with_plan(dir.path());
+        journal.sync_begin(&pending(&journal)).unwrap();
+        assert!(journal.sync_validated().is_err());
+        assert!(journal
+            .sync_operation_state("upsert:group-a", SyncOperationState::Committed)
+            .is_err());
+        journal
+            .sync_operation_state("upsert:group-a", SyncOperationState::Started)
+            .unwrap();
+        journal
+            .sync_operation_state("upsert:group-a", SyncOperationState::Committed)
+            .unwrap();
+        journal.sync_validated().unwrap();
+        journal.sync_commit().unwrap();
+        assert_eq!(journal.committed_manifest.as_ref().unwrap().generation, 1);
+        assert!(journal
+            .plan
+            .as_ref()
+            .unwrap()
+            .files
+            .contains_key("content-a"));
+        assert!(journal.pending_sync.is_none());
+        let before = std::fs::read(dir.path().join("journal.ndjson")).unwrap();
+        assert!(journal.write_plan(&Plan::default()).is_err());
+        assert_eq!(
+            std::fs::read(dir.path().join("journal.ndjson")).unwrap(),
+            before
+        );
+        drop(journal);
+
+        let reopened = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 1);
+        assert!(reopened
+            .plan
+            .as_ref()
+            .unwrap()
+            .files
+            .contains_key("content-a"));
+        assert!(reopened.pending_sync.is_none());
+    }
+
+    #[test]
+    fn digest_bound_abort_discards_pending_without_advancing_authority() {
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal_with_plan(dir.path());
+        journal.sync_begin(&pending(&journal)).unwrap();
+        journal.sync_abort("source changed").unwrap();
+        assert!(journal.pending_sync.is_none());
+        assert_eq!(journal.committed_manifest.as_ref().unwrap().generation, 0);
+        drop(journal);
+        let reopened = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        assert!(reopened.pending_sync.is_none());
+        assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 0);
+    }
+
+    #[test]
+    fn unknown_sync_namespace_record_fails_closed_but_preflight_exposes_pending() {
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal_with_plan(dir.path());
+        journal.sync_begin(&pending(&journal)).unwrap();
+        drop(journal);
+        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix").unwrap();
+        assert_eq!(preflight.committed_manifest.as_ref().unwrap().generation, 0);
+        assert_eq!(preflight.pending_sync.as_ref().unwrap().tx_id, "sync-1");
+        drop(preflight);
+
+        let path = dir.path().join("journal.ndjson");
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(b"{\"kind\":\"sync_future_v99\"}\n").unwrap();
+        file.sync_data().unwrap();
+        drop(file);
+        assert!(Journal::open(dir.path(), "root", "url", "prefix", 300, false).is_err());
+    }
+
+    #[test]
+    fn out_of_order_or_malformed_known_sync_records_fail_closed() {
+        for record in [
+            "{\"kind\":\"sync_commit\",\"tx_id\":\"none\",\"desired_manifest_digest\":\"none\"}\n",
+            "{\"kind\":\"sync_begin\"}\n",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            drop(journal_with_plan(dir.path()));
+            let path = dir.path().join("journal.ndjson");
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            file.write_all(record.as_bytes()).unwrap();
+            file.sync_data().unwrap();
+            let error = Journal::open(dir.path(), "root", "url", "prefix", 300, false)
+                .err()
+                .unwrap();
+            let message = format!("{error:#}");
+            assert!(
+                message.contains("pending sync") || message.contains("sync_begin"),
+                "{message}"
+            );
+        }
+    }
+
+    #[test]
+    fn torn_sync_tail_is_removed_without_creating_a_pending_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        drop(journal_with_plan(dir.path()));
+        let path = dir.path().join("journal.ndjson");
+        let durable_len = std::fs::metadata(&path).unwrap().len();
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(br#"{"kind":"sync_begin","tx_id":"torn""#)
+            .unwrap();
+        file.sync_data().unwrap();
+        drop(file);
+
+        let reopened = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        assert!(reopened.pending_sync.is_none());
+        assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 0);
+        // Reopen appends one resume record, but the torn bytes are absent.
+        let contents = std::fs::read_to_string(path).unwrap();
+        assert!(!contents.contains("\"tx_id\":\"torn\""));
+        assert!(contents.len() as u64 > durable_len);
+    }
+
+    #[test]
+    fn complete_middle_corruption_is_not_truncated_or_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        drop(journal_with_plan(dir.path()));
+        let path = dir.path().join("journal.ndjson");
+        let before = std::fs::metadata(&path).unwrap().len();
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(b"{malformed sync record}\n").unwrap();
+        file.write_all(b"{\"kind\":\"unknown-after-corruption\"}\n")
+            .unwrap();
+        file.sync_data().unwrap();
+        drop(file);
+        assert!(Journal::open(dir.path(), "root", "url", "prefix", 300, false).is_err());
+        assert!(std::fs::metadata(path).unwrap().len() > before);
+    }
+
+    #[test]
+    fn unknown_future_records_do_not_change_legacy_completion_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal_with_plan(dir.path());
+        journal
+            .file_done(&FileDone {
+                file_key: "legacy".into(),
+                path: "legacy.pdf".into(),
+                records: 1,
+                junk: 0,
+                bytes: 10,
+                generation: None,
+            })
+            .unwrap();
+        drop(journal);
+        let path = dir.path().join("journal.ndjson");
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(b"{\"kind\":\"extension_future_v99\",\"payload\":{\"x\":1}}\n")
+            .unwrap();
+        file.sync_data().unwrap();
+        drop(file);
+
+        let reopened = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        assert!(reopened.done.contains_key("legacy"));
+        assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 0);
+    }
+
+    #[test]
+    fn sync_append_and_fsync_failures_roll_back_without_phantom_pending_state() {
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        for boundary in [1, 2, 3] {
+            let dir = tempfile::tempdir().unwrap();
+            let mut journal = journal_with_plan(dir.path());
+            let desired = pending(&journal);
+            let before = std::fs::read(dir.path().join("journal.ndjson")).unwrap();
+            fail_next_sync_io(boundary);
+            assert!(journal.sync_begin(&desired).is_err());
+            assert!(journal.pending_sync.is_none());
+            drop(journal);
+            assert_eq!(
+                std::fs::read(dir.path().join("journal.ndjson")).unwrap(),
+                before
+            );
+            let reopened = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+            assert!(reopened.pending_sync.is_none());
+            assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 0);
+        }
+    }
+
+    #[test]
+    fn every_later_sync_record_rolls_back_append_partial_and_fsync_failures() {
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        for stage in ["operation", "validated", "commit", "abort"] {
+            for boundary in [1, 2, 3] {
+                let dir = tempfile::tempdir().unwrap();
+                let mut journal = journal_with_plan(dir.path());
+                journal.sync_begin(&pending(&journal)).unwrap();
+                if stage != "operation" {
+                    journal
+                        .sync_operation_state("upsert:group-a", SyncOperationState::Started)
+                        .unwrap();
+                    journal
+                        .sync_operation_state("upsert:group-a", SyncOperationState::Committed)
+                        .unwrap();
+                }
+                if matches!(stage, "commit") {
+                    journal.sync_validated().unwrap();
+                }
+                let before = std::fs::read(dir.path().join("journal.ndjson")).unwrap();
+                fail_next_sync_io(boundary);
+                let result = match stage {
+                    "operation" => {
+                        journal.sync_operation_state("upsert:group-a", SyncOperationState::Started)
+                    }
+                    "validated" => journal.sync_validated(),
+                    "commit" => journal.sync_commit(),
+                    "abort" => journal.sync_abort("test abort"),
+                    _ => unreachable!(),
+                };
+                assert!(result.is_err(), "{stage} boundary {boundary}");
+                assert_eq!(
+                    std::fs::read(dir.path().join("journal.ndjson")).unwrap(),
+                    before,
+                    "{stage} boundary {boundary}"
+                );
+                drop(journal);
+                let reopened =
+                    Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+                assert_eq!(reopened.committed_manifest.as_ref().unwrap().generation, 0);
+                assert!(reopened.pending_sync.is_some());
+            }
+        }
     }
 }
 
@@ -891,9 +1671,10 @@ mod compatibility_tests {
         let message = format!("{error:#}");
         assert!(message.contains("journal corruption"));
         // Recovery guidance must stay scoped and honest: byte-exact truncation
-        // keeps prior completions; discarding the journal re-embeds everything.
+        // keeps prior completions; an exact rebuild needs isolated state and
+        // destination identities.
         assert!(message.contains("truncate it to exactly"));
-        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
+        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -19,7 +19,7 @@ static SYNC_IO_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::Atomi
 pub(crate) static FILE_DONE_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> =
     std::sync::Mutex::new(());
 #[cfg(test)]
-static SYNC_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) static SYNC_IO_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 pub(crate) fn fail_next_file_done_io(boundary: u8) {
@@ -208,6 +208,9 @@ pub struct FileAssignment {
     /// Reversible path identity used for deterministic resume matching.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub path_id: String,
+    /// Canonical path rank input. `None` identifies a legacy plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_symlink: Option<bool>,
     pub family: String,
     pub gzip: bool,
     /// Full-content digest used to validate durable identity across resumes.
@@ -235,6 +238,10 @@ pub struct DuplicateFile {
     pub rel: String,
     #[serde(default)]
     pub path_id: String,
+    /// Whether this alias was reached through a followed symlink. `None`
+    /// identifies legacy plans which cannot prove canonical rank.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_symlink: Option<bool>,
     /// Root-relative canonical path whose records represent this content.
     pub duplicate_of: String,
     pub bytes: u64,
@@ -1137,6 +1144,7 @@ mod sync_journal_tests {
             FileAssignment {
                 rel: "a.pdf".into(),
                 path_id: "unix:61".into(),
+                is_symlink: Some(false),
                 family: "pdf".into(),
                 gzip: false,
                 content_digest: Some("digest-a".into()),

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -79,6 +79,98 @@ mod tests {
         assert!(text.contains("\"kind\":\"resume\""));
         assert!(text.contains("\"bulk_timeout_secs\":900"));
     }
+
+    #[test]
+    fn semantic_identity_is_durable_and_drift_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut first = Journal::open(dir.path(), "root", "url", "prefix", 300, true).unwrap();
+        first
+            .pin_embedding_identity(&"a".repeat(64), true, None)
+            .unwrap();
+        drop(first);
+
+        let mut resumed = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        resumed
+            .pin_embedding_identity(&"a".repeat(64), true, None)
+            .unwrap();
+        let error = resumed
+            .pin_embedding_identity(&"b".repeat(64), true, None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("refusing to mix vector spaces"), "{error}");
+        assert!(error.contains("--fresh"), "{error}");
+    }
+
+    #[test]
+    fn unpinned_backend_allows_fresh_run_but_not_resume() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = Journal::open(dir.path(), "root", "url", "prefix", 300, true).unwrap();
+        journal
+            .pin_embedding_identity(&"a".repeat(64), false, Some("remote alias can drift"))
+            .unwrap();
+        drop(journal);
+        let mut resumed = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        let error = resumed
+            .pin_embedding_identity(&"a".repeat(64), false, Some("remote alias can drift"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("remote alias can drift"), "{error}");
+        assert!(error.contains("--fresh"), "{error}");
+    }
+
+    #[test]
+    fn completed_legacy_semantic_journal_requires_fresh_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("journal.ndjson"),
+            concat!(
+                "{\"v\":1,\"kind\":\"run\",\"root\":\"root\",\"url\":\"url\",",
+                "\"prefix\":\"prefix\",\"run_id\":\"legacy\"}\n",
+                "{\"kind\":\"file_done\",\"file_key\":\"f\",\"path\":\"report.txt\",",
+                "\"records\":1,\"junk\":0,\"bytes\":10}\n"
+            ),
+        )
+        .unwrap();
+        let mut journal = Journal::open(dir.path(), "root", "url", "prefix", 300, false).unwrap();
+        let error = journal
+            .pin_embedding_identity(&"a".repeat(64), true, None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("predates embedding identity pinning"),
+            "{error}"
+        );
+        assert!(error.contains("--fresh"), "{error}");
+    }
+
+    #[test]
+    fn malformed_or_conflicting_identity_records_fail_during_replay() {
+        for tail in [
+            "{\"v\":1,\"kind\":\"embedding_identity\",\"identity_sha256\":\"bad\",\"resumable\":true}\n",
+            concat!(
+                "{\"v\":1,\"kind\":\"embedding_identity\",\"identity_sha256\":\"",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "\",\"resumable\":true}\n",
+                "{\"v\":1,\"kind\":\"embedding_identity\",\"identity_sha256\":\"",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "\",\"resumable\":true}\n"
+            ),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(
+                dir.path().join("journal.ndjson"),
+                format!(
+                    "{{\"v\":1,\"kind\":\"run\",\"root\":\"root\",\"url\":\"url\",\
+                     \"prefix\":\"prefix\",\"run_id\":\"legacy\"}}\n{tail}"
+                ),
+            )
+            .unwrap();
+            assert!(
+                Journal::open(dir.path(), "root", "url", "prefix", 300, false).is_err(),
+                "{tail}"
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -160,6 +252,8 @@ pub struct Journal {
     /// publication can never make resume skip a zero/partial generation.
     pub pending_replacements: HashMap<String, String>,
     pub plan: Option<Plan>,
+    pub embedding_identity_sha256: Option<String>,
+    pub embedding_identity_resumable: Option<bool>,
 }
 
 pub fn default_state_dir(root: &str, url: &str, prefix: &str) -> PathBuf {
@@ -218,6 +312,8 @@ impl Journal {
         let mut done = HashMap::new();
         let mut pending_replacements: HashMap<String, String> = HashMap::new();
         let mut plan = None;
+        let mut embedding_identity_sha256 = None;
+        let mut embedding_identity_resumable = None;
         let mut run_id = None;
         let mut resumed = false;
         if jpath.exists() {
@@ -267,6 +363,49 @@ impl Journal {
                                         plan = Some(p);
                                     }
                                 }
+                            }
+                            Some("embedding_identity") => {
+                                let digest = v
+                                    .get("identity_sha256")
+                                    .and_then(Value::as_str)
+                                    .filter(|digest| {
+                                        digest.len() == 64
+                                            && digest.bytes().all(|byte| {
+                                                byte.is_ascii_hexdigit()
+                                                    && !byte.is_ascii_uppercase()
+                                            })
+                                    });
+                                let resumable = v.get("resumable").and_then(Value::as_bool);
+                                if v.get("v").and_then(Value::as_u64) != Some(1)
+                                    || digest.is_none()
+                                    || resumable.is_none()
+                                    || v.as_object().is_none_or(|object| {
+                                        object.len() != 4
+                                            || !["v", "kind", "identity_sha256", "resumable"]
+                                                .iter()
+                                                .all(|key| object.contains_key(*key))
+                                    })
+                                {
+                                    anyhow::bail!(
+                                        "journal at {} contains a malformed embedding identity; \
+                                         restore it from backup or re-run with --fresh",
+                                        jpath.display()
+                                    );
+                                }
+                                if embedding_identity_sha256
+                                    .as_deref()
+                                    .is_some_and(|existing| existing != digest.unwrap())
+                                    || embedding_identity_resumable
+                                        .is_some_and(|existing| existing != resumable.unwrap())
+                                {
+                                    anyhow::bail!(
+                                        "journal at {} contains conflicting embedding identities; \
+                                         restore it from backup or re-run with --fresh",
+                                        jpath.display()
+                                    );
+                                }
+                                embedding_identity_sha256 = digest.map(str::to_owned);
+                                embedding_identity_resumable = resumable;
                             }
                             Some("file_done") => {
                                 if let Ok(fd) = serde_json::from_value::<FileDone>(v.clone()) {
@@ -345,6 +484,8 @@ impl Journal {
             done,
             pending_replacements,
             plan,
+            embedding_identity_sha256,
+            embedding_identity_resumable,
         };
         if is_new {
             j.append_transaction(
@@ -365,6 +506,57 @@ impl Journal {
             )?;
         }
         Ok(j)
+    }
+
+    /// Pin the server-side vector-space identity before any semantic write.
+    pub fn pin_embedding_identity(
+        &mut self,
+        identity_sha256: &str,
+        resumable: bool,
+        non_resumable_reason: Option<&str>,
+    ) -> Result<()> {
+        if identity_sha256.len() != 64
+            || !identity_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            anyhow::bail!("server returned an invalid embedding identity digest");
+        }
+        if self.resumed && (!resumable || self.embedding_identity_resumable == Some(false)) {
+            anyhow::bail!(
+                "server embedding backend cannot safely resume semantic indexing: {}. \
+                 Re-run with --fresh after selecting a content-addressed backend",
+                non_resumable_reason.unwrap_or("embedding identity is not immutable")
+            );
+        }
+        if let Some(existing) = &self.embedding_identity_sha256 {
+            if existing != identity_sha256 {
+                anyhow::bail!(
+                    "embedding execution identity changed since this autoindex journal was \
+                     created; refusing to mix vector spaces. Restore the original embedding \
+                     backend or re-run with --fresh"
+                );
+            }
+            return Ok(());
+        }
+        if self.resumed && !self.done.is_empty() {
+            anyhow::bail!(
+                "this semantic autoindex journal predates embedding identity pinning and cannot \
+                 be resumed safely. Re-run with --fresh to rebuild its vectors"
+            );
+        }
+        self.append_transaction(
+            &serde_json::json!({
+                "v": 1,
+                "kind": "embedding_identity",
+                "identity_sha256": identity_sha256,
+                "resumable": resumable,
+            }),
+            "embedding_identity",
+        )?;
+        self.embedding_identity_sha256 = Some(identity_sha256.to_owned());
+        self.embedding_identity_resumable = Some(resumable);
+        Ok(())
     }
 
     fn append_transaction(&mut self, v: &Value, what: &str) -> Result<()> {

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -98,7 +98,10 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("refusing to mix vector spaces"), "{error}");
+        assert!(error.contains("Restore the original"), "{error}");
         assert!(error.contains("--fresh"), "{error}");
+        assert!(error.contains("--prefix"), "{error}");
+        assert!(error.contains("delete and recreate"), "{error}");
     }
 
     #[test]
@@ -116,6 +119,8 @@ mod tests {
             .to_string();
         assert!(error.contains("remote alias can drift"), "{error}");
         assert!(error.contains("--fresh"), "{error}");
+        assert!(error.contains("--prefix"), "{error}");
+        assert!(error.contains("delete and recreate"), "{error}");
     }
 
     #[test]
@@ -141,6 +146,8 @@ mod tests {
             "{error}"
         );
         assert!(error.contains("--fresh"), "{error}");
+        assert!(error.contains("--prefix"), "{error}");
+        assert!(error.contains("delete and recreate"), "{error}");
     }
 
     #[test]
@@ -525,7 +532,9 @@ impl Journal {
         if self.resumed && (!resumable || self.embedding_identity_resumable == Some(false)) {
             anyhow::bail!(
                 "server embedding backend cannot safely resume semantic indexing: {}. \
-                 Re-run with --fresh after selecting a content-addressed backend",
+                 Restore the exact original embedding identity, or rebuild all vectors with \
+                 --fresh and a new --prefix. Before reusing the old prefix, delete and recreate \
+                 its prior autoindex indices",
                 non_resumable_reason.unwrap_or("embedding identity is not immutable")
             );
         }
@@ -534,7 +543,8 @@ impl Journal {
                 anyhow::bail!(
                     "embedding execution identity changed since this autoindex journal was \
                      created; refusing to mix vector spaces. Restore the original embedding \
-                     backend or re-run with --fresh"
+                     identity, or rebuild all vectors with --fresh and a new --prefix. Before \
+                     reusing the old prefix, delete and recreate its prior autoindex indices"
                 );
             }
             return Ok(());
@@ -542,7 +552,8 @@ impl Journal {
         if self.resumed && !self.done.is_empty() {
             anyhow::bail!(
                 "this semantic autoindex journal predates embedding identity pinning and cannot \
-                 be resumed safely. Re-run with --fresh to rebuild its vectors"
+                 be resumed safely. Rebuild all vectors with --fresh and a new --prefix. Before \
+                 reusing the old prefix, delete and recreate its prior autoindex indices"
             );
         }
         self.append_transaction(

--- a/engine/crates/xerj-autoindex/src/sync.rs
+++ b/engine/crates/xerj-autoindex/src/sync.rs
@@ -116,16 +116,27 @@ impl CommittedManifest {
                     "{file_key}: missing or lossy native canonical path identity"
                 ));
             }
-            // Legacy plans did not persist whether the canonical path was a
-            // followed symlink, so canonical rank cannot be reconstructed.
+            if file.is_symlink.is_none() {
+                reasons.push(format!(
+                    "{file_key}: legacy plan did not persist canonical symlink rank"
+                ));
+            }
+            // A Plan is not itself a generation manifest: it has no stable
+            // group ID, content byte length, or validated output counts.
             reasons.push(format!(
-                "{file_key}: legacy plan did not persist canonical symlink rank"
+                "{file_key}: legacy plan has no complete manifest group"
             ));
         }
         for alias in &plan.duplicate_files {
             if !native_path_id_supported(&alias.path_id) {
                 reasons.push(format!(
                     "{}: missing or lossy native alias path identity",
+                    alias.rel
+                ));
+            }
+            if alias.is_symlink.is_none() {
+                reasons.push(format!(
+                    "{}: legacy plan did not persist alias symlink rank",
                     alias.rel
                 ));
             }
@@ -341,11 +352,32 @@ fn validate_supported_manifest_delta(
     desired: &GenerationManifest,
 ) -> Result<()> {
     // Binding complete identity while migrating the legacy generation zero is
-    // the only identity transition this vocabulary can represent. Once bound,
-    // backend/model/source-policy changes require a future explicit operation.
+    // the only configuration transition this vocabulary can represent. A
+    // durable snapshot reference and digest are generation inputs, not engine
+    // configuration, so they must advance with each desired generation.
     if base.generation > 0 || base.execution.is_some() {
+        let same_execution_configuration = |left: &ExecutionIdentity, right: &ExecutionIdentity| {
+            let mut left = left.clone();
+            let mut right = right.clone();
+            if let (
+                SourceExecutionPolicy::DurableSnapshot { .. },
+                SourceExecutionPolicy::DurableSnapshot { .. },
+            ) = (&left.source_policy, &right.source_policy)
+            {
+                left.source_policy = SourceExecutionPolicy::DurableSnapshot {
+                    reference: String::new(),
+                    snapshot_digest: String::new(),
+                };
+                right.source_policy = left.source_policy.clone();
+            }
+            left == right
+        };
         anyhow::ensure!(
-            base.execution == desired.execution,
+            match (&base.execution, &desired.execution) {
+                (Some(left), Some(right)) => same_execution_configuration(left, right),
+                (None, None) => true,
+                _ => false,
+            },
             "execution identity or source policy changed without a supported operation"
         );
     }
@@ -718,6 +750,7 @@ fn validate_plan_projection(plan: &Plan, groups: &[ManifestGroup]) -> Result<()>
         anyhow::ensure!(
             assignment.rel == group.canonical.rel
                 && assignment.path_id == group.canonical.path_id
+                && assignment.is_symlink == Some(group.canonical.is_symlink)
                 && assignment.content_digest.as_deref() == Some(group.content_digest.as_str()),
             "plan canonical projection disagrees with manifest group"
         );
@@ -739,7 +772,7 @@ fn validate_plan_projection(plan: &Plan, groups: &[ManifestGroup]) -> Result<()>
             "group references absent dataset schema"
         );
     }
-    let expected_aliases: BTreeSet<(String, String, String, String)> = groups
+    let expected_aliases: BTreeSet<(String, String, String, bool, String)> = groups
         .iter()
         .flat_map(|group| {
             group.aliases.iter().map(|alias| {
@@ -747,23 +780,27 @@ fn validate_plan_projection(plan: &Plan, groups: &[ManifestGroup]) -> Result<()>
                     group.content_id.clone(),
                     alias.rel.clone(),
                     alias.path_id.clone(),
+                    alias.is_symlink,
                     group.canonical.rel.clone(),
                 )
             })
         })
         .collect();
-    let actual_aliases: BTreeSet<(String, String, String, String)> = plan
+    let actual_aliases: BTreeSet<(String, String, String, bool, String)> = plan
         .duplicate_files
         .iter()
-        .map(|alias: &DuplicateFile| {
-            (
+        .map(|alias: &DuplicateFile| -> Result<_> {
+            Ok((
                 alias.file_key.clone(),
                 alias.rel.clone(),
                 alias.path_id.clone(),
+                alias
+                    .is_symlink
+                    .context("plan alias has no persisted symlink rank")?,
                 alias.duplicate_of.clone(),
-            )
+            ))
         })
-        .collect();
+        .collect::<Result<_>>()?;
     anyhow::ensure!(
         actual_aliases == expected_aliases,
         "plan alias projection disagrees with manifest groups"
@@ -1059,6 +1096,7 @@ mod tests {
             FileAssignment {
                 rel: "a.pdf".into(),
                 path_id: "unix:61".into(),
+                is_symlink: None,
                 family: "pdf".into(),
                 gzip: false,
                 content_digest: Some("digest".into()),
@@ -1082,6 +1120,7 @@ mod tests {
                     FileAssignment {
                         rel: format!("{key}.pdf"),
                         path_id: format!("unix:{:02x}", key.as_bytes()[0]),
+                        is_symlink: Some(false),
                         family: "pdf".into(),
                         gzip: false,
                         content_digest: Some(format!("digest-{key}")),

--- a/engine/crates/xerj-autoindex/src/sync.rs
+++ b/engine/crates/xerj-autoindex/src/sync.rs
@@ -1,0 +1,1197 @@
+//! Pure, inert corpus-generation planning and durable replay.
+//!
+//! Nothing in this module performs HTTP I/O or changes autoindex behaviour.
+//! It defines the complete state an eventual synchronization executor must
+//! durably bind before publication.
+
+use crate::state::{DuplicateFile, Plan};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+pub const EXECUTION_IDENTITY_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ManifestPath {
+    /// Reversible platform-native path identity (`unix:`/`windows:` encoding).
+    pub path_id: String,
+    pub rel: String,
+    /// Canonical election ranks real paths before followed symlinks.
+    pub is_symlink: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManifestGroup {
+    /// Stable logical identity across rename/replacement.
+    pub group_id: String,
+    /// Collision-safe document identity assigned only after byte verification.
+    pub content_id: String,
+    /// Raw full-content digest. Never treated as globally unique by itself.
+    pub content_digest: String,
+    pub content_size: u64,
+    pub canonical: ManifestPath,
+    #[serde(default)]
+    pub aliases: Vec<ManifestPath>,
+    #[serde(default)]
+    pub dataset_slugs: Vec<String>,
+    pub expected_records: u64,
+    pub expected_passages: u64,
+    pub expected_vectors: u64,
+}
+
+impl ManifestGroup {
+    fn all_paths(&self) -> impl Iterator<Item = &ManifestPath> {
+        std::iter::once(&self.canonical).chain(self.aliases.iter())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "policy")]
+pub enum SourceExecutionPolicy {
+    DurableSnapshot {
+        reference: String,
+        snapshot_digest: String,
+    },
+    AbortOnSourceChange {
+        inventory_digest: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionIdentity {
+    pub version: u32,
+    pub root_identity: String,
+    pub url: String,
+    pub prefix: String,
+    pub follow_symlinks: bool,
+    pub chunker_identity: String,
+    pub embedding_backend: String,
+    pub embedding_model: String,
+    pub embedding_tokenizer: String,
+    pub embedding_dimension: usize,
+    pub graph_enabled: bool,
+    pub brain: String,
+    pub detector_identity: String,
+    pub schema_identity: String,
+    pub index_identity: String,
+    pub source_policy: SourceExecutionPolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerationManifest {
+    pub generation: u64,
+    /// Missing only for a legacy generation-0 plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ExecutionIdentity>,
+    pub plan: Plan,
+    pub groups: Vec<ManifestGroup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommittedManifest {
+    pub generation: u64,
+    pub manifest_digest: String,
+    pub plan: Plan,
+    pub groups: Vec<ManifestGroup>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ExecutionIdentity>,
+}
+
+#[derive(Debug, Clone)]
+pub enum LegacyBootstrap {
+    Ready(Box<CommittedManifest>),
+    MigrationRequired { reasons: Vec<String> },
+}
+
+impl CommittedManifest {
+    pub fn bootstrap_legacy(plan: Plan) -> Result<LegacyBootstrap> {
+        let mut reasons = Vec::new();
+        for (file_key, file) in &plan.files {
+            if file.content_digest.is_none() {
+                reasons.push(format!("{file_key}: missing full content digest"));
+            }
+            if !native_path_id_supported(&file.path_id) {
+                reasons.push(format!(
+                    "{file_key}: missing or lossy native canonical path identity"
+                ));
+            }
+            // Legacy plans did not persist whether the canonical path was a
+            // followed symlink, so canonical rank cannot be reconstructed.
+            reasons.push(format!(
+                "{file_key}: legacy plan did not persist canonical symlink rank"
+            ));
+        }
+        for alias in &plan.duplicate_files {
+            if !native_path_id_supported(&alias.path_id) {
+                reasons.push(format!(
+                    "{}: missing or lossy native alias path identity",
+                    alias.rel
+                ));
+            }
+        }
+        reasons.sort();
+        reasons.dedup();
+        if !reasons.is_empty() {
+            return Ok(LegacyBootstrap::MigrationRequired { reasons });
+        }
+        let manifest = GenerationManifest {
+            generation: 0,
+            execution: None,
+            plan: plan.clone(),
+            groups: Vec::new(),
+        };
+        Ok(LegacyBootstrap::Ready(Box::new(Self {
+            generation: 0,
+            manifest_digest: manifest_digest(&manifest)?,
+            plan,
+            groups: Vec::new(),
+            execution: None,
+        })))
+    }
+
+    fn from_generation(manifest: GenerationManifest, digest: String) -> Self {
+        Self {
+            generation: manifest.generation,
+            manifest_digest: digest,
+            plan: manifest.plan,
+            groups: manifest.groups,
+            execution: manifest.execution,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncOperationKind {
+    Upsert,
+    Delete,
+    Metadata,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SyncOperation {
+    pub operation_id: String,
+    pub kind: SyncOperationKind,
+    pub group_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub desired_content_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncOperationState {
+    Started,
+    Committed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingSync {
+    pub tx_id: String,
+    pub base_generation: u64,
+    pub base_manifest_digest: String,
+    pub desired_manifest_digest: String,
+    pub operation_hash: String,
+    pub desired: GenerationManifest,
+    pub operations: Vec<SyncOperation>,
+    #[serde(default)]
+    pub operation_states: BTreeMap<String, SyncOperationState>,
+    #[serde(default)]
+    pub validated: bool,
+}
+
+impl PendingSync {
+    pub fn new(
+        tx_id: String,
+        base: &CommittedManifest,
+        mut desired: GenerationManifest,
+    ) -> Result<Self> {
+        canonicalize_manifest_order(&mut desired);
+        validate_manifest(&desired, false)?;
+        validate_supported_manifest_delta(base, &desired)?;
+        let operations = plan_operations(&base.groups, &desired.groups);
+        let pending = Self {
+            tx_id,
+            base_generation: base.generation,
+            base_manifest_digest: base.manifest_digest.clone(),
+            desired_manifest_digest: manifest_digest(&desired)?,
+            operation_hash: operation_hash(&operations)?,
+            desired,
+            operations,
+            operation_states: BTreeMap::new(),
+            validated: false,
+        };
+        pending.validate_against(base)?;
+        Ok(pending)
+    }
+
+    pub fn validate_against(&self, base: &CommittedManifest) -> Result<()> {
+        anyhow::ensure!(
+            self.base_generation == base.generation
+                && self.base_manifest_digest == base.manifest_digest,
+            "sync_begin base does not match committed authority"
+        );
+        anyhow::ensure!(
+            self.desired.generation == self.base_generation + 1,
+            "desired generation must immediately follow its base"
+        );
+        validate_manifest(&self.desired, false)?;
+        validate_supported_manifest_delta(base, &self.desired)?;
+        anyhow::ensure!(
+            self.desired_manifest_digest == manifest_digest(&self.desired)?,
+            "desired manifest digest does not match sync_begin payload"
+        );
+        let expected = plan_operations(&base.groups, &self.desired.groups);
+        anyhow::ensure!(
+            self.operations == expected,
+            "sync operation list was not derived exactly from base and desired manifests"
+        );
+        anyhow::ensure!(
+            self.operation_hash == operation_hash(&expected)?,
+            "sync operation hash does not match derived operation list"
+        );
+        let operation_ids: HashSet<&str> = expected
+            .iter()
+            .map(|operation| operation.operation_id.as_str())
+            .collect();
+        anyhow::ensure!(
+            self.operation_states
+                .keys()
+                .all(|operation_id| operation_ids.contains(operation_id.as_str())),
+            "sync state references an operation absent from sync_begin"
+        );
+        Ok(())
+    }
+
+    pub fn apply_operation_state(
+        &mut self,
+        tx_id: &str,
+        operation_id: &str,
+        state: SyncOperationState,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            self.tx_id == tx_id,
+            "operation state belongs to another sync"
+        );
+        anyhow::ensure!(
+            self.operations
+                .iter()
+                .any(|operation| operation.operation_id == operation_id),
+            "operation state references unknown operation {operation_id}"
+        );
+        let legal = match self.operation_states.get(operation_id) {
+            None => state == SyncOperationState::Started,
+            Some(previous) => {
+                previous == &state
+                    || previous == &SyncOperationState::Started
+                        && state == SyncOperationState::Committed
+            }
+        };
+        anyhow::ensure!(
+            legal,
+            "illegal operation transition {:?} -> {state:?}",
+            self.operation_states.get(operation_id)
+        );
+        self.operation_states
+            .insert(operation_id.to_string(), state);
+        Ok(())
+    }
+
+    pub fn all_operations_committed(&self) -> bool {
+        self.operations.iter().all(|operation| {
+            self.operation_states.get(&operation.operation_id)
+                == Some(&SyncOperationState::Committed)
+        })
+    }
+
+    pub fn apply_validated(&mut self, tx_id: &str, digest: &str) -> Result<()> {
+        anyhow::ensure!(self.tx_id == tx_id, "validation belongs to another sync");
+        anyhow::ensure!(
+            self.desired_manifest_digest == digest,
+            "validation manifest digest does not match sync_begin"
+        );
+        anyhow::ensure!(
+            self.all_operations_committed(),
+            "cannot validate sync with unfinished operations"
+        );
+        self.validated = true;
+        Ok(())
+    }
+
+    pub fn apply_commit(self, tx_id: &str, digest: &str) -> Result<CommittedManifest> {
+        anyhow::ensure!(self.tx_id == tx_id, "commit belongs to another sync");
+        anyhow::ensure!(
+            self.desired_manifest_digest == digest,
+            "commit manifest digest does not match sync_begin"
+        );
+        anyhow::ensure!(self.validated, "cannot commit an unvalidated sync");
+        anyhow::ensure!(
+            self.all_operations_committed(),
+            "cannot commit sync with unfinished operations"
+        );
+        Ok(CommittedManifest::from_generation(
+            self.desired,
+            self.desired_manifest_digest,
+        ))
+    }
+}
+
+fn validate_supported_manifest_delta(
+    base: &CommittedManifest,
+    desired: &GenerationManifest,
+) -> Result<()> {
+    // Binding complete identity while migrating the legacy generation zero is
+    // the only identity transition this vocabulary can represent. Once bound,
+    // backend/model/source-policy changes require a future explicit operation.
+    if base.generation > 0 || base.execution.is_some() {
+        anyhow::ensure!(
+            base.execution == desired.execution,
+            "execution identity or source policy changed without a supported operation"
+        );
+    }
+    anyhow::ensure!(
+        base.plan.alias_paths_indexed == desired.plan.alias_paths_indexed,
+        "plan flags changed without a supported operation"
+    );
+    anyhow::ensure!(
+        canonical_json_bytes(&base.plan.junk_files)?
+            == canonical_json_bytes(&desired.plan.junk_files)?,
+        "junk plan changed without a supported operation"
+    );
+    let normalize_datasets = |datasets: &[crate::state::PlanDataset]| {
+        let mut datasets = datasets.to_vec();
+        for dataset in &mut datasets {
+            // Membership operations legitimately change this projection.
+            dataset.file_count = 0;
+        }
+        datasets.sort_by(|left, right| {
+            left.slug
+                .cmp(&right.slug)
+                .then_with(|| left.index.cmp(&right.index))
+                .then_with(|| left.group.cmp(&right.group))
+        });
+        for dataset in &mut datasets {
+            dataset
+                .specs
+                .sort_by(|left, right| left.name.cmp(&right.name));
+        }
+        datasets
+    };
+    anyhow::ensure!(
+        canonical_json_bytes(&normalize_datasets(&base.plan.datasets))?
+            == canonical_json_bytes(&normalize_datasets(&desired.plan.datasets))?,
+        "dataset schema/index plan changed without a schema-generation operation"
+    );
+    Ok(())
+}
+
+pub fn plan_operations(base: &[ManifestGroup], desired: &[ManifestGroup]) -> Vec<SyncOperation> {
+    let base: BTreeMap<&str, &ManifestGroup> = base
+        .iter()
+        .map(|group| (group.group_id.as_str(), group))
+        .collect();
+    let desired: BTreeMap<&str, &ManifestGroup> = desired
+        .iter()
+        .map(|group| (group.group_id.as_str(), group))
+        .collect();
+    let mut operations = Vec::new();
+    for (group_id, old) in &base {
+        match desired.get(group_id) {
+            None => operations.push(operation(SyncOperationKind::Delete, group_id, None)),
+            Some(new)
+                if old.content_id != new.content_id
+                    || old.content_digest != new.content_digest
+                    || old.content_size != new.content_size =>
+            {
+                operations.push(operation(
+                    SyncOperationKind::Upsert,
+                    group_id,
+                    Some(new.content_id.clone()),
+                ));
+            }
+            Some(new) if *old != *new => operations.push(operation(
+                SyncOperationKind::Metadata,
+                group_id,
+                Some(new.content_id.clone()),
+            )),
+            Some(_) => {}
+        }
+    }
+    for (group_id, new) in desired {
+        if !base.contains_key(group_id) {
+            operations.push(operation(
+                SyncOperationKind::Upsert,
+                group_id,
+                Some(new.content_id.clone()),
+            ));
+        }
+    }
+    operations.sort();
+    operations
+}
+
+fn operation(
+    kind: SyncOperationKind,
+    group_id: &str,
+    desired_content_id: Option<String>,
+) -> SyncOperation {
+    SyncOperation {
+        operation_id: format!("{kind:?}:{group_id}").to_ascii_lowercase(),
+        kind,
+        group_id: group_id.to_string(),
+        desired_content_id,
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(not(test), allow(dead_code))]
+pub struct DesiredContentGroup {
+    pub content_id: String,
+    pub content_digest: String,
+    pub content_size: u64,
+    pub paths: Vec<ManifestPath>,
+    pub dataset_slugs: Vec<String>,
+    pub expected_records: u64,
+    pub expected_passages: u64,
+    pub expected_vectors: u64,
+}
+
+/// Content identity is collision-safe and byte-verified by the inventory
+/// layer. Raw digest equality alone never merges groups.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn reconcile_groups(
+    previous: &[ManifestGroup],
+    mut desired: Vec<DesiredContentGroup>,
+) -> Result<Vec<ManifestGroup>> {
+    validate_groups(previous)?;
+    desired.sort_by(|left, right| {
+        left.content_id
+            .cmp(&right.content_id)
+            .then_with(|| canonical_path(&left.paths).cmp(&canonical_path(&right.paths)))
+    });
+    let old_by_content: HashMap<&str, &ManifestGroup> = previous
+        .iter()
+        .map(|group| (group.content_id.as_str(), group))
+        .collect();
+    anyhow::ensure!(
+        old_by_content.len() == previous.len(),
+        "collision-safe content IDs must be unique"
+    );
+    let surviving_content: HashSet<String> = desired
+        .iter()
+        .map(|group| group.content_id.clone())
+        .collect();
+    let mut old_by_path = HashMap::new();
+    for group in previous {
+        for path in group.all_paths() {
+            anyhow::ensure!(
+                old_by_path.insert(path.path_id.as_str(), group).is_none(),
+                "native path identity belongs to multiple committed groups"
+            );
+        }
+    }
+    let mut claimed = HashSet::new();
+    let mut seen_paths = HashSet::new();
+    let mut result = Vec::new();
+    for mut candidate in desired {
+        normalize_paths(&mut candidate.paths, &mut seen_paths)?;
+        let canonical = candidate.paths.remove(0);
+        let aliases = candidate.paths;
+        let content_owner = old_by_content.get(candidate.content_id.as_str()).copied();
+        let mut path_owners: BTreeSet<&str> = std::iter::once(&canonical)
+            .chain(aliases.iter())
+            .filter_map(|path| old_by_path.get(path.path_id.as_str()).copied())
+            .filter(|owner| !surviving_content.contains(owner.content_id.as_str()))
+            .map(|owner| owner.group_id.as_str())
+            .collect();
+        let group_id = if let Some(owner) = content_owner {
+            anyhow::ensure!(
+                path_owners.is_empty() || path_owners.contains(owner.group_id.as_str()),
+                "desired group has conflicting content and path identities"
+            );
+            owner.group_id.clone()
+        } else if path_owners.len() == 1 {
+            path_owners.pop_first().unwrap().to_string()
+        } else if path_owners.is_empty() {
+            format!(
+                "axg1-{:032x}",
+                xxhash_rust::xxh3::xxh3_128(
+                    format!("{}\0{}", candidate.content_id, canonical.path_id).as_bytes()
+                )
+            )
+        } else {
+            anyhow::bail!("desired content merges multiple historical groups");
+        };
+        anyhow::ensure!(claimed.insert(group_id.clone()), "group claimed twice");
+        candidate.dataset_slugs.sort();
+        candidate.dataset_slugs.dedup();
+        result.push(ManifestGroup {
+            group_id,
+            content_id: candidate.content_id,
+            content_digest: candidate.content_digest,
+            content_size: candidate.content_size,
+            canonical,
+            aliases,
+            dataset_slugs: candidate.dataset_slugs,
+            expected_records: candidate.expected_records,
+            expected_passages: candidate.expected_passages,
+            expected_vectors: candidate.expected_vectors,
+        });
+    }
+    result.sort_by(|left, right| left.group_id.cmp(&right.group_id));
+    Ok(result)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn canonical_path(paths: &[ManifestPath]) -> (bool, &str) {
+    paths
+        .iter()
+        .map(|path| (path.is_symlink, path.path_id.as_str()))
+        .min()
+        .unwrap_or((true, ""))
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn normalize_paths(paths: &mut [ManifestPath], seen: &mut HashSet<String>) -> Result<()> {
+    anyhow::ensure!(!paths.is_empty(), "desired content group has no paths");
+    for path in paths.iter() {
+        anyhow::ensure!(
+            native_path_id_supported(&path.path_id),
+            "path {} has no supported reversible native identity",
+            path.rel
+        );
+        anyhow::ensure!(
+            seen.insert(path.path_id.clone()),
+            "native path identity occurs more than once"
+        );
+    }
+    paths.sort_by(|left, right| {
+        (left.is_symlink, left.path_id.as_str()).cmp(&(right.is_symlink, right.path_id.as_str()))
+    });
+    Ok(())
+}
+
+fn native_path_id_supported(path_id: &str) -> bool {
+    let valid_hex = |hex: &str, width: usize| {
+        !hex.is_empty()
+            && hex.len().is_multiple_of(width)
+            && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+    };
+    path_id
+        .strip_prefix("unix:")
+        .is_some_and(|hex| valid_hex(hex, 2))
+        || path_id
+            .strip_prefix("windows:")
+            .is_some_and(|hex| valid_hex(hex, 4))
+}
+
+fn validate_manifest(manifest: &GenerationManifest, legacy: bool) -> Result<()> {
+    if manifest.generation == 0 && legacy {
+        anyhow::ensure!(
+            manifest.execution.is_none(),
+            "legacy generation zero cannot invent execution identity"
+        );
+    } else {
+        let execution = manifest
+            .execution
+            .as_ref()
+            .context("new generation requires complete execution identity")?;
+        anyhow::ensure!(
+            execution.version == EXECUTION_IDENTITY_VERSION,
+            "unsupported execution identity version"
+        );
+        for (name, value) in [
+            ("root_identity", execution.root_identity.as_str()),
+            ("url", execution.url.as_str()),
+            ("prefix", execution.prefix.as_str()),
+            ("chunker_identity", execution.chunker_identity.as_str()),
+            ("embedding_backend", execution.embedding_backend.as_str()),
+            ("embedding_model", execution.embedding_model.as_str()),
+            (
+                "embedding_tokenizer",
+                execution.embedding_tokenizer.as_str(),
+            ),
+            ("detector_identity", execution.detector_identity.as_str()),
+            ("schema_identity", execution.schema_identity.as_str()),
+            ("index_identity", execution.index_identity.as_str()),
+        ] {
+            anyhow::ensure!(!value.is_empty(), "execution identity {name} is empty");
+        }
+        match &execution.source_policy {
+            SourceExecutionPolicy::DurableSnapshot {
+                reference,
+                snapshot_digest,
+            } => anyhow::ensure!(
+                !reference.is_empty() && !snapshot_digest.is_empty(),
+                "durable source snapshot identity is incomplete"
+            ),
+            SourceExecutionPolicy::AbortOnSourceChange { inventory_digest } => {
+                anyhow::ensure!(
+                    !inventory_digest.is_empty(),
+                    "abort-on-change policy needs inventory digest"
+                )
+            }
+        }
+    }
+    validate_groups(&manifest.groups)?;
+    validate_plan_projection(&manifest.plan, &manifest.groups)
+}
+
+fn validate_groups(groups: &[ManifestGroup]) -> Result<()> {
+    let mut group_ids = HashSet::new();
+    let mut content_ids = HashSet::new();
+    let mut path_ids = HashSet::new();
+    for group in groups {
+        anyhow::ensure!(group_ids.insert(&group.group_id), "duplicate group ID");
+        anyhow::ensure!(
+            content_ids.insert(&group.content_id),
+            "duplicate collision-safe content ID"
+        );
+        anyhow::ensure!(
+            !group.content_digest.is_empty(),
+            "group has no raw content digest"
+        );
+        anyhow::ensure!(
+            native_path_id_supported(&group.canonical.path_id),
+            "canonical path identity is unsupported"
+        );
+        anyhow::ensure!(
+            !group.canonical.is_symlink || group.aliases.iter().all(|p| p.is_symlink),
+            "a symlink cannot be canonical while a real path survives"
+        );
+        anyhow::ensure!(
+            group.aliases.iter().all(|alias| {
+                (group.canonical.is_symlink, group.canonical.path_id.as_str())
+                    < (alias.is_symlink, alias.path_id.as_str())
+            }),
+            "canonical path does not have the lowest canonical rank"
+        );
+        for path in group.all_paths() {
+            anyhow::ensure!(
+                path_ids.insert(&path.path_id),
+                "native path identity occurs in multiple groups"
+            );
+        }
+        anyhow::ensure!(
+            group.aliases.windows(2).all(|pair| {
+                (pair[0].is_symlink, pair[0].path_id.as_str())
+                    < (pair[1].is_symlink, pair[1].path_id.as_str())
+            }),
+            "aliases are not in canonical rank order"
+        );
+        anyhow::ensure!(
+            group.dataset_slugs.windows(2).all(|pair| pair[0] < pair[1]),
+            "dataset assignments are not canonical"
+        );
+    }
+    anyhow::ensure!(
+        groups
+            .windows(2)
+            .all(|pair| pair[0].group_id < pair[1].group_id),
+        "manifest groups are not canonical"
+    );
+    Ok(())
+}
+
+fn validate_plan_projection(plan: &Plan, groups: &[ManifestGroup]) -> Result<()> {
+    let dataset_slugs: HashSet<&str> = plan
+        .datasets
+        .iter()
+        .map(|dataset| dataset.slug.as_str())
+        .collect();
+    anyhow::ensure!(
+        dataset_slugs.len() == plan.datasets.len(),
+        "plan has duplicate dataset slugs"
+    );
+    let groups_by_content: HashMap<&str, &ManifestGroup> = groups
+        .iter()
+        .map(|group| (group.content_id.as_str(), group))
+        .collect();
+    anyhow::ensure!(
+        plan.files.len() == groups.len(),
+        "plan files and manifest groups disagree"
+    );
+    for (content_id, assignment) in &plan.files {
+        let group = groups_by_content
+            .get(content_id.as_str())
+            .context("plan file has no manifest group")?;
+        anyhow::ensure!(
+            assignment.rel == group.canonical.rel
+                && assignment.path_id == group.canonical.path_id
+                && assignment.content_digest.as_deref() == Some(group.content_digest.as_str()),
+            "plan canonical projection disagrees with manifest group"
+        );
+        let mut assigned: Vec<String> = assignment
+            .assignments
+            .iter()
+            .map(|(_, slug)| slug.clone())
+            .collect();
+        assigned.sort();
+        assigned.dedup();
+        anyhow::ensure!(
+            assigned == group.dataset_slugs,
+            "plan dataset projection disagrees with manifest group"
+        );
+        anyhow::ensure!(
+            assigned
+                .iter()
+                .all(|slug| dataset_slugs.contains(slug.as_str())),
+            "group references absent dataset schema"
+        );
+    }
+    let expected_aliases: BTreeSet<(String, String, String, String)> = groups
+        .iter()
+        .flat_map(|group| {
+            group.aliases.iter().map(|alias| {
+                (
+                    group.content_id.clone(),
+                    alias.rel.clone(),
+                    alias.path_id.clone(),
+                    group.canonical.rel.clone(),
+                )
+            })
+        })
+        .collect();
+    let actual_aliases: BTreeSet<(String, String, String, String)> = plan
+        .duplicate_files
+        .iter()
+        .map(|alias: &DuplicateFile| {
+            (
+                alias.file_key.clone(),
+                alias.rel.clone(),
+                alias.path_id.clone(),
+                alias.duplicate_of.clone(),
+            )
+        })
+        .collect();
+    anyhow::ensure!(
+        actual_aliases == expected_aliases,
+        "plan alias projection disagrees with manifest groups"
+    );
+    Ok(())
+}
+
+fn canonicalize_manifest_order(manifest: &mut GenerationManifest) {
+    manifest.plan.datasets.sort_by(|left, right| {
+        left.slug
+            .cmp(&right.slug)
+            .then_with(|| left.index.cmp(&right.index))
+            .then_with(|| left.group.cmp(&right.group))
+    });
+    for dataset in &mut manifest.plan.datasets {
+        dataset
+            .specs
+            .sort_by(|left, right| left.name.cmp(&right.name));
+    }
+    for assignment in manifest.plan.files.values_mut() {
+        assignment.assignments.sort();
+        assignment.assignments.dedup();
+    }
+    manifest.plan.junk_files.sort_by(|left, right| {
+        left.file_key
+            .cmp(&right.file_key)
+            .then_with(|| left.rel.cmp(&right.rel))
+    });
+    manifest.plan.duplicate_files.sort_by(|left, right| {
+        left.file_key
+            .cmp(&right.file_key)
+            .then_with(|| left.path_id.cmp(&right.path_id))
+            .then_with(|| left.rel.cmp(&right.rel))
+    });
+    for group in &mut manifest.groups {
+        group.aliases.sort_by(|left, right| {
+            (left.is_symlink, left.path_id.as_str())
+                .cmp(&(right.is_symlink, right.path_id.as_str()))
+        });
+        group.dataset_slugs.sort();
+        group.dataset_slugs.dedup();
+    }
+    manifest
+        .groups
+        .sort_by(|left, right| left.group_id.cmp(&right.group_id));
+}
+
+pub fn manifest_digest(manifest: &GenerationManifest) -> Result<String> {
+    let mut normalized = manifest.clone();
+    canonicalize_manifest_order(&mut normalized);
+    let encoded = canonical_json_bytes(&normalized)?;
+    Ok(format!(
+        "axm1-{:032x}",
+        xxhash_rust::xxh3::xxh3_128(&encoded)
+    ))
+}
+
+pub fn operation_hash(operations: &[SyncOperation]) -> Result<String> {
+    let mut normalized = operations.to_vec();
+    normalized.sort();
+    let encoded = canonical_json_bytes(&normalized)?;
+    Ok(format!(
+        "axo1-{:032x}",
+        xxhash_rust::xxh3::xxh3_128(&encoded)
+    ))
+}
+
+fn canonical_json_bytes<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>> {
+    fn canonicalize(value: Value) -> Value {
+        match value {
+            Value::Object(object) => {
+                let sorted: BTreeMap<String, Value> = object
+                    .into_iter()
+                    .map(|(key, value)| (key, canonicalize(value)))
+                    .collect();
+                Value::Object(sorted.into_iter().collect())
+            }
+            Value::Array(values) => Value::Array(values.into_iter().map(canonicalize).collect()),
+            scalar => scalar,
+        }
+    }
+    Ok(serde_json::to_vec(&canonicalize(serde_json::to_value(
+        value,
+    )?))?)
+}
+
+pub fn apply_begin(
+    committed: &CommittedManifest,
+    pending: &mut Option<PendingSync>,
+    begin: PendingSync,
+) -> Result<()> {
+    anyhow::ensure!(pending.is_none(), "another sync is already pending");
+    begin.validate_against(committed)?;
+    *pending = Some(begin);
+    Ok(())
+}
+
+pub fn is_sync_record_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "sync_begin" | "sync_operation_state" | "sync_validated" | "sync_commit" | "sync_abort"
+    )
+}
+
+pub fn replay_record(
+    record: &Value,
+    committed: &mut Option<CommittedManifest>,
+    pending: &mut Option<PendingSync>,
+) -> Result<()> {
+    let kind = record_str(record, "kind")?;
+    match kind {
+        "sync_begin" => {
+            let begin: PendingSync =
+                serde_json::from_value(record.clone()).context("decode durable sync_begin")?;
+            apply_begin(
+                committed
+                    .as_ref()
+                    .context("sync_begin has no committed base manifest")?,
+                pending,
+                begin,
+            )
+        }
+        "sync_operation_state" => {
+            let tx = record_str(record, "tx_id")?;
+            let operation = record_str(record, "operation_id")?;
+            let state = serde_json::from_value(
+                record
+                    .get("state")
+                    .cloned()
+                    .context("sync operation state is missing")?,
+            )?;
+            pending
+                .as_mut()
+                .context("operation state has no pending sync")?
+                .apply_operation_state(tx, operation, state)
+        }
+        "sync_validated" => pending
+            .as_mut()
+            .context("validation has no pending sync")?
+            .apply_validated(
+                record_str(record, "tx_id")?,
+                record_str(record, "desired_manifest_digest")?,
+            ),
+        "sync_commit" => {
+            let active = pending.take().context("commit has no pending sync")?;
+            *committed = Some(active.apply_commit(
+                record_str(record, "tx_id")?,
+                record_str(record, "desired_manifest_digest")?,
+            )?);
+            Ok(())
+        }
+        "sync_abort" => {
+            let active = pending.as_ref().context("abort has no pending sync")?;
+            anyhow::ensure!(
+                active.tx_id == record_str(record, "tx_id")?
+                    && active.desired_manifest_digest
+                        == record_str(record, "desired_manifest_digest")?,
+                "abort does not bind the pending transaction and manifest"
+            );
+            *pending = None;
+            Ok(())
+        }
+        _ => anyhow::bail!("unknown sync record kind {kind}"),
+    }
+}
+
+fn record_str<'a>(record: &'a Value, field: &str) -> Result<&'a str> {
+    record
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("sync record has no {field}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{FileAssignment, PlanDataset};
+
+    fn path(id_hex: &str, symlink: bool) -> ManifestPath {
+        ManifestPath {
+            path_id: format!("unix:{id_hex}"),
+            rel: format!("{id_hex}.pdf"),
+            is_symlink: symlink,
+        }
+    }
+
+    fn group(id: &str, content: &str, path: ManifestPath) -> ManifestGroup {
+        ManifestGroup {
+            group_id: id.into(),
+            content_id: content.into(),
+            content_digest: format!("digest-{content}"),
+            content_size: 10,
+            canonical: path,
+            aliases: Vec::new(),
+            dataset_slugs: vec!["reports".into()],
+            expected_records: 1,
+            expected_passages: 1,
+            expected_vectors: 1,
+        }
+    }
+
+    fn desired(content: &str, paths: Vec<ManifestPath>) -> DesiredContentGroup {
+        DesiredContentGroup {
+            content_id: content.into(),
+            content_digest: format!("digest-{content}"),
+            content_size: 10,
+            paths,
+            dataset_slugs: vec!["reports".into()],
+            expected_records: 1,
+            expected_passages: 1,
+            expected_vectors: 1,
+        }
+    }
+
+    #[test]
+    fn canonical_prefers_real_then_native_bytes_including_non_utf8_identity() {
+        let groups = reconcile_groups(
+            &[],
+            vec![desired(
+                "content",
+                vec![path("ff", false), path("01", true), path("80", false)],
+            )],
+        )
+        .unwrap();
+        assert_eq!(groups[0].canonical.path_id, "unix:80");
+        assert!(!groups[0].canonical.is_symlink);
+    }
+
+    #[test]
+    fn equal_raw_digest_does_not_merge_distinct_collision_safe_content_ids() {
+        let mut a = desired("verified-a", vec![path("61", false)]);
+        let mut b = desired("verified-b", vec![path("62", false)]);
+        b.content_digest = a.content_digest.clone();
+        a.content_size = 9;
+        b.content_size = 9;
+        let groups = reconcile_groups(&[], vec![a, b]).unwrap();
+        assert_eq!(groups.len(), 2);
+        assert_ne!(groups[0].content_id, groups[1].content_id);
+    }
+
+    #[test]
+    fn changed_former_canonical_cannot_steal_surviving_content_group() {
+        let mut old = group("logical", "old-content", path("61", false));
+        old.aliases.push(path("62", false));
+        let result = reconcile_groups(
+            &[old],
+            vec![
+                desired("new-content", vec![path("61", false)]),
+                desired("old-content", vec![path("62", false)]),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            result
+                .iter()
+                .find(|group| group.content_id == "old-content")
+                .unwrap()
+                .group_id,
+            "logical"
+        );
+    }
+
+    #[test]
+    fn operation_planner_covers_add_delete_metadata_and_mixed() {
+        let unchanged = group("same", "same", path("01", false));
+        let deleted = group("gone", "gone", path("02", false));
+        let metadata_old = group("meta", "meta", path("03", false));
+        let mut metadata_new = metadata_old.clone();
+        metadata_new.expected_records = 2;
+        let added = group("new", "new", path("04", false));
+        let operations = plan_operations(
+            &[deleted, metadata_old, unchanged.clone()],
+            &[added, metadata_new, unchanged],
+        );
+        assert_eq!(
+            operations
+                .iter()
+                .map(|operation| operation.kind.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                SyncOperationKind::Delete,
+                SyncOperationKind::Metadata,
+                SyncOperationKind::Upsert
+            ])
+        );
+    }
+
+    #[test]
+    fn legacy_nonempty_plan_requires_explicit_migration() {
+        let mut plan = Plan::default();
+        plan.files.insert(
+            "key".into(),
+            FileAssignment {
+                rel: "a.pdf".into(),
+                path_id: "unix:61".into(),
+                family: "pdf".into(),
+                gzip: false,
+                content_digest: Some("digest".into()),
+                assignments: Vec::new(),
+            },
+        );
+        assert!(matches!(
+            CommittedManifest::bootstrap_legacy(plan).unwrap(),
+            LegacyBootstrap::MigrationRequired { .. }
+        ));
+    }
+
+    #[test]
+    fn canonical_digest_ignores_hashmap_and_semantic_group_order() {
+        let mut first = Plan::default();
+        let mut second = Plan::default();
+        for (plan, order) in [(&mut first, ["a", "b"]), (&mut second, ["b", "a"])] {
+            for key in order {
+                plan.files.insert(
+                    key.into(),
+                    FileAssignment {
+                        rel: format!("{key}.pdf"),
+                        path_id: format!("unix:{:02x}", key.as_bytes()[0]),
+                        family: "pdf".into(),
+                        gzip: false,
+                        content_digest: Some(format!("digest-{key}")),
+                        assignments: Vec::new(),
+                    },
+                );
+            }
+        }
+        let group_a = group("a", "a", path("61", false));
+        let group_b = group("b", "b", path("62", false));
+        let a = GenerationManifest {
+            generation: 0,
+            execution: None,
+            plan: first,
+            groups: vec![group_a.clone(), group_b.clone()],
+        };
+        let b = GenerationManifest {
+            generation: 0,
+            execution: None,
+            plan: second,
+            groups: vec![group_b, group_a],
+        };
+        assert_eq!(manifest_digest(&a).unwrap(), manifest_digest(&b).unwrap());
+    }
+
+    fn identity(inventory: &str) -> ExecutionIdentity {
+        ExecutionIdentity {
+            version: EXECUTION_IDENTITY_VERSION,
+            root_identity: "unix:root".into(),
+            url: "url".into(),
+            prefix: "prefix".into(),
+            follow_symlinks: false,
+            chunker_identity: "chunker-v1".into(),
+            embedding_backend: "lexical".into(),
+            embedding_model: "feature-hash".into(),
+            embedding_tokenizer: "builtin".into(),
+            embedding_dimension: 384,
+            graph_enabled: false,
+            brain: "none".into(),
+            detector_identity: "detectors-v1".into(),
+            schema_identity: "schema-v1".into(),
+            index_identity: "index-v1".into(),
+            source_policy: SourceExecutionPolicy::AbortOnSourceChange {
+                inventory_digest: inventory.into(),
+            },
+        }
+    }
+
+    #[test]
+    fn no_op_plan_or_bound_execution_change_is_refused() {
+        let mut legacy_plan = Plan::default();
+        legacy_plan.datasets.push(PlanDataset {
+            slug: "reports".into(),
+            index: "prefix-reports".into(),
+            family: "pdf".into(),
+            group: None,
+            specs: Vec::new(),
+            time_field: None,
+            semantic_field: None,
+            sampled_records: 0,
+            file_count: 0,
+        });
+        let LegacyBootstrap::Ready(legacy) =
+            CommittedManifest::bootstrap_legacy(legacy_plan.clone()).unwrap()
+        else {
+            panic!("empty legacy membership is migratable");
+        };
+        let first = GenerationManifest {
+            generation: 1,
+            execution: Some(identity("inventory-a")),
+            plan: legacy_plan.clone(),
+            groups: Vec::new(),
+        };
+        let pending = PendingSync::new("bind".into(), &legacy, first.clone()).unwrap();
+
+        let committed =
+            CommittedManifest::from_generation(first.clone(), pending.desired_manifest_digest);
+        let mut changed_execution = first.clone();
+        changed_execution.generation = 2;
+        changed_execution.execution = Some(identity("inventory-b"));
+        assert!(
+            PendingSync::new("changed-execution".into(), &committed, changed_execution).is_err()
+        );
+
+        let mut changed_plan = first;
+        changed_plan.plan.alias_paths_indexed = true;
+        assert!(PendingSync::new("changed-plan".into(), &legacy, changed_plan).is_err());
+    }
+
+    #[test]
+    fn serialized_malicious_operation_list_is_rejected_against_manifests() {
+        let LegacyBootstrap::Ready(base) =
+            CommittedManifest::bootstrap_legacy(Plan::default()).unwrap()
+        else {
+            panic!("empty legacy plan is ready");
+        };
+        let desired = GenerationManifest {
+            generation: 1,
+            execution: Some(identity("inventory-a")),
+            plan: Plan::default(),
+            groups: Vec::new(),
+        };
+        let valid = PendingSync::new("tx".into(), &base, desired).unwrap();
+        let mut encoded = serde_json::to_value(valid).unwrap();
+        encoded["operations"] = serde_json::json!([{
+            "operation_id": "delete:invented",
+            "kind": "delete",
+            "group_id": "invented"
+        }]);
+        let malicious: PendingSync = serde_json::from_value(encoded).unwrap();
+        assert!(malicious.validate_against(&base).is_err());
+    }
+}

--- a/engine/crates/xerj-autoindex/src/sync.rs
+++ b/engine/crates/xerj-autoindex/src/sync.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-pub const EXECUTION_IDENTITY_VERSION: u32 = 1;
+pub const EXECUTION_IDENTITY_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ManifestPath {
@@ -66,10 +66,13 @@ pub struct ExecutionIdentity {
     pub prefix: String,
     pub follow_symlinks: bool,
     pub chunker_identity: String,
+    /// Opaque, server-authenticated identity of the exact embedding execution
+    /// space. Autoindex must never synthesize model/tokenizer labels.
+    pub embedding_identity_sha256: String,
     pub embedding_backend: String,
-    pub embedding_model: String,
-    pub embedding_tokenizer: String,
     pub embedding_dimension: usize,
+    pub embedding_semantic_contract: String,
+    pub embedding_resumable: bool,
     pub graph_enabled: bool,
     pub brain: String,
     pub detector_identity: String,
@@ -105,6 +108,27 @@ pub enum LegacyBootstrap {
 }
 
 impl CommittedManifest {
+    pub fn genesis() -> Result<Self> {
+        match Self::bootstrap_legacy(Plan::default())? {
+            LegacyBootstrap::Ready(manifest) => Ok(*manifest),
+            LegacyBootstrap::MigrationRequired { .. } => {
+                anyhow::bail!("empty generation-zero manifest unexpectedly requires migration")
+            }
+        }
+    }
+
+    fn validate_genesis(&self) -> Result<()> {
+        anyhow::ensure!(
+            self.generation == 0
+                && self.manifest_digest == Self::genesis()?.manifest_digest
+                && serde_json::to_value(&self.plan)? == serde_json::to_value(Plan::default())?
+                && self.groups.is_empty()
+                && self.execution.is_none(),
+            "generation-zero bootstrap manifest is not exact genesis"
+        );
+        Ok(())
+    }
+
     pub fn bootstrap_legacy(plan: Plan) -> Result<LegacyBootstrap> {
         let mut reasons = Vec::new();
         for (file_key, file) in &plan.files {
@@ -355,6 +379,13 @@ fn validate_supported_manifest_delta(
     // the only configuration transition this vocabulary can represent. A
     // durable snapshot reference and digest are generation inputs, not engine
     // configuration, so they must advance with each desired generation.
+    if base.generation == 0 && base.execution.is_none() && base.groups.is_empty() {
+        anyhow::ensure!(
+            base.manifest_digest == CommittedManifest::genesis()?.manifest_digest,
+            "generation-one migration base is not exact genesis"
+        );
+        return Ok(());
+    }
     if base.generation > 0 || base.execution.is_some() {
         let same_execution_configuration = |left: &ExecutionIdentity, right: &ExecutionIdentity| {
             let mut left = left.clone();
@@ -385,11 +416,10 @@ fn validate_supported_manifest_delta(
         base.plan.alias_paths_indexed == desired.plan.alias_paths_indexed,
         "plan flags changed without a supported operation"
     );
-    anyhow::ensure!(
-        canonical_json_bytes(&base.plan.junk_files)?
-            == canonical_json_bytes(&desired.plan.junk_files)?,
-        "junk plan changed without a supported operation"
-    );
+    // Junk is a local inference result, not remotely published generation
+    // membership. Adding/removing an unsupported file may advance the
+    // manifest for truthful map/status output, but it intentionally derives
+    // no remote data or catalog operation.
     let normalize_datasets = |datasets: &[crate::state::PlanDataset]| {
         let mut datasets = datasets.to_vec();
         for dataset in &mut datasets {
@@ -632,16 +662,25 @@ fn validate_manifest(manifest: &GenerationManifest, legacy: bool) -> Result<()> 
             execution.version == EXECUTION_IDENTITY_VERSION,
             "unsupported execution identity version"
         );
+        anyhow::ensure!(
+            !execution.graph_enabled
+                && execution.brain == "disabled"
+                && execution.detector_identity == "disabled",
+            "incremental generation manifests require graph-disabled execution identity"
+        );
         for (name, value) in [
             ("root_identity", execution.root_identity.as_str()),
             ("url", execution.url.as_str()),
             ("prefix", execution.prefix.as_str()),
             ("chunker_identity", execution.chunker_identity.as_str()),
-            ("embedding_backend", execution.embedding_backend.as_str()),
-            ("embedding_model", execution.embedding_model.as_str()),
             (
-                "embedding_tokenizer",
-                execution.embedding_tokenizer.as_str(),
+                "embedding_identity_sha256",
+                execution.embedding_identity_sha256.as_str(),
+            ),
+            ("embedding_backend", execution.embedding_backend.as_str()),
+            (
+                "embedding_semantic_contract",
+                execution.embedding_semantic_contract.as_str(),
             ),
             ("detector_identity", execution.detector_identity.as_str()),
             ("schema_identity", execution.schema_identity.as_str()),
@@ -649,6 +688,22 @@ fn validate_manifest(manifest: &GenerationManifest, legacy: bool) -> Result<()> 
         ] {
             anyhow::ensure!(!value.is_empty(), "execution identity {name} is empty");
         }
+        anyhow::ensure!(
+            execution.embedding_identity_sha256.len() == 64
+                && execution
+                    .embedding_identity_sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()),
+            "embedding execution identity must be a lowercase SHA-256 digest"
+        );
+        anyhow::ensure!(
+            execution.embedding_dimension > 0,
+            "embedding execution dimension must be positive"
+        );
+        anyhow::ensure!(
+            execution.embedding_resumable,
+            "a durable generation requires a resumable embedding execution identity"
+        );
         match &execution.source_policy {
             SourceExecutionPolicy::DurableSnapshot {
                 reference,
@@ -901,7 +956,12 @@ pub fn apply_begin(
 pub fn is_sync_record_kind(kind: &str) -> bool {
     matches!(
         kind,
-        "sync_begin" | "sync_operation_state" | "sync_validated" | "sync_commit" | "sync_abort"
+        "sync_bootstrap"
+            | "sync_begin"
+            | "sync_operation_state"
+            | "sync_validated"
+            | "sync_commit"
+            | "sync_abort"
     )
 }
 
@@ -912,6 +972,26 @@ pub fn replay_record(
 ) -> Result<()> {
     let kind = record_str(record, "kind")?;
     match kind {
+        "sync_bootstrap" => {
+            anyhow::ensure!(
+                pending.is_none(),
+                "sync_bootstrap cannot replace pending sync"
+            );
+            anyhow::ensure!(
+                committed.is_none(),
+                "sync_bootstrap cannot replace committed authority"
+            );
+            let manifest: CommittedManifest = serde_json::from_value(
+                record
+                    .get("manifest")
+                    .cloned()
+                    .context("sync_bootstrap has no manifest")?,
+            )
+            .context("decode durable sync_bootstrap")?;
+            manifest.validate_genesis()?;
+            *committed = Some(manifest);
+            Ok(())
+        }
         "sync_begin" => {
             let begin: PendingSync =
                 serde_json::from_value(record.clone()).context("decode durable sync_begin")?;
@@ -1013,6 +1093,34 @@ mod tests {
             expected_passages: 1,
             expected_vectors: 1,
         }
+    }
+
+    #[test]
+    fn bootstrap_replay_accepts_only_exact_empty_genesis() {
+        let genesis = CommittedManifest::genesis().unwrap();
+        let record = serde_json::json!({
+            "kind": "sync_bootstrap",
+            "manifest": genesis,
+        });
+        let mut committed = None;
+        let mut pending = None;
+        replay_record(&record, &mut committed, &mut pending).unwrap();
+        assert_eq!(committed.unwrap().generation, 0);
+
+        let mut non_genesis = CommittedManifest::genesis().unwrap();
+        non_genesis.generation = 1;
+        let record = serde_json::json!({
+            "kind": "sync_bootstrap",
+            "manifest": non_genesis,
+        });
+        assert!(replay_record(&record, &mut None, &mut None).is_err());
+
+        let mut committed = Some(CommittedManifest::genesis().unwrap());
+        let record = serde_json::json!({
+            "kind": "sync_bootstrap",
+            "manifest": CommittedManifest::genesis().unwrap(),
+        });
+        assert!(replay_record(&record, &mut committed, &mut None).is_err());
     }
 
     #[test]
@@ -1154,13 +1262,14 @@ mod tests {
             prefix: "prefix".into(),
             follow_symlinks: false,
             chunker_identity: "chunker-v1".into(),
+            embedding_identity_sha256: "a".repeat(64),
             embedding_backend: "lexical".into(),
-            embedding_model: "feature-hash".into(),
-            embedding_tokenizer: "builtin".into(),
             embedding_dimension: 384,
+            embedding_semantic_contract: "semantic_text-derived-vector.v1".into(),
+            embedding_resumable: true,
             graph_enabled: false,
-            brain: "none".into(),
-            detector_identity: "detectors-v1".into(),
+            brain: "disabled".into(),
+            detector_identity: "disabled".into(),
             schema_identity: "schema-v1".into(),
             index_identity: "index-v1".into(),
             source_policy: SourceExecutionPolicy::AbortOnSourceChange {
@@ -1183,11 +1292,7 @@ mod tests {
             sampled_records: 0,
             file_count: 0,
         });
-        let LegacyBootstrap::Ready(legacy) =
-            CommittedManifest::bootstrap_legacy(legacy_plan.clone()).unwrap()
-        else {
-            panic!("empty legacy membership is migratable");
-        };
+        let legacy = CommittedManifest::genesis().unwrap();
         let first = GenerationManifest {
             generation: 1,
             execution: Some(identity("inventory-a")),
@@ -1204,10 +1309,21 @@ mod tests {
         assert!(
             PendingSync::new("changed-execution".into(), &committed, changed_execution).is_err()
         );
+        let mut changed_generated_flag = first.clone();
+        changed_generated_flag.generation = 2;
+        changed_generated_flag.plan.alias_paths_indexed =
+            !changed_generated_flag.plan.alias_paths_indexed;
+        assert!(PendingSync::new(
+            "changed-generated-flag".into(),
+            &committed,
+            changed_generated_flag
+        )
+        .is_err());
 
         let mut changed_plan = first;
+        changed_plan.generation = 2;
         changed_plan.plan.alias_paths_indexed = true;
-        assert!(PendingSync::new("changed-plan".into(), &legacy, changed_plan).is_err());
+        assert!(PendingSync::new("changed-plan".into(), &committed, changed_plan).is_err());
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -1,0 +1,1545 @@
+//! Durable source preparation for incremental corpus reconciliation.
+//!
+//! This slice deliberately performs no remote mutation. It projects a
+//! byte-verified inventory into generation groups and makes desired bytes
+//! immutable before a later executor writes `sync_begin`.
+
+use crate::content::Inventory;
+use crate::state::{Journal, Plan};
+use crate::sync::{
+    self, CommittedManifest, DesiredContentGroup, GenerationManifest, ManifestGroup, ManifestPath,
+    PendingSync, SourceExecutionPolicy, SyncOperation, SyncOperationState,
+};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
+
+const SNAPSHOT_VERSION: u32 = 1;
+
+#[cfg(test)]
+static SNAPSHOT_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+#[cfg(test)]
+static SNAPSHOT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[cfg(test)]
+static REPLAY_FAIL_AFTER_APPLY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotFile {
+    pub content_id: String,
+    pub content_digest: String,
+    pub content_size: u64,
+    pub relative_blob: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prepared: Option<PreparedArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PreparedArtifact {
+    pub relative_ndjson: String,
+    pub records: u64,
+    pub passages: u64,
+    pub vectors: u64,
+    pub bytes: u64,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceSnapshot {
+    pub version: u32,
+    pub tx_id: String,
+    pub files: Vec<SnapshotFile>,
+    pub snapshot_digest: String,
+}
+
+/// Remote mutations must be convergent: calling `apply` twice for one
+/// operation after an accepted-but-unrecorded response must produce exactly
+/// the same live state. `validate` is the final generation-wide barrier.
+#[cfg_attr(not(test), allow(dead_code))]
+pub trait SyncOperationBackend {
+    fn apply(
+        &mut self,
+        operation: &SyncOperation,
+        base: &CommittedManifest,
+        desired: &GenerationManifest,
+        snapshot: &SourceSnapshot,
+    ) -> Result<()>;
+
+    fn validate(
+        &mut self,
+        base: &CommittedManifest,
+        desired: &GenerationManifest,
+        snapshot: &SourceSnapshot,
+    ) -> Result<()>;
+}
+
+/// Production ES-compatible operation backend for graph-disabled generations.
+///
+/// Upserts stream sealed index actions after removing both replaced and
+/// retry-partial content. Metadata operations read deterministic IDs from the
+/// committed snapshot and issue partial updates containing provenance only,
+/// so unchanged semantic fields are never re-embedded.
+#[cfg_attr(not(test), allow(dead_code))]
+pub struct EsSyncBackend<'a> {
+    es: &'a crate::esclient::Es,
+    state_dir: &'a Path,
+    bulk_bytes: usize,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl<'a> EsSyncBackend<'a> {
+    pub fn new(es: &'a crate::esclient::Es, state_dir: &'a Path, bulk_bytes: usize) -> Self {
+        Self {
+            es,
+            state_dir,
+            bulk_bytes: bulk_bytes.max(64 * 1024),
+        }
+    }
+
+    fn delete_group(&self, group: &ManifestGroup, plan: &Plan) -> Result<()> {
+        for index in group_indices(group, plan)? {
+            self.es.delete_by_query(
+                &index,
+                &serde_json::json!({"term": {
+                    "ax_file": &group.content_id
+                }}),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn replay_prepared(&self, snapshot: &SourceSnapshot, content_id: &str) -> Result<()> {
+        let prepared = prepared_for(snapshot, content_id)?;
+        let snapshot_dir = self.state_dir.join("sync-snapshots").join(&snapshot.tx_id);
+        let file = File::open(snapshot_dir.join(&prepared.relative_ndjson))?;
+        stream_ndjson_pairs(BufReader::new(file), self.bulk_bytes, |body| {
+            checked_bulk(self.es, body)
+        })
+    }
+
+    fn replay_metadata(
+        &self,
+        base: &CommittedManifest,
+        desired_group: &ManifestGroup,
+    ) -> Result<()> {
+        let base_snapshot = open_committed_snapshot(self.state_dir, base)?;
+        let old_group = base
+            .groups
+            .iter()
+            .find(|group| group.group_id == desired_group.group_id)
+            .context("metadata operation has no committed group")?;
+        let prepared = prepared_for(&base_snapshot, &old_group.content_id)?;
+        let snapshot_dir = self
+            .state_dir
+            .join("sync-snapshots")
+            .join(&base_snapshot.tx_id);
+        let reader = BufReader::new(File::open(snapshot_dir.join(&prepared.relative_ndjson))?);
+        let paths: Vec<Value> = std::iter::once(&desired_group.canonical)
+            .chain(desired_group.aliases.iter())
+            .map(|path| Value::String(path.rel.clone()))
+            .collect();
+        stream_metadata_updates(
+            reader,
+            self.bulk_bytes,
+            &desired_group.canonical.rel,
+            &paths,
+            |body| checked_bulk(self.es, body),
+        )
+    }
+
+    fn exact_group_count(&self, group: &ManifestGroup, plan: &Plan) -> Result<u64> {
+        let mut total = 0u64;
+        for index in group_indices(group, plan)? {
+            let response = self.es.search(
+                &index,
+                &serde_json::json!({
+                    "size": 0,
+                    "track_total_hits": true,
+                    "query": {"term": {"ax_file": &group.content_id}}
+                }),
+            )?;
+            total = total
+                .checked_add(
+                    response
+                        .pointer("/hits/total/value")
+                        .and_then(Value::as_u64)
+                        .context("exact validation response has no total hit count")?,
+                )
+                .context("exact validation count overflow")?;
+        }
+        Ok(total)
+    }
+}
+
+impl SyncOperationBackend for EsSyncBackend<'_> {
+    fn apply(
+        &mut self,
+        operation: &SyncOperation,
+        base: &CommittedManifest,
+        desired: &GenerationManifest,
+        snapshot: &SourceSnapshot,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            desired
+                .execution
+                .as_ref()
+                .is_some_and(|execution| !execution.graph_enabled),
+            "production incremental graph reconciliation is not enabled yet"
+        );
+        let old = base
+            .groups
+            .iter()
+            .find(|group| group.group_id == operation.group_id);
+        let new = desired
+            .groups
+            .iter()
+            .find(|group| group.group_id == operation.group_id);
+        match operation.kind {
+            crate::sync::SyncOperationKind::Delete => self.delete_group(
+                old.context("delete operation has no committed group")?,
+                &base.plan,
+            ),
+            crate::sync::SyncOperationKind::Upsert => {
+                if let Some(old) = old {
+                    self.delete_group(old, &base.plan)?;
+                }
+                let new = new.context("upsert operation has no desired group")?;
+                // Remove a partial prior retry of the desired identity too.
+                self.delete_group(new, &desired.plan)?;
+                self.replay_prepared(snapshot, &new.content_id)
+            }
+            crate::sync::SyncOperationKind::Metadata => self.replay_metadata(
+                base,
+                new.context("metadata operation has no desired group")?,
+            ),
+        }
+    }
+
+    fn validate(
+        &mut self,
+        base: &CommittedManifest,
+        desired: &GenerationManifest,
+        _snapshot: &SourceSnapshot,
+    ) -> Result<()> {
+        for dataset in &desired.plan.datasets {
+            self.es.refresh(&dataset.index)?;
+        }
+        for group in &desired.groups {
+            anyhow::ensure!(
+                self.exact_group_count(group, &desired.plan)? == group.expected_records,
+                "live record count disagrees with desired group {}",
+                group.group_id
+            );
+        }
+        let desired_ids: std::collections::HashSet<&str> = desired
+            .groups
+            .iter()
+            .map(|group| group.content_id.as_str())
+            .collect();
+        for old in &base.groups {
+            if !desired_ids.contains(old.content_id.as_str()) {
+                anyhow::ensure!(
+                    self.exact_group_count(old, &base.plan)? == 0,
+                    "replaced or deleted content {} remains live",
+                    old.content_id
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resume a journaled generation strictly from its verified snapshot.
+///
+/// The durable order is Started -> convergent remote apply -> Committed.
+/// Therefore a crash after an accepted response repeats the same operation;
+/// a crash after Committed skips it. Only an exact backend validation allows
+/// `sync_validated` and the minimal authority switch in `sync_commit`.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn replay_pending_operations(
+    state_dir: &Path,
+    journal: &mut Journal,
+    backend: &mut impl SyncOperationBackend,
+) -> Result<()> {
+    let pending = journal
+        .pending_sync
+        .clone()
+        .context("cannot replay without a pending corpus generation")?;
+    let base = journal
+        .committed_manifest
+        .clone()
+        .context("pending corpus generation has no committed base")?;
+    pending.validate_against(&base)?;
+    let snapshot = open_snapshot(state_dir, &pending.tx_id)?;
+    verify_snapshot_binding(&pending, &snapshot)?;
+
+    for operation in &pending.operations {
+        let state = journal
+            .pending_sync
+            .as_ref()
+            .and_then(|sync| sync.operation_states.get(&operation.operation_id))
+            .cloned();
+        if state == Some(SyncOperationState::Committed) {
+            continue;
+        }
+        if state.is_none() {
+            journal.sync_operation_state(&operation.operation_id, SyncOperationState::Started)?;
+        }
+        backend.apply(operation, &base, &pending.desired, &snapshot)?;
+        replay_fail_after_apply()?;
+        journal.sync_operation_state(&operation.operation_id, SyncOperationState::Committed)?;
+    }
+    backend.validate(&base, &pending.desired, &snapshot)?;
+    journal.sync_validated()?;
+    journal.sync_commit()
+}
+
+/// Test helper proving a pending generation binds before mutable discovery.
+/// Production calls `replay_pending_operations` at this boundary.
+#[cfg(test)]
+pub fn require_resumable_pending_source(
+    state_dir: &Path,
+    pending: Option<&PendingSync>,
+) -> Result<()> {
+    let Some(pending) = pending else {
+        return Ok(());
+    };
+    let snapshot = open_snapshot(state_dir, &pending.tx_id).with_context(|| {
+        format!(
+            "pending corpus generation {} must resume before source discovery",
+            pending.tx_id
+        )
+    })?;
+    verify_snapshot_binding(pending, &snapshot)?;
+    anyhow::bail!(
+        "corpus generation {} is pending with verified durable source snapshot {} ({} files); \
+         incremental operation replay is not enabled by this executor slice, so no source \
+         discovery or remote mutation was attempted",
+        pending.tx_id,
+        snapshot.snapshot_digest,
+        snapshot.files.len()
+    )
+}
+
+fn verify_snapshot_binding(pending: &PendingSync, snapshot: &SourceSnapshot) -> Result<()> {
+    let execution = pending
+        .desired
+        .execution
+        .as_ref()
+        .context("pending generation has no execution identity")?;
+    let SourceExecutionPolicy::DurableSnapshot {
+        reference,
+        snapshot_digest,
+    } = &execution.source_policy
+    else {
+        anyhow::bail!("pending generation is not bound to a durable source snapshot");
+    };
+    anyhow::ensure!(
+        reference == &format!("sync-snapshots/{}", pending.tx_id)
+            && snapshot_digest == &snapshot.snapshot_digest,
+        "pending generation source snapshot binding does not match verified snapshot"
+    );
+    Ok(())
+}
+
+fn open_committed_snapshot(
+    state_dir: &Path,
+    committed: &CommittedManifest,
+) -> Result<SourceSnapshot> {
+    let execution = committed
+        .execution
+        .as_ref()
+        .context("committed generation has no execution identity")?;
+    let SourceExecutionPolicy::DurableSnapshot {
+        reference,
+        snapshot_digest,
+    } = &execution.source_policy
+    else {
+        anyhow::bail!("committed generation is not bound to a durable snapshot");
+    };
+    let tx_id = reference
+        .strip_prefix("sync-snapshots/")
+        .context("committed snapshot reference is not state-relative")?;
+    let snapshot = open_snapshot(state_dir, tx_id)?;
+    anyhow::ensure!(
+        &snapshot.snapshot_digest == snapshot_digest,
+        "committed snapshot digest mismatch"
+    );
+    Ok(snapshot)
+}
+
+fn prepared_for<'a>(
+    snapshot: &'a SourceSnapshot,
+    content_id: &str,
+) -> Result<&'a PreparedArtifact> {
+    snapshot
+        .files
+        .iter()
+        .find(|file| file.content_id == content_id)
+        .and_then(|file| file.prepared.as_ref())
+        .with_context(|| format!("content {content_id} has no sealed prepared artifact"))
+}
+
+fn group_indices(group: &ManifestGroup, plan: &Plan) -> Result<Vec<String>> {
+    let by_slug: HashMap<&str, &str> = plan
+        .datasets
+        .iter()
+        .map(|dataset| (dataset.slug.as_str(), dataset.index.as_str()))
+        .collect();
+    let mut indices = group
+        .dataset_slugs
+        .iter()
+        .map(|slug| {
+            by_slug
+                .get(slug.as_str())
+                .map(|index| (*index).to_string())
+                .with_context(|| format!("group references absent dataset {slug}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    indices.sort();
+    indices.dedup();
+    Ok(indices)
+}
+
+fn checked_bulk(es: &crate::esclient::Es, body: Vec<u8>) -> Result<()> {
+    if body.is_empty() {
+        return Ok(());
+    }
+    let outcome = es.bulk(body)?;
+    anyhow::ensure!(
+        outcome.item_errors == 0,
+        "prepared bulk contained {} rejected items: {}",
+        outcome.item_errors,
+        outcome
+            .first_error
+            .unwrap_or_else(|| "unknown error".into())
+    );
+    Ok(())
+}
+
+fn stream_ndjson_pairs(
+    mut reader: impl std::io::BufRead,
+    bulk_bytes: usize,
+    mut send: impl FnMut(Vec<u8>) -> Result<()>,
+) -> Result<()> {
+    let mut body = Vec::with_capacity(bulk_bytes);
+    loop {
+        let mut action = Vec::new();
+        if reader.read_until(b'\n', &mut action)? == 0 {
+            break;
+        }
+        let mut document = Vec::new();
+        anyhow::ensure!(
+            reader.read_until(b'\n', &mut document)? > 0,
+            "prepared NDJSON ended without a document"
+        );
+        if !body.is_empty() && body.len() + action.len() + document.len() > bulk_bytes {
+            send(std::mem::take(&mut body))?;
+            body.reserve(bulk_bytes);
+        }
+        body.extend_from_slice(&action);
+        body.extend_from_slice(&document);
+    }
+    send(body)
+}
+
+fn stream_metadata_updates(
+    mut reader: impl std::io::BufRead,
+    bulk_bytes: usize,
+    canonical: &str,
+    paths: &[Value],
+    mut send: impl FnMut(Vec<u8>) -> Result<()>,
+) -> Result<()> {
+    let mut body = Vec::with_capacity(bulk_bytes);
+    loop {
+        let mut action_line = String::new();
+        if reader.read_line(&mut action_line)? == 0 {
+            break;
+        }
+        let mut ignored_document = String::new();
+        anyhow::ensure!(
+            reader.read_line(&mut ignored_document)? > 0,
+            "prepared NDJSON ended without a document"
+        );
+        let action: Value = serde_json::from_str(&action_line)?;
+        let index = action
+            .pointer("/index/_index")
+            .and_then(Value::as_str)
+            .context("prepared action has no index")?;
+        let id = action
+            .pointer("/index/_id")
+            .and_then(Value::as_str)
+            .context("prepared action has no ID")?;
+        let update =
+            serde_json::to_vec(&serde_json::json!({"update": {"_index": index, "_id": id}}))?;
+        let patch = serde_json::to_vec(&serde_json::json!({"doc": {
+            "ax_path": canonical,
+            "ax_paths": paths
+        }}))?;
+        let required = update.len() + patch.len() + 2;
+        if !body.is_empty() && body.len() + required > bulk_bytes {
+            send(std::mem::take(&mut body))?;
+            body.reserve(bulk_bytes);
+        }
+        body.extend_from_slice(&update);
+        body.push(b'\n');
+        body.extend_from_slice(&patch);
+        body.push(b'\n');
+    }
+    send(body)
+}
+
+/// Build desired groups without guessing assignments. Output counts survive
+/// only when the committed content identity is byte-identical.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn groups_from_inventory(
+    inventory: &Inventory,
+    plan: &Plan,
+    previous: &[ManifestGroup],
+) -> Result<Vec<ManifestGroup>> {
+    ensure_inventory_lengths(inventory)?;
+    let previous_by_content: HashMap<&str, &ManifestGroup> = previous
+        .iter()
+        .map(|group| (group.content_id.as_str(), group))
+        .collect();
+    let mut aliases_by_key: HashMap<&str, Vec<ManifestPath>> = HashMap::new();
+    for alias in &inventory.duplicates {
+        aliases_by_key
+            .entry(alias.file_key.as_str())
+            .or_default()
+            .push(ManifestPath {
+                path_id: alias.path_id.clone(),
+                rel: alias.rel.clone(),
+                is_symlink: alias.is_symlink.with_context(|| {
+                    format!("alias {} has no persisted symlink rank", alias.rel)
+                })?,
+            });
+    }
+    let desired = inventory
+        .files
+        .iter()
+        .zip(&inventory.keys)
+        .zip(&inventory.digests)
+        .map(|((file, content_id), content_digest)| {
+            let assignment = plan.files.get(content_id).with_context(|| {
+                format!("typed plan has no assignment for content {content_id}")
+            })?;
+            anyhow::ensure!(
+                assignment.rel == file.rel
+                    && assignment.path_id == file.rel_id
+                    && assignment.content_digest.as_deref() == Some(content_digest.as_str()),
+                "typed plan canonical projection disagrees with inventory for {}",
+                file.rel
+            );
+            let mut dataset_slugs: Vec<String> = assignment
+                .assignments
+                .iter()
+                .map(|(_, slug)| slug.clone())
+                .collect();
+            dataset_slugs.sort();
+            dataset_slugs.dedup();
+            let prior = previous_by_content.get(content_id.as_str()).copied();
+            Ok(DesiredContentGroup {
+                content_id: content_id.clone(),
+                content_digest: content_digest.clone(),
+                content_size: file.size,
+                paths: std::iter::once(ManifestPath {
+                    path_id: file.rel_id.clone(),
+                    rel: file.rel.clone(),
+                    is_symlink: file.is_symlink,
+                })
+                .chain(
+                    aliases_by_key
+                        .get(content_id.as_str())
+                        .into_iter()
+                        .flatten()
+                        .cloned(),
+                )
+                .collect(),
+                dataset_slugs,
+                expected_records: prior.map_or(0, |group| group.expected_records),
+                expected_passages: prior.map_or(0, |group| group.expected_passages),
+                expected_vectors: prior.map_or(0, |group| group.expected_vectors),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    sync::reconcile_groups(previous, desired)
+}
+
+/// Bind exact prepared output cardinalities into the desired manifest before
+/// `sync_begin`. Content without a prepared artifact is rejected; unchanged
+/// groups should retain their already committed counts instead.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn bind_prepared_counts(
+    groups: &mut [ManifestGroup],
+    snapshot: &SourceSnapshot,
+    prepared_content: &[String],
+) -> Result<()> {
+    let prepared_content: std::collections::HashSet<&str> =
+        prepared_content.iter().map(String::as_str).collect();
+    let by_content: HashMap<&str, &PreparedArtifact> = snapshot
+        .files
+        .iter()
+        .filter_map(|file| {
+            file.prepared
+                .as_ref()
+                .map(|prepared| (file.content_id.as_str(), prepared))
+        })
+        .collect();
+    for group in groups {
+        if !prepared_content.contains(group.content_id.as_str()) {
+            continue;
+        }
+        let prepared = by_content
+            .get(group.content_id.as_str())
+            .context("desired content has no prepared artifact")?;
+        group.expected_records = prepared.records;
+        group.expected_passages = prepared.passages;
+        group.expected_vectors = prepared.vectors;
+    }
+    Ok(())
+}
+
+/// Fsync blobs and manifest in a private directory, then atomically publish
+/// the transaction snapshot. Retries reuse a verified final snapshot or
+/// replace only that transaction's incomplete staging directory.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn create_snapshot(
+    state_dir: &Path,
+    tx_id: &str,
+    inventory: &Inventory,
+) -> Result<SourceSnapshot> {
+    create_snapshot_inner(state_dir, tx_id, inventory, None)
+}
+
+/// Seal deterministic bulk actions together with source bytes. Extraction and
+/// coercion happen before `sync_begin`; retries stream this artifact and never
+/// re-extract or re-embed unchanged content.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn create_prepared_snapshot(
+    state_dir: &Path,
+    tx_id: &str,
+    inventory: &Inventory,
+    plan: &Plan,
+) -> Result<SourceSnapshot> {
+    create_snapshot_inner(state_dir, tx_id, inventory, Some(plan))
+}
+
+fn create_snapshot_inner(
+    state_dir: &Path,
+    tx_id: &str,
+    inventory: &Inventory,
+    plan: Option<&Plan>,
+) -> Result<SourceSnapshot> {
+    validate_tx_id(tx_id)?;
+    ensure_inventory_lengths(inventory)?;
+    let root = state_dir.join("sync-snapshots");
+    std::fs::create_dir_all(&root)?;
+    let final_dir = root.join(tx_id);
+    if final_dir.exists() {
+        return open_snapshot(state_dir, tx_id);
+    }
+    let staging = root.join(format!(".{tx_id}.partial"));
+    if staging.exists() {
+        std::fs::remove_dir_all(&staging)?;
+    }
+    std::fs::create_dir(&staging)?;
+    let blobs = staging.join("blobs");
+    std::fs::create_dir(&blobs)?;
+    let prepared_dir = staging.join("prepared");
+    if plan.is_some() {
+        std::fs::create_dir(&prepared_dir)?;
+    }
+    let mut files = Vec::with_capacity(inventory.files.len());
+    for (ordinal, ((source, content_id), content_digest)) in inventory
+        .files
+        .iter()
+        .zip(&inventory.keys)
+        .zip(&inventory.digests)
+        .enumerate()
+    {
+        crate::content::verify(&source.path, source.size, content_digest)?;
+        let relative_blob = format!("blobs/{ordinal:08}");
+        let destination = staging.join(&relative_blob);
+        copy_synced(&source.path, &destination)?;
+        crate::content::verify(&destination, source.size, content_digest)?;
+        let prepared = plan
+            .map(|plan| prepare_artifact(&staging, ordinal, source, content_id, &destination, plan))
+            .transpose()?;
+        files.push(SnapshotFile {
+            content_id: content_id.clone(),
+            content_digest: content_digest.clone(),
+            content_size: source.size,
+            relative_blob,
+            prepared,
+        });
+    }
+    snapshot_failpoint(1)?;
+    let snapshot = SourceSnapshot {
+        version: SNAPSHOT_VERSION,
+        tx_id: tx_id.to_string(),
+        snapshot_digest: snapshot_digest(tx_id, &files)?,
+        files,
+    };
+    write_synced_json(&staging.join("manifest.json"), &snapshot)?;
+    sync_dir(&blobs)?;
+    if plan.is_some() {
+        sync_dir(&prepared_dir)?;
+    }
+    sync_dir(&staging)?;
+    snapshot_failpoint(2)?;
+    std::fs::rename(&staging, &final_dir)?;
+    sync_dir(&root)?;
+    snapshot_failpoint(3)?;
+    open_snapshot(state_dir, tx_id)
+}
+
+pub fn open_snapshot(state_dir: &Path, tx_id: &str) -> Result<SourceSnapshot> {
+    validate_tx_id(tx_id)?;
+    let dir = state_dir.join("sync-snapshots").join(tx_id);
+    let snapshot: SourceSnapshot =
+        serde_json::from_slice(&std::fs::read(dir.join("manifest.json"))?)?;
+    anyhow::ensure!(
+        snapshot.version == SNAPSHOT_VERSION && snapshot.tx_id == tx_id,
+        "source snapshot identity mismatch"
+    );
+    anyhow::ensure!(
+        snapshot.snapshot_digest == snapshot_digest(tx_id, &snapshot.files)?,
+        "source snapshot manifest digest mismatch"
+    );
+    for file in &snapshot.files {
+        anyhow::ensure!(
+            file.relative_blob.starts_with("blobs/")
+                && !file.relative_blob.contains("..")
+                && !Path::new(&file.relative_blob).is_absolute(),
+            "invalid source snapshot blob path"
+        );
+        crate::content::verify(
+            &dir.join(&file.relative_blob),
+            file.content_size,
+            &file.content_digest,
+        )?;
+        if let Some(prepared) = &file.prepared {
+            validate_relative_path(&prepared.relative_ndjson, "prepared/")?;
+            let path = dir.join(&prepared.relative_ndjson);
+            let metadata = std::fs::metadata(&path)?;
+            anyhow::ensure!(
+                metadata.len() == prepared.bytes
+                    && stream_digest(&path, "axp1")? == prepared.digest,
+                "prepared artifact digest or size mismatch"
+            );
+        }
+    }
+    Ok(snapshot)
+}
+
+fn prepare_artifact(
+    staging: &Path,
+    ordinal: usize,
+    source: &crate::walk::FileEntry,
+    content_id: &str,
+    snapshot_blob: &Path,
+    plan: &Plan,
+) -> Result<PreparedArtifact> {
+    let assignment = plan
+        .files
+        .get(content_id)
+        .with_context(|| format!("plan has no assignment for {}", source.rel))?;
+    let datasets: HashMap<&str, &crate::state::PlanDataset> = plan
+        .datasets
+        .iter()
+        .map(|dataset| (dataset.slug.as_str(), dataset))
+        .collect();
+    let coercions: HashMap<&str, HashMap<String, crate::coerce::Coerce>> = plan
+        .datasets
+        .iter()
+        .map(|dataset| {
+            (
+                dataset.slug.as_str(),
+                crate::coerce::plan_from_specs(&dataset.specs),
+            )
+        })
+        .collect();
+    let mut paths = vec![assignment.rel.clone()];
+    paths.extend(
+        plan.duplicate_files
+            .iter()
+            .filter(|alias| alias.file_key == content_id)
+            .map(|alias| alias.rel.clone()),
+    );
+    paths.sort();
+    paths.dedup();
+    let assignments: HashMap<Option<String>, &str> = assignment
+        .assignments
+        .iter()
+        .map(|(group, slug)| (group.clone(), slug.as_str()))
+        .collect();
+    let sniffed = crate::sniff::sniff(&source.path)
+        .with_context(|| format!("sniff {} for durable preparation", source.rel))?;
+    let relative_ndjson = format!("prepared/{ordinal:08}.ndjson");
+    let path = staging.join(&relative_ndjson);
+    let file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&path)?;
+    let mut writer = BufWriter::new(file);
+    let mut records = 0u64;
+    let mut passages = 0u64;
+    let mut vectors = 0u64;
+    let mut sink_error: Option<anyhow::Error> = None;
+    let mut sink = |record: crate::extract::RawRecord| -> bool {
+        let Some(slug) = assignments
+            .get(&record.group)
+            .or_else(|| assignments.get(&None))
+            .copied()
+        else {
+            sink_error = Some(anyhow::anyhow!(
+                "record {} has no stable dataset assignment",
+                record.locator
+            ));
+            return false;
+        };
+        let Some(dataset) = datasets.get(slug).copied() else {
+            sink_error = Some(anyhow::anyhow!(
+                "dataset {slug} is absent from prepared plan"
+            ));
+            return false;
+        };
+        let mut fields: Map<String, Value> = record.fields;
+        let Some(coercion) = coercions.get(slug) else {
+            sink_error = Some(anyhow::anyhow!("dataset {slug} has no coercion plan"));
+            return false;
+        };
+        crate::coerce::coerce_record(&mut fields, coercion);
+        fields.insert("ax_path".into(), Value::String(assignment.rel.clone()));
+        fields.insert(
+            "ax_paths".into(),
+            Value::Array(paths.iter().cloned().map(Value::String).collect()),
+        );
+        fields.insert("ax_file".into(), Value::String(content_id.to_string()));
+        fields.insert("ax_locator".into(), Value::String(record.locator.clone()));
+        fields.insert("ax_dataset".into(), Value::String(slug.to_string()));
+        fields.insert("ax_run".into(), Value::String("generation-pending".into()));
+        fields.insert(
+            "ax_format".into(),
+            Value::String(source.path.extension().map_or_else(
+                || "unknown".into(),
+                |extension| extension.to_string_lossy().to_ascii_lowercase(),
+            )),
+        );
+        let id = crate::ids::doc_id(slug, content_id, &record.locator);
+        let action = serde_json::json!({"index": {"_index": dataset.index, "_id": id}});
+        if writeln!(writer, "{action}")
+            .and_then(|_| writeln!(writer, "{}", Value::Object(fields.clone())))
+            .is_err()
+        {
+            sink_error = Some(anyhow::anyhow!("write prepared NDJSON"));
+            return false;
+        }
+        records += 1;
+        if dataset
+            .semantic_field
+            .as_ref()
+            .is_some_and(|field| fields.get(field).is_some())
+        {
+            passages += 1;
+            vectors += 1;
+        }
+        true
+    };
+    let stats = crate::extract::extract(snapshot_blob, &sniffed, None, &mut sink)
+        .with_context(|| format!("extract {} into durable preparation", source.rel))?;
+    anyhow::ensure!(
+        stats.junk == 0,
+        "durable preparation of {} produced {} junk records",
+        source.rel,
+        stats.junk
+    );
+    if let Some(error) = sink_error {
+        return Err(error);
+    }
+    writer.flush()?;
+    writer.get_ref().sync_all()?;
+    drop(writer);
+    let bytes = std::fs::metadata(&path)?.len();
+    Ok(PreparedArtifact {
+        relative_ndjson,
+        records,
+        passages,
+        vectors,
+        bytes,
+        digest: stream_digest(&path, "axp1")?,
+    })
+}
+
+fn validate_relative_path(path: &str, prefix: &str) -> Result<()> {
+    anyhow::ensure!(
+        path.starts_with(prefix) && !path.contains("..") && !Path::new(path).is_absolute(),
+        "invalid snapshot artifact path"
+    );
+    Ok(())
+}
+
+fn stream_digest(path: &Path, prefix: &str) -> Result<String> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let mut hash = xxhash_rust::xxh3::Xxh3::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hash.update(&buffer[..read]);
+    }
+    Ok(format!("{prefix}-{:016x}", hash.digest()))
+}
+
+fn ensure_inventory_lengths(inventory: &Inventory) -> Result<()> {
+    anyhow::ensure!(
+        inventory.files.len() == inventory.keys.len()
+            && inventory.keys.len() == inventory.digests.len(),
+        "inventory vectors have inconsistent lengths"
+    );
+    Ok(())
+}
+
+fn snapshot_digest(tx_id: &str, files: &[SnapshotFile]) -> Result<String> {
+    let mut files = files.to_vec();
+    files.sort_by(|left, right| {
+        left.content_id
+            .cmp(&right.content_id)
+            .then_with(|| left.relative_blob.cmp(&right.relative_blob))
+    });
+    let encoded = serde_json::to_vec(&(SNAPSHOT_VERSION, tx_id, files))?;
+    Ok(format!(
+        "axs1-{:032x}",
+        xxhash_rust::xxh3::xxh3_128(&encoded)
+    ))
+}
+
+fn validate_tx_id(tx_id: &str) -> Result<()> {
+    anyhow::ensure!(
+        !tx_id.is_empty()
+            && tx_id.len() <= 128
+            && tx_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')),
+        "invalid source snapshot transaction ID"
+    );
+    Ok(())
+}
+
+fn copy_synced(source: &Path, destination: &Path) -> Result<()> {
+    let mut input = File::open(source)?;
+    let mut output = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(destination)?;
+    std::io::copy(&mut input, &mut output)?;
+    output.sync_all()?;
+    Ok(())
+}
+
+fn write_synced_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    let mut file = OpenOptions::new().create_new(true).write(true).open(path)?;
+    serde_json::to_writer(&mut file, value)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn sync_dir(path: &Path) -> Result<()> {
+    File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+fn fail_next_snapshot(boundary: u8) {
+    SNAPSHOT_FAILPOINT.store(boundary, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn snapshot_failpoint(boundary: u8) -> Result<()> {
+    if SNAPSHOT_FAILPOINT.compare_exchange(
+        boundary,
+        0,
+        std::sync::atomic::Ordering::SeqCst,
+        std::sync::atomic::Ordering::SeqCst,
+    ) == Ok(boundary)
+    {
+        anyhow::bail!("injected snapshot failure at boundary {boundary}");
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn snapshot_failpoint(_boundary: u8) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+fn fail_replay_after_next_apply() {
+    REPLAY_FAIL_AFTER_APPLY.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn replay_fail_after_apply() -> Result<()> {
+    if REPLAY_FAIL_AFTER_APPLY.swap(false, std::sync::atomic::Ordering::SeqCst) {
+        anyhow::bail!("injected crash after accepted operation");
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn replay_fail_after_apply() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{FileAssignment, PlanDataset};
+    use crate::sync::{
+        ExecutionIdentity, GenerationManifest, SourceExecutionPolicy, SyncOperationKind,
+        EXECUTION_IDENTITY_VERSION,
+    };
+    use crate::walk;
+    use std::collections::BTreeMap;
+
+    fn inventory(root: &Path) -> Inventory {
+        crate::content::resolve(walk::walk(root, false).unwrap()).unwrap()
+    }
+
+    fn plan_for(inventory: &Inventory) -> Plan {
+        let key = inventory.keys[0].clone();
+        let file = &inventory.files[0];
+        Plan {
+            datasets: vec![PlanDataset {
+                slug: "docs".into(),
+                index: "ax-docs".into(),
+                family: "text".into(),
+                group: None,
+                specs: vec![],
+                time_field: None,
+                semantic_field: None,
+                sampled_records: 1,
+                file_count: 1,
+            }],
+            files: HashMap::from([(
+                key,
+                FileAssignment {
+                    rel: file.rel.clone(),
+                    path_id: file.rel_id.clone(),
+                    is_symlink: Some(file.is_symlink),
+                    family: "text".into(),
+                    gzip: false,
+                    content_digest: Some(inventory.digests[0].clone()),
+                    assignments: vec![(None, "docs".into())],
+                },
+            )]),
+            alias_paths_indexed: false,
+            ..Plan::default()
+        }
+    }
+
+    fn execution(tx_id: &str, digest: &str) -> ExecutionIdentity {
+        ExecutionIdentity {
+            version: EXECUTION_IDENTITY_VERSION,
+            root_identity: "root".into(),
+            url: "http://engine".into(),
+            prefix: "ax".into(),
+            follow_symlinks: false,
+            chunker_identity: "chunker-v1".into(),
+            embedding_backend: "lexical".into(),
+            embedding_model: "feature-hash".into(),
+            embedding_tokenizer: "none".into(),
+            embedding_dimension: 384,
+            graph_enabled: false,
+            brain: "brain".into(),
+            detector_identity: "none".into(),
+            schema_identity: "schema-v1".into(),
+            index_identity: "index-v1".into(),
+            source_policy: SourceExecutionPolicy::DurableSnapshot {
+                reference: format!("sync-snapshots/{tx_id}"),
+                snapshot_digest: digest.into(),
+            },
+        }
+    }
+
+    fn desired(
+        generation: u64,
+        tx_id: &str,
+        snapshot: &SourceSnapshot,
+        plan: Plan,
+        groups: Vec<ManifestGroup>,
+    ) -> GenerationManifest {
+        GenerationManifest {
+            generation,
+            execution: Some(execution(tx_id, &snapshot.snapshot_digest)),
+            plan,
+            groups,
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct LiveGroup {
+        content_id: String,
+        canonical: String,
+        aliases: Vec<String>,
+    }
+
+    #[derive(Default)]
+    struct FakeBackend {
+        live: BTreeMap<String, LiveGroup>,
+        applications: Vec<String>,
+    }
+
+    impl SyncOperationBackend for FakeBackend {
+        fn apply(
+            &mut self,
+            operation: &SyncOperation,
+            _base: &CommittedManifest,
+            desired: &GenerationManifest,
+            _snapshot: &SourceSnapshot,
+        ) -> Result<()> {
+            self.applications.push(operation.operation_id.clone());
+            match operation.kind {
+                SyncOperationKind::Delete => {
+                    self.live.remove(&operation.group_id);
+                }
+                SyncOperationKind::Upsert | SyncOperationKind::Metadata => {
+                    let group = desired
+                        .groups
+                        .iter()
+                        .find(|group| group.group_id == operation.group_id)
+                        .context("desired operation group is absent")?;
+                    self.live.insert(
+                        group.group_id.clone(),
+                        LiveGroup {
+                            content_id: group.content_id.clone(),
+                            canonical: group.canonical.path_id.clone(),
+                            aliases: group
+                                .aliases
+                                .iter()
+                                .map(|alias| alias.path_id.clone())
+                                .collect(),
+                        },
+                    );
+                }
+            }
+            Ok(())
+        }
+
+        fn validate(
+            &mut self,
+            _base: &CommittedManifest,
+            desired: &GenerationManifest,
+            _snapshot: &SourceSnapshot,
+        ) -> Result<()> {
+            let expected: BTreeMap<String, LiveGroup> = desired
+                .groups
+                .iter()
+                .map(|group| {
+                    (
+                        group.group_id.clone(),
+                        LiveGroup {
+                            content_id: group.content_id.clone(),
+                            canonical: group.canonical.path_id.clone(),
+                            aliases: group
+                                .aliases
+                                .iter()
+                                .map(|alias| alias.path_id.clone())
+                                .collect(),
+                        },
+                    )
+                })
+                .collect();
+            anyhow::ensure!(self.live == expected, "fake live generation mismatch");
+            Ok(())
+        }
+    }
+
+    fn begin(
+        journal: &mut Journal,
+        tx_id: &str,
+        snapshot: &SourceSnapshot,
+        plan: Plan,
+        groups: Vec<ManifestGroup>,
+    ) {
+        let base = journal.committed_manifest.as_ref().unwrap();
+        let pending = PendingSync::new(
+            tx_id.into(),
+            base,
+            desired(base.generation + 1, tx_id, snapshot, plan, groups),
+        )
+        .unwrap();
+        journal.sync_begin(&pending).unwrap();
+    }
+
+    fn empty_base_for(plan: &Plan) -> Plan {
+        let mut base = plan.clone();
+        base.files.clear();
+        base.duplicate_files.clear();
+        for dataset in &mut base.datasets {
+            dataset.file_count = 0;
+        }
+        base
+    }
+
+    #[test]
+    fn inventory_bridge_retains_counts_only_for_identical_content() {
+        let corpus = tempfile::tempdir().unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "alpha").unwrap();
+        let inventory = inventory(corpus.path());
+        let plan = plan_for(&inventory);
+        let first = groups_from_inventory(&inventory, &plan, &[]).unwrap();
+        assert_eq!(first[0].expected_records, 0);
+        let mut committed = first;
+        committed[0].expected_records = 7;
+        committed[0].expected_passages = 3;
+        committed[0].expected_vectors = 3;
+        let resumed = groups_from_inventory(&inventory, &plan, &committed).unwrap();
+        assert_eq!(
+            (
+                resumed[0].expected_records,
+                resumed[0].expected_passages,
+                resumed[0].expected_vectors
+            ),
+            (7, 3, 3)
+        );
+    }
+
+    #[test]
+    fn snapshot_is_immutable_and_detects_blob_corruption() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let corpus = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "alpha").unwrap();
+        let inventory = inventory(corpus.path());
+        let snapshot = create_snapshot(state.path(), "tx-1", &inventory).unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "changed source").unwrap();
+        assert_eq!(open_snapshot(state.path(), "tx-1").unwrap(), snapshot);
+        let blob = state
+            .path()
+            .join("sync-snapshots/tx-1")
+            .join(&snapshot.files[0].relative_blob);
+        std::fs::write(blob, "corrupt").unwrap();
+        assert!(open_snapshot(state.path(), "tx-1").is_err());
+    }
+
+    #[test]
+    fn prepared_snapshot_streams_exact_actions_counts_and_digest() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let corpus = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        std::fs::write(
+            corpus.path().join("a.jsonl"),
+            "{\"message\":\"alpha\"}\n{\"message\":\"beta\"}\n",
+        )
+        .unwrap();
+        let inventory = inventory(corpus.path());
+        let plan = plan_for(&inventory);
+        let snapshot =
+            create_prepared_snapshot(state.path(), "tx-prepared", &inventory, &plan).unwrap();
+        let prepared = snapshot.files[0].prepared.as_ref().unwrap();
+        assert_eq!(prepared.records, 2);
+        assert!(prepared.bytes > 0);
+        let ndjson = std::fs::read_to_string(
+            state
+                .path()
+                .join("sync-snapshots/tx-prepared")
+                .join(&prepared.relative_ndjson),
+        )
+        .unwrap();
+        assert_eq!(ndjson.lines().count(), 4);
+        assert!(ndjson.contains("\"ax_file\""));
+        assert!(ndjson.contains("\"_index\":\"ax-docs\""));
+
+        let mut groups = groups_from_inventory(&inventory, &plan, &[]).unwrap();
+        bind_prepared_counts(&mut groups, &snapshot, &inventory.keys).unwrap();
+        assert_eq!(groups[0].expected_records, 2);
+        let artifact_path = state
+            .path()
+            .join("sync-snapshots/tx-prepared")
+            .join(&prepared.relative_ndjson);
+        std::fs::write(artifact_path, "corrupt").unwrap();
+        assert!(open_snapshot(state.path(), "tx-prepared").is_err());
+    }
+
+    #[test]
+    fn prepared_and_metadata_streams_preserve_pairs_under_tiny_budgets() {
+        let input = concat!(
+            "{\"index\":{\"_index\":\"docs\",\"_id\":\"a\"}}\n",
+            "{\"body\":\"alpha\"}\n",
+            "{\"index\":{\"_index\":\"docs\",\"_id\":\"b\"}}\n",
+            "{\"body\":\"beta\"}\n"
+        );
+        let mut index_chunks = Vec::new();
+        stream_ndjson_pairs(input.as_bytes(), 1, |body| {
+            index_chunks.push(String::from_utf8(body).unwrap());
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(index_chunks.len(), 2);
+        assert!(index_chunks.iter().all(|chunk| chunk.lines().count() == 2));
+
+        let mut update_chunks = Vec::new();
+        stream_metadata_updates(
+            input.as_bytes(),
+            1,
+            "renamed.txt",
+            &[Value::String("renamed.txt".into())],
+            |body| {
+                update_chunks.push(String::from_utf8(body).unwrap());
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(update_chunks.len(), 2);
+        assert!(update_chunks.iter().all(|chunk| {
+            chunk.lines().count() == 2
+                && chunk.contains("\"update\"")
+                && chunk.contains("\"ax_path\":\"renamed.txt\"")
+                && !chunk.contains("\"body\"")
+        }));
+
+        let es = crate::esclient::Es::new("http://127.0.0.1:1", None).unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let _backend = EsSyncBackend::new(&es, state.path(), 1);
+    }
+
+    #[test]
+    fn every_snapshot_crash_boundary_restarts_deterministically() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for boundary in 1..=3 {
+            let corpus = tempfile::tempdir().unwrap();
+            let state = tempfile::tempdir().unwrap();
+            std::fs::write(corpus.path().join("a.txt"), "alpha").unwrap();
+            let inventory = inventory(corpus.path());
+            fail_next_snapshot(boundary);
+            assert!(create_snapshot(state.path(), "tx-restart", &inventory).is_err());
+            let recovered = create_snapshot(state.path(), "tx-restart", &inventory).unwrap();
+            assert_eq!(
+                open_snapshot(state.path(), "tx-restart").unwrap(),
+                recovered
+            );
+        }
+    }
+
+    #[test]
+    fn pending_generation_is_bound_before_mutable_source_replanning() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let state = tempfile::tempdir().unwrap();
+        let corpus = tempfile::tempdir().unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "alpha").unwrap();
+        let inventory = inventory(corpus.path());
+        let snapshot = create_snapshot(state.path(), "tx-pending", &inventory).unwrap();
+        let pending: PendingSync = serde_json::from_value(serde_json::json!({
+            "tx_id": "tx-pending",
+            "base_generation": 0,
+            "base_manifest_digest": "base",
+            "desired_manifest_digest": "desired",
+            "operation_hash": "operations",
+            "desired": {
+                "generation": 1,
+                "execution": {
+                    "version": 1,
+                    "root_identity": "root",
+                    "url": "http://engine",
+                    "prefix": "ax",
+                    "follow_symlinks": false,
+                    "chunker_identity": "chunker",
+                    "embedding_backend": "lexical",
+                    "embedding_model": "feature-hash",
+                    "embedding_tokenizer": "none",
+                    "embedding_dimension": 384,
+                    "graph_enabled": false,
+                    "brain": "brain",
+                    "detector_identity": "none",
+                    "schema_identity": "schema",
+                    "index_identity": "index",
+                    "source_policy": {
+                        "policy": "durable_snapshot",
+                        "reference": "sync-snapshots/tx-pending",
+                        "snapshot_digest": snapshot.snapshot_digest
+                    }
+                },
+                "plan": {
+                    "datasets": [],
+                    "files": {},
+                    "junk_files": [],
+                    "duplicate_files": [],
+                    "alias_paths_indexed": false
+                },
+                "groups": []
+            },
+            "operations": []
+        }))
+        .unwrap();
+        let error = require_resumable_pending_source(state.path(), Some(&pending))
+            .unwrap_err()
+            .to_string();
+        std::fs::write(corpus.path().join("a.txt"), "mutated after sync_begin").unwrap();
+        let repeated = require_resumable_pending_source(state.path(), Some(&pending))
+            .unwrap_err()
+            .to_string();
+        assert_eq!(error, repeated);
+        assert!(error.contains("verified durable source snapshot"));
+    }
+
+    #[test]
+    fn accepted_upsert_replays_without_duplicate_live_state() {
+        let _journal_guard = crate::state::SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let corpus = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "alpha").unwrap();
+        let inventory = inventory(corpus.path());
+        let plan = plan_for(&inventory);
+        let groups = groups_from_inventory(&inventory, &plan, &[]).unwrap();
+        let snapshot = create_snapshot(state.path(), "tx-add", &inventory).unwrap();
+        let mut journal =
+            Journal::open(state.path(), "root", "http://engine", "ax", 300, false).unwrap();
+        journal.write_plan(&empty_base_for(&plan)).unwrap();
+        begin(&mut journal, "tx-add", &snapshot, plan, groups);
+        let mut backend = FakeBackend::default();
+
+        fail_replay_after_next_apply();
+        assert!(replay_pending_operations(state.path(), &mut journal, &mut backend).is_err());
+        assert_eq!(backend.live.len(), 1);
+        drop(journal);
+
+        let mut journal =
+            Journal::open(state.path(), "root", "http://engine", "ax", 300, false).unwrap();
+        replay_pending_operations(state.path(), &mut journal, &mut backend).unwrap();
+        assert_eq!(backend.live.len(), 1);
+        assert_eq!(backend.applications.len(), 2);
+        assert!(journal.pending_sync.is_none());
+        assert_eq!(journal.committed_manifest.as_ref().unwrap().generation, 1);
+    }
+
+    #[test]
+    fn replay_converges_change_metadata_and_delete_without_resurrection() {
+        let _journal_guard = crate::state::SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let state = tempfile::tempdir().unwrap();
+        let corpus = tempfile::tempdir().unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "alpha").unwrap();
+        let first_inventory = inventory(corpus.path());
+        let first_plan = plan_for(&first_inventory);
+        let first_groups = groups_from_inventory(&first_inventory, &first_plan, &[]).unwrap();
+        let first_snapshot = create_snapshot(state.path(), "tx-first", &first_inventory).unwrap();
+        let mut journal =
+            Journal::open(state.path(), "root", "http://engine", "ax", 300, false).unwrap();
+        journal.write_plan(&empty_base_for(&first_plan)).unwrap();
+        begin(
+            &mut journal,
+            "tx-first",
+            &first_snapshot,
+            first_plan,
+            first_groups,
+        );
+        let mut backend = FakeBackend::default();
+        replay_pending_operations(state.path(), &mut journal, &mut backend).unwrap();
+        let stable_group_id = journal.committed_manifest.as_ref().unwrap().groups[0]
+            .group_id
+            .clone();
+
+        std::fs::write(corpus.path().join("a.txt"), "beta").unwrap();
+        let changed_inventory = inventory(corpus.path());
+        let changed_plan = plan_for(&changed_inventory);
+        let changed_groups = groups_from_inventory(
+            &changed_inventory,
+            &changed_plan,
+            &journal.committed_manifest.as_ref().unwrap().groups,
+        )
+        .unwrap();
+        assert_eq!(changed_groups[0].group_id, stable_group_id);
+        let changed_snapshot =
+            create_snapshot(state.path(), "tx-change", &changed_inventory).unwrap();
+        begin(
+            &mut journal,
+            "tx-change",
+            &changed_snapshot,
+            changed_plan,
+            changed_groups,
+        );
+        fail_replay_after_next_apply();
+        assert!(replay_pending_operations(state.path(), &mut journal, &mut backend).is_err());
+        replay_pending_operations(state.path(), &mut journal, &mut backend).unwrap();
+        let changed_content = backend.live[&stable_group_id].content_id.clone();
+
+        let mut renamed_plan = journal.committed_manifest.as_ref().unwrap().plan.clone();
+        let content_id = renamed_plan.files.keys().next().unwrap().clone();
+        let assignment = renamed_plan.files.get_mut(&content_id).unwrap();
+        assignment.rel = "renamed.txt".into();
+        assignment.path_id = "unix:72656e616d65642e747874".into();
+        let mut renamed_groups = journal.committed_manifest.as_ref().unwrap().groups.clone();
+        renamed_groups[0].canonical.rel = "renamed.txt".into();
+        renamed_groups[0].canonical.path_id = "unix:72656e616d65642e747874".into();
+        let renamed_snapshot =
+            create_snapshot(state.path(), "tx-metadata", &changed_inventory).unwrap();
+        begin(
+            &mut journal,
+            "tx-metadata",
+            &renamed_snapshot,
+            renamed_plan,
+            renamed_groups,
+        );
+        replay_pending_operations(state.path(), &mut journal, &mut backend).unwrap();
+        assert_eq!(backend.live[&stable_group_id].content_id, changed_content);
+        assert_eq!(
+            backend.live[&stable_group_id].canonical,
+            "unix:72656e616d65642e747874"
+        );
+
+        let empty = Inventory {
+            files: vec![],
+            keys: vec![],
+            digests: vec![],
+            duplicates: vec![],
+        };
+        let empty_snapshot = create_snapshot(state.path(), "tx-delete", &empty).unwrap();
+        let mut empty_plan = journal.committed_manifest.as_ref().unwrap().plan.clone();
+        empty_plan.files.clear();
+        empty_plan.datasets[0].file_count = 0;
+        begin(
+            &mut journal,
+            "tx-delete",
+            &empty_snapshot,
+            empty_plan,
+            vec![],
+        );
+        fail_replay_after_next_apply();
+        assert!(replay_pending_operations(state.path(), &mut journal, &mut backend).is_err());
+        assert!(backend.live.is_empty());
+        replay_pending_operations(state.path(), &mut journal, &mut backend).unwrap();
+        assert!(backend.live.is_empty());
+        assert!(journal
+            .committed_manifest
+            .as_ref()
+            .unwrap()
+            .groups
+            .is_empty());
+    }
+}

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -173,6 +173,100 @@ impl<'a> EsSyncBackend<'a> {
         }
         Ok(total)
     }
+
+    fn exact_semantic_count(&self, group: &ManifestGroup, plan: &Plan) -> Result<u64> {
+        let by_slug: HashMap<&str, &crate::state::PlanDataset> = plan
+            .datasets
+            .iter()
+            .map(|dataset| (dataset.slug.as_str(), dataset))
+            .collect();
+        let mut total = 0u64;
+        for slug in &group.dataset_slugs {
+            let dataset = by_slug
+                .get(slug.as_str())
+                .copied()
+                .with_context(|| format!("group references absent dataset {slug}"))?;
+            let Some(field) = &dataset.semantic_field else {
+                continue;
+            };
+            let response = self.es.search(
+                &dataset.index,
+                &serde_json::json!({
+                    "size": 0,
+                    "track_total_hits": true,
+                    "query": {"bool": {"must": [
+                        {"term": {"ax_file": &group.content_id}},
+                        {"exists": {"field": field}}
+                    ]}}
+                }),
+            )?;
+            total = total
+                .checked_add(
+                    response
+                        .pointer("/hits/total/value")
+                        .and_then(Value::as_u64)
+                        .context("semantic validation response has no total hit count")?,
+                )
+                .context("semantic validation count overflow")?;
+        }
+        Ok(total)
+    }
+
+    fn reconcile_file_catalog(
+        &self,
+        old: Option<&ManifestGroup>,
+        new: Option<&ManifestGroup>,
+        desired: &GenerationManifest,
+    ) -> Result<()> {
+        for content_id in old
+            .into_iter()
+            .map(|group| group.content_id.as_str())
+            .chain(new.into_iter().map(|group| group.content_id.as_str()))
+        {
+            self.es.delete_by_query(
+                crate::catalog::CATALOG_INDEX,
+                &serde_json::json!({"term": {"file_key": content_id}}),
+            )?;
+        }
+        let Some(group) = new else {
+            return Ok(());
+        };
+        let assignment = desired
+            .plan
+            .files
+            .get(&group.content_id)
+            .context("catalog group has no desired file assignment")?;
+        let format = if assignment.gzip {
+            format!("{}(gzip)", assignment.family)
+        } else {
+            assignment.family.clone()
+        };
+        let (id, doc) = crate::catalog::file_doc(
+            &group.content_id,
+            &group.canonical.rel,
+            &format,
+            "indexed",
+            None,
+            group.expected_records,
+            0,
+            group.content_size,
+            &format!("generation-{}", desired.generation),
+        );
+        let mut body = Vec::new();
+        append_index_action(crate::catalog::CATALOG_INDEX, &id, &doc, &mut body)?;
+        for alias in &group.aliases {
+            let (id, doc) = crate::catalog::duplicate_file_doc(
+                &group.content_id,
+                &alias.rel,
+                &alias.path_id,
+                &group.canonical.rel,
+                group.content_size,
+                &format!("generation-{}", desired.generation),
+            );
+            append_index_action(crate::catalog::CATALOG_INDEX, &id, &doc, &mut body)?;
+        }
+        checked_bulk(self.es, body)
+    }
 }
 
 impl SyncOperationBackend for EsSyncBackend<'_> {
@@ -202,7 +296,7 @@ impl SyncOperationBackend for EsSyncBackend<'_> {
             crate::sync::SyncOperationKind::Delete => self.delete_group(
                 old.context("delete operation has no committed group")?,
                 &base.plan,
-            ),
+            )?,
             crate::sync::SyncOperationKind::Upsert => {
                 if let Some(old) = old {
                     self.delete_group(old, &base.plan)?;
@@ -210,13 +304,16 @@ impl SyncOperationBackend for EsSyncBackend<'_> {
                 let new = new.context("upsert operation has no desired group")?;
                 // Remove a partial prior retry of the desired identity too.
                 self.delete_group(new, &desired.plan)?;
-                self.replay_prepared(snapshot, &new.content_id)
+                self.replay_prepared(snapshot, &new.content_id)?;
             }
-            crate::sync::SyncOperationKind::Metadata => self.replay_metadata(
-                base,
-                new.context("metadata operation has no desired group")?,
-            ),
+            crate::sync::SyncOperationKind::Metadata => {
+                self.replay_metadata(
+                    base,
+                    new.context("metadata operation has no desired group")?,
+                )?;
+            }
         }
+        self.reconcile_file_catalog(old, new, desired)
     }
 
     fn validate(
@@ -228,10 +325,31 @@ impl SyncOperationBackend for EsSyncBackend<'_> {
         for dataset in &desired.plan.datasets {
             self.es.refresh(&dataset.index)?;
         }
+        self.es.refresh(crate::catalog::CATALOG_INDEX)?;
         for group in &desired.groups {
             anyhow::ensure!(
                 self.exact_group_count(group, &desired.plan)? == group.expected_records,
                 "live record count disagrees with desired group {}",
+                group.group_id
+            );
+            let semantic = self.exact_semantic_count(group, &desired.plan)?;
+            anyhow::ensure!(
+                semantic == group.expected_passages && semantic == group.expected_vectors,
+                "live semantic count disagrees with desired group {}",
+                group.group_id
+            );
+            let catalog = self.es.search(
+                crate::catalog::CATALOG_INDEX,
+                &serde_json::json!({
+                    "size": 0,
+                    "track_total_hits": true,
+                    "query": {"term": {"file_key": &group.content_id}}
+                }),
+            )?;
+            anyhow::ensure!(
+                catalog.pointer("/hits/total/value").and_then(Value::as_u64)
+                    == Some(1 + group.aliases.len() as u64),
+                "catalog canonical/alias count disagrees with desired group {}",
                 group.group_id
             );
         }
@@ -418,6 +536,17 @@ fn checked_bulk(es: &crate::esclient::Es, body: Vec<u8>) -> Result<()> {
             .first_error
             .unwrap_or_else(|| "unknown error".into())
     );
+    Ok(())
+}
+
+fn append_index_action(index: &str, id: &str, doc: &Value, body: &mut Vec<u8>) -> Result<()> {
+    serde_json::to_writer(
+        &mut *body,
+        &serde_json::json!({"index": {"_index": index, "_id": id}}),
+    )?;
+    body.push(b'\n');
+    serde_json::to_writer(&mut *body, doc)?;
+    body.push(b'\n');
     Ok(())
 }
 

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -13,19 +13,27 @@ use crate::sync::{
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
-const SNAPSHOT_VERSION: u32 = 1;
+const SNAPSHOT_VERSION: u32 = 2;
 
 #[cfg(test)]
 static SNAPSHOT_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 #[cfg(test)]
 static SNAPSHOT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(test)]
+static POST_SEAL_SOURCE_REPLACEMENT: std::sync::Mutex<Option<(std::path::PathBuf, Vec<u8>)>> =
+    std::sync::Mutex::new(None);
+#[cfg(test)]
 static REPLAY_FAIL_AFTER_APPLY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+#[cfg(test)]
+pub(crate) static REPLAY_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[cfg(test)]
+static GC_FAIL_AFTER_RENAME: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -52,8 +60,88 @@ pub struct PreparedArtifact {
 pub struct SourceSnapshot {
     pub version: u32,
     pub tx_id: String,
+    /// Publication timestamp sealed once and reused by every replay.
+    pub started: String,
+    pub preparation_contract_digest: String,
+    pub footprint: SnapshotFootprint,
     pub files: Vec<SnapshotFile>,
     pub snapshot_digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SnapshotFootprint {
+    pub source_bytes: u64,
+    pub prepared_bytes: u64,
+    pub total_bytes: u64,
+    pub hard_budget_bytes: u64,
+}
+
+/// Logical payload accounting for source and prepared-record bytes.
+/// This is deliberately not a filesystem-allocation limit: directory,
+/// manifest, and block-allocation overhead are excluded.
+struct PayloadBudget {
+    used: u64,
+    limit: u64,
+}
+
+impl PayloadBudget {
+    fn charge(&mut self, bytes: usize) -> std::io::Result<()> {
+        let bytes = u64::try_from(bytes)
+            .map_err(|_| std::io::Error::other("snapshot payload write length overflow"))?;
+        let next = self
+            .used
+            .checked_add(bytes)
+            .ok_or_else(|| std::io::Error::other("snapshot payload byte count overflow"))?;
+        if next > self.limit {
+            return Err(std::io::Error::other(format!(
+                "snapshot logical payload write of {bytes} bytes would raise staged payload from \
+                 {} to {next} bytes, exceeding configured limit of {} bytes; no generation was \
+                 committed and the partial snapshot is removed automatically",
+                self.used, self.limit
+            )));
+        }
+        self.used = next;
+        Ok(())
+    }
+}
+
+struct BudgetWriter<'a, W> {
+    inner: W,
+    budget: &'a mut PayloadBudget,
+}
+
+impl<W: Write> Write for BudgetWriter<'_, W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.budget.charge(buf.len())?;
+        match self.inner.write(buf) {
+            Ok(written) if written == buf.len() => Ok(written),
+            Ok(written) => {
+                self.budget.used -= (buf.len() - written) as u64;
+                Ok(written)
+            }
+            Err(error) => {
+                self.budget.used -= buf.len() as u64;
+                Err(error)
+            }
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+struct StagingCleanup {
+    path: std::path::PathBuf,
+    armed: bool,
+}
+
+impl Drop for StagingCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
 }
 
 /// Remote mutations must be convergent: calling `apply` twice for one
@@ -61,6 +149,10 @@ pub struct SourceSnapshot {
 /// the same live state. `validate` is the final generation-wide barrier.
 #[cfg_attr(not(test), allow(dead_code))]
 pub trait SyncOperationBackend {
+    fn provision_generation(&mut self, _desired: &GenerationManifest) -> Result<()> {
+        Ok(())
+    }
+
     fn apply(
         &mut self,
         operation: &SyncOperation,
@@ -75,6 +167,17 @@ pub trait SyncOperationBackend {
         desired: &GenerationManifest,
         snapshot: &SourceSnapshot,
     ) -> Result<()>;
+
+    /// Publish and exactly read back the complete agent-facing catalog for
+    /// this generation. This runs before the validation/authority barrier.
+    fn publish_generation_catalog(
+        &mut self,
+        _base: &CommittedManifest,
+        _desired: &GenerationManifest,
+        _snapshot: &SourceSnapshot,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Production ES-compatible operation backend for graph-disabled generations.
@@ -212,64 +315,162 @@ impl<'a> EsSyncBackend<'a> {
         Ok(total)
     }
 
-    fn reconcile_file_catalog(
-        &self,
-        old: Option<&ManifestGroup>,
-        new: Option<&ManifestGroup>,
-        desired: &GenerationManifest,
-    ) -> Result<()> {
-        for content_id in old
-            .into_iter()
-            .map(|group| group.content_id.as_str())
-            .chain(new.into_iter().map(|group| group.content_id.as_str()))
-        {
-            self.es.delete_by_query(
-                crate::catalog::CATALOG_INDEX,
-                &serde_json::json!({"term": {"file_key": content_id}}),
-            )?;
-        }
-        let Some(group) = new else {
-            return Ok(());
-        };
-        let assignment = desired
-            .plan
-            .files
-            .get(&group.content_id)
-            .context("catalog group has no desired file assignment")?;
-        let format = if assignment.gzip {
-            format!("{}(gzip)", assignment.family)
-        } else {
-            assignment.family.clone()
-        };
-        let (id, doc) = crate::catalog::file_doc(
-            &group.content_id,
-            &group.canonical.rel,
-            &format,
-            "indexed",
-            None,
-            group.expected_records,
-            0,
-            group.content_size,
-            &format!("generation-{}", desired.generation),
-        );
-        let mut body = Vec::new();
-        append_index_action(crate::catalog::CATALOG_INDEX, &id, &doc, &mut body)?;
-        for alias in &group.aliases {
-            let (id, doc) = crate::catalog::duplicate_file_doc(
-                &group.content_id,
-                &alias.rel,
-                &alias.path_id,
-                &group.canonical.rel,
-                group.content_size,
-                &format!("generation-{}", desired.generation),
+    fn catalog_generation(&self, run_id: &str) -> Result<BTreeMap<String, Value>> {
+        let mut documents = BTreeMap::new();
+        let mut search_after: Option<Value> = None;
+        loop {
+            let mut body = serde_json::json!({
+                "size": 1000,
+                "sort": [{"_id": "asc"}],
+                "query": {"term": {"run_id": run_id}}
+            });
+            if let Some(after) = &search_after {
+                body["search_after"] = after.clone();
+            }
+            let response = self.es.search(crate::catalog::CATALOG_INDEX, &body)?;
+            let hits = response
+                .pointer("/hits/hits")
+                .and_then(Value::as_array)
+                .context("catalog generation query has no hits")?;
+            for hit in hits {
+                let id = hit
+                    .get("_id")
+                    .and_then(Value::as_str)
+                    .context("catalog hit has no _id")?
+                    .to_owned();
+                let source = hit
+                    .get("_source")
+                    .cloned()
+                    .context("catalog hit has no _source")?;
+                anyhow::ensure!(
+                    documents.insert(id.clone(), source).is_none(),
+                    "catalog generation query returned duplicate ID {id}"
+                );
+            }
+            if hits.len() < 1000 {
+                break;
+            }
+            search_after = hits.last().and_then(|hit| hit.get("sort")).cloned();
+            anyhow::ensure!(
+                search_after.is_some(),
+                "full catalog generation page has no continuation sort key"
             );
-            append_index_action(crate::catalog::CATALOG_INDEX, &id, &doc, &mut body)?;
         }
-        checked_bulk(self.es, body)
+        Ok(documents)
+    }
+
+    fn exact_dataset_catalog_stats(
+        &self,
+        desired: &GenerationManifest,
+    ) -> Result<BTreeMap<String, crate::generation_catalog::DatasetCatalogStats>> {
+        let mut out = BTreeMap::new();
+        for dataset in &desired.plan.datasets {
+            let groups: Vec<&ManifestGroup> = desired
+                .groups
+                .iter()
+                .filter(|group| group.dataset_slugs.contains(&dataset.slug))
+                .collect();
+            let content_ids: Vec<&str> = groups
+                .iter()
+                .map(|group| group.content_id.as_str())
+                .collect();
+            let mut body = serde_json::json!({
+                "size": 0,
+                "track_total_hits": true,
+                "query": {"terms": {"ax_file": content_ids}}
+            });
+            if let Some(field) = &dataset.time_field {
+                body["aggs"] = serde_json::json!({
+                    "time_min": {"min": {"field": field}},
+                    "time_max": {"max": {"field": field}}
+                });
+            }
+            let response = self.es.search(&dataset.index, &body)?;
+            let record_count = response
+                .pointer("/hits/total/value")
+                .and_then(Value::as_u64)
+                .context("dataset exact read-back has no total")?;
+            let expected = groups.iter().try_fold(0u64, |sum, group| {
+                sum.checked_add(group.expected_records)
+                    .context("dataset expected record count overflow")
+            })?;
+            anyhow::ensure!(
+                record_count == expected,
+                "dataset {} exact read-back count {record_count} disagrees with sealed count \
+                 {expected}",
+                dataset.slug
+            );
+            let mut formats: Vec<String> = desired
+                .plan
+                .files
+                .values()
+                .filter(|assignment| {
+                    assignment
+                        .assignments
+                        .iter()
+                        .any(|(_, slug)| slug == &dataset.slug)
+                })
+                .map(|assignment| {
+                    if assignment.gzip {
+                        format!("{}(gzip)", assignment.family)
+                    } else {
+                        assignment.family.clone()
+                    }
+                })
+                .collect();
+            formats.sort();
+            formats.dedup();
+            let bytes = groups.iter().try_fold(0u64, |sum, group| {
+                sum.checked_add(group.content_size)
+                    .context("dataset source byte count overflow")
+            })?;
+            let time = |name: &str| {
+                response
+                    .pointer(&format!("/aggregations/{name}/value_as_string"))
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            };
+            out.insert(
+                dataset.slug.clone(),
+                crate::generation_catalog::DatasetCatalogStats {
+                    record_count,
+                    junk_records: 0,
+                    bytes,
+                    formats,
+                    time_min: time("time_min"),
+                    time_max: time("time_max"),
+                    sample_queries: crate::catalog::build_sample_queries(dataset, &[]),
+                    notes: dataset
+                        .group
+                        .iter()
+                        .map(|group| format!("source table: {group}"))
+                        .chain(dataset.specs.iter().flat_map(|spec| {
+                            spec.notes
+                                .iter()
+                                .map(move |note| format!("{}: {note}", spec.name))
+                        }))
+                        .collect(),
+                },
+            );
+        }
+        Ok(out)
     }
 }
 
 impl SyncOperationBackend for EsSyncBackend<'_> {
+    fn provision_generation(&mut self, desired: &GenerationManifest) -> Result<()> {
+        let execution = desired
+            .execution
+            .as_ref()
+            .context("desired generation has no execution identity")?;
+        let (_, index_identity) = crate::generation_contract_identities(&desired.plan)?;
+        anyhow::ensure!(
+            execution.index_identity == index_identity,
+            "desired generation index identity disagrees with its frozen mappings"
+        );
+        crate::ensure_generation_mappings(self.es, &desired.plan)
+    }
+
     fn apply(
         &mut self,
         operation: &SyncOperation,
@@ -313,7 +514,73 @@ impl SyncOperationBackend for EsSyncBackend<'_> {
                 )?;
             }
         }
-        self.reconcile_file_catalog(old, new, desired)
+        Ok(())
+    }
+
+    fn publish_generation_catalog(
+        &mut self,
+        base: &CommittedManifest,
+        desired: &GenerationManifest,
+        snapshot: &SourceSnapshot,
+    ) -> Result<()> {
+        for index in desired
+            .plan
+            .datasets
+            .iter()
+            .map(|dataset| dataset.index.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+        {
+            self.es.refresh(index)?;
+        }
+        self.es.refresh(crate::catalog::CATALOG_INDEX)?;
+        let prior_run_id =
+            base.execution
+                .as_ref()
+                .and_then(|execution| match &execution.source_policy {
+                    SourceExecutionPolicy::DurableSnapshot { reference, .. } => {
+                        reference.strip_prefix("sync-snapshots/")
+                    }
+                    SourceExecutionPolicy::AbortOnSourceChange { .. } => None,
+                });
+        let prior_documents = prior_run_id
+            .map(|run_id| self.catalog_generation(run_id))
+            .transpose()?
+            .unwrap_or_default();
+        let prior_ids = prior_documents.keys().cloned().collect();
+        let stats = self.exact_dataset_catalog_stats(desired)?;
+        let projection = crate::generation_catalog::project_generation(
+            base,
+            desired,
+            &crate::generation_catalog::GenerationCatalogMetadata {
+                generation_id: snapshot.tx_id.clone(),
+                started: snapshot.started.clone(),
+            },
+            &stats,
+            &BTreeMap::new(),
+            &prior_ids,
+        )?;
+        let mut body = Vec::new();
+        for id in &projection.stale_ids {
+            let action =
+                serde_json::json!({"delete": {"_index": crate::catalog::CATALOG_INDEX, "_id": id}});
+            body.extend_from_slice(serde_json::to_string(&action)?.as_bytes());
+            body.push(b'\n');
+        }
+        for (id, document) in &projection.documents {
+            append_index_action(crate::catalog::CATALOG_INDEX, id, document, &mut body)?;
+        }
+        checked_bulk(self.es, body)?;
+        self.es.refresh(crate::catalog::CATALOG_INDEX)?;
+        projection.validate_observed(&self.catalog_generation(&snapshot.tx_id)?)?;
+        if let Some(prior_run_id) = prior_run_id {
+            let remaining = self.catalog_generation(prior_run_id)?;
+            anyhow::ensure!(
+                remaining.is_empty(),
+                "prior catalog generation {prior_run_id} still has {} managed documents",
+                remaining.len()
+            );
+        }
+        Ok(())
     }
 
     fn validate(
@@ -394,6 +661,7 @@ pub fn replay_pending_operations(
     pending.validate_against(&base)?;
     let snapshot = open_snapshot(state_dir, &pending.tx_id)?;
     verify_snapshot_binding(&pending, &snapshot)?;
+    backend.provision_generation(&pending.desired)?;
 
     for operation in &pending.operations {
         let state = journal
@@ -411,9 +679,110 @@ pub fn replay_pending_operations(
         replay_fail_after_apply()?;
         journal.sync_operation_state(&operation.operation_id, SyncOperationState::Committed)?;
     }
+    backend.publish_generation_catalog(&base, &pending.desired, &snapshot)?;
     backend.validate(&base, &pending.desired, &snapshot)?;
     journal.sync_validated()?;
-    journal.sync_commit()
+    journal.sync_commit()?;
+    gc_snapshots(state_dir, journal).context(
+        "generation committed durably, but snapshot cleanup failed; inspect the attached cause \
+         (remove a refused symlink or repair the reported filesystem permission/I/O problem), \
+         then retry the same command to continue bounded cleanup without republishing data",
+    )
+}
+
+const SNAPSHOT_GC_BATCH_SIZE: usize = 4096;
+
+fn protected_snapshot(
+    state_dir: &Path,
+    execution: &crate::sync::ExecutionIdentity,
+) -> Result<String> {
+    let SourceExecutionPolicy::DurableSnapshot {
+        reference,
+        snapshot_digest,
+    } = &execution.source_policy
+    else {
+        anyhow::bail!("generated authority does not reference a durable snapshot");
+    };
+    let tx_id = reference
+        .strip_prefix("sync-snapshots/")
+        .context("protected snapshot reference is not state-relative")?;
+    validate_tx_id(tx_id)?;
+    let snapshot = open_snapshot(state_dir, tx_id)?;
+    anyhow::ensure!(
+        snapshot.snapshot_digest == *snapshot_digest,
+        "protected snapshot digest disagrees with journal authority"
+    );
+    Ok(tx_id.to_owned())
+}
+
+/// Reclaim only snapshots proven unreferenced by replayed journal authority.
+/// The caller owns the journal lock for the complete validation/rename/fsync
+/// sequence.
+pub fn gc_snapshots(state_dir: &Path, journal: &Journal) -> Result<()> {
+    let root = state_dir.join("sync-snapshots");
+    let mut protected = std::collections::HashSet::new();
+    if let Some(execution) = journal
+        .committed_manifest
+        .as_ref()
+        .and_then(|manifest| manifest.execution.as_ref())
+    {
+        protected.insert(protected_snapshot(state_dir, execution)?);
+    }
+    if let Some(execution) = journal
+        .pending_sync
+        .as_ref()
+        .and_then(|pending| pending.desired.execution.as_ref())
+    {
+        protected.insert(protected_snapshot(state_dir, execution)?);
+    }
+    let entries = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut entries = entries.collect::<std::io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+    // Validate the complete directory before the first mutation. In
+    // particular, a late symlink must not be discovered after earlier
+    // snapshots have already been deleted.
+    for entry in &entries {
+        anyhow::ensure!(
+            !entry.file_type()?.is_symlink(),
+            "snapshot cleanup refuses symlink {}",
+            entry.path().display()
+        );
+    }
+    let directory = File::open(&root)?;
+    for entry in entries.into_iter().take(SNAPSHOT_GC_BATCH_SIZE) {
+        let metadata = entry.file_type()?;
+        if !metadata.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if protected.contains(&name) {
+            continue;
+        }
+        let tombstone = if name.ends_with(".gc") {
+            entry.path()
+        } else {
+            let tombstone = root.join(format!(".{name}.gc"));
+            anyhow::ensure!(
+                !tombstone.exists(),
+                "snapshot tombstone already exists: {}",
+                tombstone.display()
+            );
+            std::fs::rename(entry.path(), &tombstone)?;
+            directory.sync_all()?;
+            #[cfg(test)]
+            if GC_FAIL_AFTER_RENAME.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("injected snapshot GC crash after durable tombstone rename");
+            }
+            tombstone
+        };
+        std::fs::remove_dir_all(&tombstone)?;
+        directory.sync_all()?;
+    }
+    Ok(())
 }
 
 /// Test helper proving a pending generation binds before mutable discovery.
@@ -742,7 +1111,14 @@ pub fn create_snapshot(
     tx_id: &str,
     inventory: &Inventory,
 ) -> Result<SourceSnapshot> {
-    create_snapshot_inner(state_dir, tx_id, inventory, None)
+    create_snapshot_inner(
+        state_dir,
+        tx_id,
+        inventory,
+        None,
+        "source-snapshot-v1",
+        u64::MAX,
+    )
 }
 
 /// Seal deterministic bulk actions together with source bytes. Extraction and
@@ -754,8 +1130,17 @@ pub fn create_prepared_snapshot(
     tx_id: &str,
     inventory: &Inventory,
     plan: &Plan,
+    preparation_contract_digest: &str,
+    hard_budget_bytes: u64,
 ) -> Result<SourceSnapshot> {
-    create_snapshot_inner(state_dir, tx_id, inventory, Some(plan))
+    create_snapshot_inner(
+        state_dir,
+        tx_id,
+        inventory,
+        Some(plan),
+        preparation_contract_digest,
+        hard_budget_bytes,
+    )
 }
 
 fn create_snapshot_inner(
@@ -763,6 +1148,8 @@ fn create_snapshot_inner(
     tx_id: &str,
     inventory: &Inventory,
     plan: Option<&Plan>,
+    preparation_contract_digest: &str,
+    hard_budget_bytes: u64,
 ) -> Result<SourceSnapshot> {
     validate_tx_id(tx_id)?;
     ensure_inventory_lengths(inventory)?;
@@ -770,19 +1157,69 @@ fn create_snapshot_inner(
     std::fs::create_dir_all(&root)?;
     let final_dir = root.join(tx_id);
     if final_dir.exists() {
-        return open_snapshot(state_dir, tx_id);
+        let existing = open_snapshot(state_dir, tx_id)?;
+        anyhow::ensure!(
+            existing.preparation_contract_digest == preparation_contract_digest,
+            "existing final snapshot was prepared under a different contract"
+        );
+        let requested = inventory
+            .keys
+            .iter()
+            .zip(&inventory.digests)
+            .zip(&inventory.files)
+            .map(|((content_id, digest), file)| (content_id.as_str(), digest.as_str(), file.size))
+            .collect::<Vec<_>>();
+        let sealed = existing
+            .files
+            .iter()
+            .map(|file| {
+                (
+                    file.content_id.as_str(),
+                    file.content_digest.as_str(),
+                    file.content_size,
+                )
+            })
+            .collect::<Vec<_>>();
+        anyhow::ensure!(
+            sealed == requested,
+            "existing final snapshot inventory differs from this preparation attempt"
+        );
+        anyhow::ensure!(
+            existing.footprint.total_bytes <= hard_budget_bytes,
+            "existing final snapshot exceeds the current logical payload limit"
+        );
+        return Ok(existing);
     }
     let staging = root.join(format!(".{tx_id}.partial"));
     if staging.exists() {
         std::fs::remove_dir_all(&staging)?;
     }
     std::fs::create_dir(&staging)?;
+    let mut cleanup = StagingCleanup {
+        path: staging.clone(),
+        armed: true,
+    };
     let blobs = staging.join("blobs");
     std::fs::create_dir(&blobs)?;
     let prepared_dir = staging.join("prepared");
     if plan.is_some() {
         std::fs::create_dir(&prepared_dir)?;
     }
+    let source_bytes = inventory.files.iter().try_fold(0u64, |total, file| {
+        total
+            .checked_add(file.size)
+            .context("snapshot source byte overflow")
+    })?;
+    if source_bytes > hard_budget_bytes {
+        anyhow::bail!(
+            "snapshot source footprint {source_bytes} bytes exceeds logical payload limit \
+             {hard_budget_bytes} bytes before preparation"
+        );
+    }
+    let mut budget = PayloadBudget {
+        used: 0,
+        limit: hard_budget_bytes,
+    };
     let mut files = Vec::with_capacity(inventory.files.len());
     for (ordinal, ((source, content_id), content_digest)) in inventory
         .files
@@ -794,10 +1231,23 @@ fn create_snapshot_inner(
         crate::content::verify(&source.path, source.size, content_digest)?;
         let relative_blob = format!("blobs/{ordinal:08}");
         let destination = staging.join(&relative_blob);
-        copy_synced(&source.path, &destination)?;
+        copy_synced(&source.path, &destination, &mut budget)?;
         crate::content::verify(&destination, source.size, content_digest)?;
+        #[cfg(test)]
+        apply_post_seal_source_replacement(&source.path)?;
         let prepared = plan
-            .map(|plan| prepare_artifact(&staging, ordinal, source, content_id, &destination, plan))
+            .map(|plan| {
+                prepare_artifact(
+                    &staging,
+                    ordinal,
+                    tx_id,
+                    source,
+                    content_id,
+                    &destination,
+                    plan,
+                    &mut budget,
+                )
+            })
             .transpose()?;
         files.push(SnapshotFile {
             content_id: content_id.clone(),
@@ -807,13 +1257,42 @@ fn create_snapshot_inner(
             prepared,
         });
     }
+    let prepared_bytes = files.iter().try_fold(0u64, |total, file| {
+        total
+            .checked_add(file.prepared.as_ref().map_or(0, |artifact| artifact.bytes))
+            .context("prepared snapshot byte overflow")
+    })?;
+    let total_bytes = source_bytes
+        .checked_add(prepared_bytes)
+        .context("total snapshot byte overflow")?;
+    anyhow::ensure!(
+        total_bytes == budget.used && total_bytes <= hard_budget_bytes,
+        "snapshot logical payload accounting mismatch"
+    );
+    let footprint = SnapshotFootprint {
+        source_bytes,
+        prepared_bytes,
+        total_bytes,
+        hard_budget_bytes,
+    };
     snapshot_failpoint(1)?;
     let snapshot = SourceSnapshot {
         version: SNAPSHOT_VERSION,
         tx_id: tx_id.to_string(),
-        snapshot_digest: snapshot_digest(tx_id, &files)?,
+        preparation_contract_digest: preparation_contract_digest.to_owned(),
+        footprint: footprint.clone(),
+        started: chrono::Utc::now().to_rfc3339(),
+        snapshot_digest: String::new(),
         files,
     };
+    let mut snapshot = snapshot;
+    snapshot.snapshot_digest = snapshot_digest(
+        tx_id,
+        &snapshot.started,
+        preparation_contract_digest,
+        &footprint,
+        &snapshot.files,
+    )?;
     write_synced_json(&staging.join("manifest.json"), &snapshot)?;
     sync_dir(&blobs)?;
     if plan.is_some() {
@@ -822,6 +1301,7 @@ fn create_snapshot_inner(
     sync_dir(&staging)?;
     snapshot_failpoint(2)?;
     std::fs::rename(&staging, &final_dir)?;
+    cleanup.armed = false;
     sync_dir(&root)?;
     snapshot_failpoint(3)?;
     open_snapshot(state_dir, tx_id)
@@ -836,8 +1316,33 @@ pub fn open_snapshot(state_dir: &Path, tx_id: &str) -> Result<SourceSnapshot> {
         snapshot.version == SNAPSHOT_VERSION && snapshot.tx_id == tx_id,
         "source snapshot identity mismatch"
     );
+    let source_bytes = snapshot.files.iter().try_fold(0u64, |sum, file| {
+        sum.checked_add(file.content_size)
+            .context("snapshot source footprint overflow")
+    })?;
+    let prepared_bytes = snapshot.files.iter().try_fold(0u64, |sum, file| {
+        sum.checked_add(file.prepared.as_ref().map_or(0, |artifact| artifact.bytes))
+            .context("snapshot prepared footprint overflow")
+    })?;
+    let total_bytes = source_bytes
+        .checked_add(prepared_bytes)
+        .context("snapshot total footprint overflow")?;
     anyhow::ensure!(
-        snapshot.snapshot_digest == snapshot_digest(tx_id, &snapshot.files)?,
+        snapshot.footprint.source_bytes == source_bytes
+            && snapshot.footprint.prepared_bytes == prepared_bytes
+            && snapshot.footprint.total_bytes == total_bytes
+            && total_bytes <= snapshot.footprint.hard_budget_bytes,
+        "source snapshot footprint does not match its sealed artifacts"
+    );
+    anyhow::ensure!(
+        snapshot.snapshot_digest
+            == snapshot_digest(
+                tx_id,
+                &snapshot.started,
+                &snapshot.preparation_contract_digest,
+                &snapshot.footprint,
+                &snapshot.files,
+            )?,
         "source snapshot manifest digest mismatch"
     );
     for file in &snapshot.files {
@@ -866,13 +1371,16 @@ pub fn open_snapshot(state_dir: &Path, tx_id: &str) -> Result<SourceSnapshot> {
     Ok(snapshot)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn prepare_artifact(
     staging: &Path,
     ordinal: usize,
+    generation_identity: &str,
     source: &crate::walk::FileEntry,
     content_id: &str,
     snapshot_blob: &Path,
     plan: &Plan,
+    budget: &mut PayloadBudget,
 ) -> Result<PreparedArtifact> {
     let assignment = plan
         .files
@@ -907,7 +1415,7 @@ fn prepare_artifact(
         .iter()
         .map(|(group, slug)| (group.clone(), slug.as_str()))
         .collect();
-    let sniffed = crate::sniff::sniff(&source.path)
+    let sniffed = crate::sniff::sniff_with_name(snapshot_blob, &source.path)
         .with_context(|| format!("sniff {} for durable preparation", source.rel))?;
     let relative_ndjson = format!("prepared/{ordinal:08}.ndjson");
     let path = staging.join(&relative_ndjson);
@@ -915,7 +1423,10 @@ fn prepare_artifact(
         .create_new(true)
         .write(true)
         .open(&path)?;
-    let mut writer = BufWriter::new(file);
+    let mut writer = BudgetWriter {
+        inner: BufWriter::new(file),
+        budget,
+    };
     let mut records = 0u64;
     let mut passages = 0u64;
     let mut vectors = 0u64;
@@ -952,7 +1463,10 @@ fn prepare_artifact(
         fields.insert("ax_file".into(), Value::String(content_id.to_string()));
         fields.insert("ax_locator".into(), Value::String(record.locator.clone()));
         fields.insert("ax_dataset".into(), Value::String(slug.to_string()));
-        fields.insert("ax_run".into(), Value::String("generation-pending".into()));
+        fields.insert(
+            "ax_run".into(),
+            Value::String(generation_identity.to_owned()),
+        );
         fields.insert(
             "ax_format".into(),
             Value::String(source.path.extension().map_or_else(
@@ -962,11 +1476,10 @@ fn prepare_artifact(
         );
         let id = crate::ids::doc_id(slug, content_id, &record.locator);
         let action = serde_json::json!({"index": {"_index": dataset.index, "_id": id}});
-        if writeln!(writer, "{action}")
+        if let Err(error) = writeln!(writer, "{action}")
             .and_then(|_| writeln!(writer, "{}", Value::Object(fields.clone())))
-            .is_err()
         {
-            sink_error = Some(anyhow::anyhow!("write prepared NDJSON"));
+            sink_error = Some(anyhow::Error::new(error).context("write prepared NDJSON"));
             return false;
         }
         records += 1;
@@ -992,7 +1505,7 @@ fn prepare_artifact(
         return Err(error);
     }
     writer.flush()?;
-    writer.get_ref().sync_all()?;
+    writer.inner.get_ref().sync_all()?;
     drop(writer);
     let bytes = std::fs::metadata(&path)?.len();
     Ok(PreparedArtifact {
@@ -1036,14 +1549,27 @@ fn ensure_inventory_lengths(inventory: &Inventory) -> Result<()> {
     Ok(())
 }
 
-fn snapshot_digest(tx_id: &str, files: &[SnapshotFile]) -> Result<String> {
+fn snapshot_digest(
+    tx_id: &str,
+    started: &str,
+    preparation_contract_digest: &str,
+    footprint: &SnapshotFootprint,
+    files: &[SnapshotFile],
+) -> Result<String> {
     let mut files = files.to_vec();
     files.sort_by(|left, right| {
         left.content_id
             .cmp(&right.content_id)
             .then_with(|| left.relative_blob.cmp(&right.relative_blob))
     });
-    let encoded = serde_json::to_vec(&(SNAPSHOT_VERSION, tx_id, files))?;
+    let encoded = serde_json::to_vec(&(
+        SNAPSHOT_VERSION,
+        tx_id,
+        started,
+        preparation_contract_digest,
+        footprint,
+        files,
+    ))?;
     Ok(format!(
         "axs1-{:032x}",
         xxhash_rust::xxh3::xxh3_128(&encoded)
@@ -1062,14 +1588,18 @@ fn validate_tx_id(tx_id: &str) -> Result<()> {
     Ok(())
 }
 
-fn copy_synced(source: &Path, destination: &Path) -> Result<()> {
+fn copy_synced(source: &Path, destination: &Path, budget: &mut PayloadBudget) -> Result<()> {
     let mut input = File::open(source)?;
-    let mut output = OpenOptions::new()
+    let output = OpenOptions::new()
         .create_new(true)
         .write(true)
         .open(destination)?;
+    let mut output = BudgetWriter {
+        inner: output,
+        budget,
+    };
     std::io::copy(&mut input, &mut output)?;
-    output.sync_all()?;
+    output.inner.sync_all()?;
     Ok(())
 }
 
@@ -1083,6 +1613,29 @@ fn write_synced_json(path: &Path, value: &impl Serialize) -> Result<()> {
 
 fn sync_dir(path: &Path) -> Result<()> {
     File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+fn arm_source_mutation_after_seal(path: &Path, replacement: &[u8]) {
+    *POST_SEAL_SOURCE_REPLACEMENT.lock().unwrap() =
+        Some((path.to_path_buf(), replacement.to_vec()));
+}
+
+#[cfg(test)]
+fn apply_post_seal_source_replacement(path: &Path) -> Result<()> {
+    let replacement = {
+        let mut armed = POST_SEAL_SOURCE_REPLACEMENT.lock().unwrap();
+        if armed.as_ref().is_some_and(|(expected, _)| expected == path) {
+            armed.take().map(|(_, bytes)| bytes)
+        } else {
+            None
+        }
+    };
+    if let Some(replacement) = replacement {
+        std::fs::write(path, replacement)
+            .with_context(|| format!("inject post-seal source replacement {}", path.display()))?;
+    }
     Ok(())
 }
 
@@ -1183,13 +1736,14 @@ mod tests {
             prefix: "ax".into(),
             follow_symlinks: false,
             chunker_identity: "chunker-v1".into(),
+            embedding_identity_sha256: "a".repeat(64),
             embedding_backend: "lexical".into(),
-            embedding_model: "feature-hash".into(),
-            embedding_tokenizer: "none".into(),
             embedding_dimension: 384,
+            embedding_semantic_contract: "semantic_text-derived-vector.v1".into(),
+            embedding_resumable: true,
             graph_enabled: false,
-            brain: "brain".into(),
-            detector_identity: "none".into(),
+            brain: "disabled".into(),
+            detector_identity: "disabled".into(),
             schema_identity: "schema-v1".into(),
             index_identity: "index-v1".into(),
             source_policy: SourceExecutionPolicy::DurableSnapshot {
@@ -1225,9 +1779,16 @@ mod tests {
     struct FakeBackend {
         live: BTreeMap<String, LiveGroup>,
         applications: Vec<String>,
+        provisions: usize,
+        validations: usize,
     }
 
     impl SyncOperationBackend for FakeBackend {
+        fn provision_generation(&mut self, _desired: &GenerationManifest) -> Result<()> {
+            self.provisions += 1;
+            Ok(())
+        }
+
         fn apply(
             &mut self,
             operation: &SyncOperation,
@@ -1269,6 +1830,7 @@ mod tests {
             desired: &GenerationManifest,
             _snapshot: &SourceSnapshot,
         ) -> Result<()> {
+            self.validations += 1;
             let expected: BTreeMap<String, LiveGroup> = desired
                 .groups
                 .iter()
@@ -1307,16 +1869,6 @@ mod tests {
         )
         .unwrap();
         journal.sync_begin(&pending).unwrap();
-    }
-
-    fn empty_base_for(plan: &Plan) -> Plan {
-        let mut base = plan.clone();
-        base.files.clear();
-        base.duplicate_files.clear();
-        for dataset in &mut base.datasets {
-            dataset.file_count = 0;
-        }
-        base
     }
 
     #[test]
@@ -1376,8 +1928,15 @@ mod tests {
         .unwrap();
         let inventory = inventory(corpus.path());
         let plan = plan_for(&inventory);
-        let snapshot =
-            create_prepared_snapshot(state.path(), "tx-prepared", &inventory, &plan).unwrap();
+        let snapshot = create_prepared_snapshot(
+            state.path(),
+            "tx-prepared",
+            &inventory,
+            &plan,
+            "test-preparation-v1",
+            u64::MAX,
+        )
+        .unwrap();
         let prepared = snapshot.files[0].prepared.as_ref().unwrap();
         assert_eq!(prepared.records, 2);
         assert!(prepared.bytes > 0);
@@ -1401,6 +1960,153 @@ mod tests {
             .join(&prepared.relative_ndjson);
         std::fs::write(artifact_path, "corrupt").unwrap();
         assert!(open_snapshot(state.path(), "tx-prepared").is_err());
+    }
+
+    #[test]
+    fn preparation_sniffs_and_extracts_only_the_sealed_blob_after_live_mutation() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let corpus = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let source = corpus.path().join("records.jsonl");
+        let sealed = b"{\"message\":\"sealed alpha\"}\n{\"message\":\"sealed beta\"}\n";
+        let replacement = b"id,value\n9,live mutation\n";
+        std::fs::write(&source, sealed).unwrap();
+        let inventory = inventory(corpus.path());
+        let plan = plan_for(&inventory);
+        arm_source_mutation_after_seal(&source, replacement);
+
+        let snapshot = create_prepared_snapshot(
+            state.path(),
+            "tx-post-seal-mutation",
+            &inventory,
+            &plan,
+            "test-preparation-v1",
+            u64::MAX,
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&source).unwrap(), replacement);
+        let prepared = snapshot.files[0].prepared.as_ref().unwrap();
+        assert_eq!(prepared.records, 2);
+        let root = state.path().join("sync-snapshots/tx-post-seal-mutation");
+        let ndjson = std::fs::read_to_string(root.join(&prepared.relative_ndjson)).unwrap();
+        assert!(ndjson.contains("sealed alpha"), "{ndjson}");
+        assert!(ndjson.contains("sealed beta"), "{ndjson}");
+        assert!(!ndjson.contains("live mutation"), "{ndjson}");
+        for document in ndjson
+            .lines()
+            .skip(1)
+            .step_by(2)
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        {
+            assert_eq!(document["ax_format"], "jsonl");
+            assert!(document.get("message").is_some(), "{document}");
+            assert!(document.get("id").is_none(), "{document}");
+            assert!(document.get("value").is_none(), "{document}");
+        }
+        assert_eq!(
+            std::fs::read(root.join(&snapshot.files[0].relative_blob)).unwrap(),
+            sealed
+        );
+    }
+
+    #[test]
+    fn prepared_snapshot_budget_aborts_and_removes_staging() {
+        let corpus = tempfile::tempdir().unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "budgeted source bytes").unwrap();
+        let inventory =
+            crate::content::resolve(crate::walk::walk(corpus.path(), false).unwrap()).unwrap();
+        let plan = plan_for(&inventory);
+        let state = tempfile::tempdir().unwrap();
+        let error = create_prepared_snapshot(
+            state.path(),
+            "tx-budget",
+            &inventory,
+            &plan,
+            "test-preparation-v1",
+            inventory.files[0].size + 1,
+        )
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("logical payload"));
+        assert!(!state
+            .path()
+            .join("sync-snapshots/.tx-budget.partial")
+            .exists());
+        assert!(!state.path().join("sync-snapshots/tx-budget").exists());
+    }
+
+    #[test]
+    fn payload_writer_refuses_bytes_before_they_reach_disk() {
+        let state = tempfile::tempdir().unwrap();
+        let path = state.path().join("payload");
+        let file = File::create(&path).unwrap();
+        let mut budget = PayloadBudget { used: 0, limit: 3 };
+        let mut writer = BudgetWriter {
+            inner: file,
+            budget: &mut budget,
+        };
+        writer.write_all(b"abc").unwrap();
+        assert!(writer.write_all(b"d").is_err());
+        writer.flush().unwrap();
+        drop(writer);
+        assert_eq!(std::fs::metadata(path).unwrap().len(), 3);
+        assert_eq!(budget.used, 3);
+    }
+
+    #[test]
+    fn gc_tombstone_crash_is_retryable_and_symlinks_are_refused() {
+        let state = tempfile::tempdir().unwrap();
+        let mut journal = Journal::open(state.path(), "root", "url", "prefix", 300, false).unwrap();
+        journal.sync_bootstrap_genesis().unwrap();
+        let snapshots = state.path().join("sync-snapshots");
+        std::fs::create_dir_all(snapshots.join("orphan")).unwrap();
+        std::fs::write(snapshots.join("orphan/blob"), b"x").unwrap();
+        GC_FAIL_AFTER_RENAME.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(gc_snapshots(state.path(), &journal).is_err());
+        assert!(!snapshots.join("orphan").exists());
+        assert!(snapshots.join(".orphan.gc").exists());
+        gc_snapshots(state.path(), &journal).unwrap();
+        assert!(!snapshots.join(".orphan.gc").exists());
+
+        #[cfg(unix)]
+        {
+            std::fs::create_dir(snapshots.join("a-orphan")).unwrap();
+            std::os::unix::fs::symlink(state.path(), snapshots.join("hostile")).unwrap();
+            assert!(gc_snapshots(state.path(), &journal).is_err());
+            assert!(snapshots.join("a-orphan").exists());
+            assert!(snapshots.join("hostile").exists());
+        }
+    }
+
+    #[test]
+    fn gc_validates_every_protected_snapshot_before_deleting_orphans() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let corpus = tempfile::tempdir().unwrap();
+        std::fs::write(corpus.path().join("a.txt"), "protected bytes").unwrap();
+        let inventory =
+            crate::content::resolve(crate::walk::walk(corpus.path(), false).unwrap()).unwrap();
+        let plan = plan_for(&inventory);
+        let state = tempfile::tempdir().unwrap();
+        let snapshot = create_snapshot(state.path(), "tx-protected", &inventory).unwrap();
+        let mut journal = Journal::open(state.path(), "root", "url", "prefix", 300, false).unwrap();
+        journal.sync_bootstrap_genesis().unwrap();
+        let groups = groups_from_inventory(&inventory, &plan, &[]).unwrap();
+        begin(&mut journal, "tx-protected", &snapshot, plan, groups);
+        let orphan = state.path().join("sync-snapshots/orphan");
+        std::fs::create_dir(&orphan).unwrap();
+        std::fs::write(orphan.join("blob"), b"orphan").unwrap();
+        let protected_blob = state
+            .path()
+            .join("sync-snapshots/tx-protected")
+            .join(&snapshot.files[0].relative_blob);
+        std::fs::write(protected_blob, b"corrupt").unwrap();
+        assert!(gc_snapshots(state.path(), &journal).is_err());
+        assert!(orphan.exists(), "validation must precede every deletion");
+        assert!(state.path().join("sync-snapshots/tx-protected").exists());
     }
 
     #[test]
@@ -1490,13 +2196,14 @@ mod tests {
                     "prefix": "ax",
                     "follow_symlinks": false,
                     "chunker_identity": "chunker",
+                    "embedding_identity_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     "embedding_backend": "lexical",
-                    "embedding_model": "feature-hash",
-                    "embedding_tokenizer": "none",
                     "embedding_dimension": 384,
+                    "embedding_semantic_contract": "semantic_text-derived-vector.v1",
+                    "embedding_resumable": true,
                     "graph_enabled": false,
-                    "brain": "brain",
-                    "detector_identity": "none",
+                    "brain": "disabled",
+                    "detector_identity": "disabled",
                     "schema_identity": "schema",
                     "index_identity": "index",
                     "source_policy": {
@@ -1545,7 +2252,7 @@ mod tests {
         let snapshot = create_snapshot(state.path(), "tx-add", &inventory).unwrap();
         let mut journal =
             Journal::open(state.path(), "root", "http://engine", "ax", 300, false).unwrap();
-        journal.write_plan(&empty_base_for(&plan)).unwrap();
+        journal.sync_bootstrap_genesis().unwrap();
         begin(&mut journal, "tx-add", &snapshot, plan, groups);
         let mut backend = FakeBackend::default();
 
@@ -1580,7 +2287,7 @@ mod tests {
         let first_snapshot = create_snapshot(state.path(), "tx-first", &first_inventory).unwrap();
         let mut journal =
             Journal::open(state.path(), "root", "http://engine", "ax", 300, false).unwrap();
-        journal.write_plan(&empty_base_for(&first_plan)).unwrap();
+        journal.sync_bootstrap_genesis().unwrap();
         begin(
             &mut journal,
             "tx-first",
@@ -1670,5 +2377,40 @@ mod tests {
             .unwrap()
             .groups
             .is_empty());
+    }
+
+    #[test]
+    fn serialized_graph_identity_with_zero_operations_fails_before_backend_or_commit() {
+        let state = tempfile::tempdir().unwrap();
+        let inventory = Inventory {
+            files: vec![],
+            keys: vec![],
+            digests: vec![],
+            duplicates: vec![],
+        };
+        let snapshot = create_snapshot(state.path(), "tx-hostile", &inventory).unwrap();
+        let mut journal =
+            Journal::open(state.path(), "root", "http://engine", "ax", 300, false).unwrap();
+        journal.sync_bootstrap_genesis().unwrap();
+        let base = journal.committed_manifest.as_ref().unwrap().clone();
+        let desired = desired(1, "tx-hostile", &snapshot, Plan::default(), vec![]);
+        let valid = PendingSync::new("tx-hostile".into(), &base, desired).unwrap();
+        assert!(valid.operations.is_empty());
+        journal.sync_begin(&valid).unwrap();
+
+        let mut encoded = serde_json::to_value(journal.pending_sync.as_ref().unwrap()).unwrap();
+        encoded["desired"]["execution"]["graph_enabled"] = Value::Bool(true);
+        encoded["desired"]["execution"]["brain"] = Value::String("hostile".into());
+        encoded["desired"]["execution"]["detector_identity"] =
+            Value::String("hostile-detectors".into());
+        journal.pending_sync = Some(serde_json::from_value(encoded).unwrap());
+
+        let mut backend = FakeBackend::default();
+        assert!(replay_pending_operations(state.path(), &mut journal, &mut backend).is_err());
+        assert_eq!(backend.provisions, 0);
+        assert!(backend.applications.is_empty());
+        assert_eq!(backend.validations, 0);
+        assert_eq!(journal.committed_manifest.as_ref().unwrap().generation, 0);
+        assert!(journal.pending_sync.is_some());
     }
 }

--- a/engine/crates/xerj-common/src/config.rs
+++ b/engine/crates/xerj-common/src/config.rs
@@ -894,6 +894,20 @@ pub struct EmbeddingConfig {
     pub onnx_max_input_bytes_per_call: usize,
     /// Aggregate UTF-8 bytes admitted globally per shared ONNX model/session.
     pub onnx_max_inflight_input_bytes: usize,
+    /// Engine-lifetime immutable ONNX assets. Cloned configurations share this
+    /// cell, so identity reporting and lazy loading consume the same bytes.
+    /// It is runtime state, never configuration input or serialized output.
+    #[serde(skip)]
+    pub runtime_onnx_assets:
+        std::sync::Arc<std::sync::OnceLock<Result<EmbeddingAssetSnapshot, String>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EmbeddingAssetSnapshot {
+    pub model_bytes: std::sync::Arc<[u8]>,
+    pub tokenizer_bytes: std::sync::Arc<[u8]>,
+    pub model_sha256: String,
+    pub tokenizer_sha256: String,
 }
 
 impl Default for EmbeddingConfig {
@@ -920,6 +934,7 @@ impl Default for EmbeddingConfig {
             onnx_max_inflight_calls: 8,
             onnx_max_input_bytes_per_call: 8 * 1024 * 1024,
             onnx_max_inflight_input_bytes: 32 * 1024 * 1024,
+            runtime_onnx_assets: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 }

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -15,6 +15,21 @@ use xerj_common::types::{IndexName, Schema};
 use crate::index::{Index, IndexStats};
 use crate::{EngineError, Result};
 
+/// Privacy-safe identity of the embedding execution contract exposed to
+/// remote ingestion clients. The digest is opaque: model paths, provider URLs,
+/// credentials, and model names never cross the API boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingExecutionIdentity {
+    pub version: u32,
+    pub backend: String,
+    pub identity_sha256: String,
+    pub dimensions: usize,
+    pub semantic_contract: String,
+    pub resumable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub non_resumable_reason: Option<String>,
+}
+
 // ── Clustering types ─────────────────────────────────────────────────────────
 
 /// Node identity and cluster membership configuration.
@@ -1492,6 +1507,12 @@ impl Engine {
     /// coupling to the full engine internals.
     pub fn config(&self) -> &Config {
         &self.config
+    }
+
+    /// Return the effective embedding identity without exposing configuration
+    /// secrets or local asset paths.
+    pub fn embedding_execution_identity(&self) -> Result<EmbeddingExecutionIdentity> {
+        crate::index::embedding_execution_identity(&self.config.embedding)
     }
 
     /// Sum of every open index's live memtable footprint, in bytes. This is

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -381,7 +381,11 @@ impl Engine {
     }
 
     /// Create a new engine, opening any existing indices from disk.
-    pub fn new(config: Config) -> Result<Self> {
+    pub fn new(mut config: Config) -> Result<Self> {
+        // Runtime asset ownership belongs to this Engine, not to the caller's
+        // clone lineage. This ensures a later Engine re-reads same-path ONNX
+        // assets while all Index config clones within one Engine share bytes.
+        config.embedding.runtime_onnx_assets = Arc::new(std::sync::OnceLock::new());
         let data_dir = PathBuf::from(&config.server.data_dir);
         std::fs::create_dir_all(&data_dir)?;
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -23408,62 +23408,34 @@ fn validate_onnx_dimensions(fields: &[FieldConfig]) -> Result<()> {
 }
 
 #[cfg(feature = "onnx-experimental")]
-#[derive(Clone)]
-struct OnnxAssetSnapshot {
-    model_bytes: Arc<[u8]>,
-    tokenizer_bytes: Arc<[u8]>,
-    model_sha256: String,
-    tokenizer_sha256: String,
-}
-
-#[cfg(feature = "onnx-experimental")]
-fn configured_onnx_assets(cfg: &xerj_common::config::EmbeddingConfig) -> Result<OnnxAssetSnapshot> {
+fn configured_onnx_assets(
+    cfg: &xerj_common::config::EmbeddingConfig,
+) -> Result<xerj_common::config::EmbeddingAssetSnapshot> {
     use sha2::{Digest, Sha256};
-    use std::collections::HashMap;
-    use std::sync::{Mutex, OnceLock};
 
-    static SNAPSHOTS: OnceLock<Mutex<HashMap<(PathBuf, PathBuf), OnnxAssetSnapshot>>> =
-        OnceLock::new();
-    let model = Path::new(&cfg.onnx_model_path)
-        .canonicalize()
-        .map_err(|e| {
-            EngineError::Common(xerj_common::XerjError::embedding(format!(
-                "cannot resolve embedding model asset: {e}"
-            )))
-        })?;
-    let tokenizer = Path::new(&cfg.onnx_tokenizer_path)
-        .canonicalize()
-        .map_err(|e| {
-            EngineError::Common(xerj_common::XerjError::embedding(format!(
-                "cannot resolve embedding tokenizer asset: {e}"
-            )))
-        })?;
-    let key = (model.clone(), tokenizer.clone());
-    let mut snapshots = SNAPSHOTS
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(snapshot) = snapshots.get(&key) {
-        return Ok(snapshot.clone());
-    }
-    let model_bytes: Arc<[u8]> = std::fs::read(&model).map(Into::into).map_err(|e| {
-        EngineError::Common(xerj_common::XerjError::embedding(format!(
-            "cannot read embedding model asset: {e}"
-        )))
-    })?;
-    let tokenizer_bytes: Arc<[u8]> = std::fs::read(&tokenizer).map(Into::into).map_err(|e| {
-        EngineError::Common(xerj_common::XerjError::embedding(format!(
-            "cannot read embedding tokenizer asset: {e}"
-        )))
-    })?;
-    let snapshot = OnnxAssetSnapshot {
-        model_sha256: format!("{:x}", Sha256::digest(&model_bytes)),
-        tokenizer_sha256: format!("{:x}", Sha256::digest(&tokenizer_bytes)),
-        model_bytes,
-        tokenizer_bytes,
-    };
-    snapshots.insert(key, snapshot.clone());
-    Ok(snapshot)
+    cfg.runtime_onnx_assets
+        .get_or_init(|| {
+            let model = Path::new(&cfg.onnx_model_path)
+                .canonicalize()
+                .map_err(|e| format!("cannot resolve embedding model asset: {e}"))?;
+            let tokenizer = Path::new(&cfg.onnx_tokenizer_path)
+                .canonicalize()
+                .map_err(|e| format!("cannot resolve embedding tokenizer asset: {e}"))?;
+            let model_bytes: Arc<[u8]> = std::fs::read(&model)
+                .map(Into::into)
+                .map_err(|e| format!("cannot read embedding model asset: {e}"))?;
+            let tokenizer_bytes: Arc<[u8]> = std::fs::read(&tokenizer)
+                .map(Into::into)
+                .map_err(|e| format!("cannot read embedding tokenizer asset: {e}"))?;
+            Ok(xerj_common::config::EmbeddingAssetSnapshot {
+                model_sha256: format!("{:x}", Sha256::digest(&model_bytes)),
+                tokenizer_sha256: format!("{:x}", Sha256::digest(&tokenizer_bytes)),
+                model_bytes,
+                tokenizer_bytes,
+            })
+        })
+        .clone()
+        .map_err(|reason| EngineError::Common(xerj_common::XerjError::embedding(reason)))
 }
 
 fn configured_onnx_identity(
@@ -23830,6 +23802,76 @@ mod embedding_identity_tests {
             snapshot_for_loader.tokenizer_bytes.as_ref(),
             replacement_tokenizer
         );
+    }
+
+    #[cfg(feature = "onnx-experimental")]
+    #[test]
+    fn onnx_snapshot_is_scoped_to_one_runtime_config_and_released_with_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_cfg = onnx_config(dir.path(), "runtime-scope");
+        let first = configured_onnx_assets(&first_cfg).unwrap();
+        let weak_model = Arc::downgrade(&first.model_bytes);
+        let first_identity = embedding_execution_identity(&first_cfg).unwrap();
+
+        let replacement_model = vec![b'z'; first.model_bytes.len()];
+        std::fs::write(&first_cfg.onnx_model_path, &replacement_model).unwrap();
+        drop(first);
+        drop(first_cfg);
+        assert!(
+            weak_model.upgrade().is_none(),
+            "dropping the runtime config must release its immutable asset snapshot"
+        );
+
+        let second_cfg = xerj_common::config::EmbeddingConfig {
+            mode: "onnx-experimental".into(),
+            onnx_model_path: dir
+                .path()
+                .join("model-runtime-scope.onnx")
+                .to_string_lossy()
+                .into_owned(),
+            onnx_tokenizer_path: dir
+                .path()
+                .join("tokenizer-runtime-scope.json")
+                .to_string_lossy()
+                .into_owned(),
+            ..Default::default()
+        };
+        let second = configured_onnx_assets(&second_cfg).unwrap();
+        let second_identity = embedding_execution_identity(&second_cfg).unwrap();
+        assert_eq!(second.model_bytes.as_ref(), replacement_model);
+        assert_ne!(
+            first_identity.identity_sha256,
+            second_identity.identity_sha256
+        );
+    }
+
+    #[cfg(feature = "onnx-experimental")]
+    #[test]
+    fn concurrent_identity_and_loader_access_share_one_runtime_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = onnx_config(dir.path(), "concurrent");
+        let identity_cfg = cfg.clone();
+        let identity_thread =
+            std::thread::spawn(move || embedding_execution_identity(&identity_cfg).unwrap());
+        let loader_cfg = cfg.clone();
+        let loader_thread =
+            std::thread::spawn(move || configured_onnx_assets(&loader_cfg).unwrap());
+
+        let identity = identity_thread.join().unwrap();
+        let loader_snapshot = loader_thread.join().unwrap();
+        let owner_snapshot = configured_onnx_assets(&cfg).unwrap();
+        assert_eq!(
+            identity.identity_sha256,
+            embedding_execution_identity(&cfg).unwrap().identity_sha256
+        );
+        assert!(Arc::ptr_eq(
+            &loader_snapshot.model_bytes,
+            &owner_snapshot.model_bytes
+        ));
+        assert!(Arc::ptr_eq(
+            &loader_snapshot.tokenizer_bytes,
+            &owner_snapshot.tokenizer_bytes
+        ));
     }
 
     #[cfg(feature = "onnx-experimental")]

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -23901,6 +23901,55 @@ mod embedding_identity_tests {
         ));
     }
 
+    /// Run with matching production assets:
+    ///
+    /// `XERJ_ONNX_TEST_MODEL=/abs/model.onnx
+    ///  XERJ_ONNX_TEST_TOKENIZER=/abs/tokenizer.json
+    ///  cargo test -p xerj-engine --features onnx-experimental
+    ///  concurrent_identity_and_real_lazy_pool_share_snapshot -- --ignored`
+    #[cfg(feature = "onnx-experimental")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires explicit matching ONNX model and tokenizer assets"]
+    async fn concurrent_identity_and_real_lazy_pool_share_snapshot() {
+        let cfg = xerj_common::config::EmbeddingConfig {
+            mode: "onnx-experimental".into(),
+            onnx_model_path: std::env::var("XERJ_ONNX_TEST_MODEL")
+                .expect("XERJ_ONNX_TEST_MODEL is required"),
+            onnx_tokenizer_path: std::env::var("XERJ_ONNX_TEST_TOKENIZER")
+                .expect("XERJ_ONNX_TEST_TOKENIZER is required"),
+            ..Default::default()
+        };
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let identity_cfg = cfg.clone();
+        let identity_barrier = barrier.clone();
+        let identity = tokio::task::spawn_blocking(move || {
+            identity_barrier.wait();
+            embedding_execution_identity(&identity_cfg).unwrap()
+        });
+        let embedder = make_embedder(&cfg).unwrap();
+        barrier.wait();
+        let vectors = embedder
+            .embed_batch(vec!["quarterly revenue increased".into()])
+            .await
+            .unwrap();
+        let identity = identity.await.unwrap();
+        assert_eq!(identity.backend, "onnx-experimental");
+        assert_eq!(vectors.len(), 1);
+        assert_eq!(vectors[0].len(), identity.dimensions);
+        let snapshot = configured_onnx_assets(&cfg).unwrap();
+        assert_eq!(
+            identity.identity_sha256,
+            embedding_execution_identity(&cfg).unwrap().identity_sha256
+        );
+        assert_eq!(
+            snapshot.model_sha256,
+            format!(
+                "{:x}",
+                <sha2::Sha256 as sha2::Digest>::digest(&snapshot.model_bytes)
+            )
+        );
+    }
+
     #[cfg(feature = "onnx-experimental")]
     fn onnx_config(dir: &Path, suffix: &str) -> xerj_common::config::EmbeddingConfig {
         let model = dir.join(format!("model-{suffix}.onnx"));

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -23846,6 +23846,33 @@ mod embedding_identity_tests {
     }
 
     #[cfg(feature = "onnx-experimental")]
+    #[tokio::test]
+    async fn sequential_engines_from_one_caller_config_refresh_same_path_assets() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut caller_config = xerj_common::config::Config::default();
+        caller_config.server.data_dir = dir
+            .path()
+            .join("engine-data")
+            .to_string_lossy()
+            .into_owned();
+        caller_config.embedding = onnx_config(dir.path(), "engine-lifetime");
+
+        let first_engine = crate::Engine::new(caller_config.clone()).unwrap();
+        let first_identity = first_engine.embedding_execution_identity().unwrap();
+        let model_path = caller_config.embedding.onnx_model_path.clone();
+        let original_len = std::fs::metadata(&model_path).unwrap().len() as usize;
+        drop(first_engine);
+
+        std::fs::write(&model_path, vec![b'q'; original_len]).unwrap();
+        let second_engine = crate::Engine::new(caller_config).unwrap();
+        let second_identity = second_engine.embedding_execution_identity().unwrap();
+        assert_ne!(
+            first_identity.identity_sha256,
+            second_identity.identity_sha256
+        );
+    }
+
+    #[cfg(feature = "onnx-experimental")]
     #[test]
     fn concurrent_identity_and_loader_access_share_one_runtime_snapshot() {
         let dir = tempfile::tempdir().unwrap();

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -23408,53 +23408,62 @@ fn validate_onnx_dimensions(fields: &[FieldConfig]) -> Result<()> {
 }
 
 #[cfg(feature = "onnx-experimental")]
-fn sha256_file(path: &Path) -> Result<String> {
+#[derive(Clone)]
+struct OnnxAssetSnapshot {
+    model_bytes: Arc<[u8]>,
+    tokenizer_bytes: Arc<[u8]>,
+    model_sha256: String,
+    tokenizer_sha256: String,
+}
+
+#[cfg(feature = "onnx-experimental")]
+fn configured_onnx_assets(cfg: &xerj_common::config::EmbeddingConfig) -> Result<OnnxAssetSnapshot> {
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
-    use std::io::Read;
     use std::sync::{Mutex, OnceLock};
-    use std::time::UNIX_EPOCH;
 
-    static CACHE: OnceLock<Mutex<HashMap<(PathBuf, u64, u128), String>>> = OnceLock::new();
-    let canonical = path.canonicalize().map_err(|e| {
-        EngineError::Common(xerj_common::XerjError::embedding(format!(
-            "cannot resolve embedding asset {}: {e}",
-            path.display()
-        )))
-    })?;
-    let metadata = std::fs::metadata(&canonical)?;
-    let modified = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let key = (canonical.clone(), metadata.len(), modified);
-    let mut cache = CACHE
+    static SNAPSHOTS: OnceLock<Mutex<HashMap<(PathBuf, PathBuf), OnnxAssetSnapshot>>> =
+        OnceLock::new();
+    let model = Path::new(&cfg.onnx_model_path)
+        .canonicalize()
+        .map_err(|e| {
+            EngineError::Common(xerj_common::XerjError::embedding(format!(
+                "cannot resolve embedding model asset: {e}"
+            )))
+        })?;
+    let tokenizer = Path::new(&cfg.onnx_tokenizer_path)
+        .canonicalize()
+        .map_err(|e| {
+            EngineError::Common(xerj_common::XerjError::embedding(format!(
+                "cannot resolve embedding tokenizer asset: {e}"
+            )))
+        })?;
+    let key = (model.clone(), tokenizer.clone());
+    let mut snapshots = SNAPSHOTS
         .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(hash) = cache.get(&key).cloned() {
-        return Ok(hash);
+    if let Some(snapshot) = snapshots.get(&key) {
+        return Ok(snapshot.clone());
     }
-    let mut file = std::fs::File::open(&canonical).map_err(|e| {
+    let model_bytes: Arc<[u8]> = std::fs::read(&model).map(Into::into).map_err(|e| {
         EngineError::Common(xerj_common::XerjError::embedding(format!(
-            "cannot fingerprint embedding asset {}: {e}",
-            path.display()
+            "cannot read embedding model asset: {e}"
         )))
     })?;
-    let mut hasher = Sha256::new();
-    let mut buf = [0_u8; 1024 * 1024];
-    loop {
-        let n = file.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    let hash = format!("{:x}", hasher.finalize());
-    cache.insert(key, hash.clone());
-    Ok(hash)
+    let tokenizer_bytes: Arc<[u8]> = std::fs::read(&tokenizer).map(Into::into).map_err(|e| {
+        EngineError::Common(xerj_common::XerjError::embedding(format!(
+            "cannot read embedding tokenizer asset: {e}"
+        )))
+    })?;
+    let snapshot = OnnxAssetSnapshot {
+        model_sha256: format!("{:x}", Sha256::digest(&model_bytes)),
+        tokenizer_sha256: format!("{:x}", Sha256::digest(&tokenizer_bytes)),
+        model_bytes,
+        tokenizer_bytes,
+    };
+    snapshots.insert(key, snapshot.clone());
+    Ok(snapshot)
 }
 
 fn configured_onnx_identity(
@@ -23469,15 +23478,18 @@ fn configured_onnx_identity(
          onnx-experimental feature; no embedding identity marker was written",
     )));
     #[cfg(feature = "onnx-experimental")]
-    Ok(Some(PersistedEmbeddingIdentity {
-        version: 1,
-        backend: "onnx-experimental".into(),
-        model_sha256: sha256_file(Path::new(&cfg.onnx_model_path))?,
-        tokenizer_sha256: sha256_file(Path::new(&cfg.onnx_tokenizer_path))?,
-        dimensions: 384,
-        pooling: "attention-mask-mean+l2-normalize".into(),
-        max_tokens: 512,
-    }))
+    {
+        let assets = configured_onnx_assets(cfg)?;
+        Ok(Some(PersistedEmbeddingIdentity {
+            version: 1,
+            backend: "onnx-experimental".into(),
+            model_sha256: assets.model_sha256,
+            tokenizer_sha256: assets.tokenizer_sha256,
+            dimensions: 384,
+            pooling: "attention-mask-mean+l2-normalize".into(),
+            max_tokens: 512,
+        }))
+    }
 }
 
 pub(crate) fn embedding_execution_identity(
@@ -23487,8 +23499,17 @@ pub(crate) fn embedding_execution_identity(
 
     const CONTRACT: &str = "semantic_text-derived-vector.v1";
     let requested = cfg.mode.trim().to_ascii_lowercase();
-    let backend = match requested.as_str() {
-        "neural" => "neural",
+    let mut backend = match requested.as_str() {
+        "neural" => {
+            #[cfg(feature = "neural")]
+            {
+                "neural"
+            }
+            #[cfg(not(feature = "neural"))]
+            {
+                "lexical"
+            }
+        }
         "onnx-experimental" => "onnx-experimental",
         "lexical" => "lexical",
         "proxy" if cfg.default_endpoint.is_empty() => "lexical",
@@ -23496,6 +23517,9 @@ pub(crate) fn embedding_execution_identity(
         _ if cfg.default_endpoint.is_empty() => "lexical",
         _ => "proxy",
     };
+    if backend == "proxy" && !proxy_initializes(cfg) {
+        backend = "lexical";
+    }
     let (material, resumable, reason) = match backend {
         "lexical" => (
             "lexical-feature-hash.v1;dimensions=384".to_string(),
@@ -23549,6 +23573,23 @@ pub(crate) fn embedding_execution_identity(
         resumable,
         non_resumable_reason: reason,
     })
+}
+
+fn proxy_config(
+    cfg: &xerj_common::config::EmbeddingConfig,
+) -> xerj_ai::embed::EmbeddingProxyConfig {
+    xerj_ai::embed::EmbeddingProxyConfig {
+        endpoint: cfg.default_endpoint.clone(),
+        api_key: std::env::var("XERJ_EMBEDDING_API_KEY").ok(),
+        model: cfg.default_model.clone(),
+        timeout_secs: cfg.timeout_ms / 1000,
+        max_concurrent: 4,
+        max_retries: 3,
+    }
+}
+
+fn proxy_initializes(cfg: &xerj_common::config::EmbeddingConfig) -> bool {
+    xerj_ai::embed::EmbeddingProxy::new(proxy_config(cfg)).is_ok()
 }
 
 /// Fail closed rather than mixing vectors produced by different model,
@@ -23691,12 +23732,22 @@ mod embedding_identity_tests {
     }
 
     #[test]
-    fn neural_and_proxy_are_honestly_non_resumable() {
+    fn configured_backends_report_the_effective_runtime_backend() {
         let neural = xerj_common::config::EmbeddingConfig {
             mode: "neural".into(),
             ..Default::default()
         };
-        assert!(!embedding_execution_identity(&neural).unwrap().resumable);
+        let neural_identity = embedding_execution_identity(&neural).unwrap();
+        #[cfg(feature = "neural")]
+        {
+            assert_eq!(neural_identity.backend, "neural");
+            assert!(!neural_identity.resumable);
+        }
+        #[cfg(not(feature = "neural"))]
+        {
+            assert_eq!(neural_identity.backend, "lexical");
+            assert!(neural_identity.resumable);
+        }
         let proxy = xerj_common::config::EmbeddingConfig {
             mode: "proxy".into(),
             default_endpoint: "https://secret.example/v1".into(),
@@ -23704,10 +23755,22 @@ mod embedding_identity_tests {
             ..Default::default()
         };
         let identity = embedding_execution_identity(&proxy).unwrap();
+        assert_eq!(identity.backend, "proxy");
         assert!(!identity.resumable);
         let encoded = serde_json::to_string(&identity).unwrap();
         assert!(!encoded.contains("secret.example"));
         assert!(!encoded.contains("private-alias"));
+
+        for endpoint in ["", "not a url", "file:///private/model"] {
+            let fallback = xerj_common::config::EmbeddingConfig {
+                mode: "proxy".into(),
+                default_endpoint: endpoint.into(),
+                ..Default::default()
+            };
+            let identity = embedding_execution_identity(&fallback).unwrap();
+            assert_eq!(identity.backend, "lexical", "{endpoint}");
+            assert!(identity.resumable, "{endpoint}");
+        }
     }
 
     #[cfg(feature = "onnx-experimental")]
@@ -23718,6 +23781,55 @@ mod embedding_identity_tests {
         let second = embedding_execution_identity(&onnx_config(dir.path(), "b")).unwrap();
         assert!(first.resumable);
         assert_ne!(first.identity_sha256, second.identity_sha256);
+    }
+
+    #[cfg(feature = "onnx-experimental")]
+    #[test]
+    fn onnx_identity_and_lazy_loader_share_one_immutable_byte_snapshot() {
+        use std::fs::{File, FileTimes, OpenOptions};
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = onnx_config(dir.path(), "stable-path");
+        let model_path = Path::new(&cfg.onnx_model_path);
+        let tokenizer_path = Path::new(&cfg.onnx_tokenizer_path);
+        let model_modified = model_path.metadata().unwrap().modified().unwrap();
+        let tokenizer_modified = tokenizer_path.metadata().unwrap().modified().unwrap();
+
+        let identity_before = embedding_execution_identity(&cfg).unwrap();
+        let snapshot_before = configured_onnx_assets(&cfg).unwrap();
+        let replacement_model = vec![b'x'; snapshot_before.model_bytes.len()];
+        let replacement_tokenizer = vec![b'y'; snapshot_before.tokenizer_bytes.len()];
+        std::fs::write(model_path, &replacement_model).unwrap();
+        std::fs::write(tokenizer_path, &replacement_tokenizer).unwrap();
+        OpenOptions::new()
+            .write(true)
+            .open(model_path)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(model_modified))
+            .unwrap();
+        File::options()
+            .write(true)
+            .open(tokenizer_path)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(tokenizer_modified))
+            .unwrap();
+
+        let snapshot_for_loader = configured_onnx_assets(&cfg).unwrap();
+        let identity_after = embedding_execution_identity(&cfg).unwrap();
+        assert_eq!(identity_before, identity_after);
+        assert_eq!(
+            snapshot_for_loader.model_bytes.as_ref(),
+            snapshot_before.model_bytes.as_ref()
+        );
+        assert_eq!(
+            snapshot_for_loader.tokenizer_bytes.as_ref(),
+            snapshot_before.tokenizer_bytes.as_ref()
+        );
+        assert_ne!(snapshot_for_loader.model_bytes.as_ref(), replacement_model);
+        assert_ne!(
+            snapshot_for_loader.tokenizer_bytes.as_ref(),
+            replacement_tokenizer
+        );
     }
 
     #[cfg(feature = "onnx-experimental")]
@@ -23877,24 +23989,18 @@ fn make_embedder(cfg: &xerj_common::config::EmbeddingConfig) -> Result<xerj_ai::
             warn!("embedding.mode=proxy but embedding.default_endpoint is empty — falling back to lexical");
             return Ok(xerj_ai::Embedder::lexical());
         }
-        let proxy_cfg = xerj_ai::embed::EmbeddingProxyConfig {
-            endpoint: cfg.default_endpoint.clone(),
-            api_key: std::env::var("XERJ_EMBEDDING_API_KEY").ok(),
-            model: cfg.default_model.clone(),
-            timeout_secs: cfg.timeout_ms / 1000,
-            max_concurrent: 4,
-            max_retries: 3,
-        };
-        return Ok(match xerj_ai::embed::EmbeddingProxy::new(proxy_cfg) {
-            Ok(p) => {
-                info!(endpoint = %cfg.default_endpoint, "embedding backend: external proxy");
-                xerj_ai::Embedder::proxy(p)
-            }
-            Err(e) => {
-                warn!(error = %e, "embedding proxy init failed — falling back to lexical");
-                xerj_ai::Embedder::lexical()
-            }
-        });
+        return Ok(
+            match xerj_ai::embed::EmbeddingProxy::new(proxy_config(cfg)) {
+                Ok(p) => {
+                    info!(endpoint = %cfg.default_endpoint, "embedding backend: external proxy");
+                    xerj_ai::Embedder::proxy(p)
+                }
+                Err(e) => {
+                    warn!(error = %e, "embedding proxy init failed — falling back to lexical");
+                    xerj_ai::Embedder::lexical()
+                }
+            },
+        );
     }
 
     Ok(xerj_ai::Embedder::lexical())
@@ -23958,11 +24064,12 @@ fn make_onnx_embedder(cfg: &xerj_common::config::EmbeddingConfig) -> Result<xerj
             ),
         )));
     }
+    let assets = configured_onnx_assets(cfg)?;
     let onnx_cfg = xerj_ai::embedder::OnnxConfig {
-        model_sha256: sha256_file(&model_path)?,
-        tokenizer_sha256: sha256_file(&tokenizer_path)?,
-        model_path,
-        tokenizer_path,
+        model_sha256: assets.model_sha256,
+        tokenizer_sha256: assets.tokenizer_sha256,
+        model_bytes: assets.model_bytes,
+        tokenizer_bytes: assets.tokenizer_bytes,
         intra_threads: cfg.onnx_intra_threads.max(1),
         session_pool_size: cfg.onnx_session_pool_size,
         microbatch: xerj_ai::onnx::MicrobatchConfig {
@@ -23975,8 +24082,8 @@ fn make_onnx_embedder(cfg: &xerj_common::config::EmbeddingConfig) -> Result<xerj
         max_inflight_input_bytes: cfg.onnx_max_inflight_input_bytes,
     };
     info!(
-        model = %onnx_cfg.model_path.display(),
-        tokenizer = %onnx_cfg.tokenizer_path.display(),
+        model_sha256 = %onnx_cfg.model_sha256,
+        tokenizer_sha256 = %onnx_cfg.tokenizer_sha256,
         scheduling_window = cfg.onnx_scheduling_window,
         session_pool_size = onnx_cfg.session_pool_size,
         "embedding backend: experimental ONNX Runtime (loads on first use)"

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -23480,6 +23480,77 @@ fn configured_onnx_identity(
     }))
 }
 
+pub(crate) fn embedding_execution_identity(
+    cfg: &xerj_common::config::EmbeddingConfig,
+) -> Result<crate::engine::EmbeddingExecutionIdentity> {
+    use sha2::{Digest, Sha256};
+
+    const CONTRACT: &str = "semantic_text-derived-vector.v1";
+    let requested = cfg.mode.trim().to_ascii_lowercase();
+    let backend = match requested.as_str() {
+        "neural" => "neural",
+        "onnx-experimental" => "onnx-experimental",
+        "lexical" => "lexical",
+        "proxy" if cfg.default_endpoint.is_empty() => "lexical",
+        "proxy" => "proxy",
+        _ if cfg.default_endpoint.is_empty() => "lexical",
+        _ => "proxy",
+    };
+    let (material, resumable, reason) = match backend {
+        "lexical" => (
+            "lexical-feature-hash.v1;dimensions=384".to_string(),
+            true,
+            None,
+        ),
+        "onnx-experimental" => {
+            let identity = configured_onnx_identity(cfg)?.ok_or_else(|| {
+                EngineError::Common(xerj_common::XerjError::embedding(
+                    "ONNX embedding identity is unavailable",
+                ))
+            })?;
+            (
+                format!(
+                    "onnx-experimental.v1;model={};tokenizer={};dimensions={};pooling={};max_tokens={}",
+                    identity.model_sha256,
+                    identity.tokenizer_sha256,
+                    identity.dimensions,
+                    identity.pooling,
+                    identity.max_tokens
+                ),
+                true,
+                None,
+            )
+        }
+        "neural" => (
+            format!("neural-unpinned.v1;configured-model={}", cfg.neural_model),
+            false,
+            Some(
+                "the neural model is not content-addressed; use a fresh autoindex state after changing it"
+                    .to_string(),
+            ),
+        ),
+        "proxy" => (
+            format!("proxy-unpinned.v1;configured-model={}", cfg.default_model),
+            false,
+            Some(
+                "the remote provider does not attest immutable model assets; semantic resume is unsafe"
+                    .to_string(),
+            ),
+        ),
+        _ => unreachable!(),
+    };
+    let canonical = format!("{CONTRACT};backend={backend};{material}");
+    Ok(crate::engine::EmbeddingExecutionIdentity {
+        version: 1,
+        backend: backend.to_string(),
+        identity_sha256: format!("{:x}", Sha256::digest(canonical.as_bytes())),
+        dimensions: xerj_ai::local::DEFAULT_DIMS,
+        semantic_contract: CONTRACT.to_string(),
+        resumable,
+        non_resumable_reason: reason,
+    })
+}
+
 /// Fail closed rather than mixing vectors produced by different model,
 /// tokenizer, pooling, or backend configurations after a restart/resume.
 fn validate_embedding_identity(
@@ -23602,6 +23673,51 @@ mod embedding_identity_tests {
             ))
             .unwrap();
         schema
+    }
+
+    #[test]
+    fn lexical_execution_identity_is_stable_and_sanitized() {
+        let cfg = xerj_common::config::EmbeddingConfig::default();
+        let identity = embedding_execution_identity(&cfg).unwrap();
+        assert_eq!(identity.backend, "lexical");
+        assert!(identity.resumable);
+        assert_eq!(
+            identity.identity_sha256,
+            "177b14d1bdff634335a99d558343ce506f39d758942f24a6455830e5a36ddda6"
+        );
+        let encoded = serde_json::to_string(&identity).unwrap();
+        assert!(!encoded.contains("endpoint"));
+        assert!(!encoded.contains("path"));
+    }
+
+    #[test]
+    fn neural_and_proxy_are_honestly_non_resumable() {
+        let neural = xerj_common::config::EmbeddingConfig {
+            mode: "neural".into(),
+            ..Default::default()
+        };
+        assert!(!embedding_execution_identity(&neural).unwrap().resumable);
+        let proxy = xerj_common::config::EmbeddingConfig {
+            mode: "proxy".into(),
+            default_endpoint: "https://secret.example/v1".into(),
+            default_model: "private-alias".into(),
+            ..Default::default()
+        };
+        let identity = embedding_execution_identity(&proxy).unwrap();
+        assert!(!identity.resumable);
+        let encoded = serde_json::to_string(&identity).unwrap();
+        assert!(!encoded.contains("secret.example"));
+        assert!(!encoded.contains("private-alias"));
+    }
+
+    #[cfg(feature = "onnx-experimental")]
+    #[test]
+    fn onnx_execution_identity_changes_with_asset_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = embedding_execution_identity(&onnx_config(dir.path(), "a")).unwrap();
+        let second = embedding_execution_identity(&onnx_config(dir.path(), "b")).unwrap();
+        assert!(first.resumable);
+        assert_ne!(first.identity_sha256, second.identity_sha256);
     }
 
     #[cfg(feature = "onnx-experimental")]

--- a/engine/crates/xerj-engine/src/lib.rs
+++ b/engine/crates/xerj-engine/src/lib.rs
@@ -40,7 +40,7 @@ mod bounded_ingest_resources_tests;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 
-pub use engine::{Engine, HealthStatus, IndexInfo};
+pub use engine::{EmbeddingExecutionIdentity, Engine, HealthStatus, IndexInfo};
 pub use index::{
     detect_log_format, resolve_date_math, resolve_field_alias, EnrichTable, FieldEncodingInfo,
     Index, IndexResponse, IndexStats, LogFormat,

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -428,6 +428,7 @@ fn index_cfg(cfg: &BrainCfg, brain: &str, api_key: Option<String>) -> IndexCfg {
         pdf_timeout_secs: 120,
         bulk_mb: 8,
         bulk_timeout_secs: 300,
+        snapshot_max_bytes: 64u64 << 30,
         prefix: "ax".into(),
         state_dir: None,
         fresh: cfg.fresh,

--- a/landing/docs/recipes/zero-config-autoindex.html
+++ b/landing/docs/recipes/zero-config-autoindex.html
@@ -239,7 +239,7 @@ live indices at http://localhost:9280:
   ax-docs                                           1 docs
   ax-exports                                      800 docs
   autoindex-catalog                                 9 docs</pre>
-  <p><code class="inline">--fresh</code> ignores the journal and restarts (ids stay idempotent).</p>
+  <p><code class="inline">--fresh</code> starts without resume state only when the selected state directory has no durable plan; it never removes stale destination records. For an independent rebuild, use a new <code class="inline">--state-dir</code>, new <code class="inline">--prefix</code>, and new <code class="inline">--brain</code> when graph detection is enabled (or add <code class="inline">--no-graph</code>). Validate before switching readers. The shared <code class="inline">autoindex-catalog</code> and old target require explicit, validated cleanup. Generated journals with <code class="inline">--no-graph</code> reconcile additions, changes, deletions, renames, and no-op reruns. Legacy journals and graph-enabled generations refuse membership changes before remote mutation.</p>
 
   <hr>
 

--- a/landing/llms-full.txt
+++ b/landing/llms-full.txt
@@ -140,8 +140,17 @@ destabilize the server.
   xerj autoindex map      [--url U] [--json] [--dataset SLUG]
   xerj autoindex status   [--url U] [--state-dir P]
 
+--fresh starts without resume state only when the selected state directory has
+no durable plan. It never removes stale destination records. An independent
+rebuild requires a new --state-dir, new --prefix, and new --brain when graph
+detection is enabled (or --no-graph), followed by validation before switching
+readers. The shared autoindex-catalog and old target require explicit,
+validated cleanup. Generated journals with --no-graph reconcile additions,
+changes, deletions, renames, and no-op reruns. Legacy journals and graph-enabled
+generations refuse membership changes before remote mutation.
+
 Exit codes: 0 complete · 3 completed-with-junk (junk recorded, never fatal) ·
-2 usage · 1 endpoint unreachable / journal-config mismatch.
+2 usage · 1 endpoint/journal error or refused unsafe corpus-state transition.
 
 Pipeline: walk → sniff → sample → infer → map → extract → bulk → correlate →
 catalog → verify.


### PR DESCRIPTION
Depends on https://github.com/xerj-org/xerj/pull/161 and https://github.com/xerj-org/xerj/pull/160

## Summary

This change connects XERJ's durable generation machinery to the normal `xerj autoindex` loop for generated `--no-graph` journals. After an initial zero-configuration index, rerunning the same command now reconciles compatible additions, same-path content changes, same-content renames, deletions, junk transitions, and duplicate aliases without rebuilding unchanged semantic content.

The contribution preserves the original product loop:

```text
xerj autoindex <folder> --no-graph
xerj autoindex map
query
```

It does not enable graph-aware incremental synchronization or silent schema evolution. Unsupported state fails before remote mutation and gives isolated-rebuild guidance.

## Dependency and merge order

Please review and merge this as the third step in the following order:

1. Embedding execution identity prerequisite ending at `4abf38254d520d14c6e4caf904edf89d078a3d8f`.
2. Tombstone-only segment aggregate fix `672560f5fe88975d13bb29f3683bb7bb34e3947e`.
3. This incremental branch at `6dd22307ebfd8e48f35dfa3ab9f181e07e7543e1`.

The incremental branch is based on the embedding identity prerequisite. It intentionally does not include the engine tombstone fix. Real deletion reconciliation depends on that fix because its final exact aggregate validation must be able to read a surviving corpus while a valid zero-document tombstone segment exists.

## User workflow

Start XERJ normally. The default embedding backend remains lexical feature hashing:

```bash
xerj --insecure --data-dir ./xerj-data
```

Run the first generated non-graph index with a durable state directory and destination prefix:

```bash
xerj autoindex ./reports \
  --url http://127.0.0.1:9200 \
  --state-dir ./xerj-autoindex-state \
  --prefix reports \
  --no-graph \
  --json
```

Inspect the committed generation:

```bash
xerj autoindex status \
  --url http://127.0.0.1:9200 \
  --state-dir ./xerj-autoindex-state \
  --prefix reports

xerj autoindex map \
  --url http://127.0.0.1:9200 \
  --prefix reports \
  --json
```

Add, modify, rename, or delete compatible files, then rerun the exact same indexing command without `--fresh`:

```bash
xerj autoindex ./reports \
  --url http://127.0.0.1:9200 \
  --state-dir ./xerj-autoindex-state \
  --prefix reports \
  --no-graph \
  --json
```

An unchanged folder returns the exact committed summary and performs no destination mutation.

## Supported lifecycle

For a generated journal created with `--no-graph`, this change supports:

- initial generation creation;
- exact no-op rescan;
- a new file whose family and fields project unambiguously onto the frozen typed dataset;
- same-path content replacement;
- same-content path rename with metadata-only provenance updates;
- file deletion;
- junk-file membership changes;
- duplicate aliases and deterministic canonical ownership;
- replay after interruption from sealed source and prepared-record artifacts;
- retry after an accepted response whose local operation-state append was interrupted;
- complete current-generation catalog replacement;
- server restart followed by exact no-op resume.

Unchanged content is hashed during discovery but is not re-extracted, re-embedded, or republished.

## Durable generation model

The journal now distinguishes committed corpus authority from a pending desired generation:

- generation 0 is an exact empty genesis;
- `sync_begin` seals the desired manifest, operation set, execution identity, snapshot reference, and digest;
- operation-state records distinguish started and committed operations;
- `sync_validated` records exact remote convergence;
- `sync_commit` advances durable corpus authority only after all operations and the whole-generation catalog validate;
- a `finish` summary reports the committed generation, file counts, record counts, semantic state, and graph state.

A pending generation never resumes from mutable live source. Source bytes and deterministic prepared NDJSON are staged before `sync_begin` and bound by relative path, byte length, digest, record count, semantic count, preparation contract, and generation snapshot digest.

## Mapping and catalog correctness

The executor creates or updates frozen dataset mappings and the autoindex catalog mapping before the first data mutation. Create-index bodies use `mappings.properties`; `PUT /_mapping` bodies use top-level `properties`.

Every committed generation publishes and reads back one complete agent-facing catalog projection containing:

- the current run document;
- every current dataset;
- canonical indexed files;
- duplicate aliases;
- junk files;
- exact record, byte, time-range, semantic-field, and provenance metadata.

Old run projections, deleted files, vanished paths, and retry-partial identities cannot remain beside the new committed generation.

## Provenance behavior

Prepared upserts carry the desired generation's `ax_run`. Same-content renames do not republish semantic content, so they preserve document IDs, `ax_file`, locator, original `ax_run`, business fields, and vector bits while updating only `ax_path` and `ax_paths`.

Same-path content replacement receives a new content identity and new document IDs. Validation proves the old content identity is absent before the generation commits.

Deletion removes dataset records, canonical and alias catalog identities, and stale provenance before advancing authority.

## Embedding execution identity

Autoindex does not choose the server embedder. It queries the authenticated server execution identity and pins the returned opaque digest before the first semantic mutation.

For every pending semantic replay, the current server identity must match the sealed generation identity before provisioning, bulk publication, refresh, or catalog work. A different or non-resumable identity fails closed with recovery guidance rather than mixing vectors from different execution contracts.

Structured and `--no-semantic` corpora use an explicit disabled embedding identity and do not require the identity endpoint.

The default server backend remains lexical feature hashing. Neural behavior exists only when the server is explicitly started with a neural backend; this PR makes no neural quality or performance claim.

## Fail-closed boundaries

This change deliberately refuses:

- legacy nonempty journals that do not contain generated generation authority;
- graph-enabled generation membership changes;
- a new file that cannot be assigned unambiguously to the frozen dataset and field set;
- schema, dataset, mapping, semantic-field, chunker, prefix, root, endpoint, symlink-policy, or embedding-identity drift;
- malformed, reordered, digest-inconsistent, graph-bearing, or incomplete generation state;
- missing, changed, oversized, or corrupt staged artifacts;
- mapping, refresh, search, catalog, or exact validation failure;
- a pending generation whose original embedding execution identity cannot be restored.

`--fresh` is not destination cleanup and cannot discard an existing durable generated plan. For unsupported schema or identity evolution, use a new state directory and new prefix, validate the isolated rebuild, switch readers, and then clean the old destination explicitly. If graph indexing is enabled, also use a new brain namespace or deliberately disable graph writes.

## Current limitations

- Incremental reconciliation is foreground and blocking; it is not yet a detached job API.
- Only generated `--no-graph` journals receive membership reconciliation.
- Added files must fit the frozen dataset and schema. Schema/index generations and an atomic read pointer are future work.
- Each changed generation currently copies and prepares the complete corpus, so changed-generation staging is `O(N)`.
- `--snapshot-max-gb` bounds logical sealed payload bytes before writes. It is not a physical disk-space or peak-allocation guarantee.
- The latest committed snapshot and a pending snapshot are retained as required for authority and replay; stale unprotected snapshots are reclaimed crash-safely.
- The shared `autoindex-catalog` remains destination-global.
- Queries during an in-progress foreground generation may observe converging remote operations. The committed journal/catalog generation is the readiness authority; atomic query snapshots require later index-generation indirection.
- This PR does not improve PDF parsing, embedding throughput, HNSW construction, serving latency, or FinanceBench ranking.

## Real-XERJ lifecycle evidence

The clean contribution head was composed locally with the separate tombstone fix and exercised through a real isolated XERJ server, not only the mock HTTP harness.

The verifier reports **282 passed / 0 failed** across:

- initial generation 1;
- two exact generation-1 no-ops;
- generation-2 compatible addition;
- generation-3 content replacement;
- generation-4 metadata-only rename;
- generation-5 deletion;
- full server stop and reopen;
- post-restart generation-5 no-op;
- exact typed and semantic mappings;
- mapping-before-publication ordering;
- whole-generation catalog cutover;
- stable IDs and provenance;
- 384-dimensional lexical vectors;
- opaque execution identity pinning;
- zero no-op mutations and snapshot changes;
- deletion aggregate correctness before and after restart;
- absence of HTTP 5xx and `unreadable during corpus assembly`.

The journal contains exactly five `sync_begin`, five `sync_validated`, and five `sync_commit` records. The three no-op runs contain no PUT, bulk, delete, mapping, or snapshot mutation.

The raw evidence bundle is retained separately from the code contribution. Its 929-file checksum manifest verifies in full. Key immutable evidence hashes:

```text
FINAL_REPORT.md  cb95b9b66f421a4d660b358c57998fa1ab267c86e459cea84c397dc68623d560
ASSERTIONS.json  57c2f65959fd21be257d42897f71af3ef60e5bf03f9c2a6c6ce68dfa7646ce18
MANIFEST.json    6a12aa3b35db4853d031724101e6feb2459390e4bde318f47049b5177a97a783
SHA256SUMS       f854cea2e45bb7817695c3b2477432064cfa783f3462154606317ac3f27afb67
```

## Build and timing scope

The evidence used a scoped non-fat-LTO release build:

```bash
CARGO_TARGET_DIR="$PWD/target-validation" \
CARGO_PROFILE_RELEASE_LTO=false \
CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
cargo build --release -j 32 -p xerj-server
```

The cold dedicated-target build took `264.443 s`. The frozen binary is 72,176,992 bytes and hashes to:

```text
4c0bd02efaf91be00a36f5ead3f1feab4d3b9fc56c88f452979e7a5d0ce46ff8
```

Deterministic two-file JSONL autoindex command walls were:

| Operation | Wall |
|---|---:|
| Initial | 0.956 s |
| No-op 1 | 0.188 s |
| No-op 2 | 0.185 s |
| Add | 1.382 s |
| Replace | 1.524 s |
| Rename | 1.347 s |
| Delete | 1.114 s |
| Restart no-op | 0.206 s |

These timings prove that the manual lifecycle completed promptly. They are not a performance benchmark, scaling result, PDF result, or product throughput claim.

## Honest serialization observation

One unchanged vector acquired 19 different last-decimal JSON spellings after background storage/merge work, with maximum absolute decimal difference `1.3877787807814457e-17`. Every affected value converted to the same IEEE-754 f32 bit pattern.

This is not re-embedding or semantic drift. Document ID, text, provenance, and every stored f32 vector bit remain unchanged. It does mean raw `_source` JSON bytes are not a stable vector-identity representation across storage paths, so the verifier compares vectors at their declared f32 storage precision while comparing every other source field exactly. Both raw responses are retained in the evidence.

## Manual reproduction

The following reproduces the supported lifecycle with a clean isolated server. Use two-line JSONL files so discovery classifies them as JSONL rather than a one-value JSON file.

Create `reports/quarterly.jsonl`:

```json
{"company":"Northwind Systems","fiscal_year":2024,"quarter":1,"revenue":1250000.50,"profitable":true,"report_date":"2024-03-31","narrative":"Northwind Systems reported strong subscription renewals during the first quarter. Operating income improved because cloud infrastructure costs declined and enterprise customers expanded their contracts across multiple regions."}
{"company":"Northwind Systems","fiscal_year":2024,"quarter":2,"revenue":1395000.75,"profitable":true,"report_date":"2024-06-30","narrative":"Second-quarter revenue increased as annual enterprise agreements renewed earlier than expected. Management highlighted durable demand, lower customer churn, and continued investment in product reliability and international expansion."}
```

Start XERJ and index generation 1:

```bash
xerj --insecure --data-dir ./xerj-data --embed-mode lexical

xerj autoindex ./reports \
  --url http://127.0.0.1:9200 \
  --state-dir ./xerj-state \
  --prefix re2e \
  --no-graph \
  --workers 1 \
  --pdf-workers 1 \
  --bulk-mb 1 \
  --bulk-timeout-secs 300 \
  --snapshot-max-gb 1 \
  --json
```

Run the same command again and verify it returns generation 1 without destination mutations.

Add `reports/subsidiary.jsonl` with the same field set:

```json
{"company":"Contoso Analytics","fiscal_year":2024,"quarter":3,"revenue":875000.25,"profitable":true,"report_date":"2024-09-30","narrative":"Contoso Analytics expanded its reporting platform during the third quarter. Customer retention remained strong as finance teams adopted automated reconciliation workflows and additional compliance dashboards."}
{"company":"Contoso Analytics","fiscal_year":2024,"quarter":4,"revenue":940000.00,"profitable":true,"report_date":"2024-12-31","narrative":"Fourth-quarter growth reflected renewals from regional accounting firms and broader adoption of document analysis tools. Management emphasized reliable evidence tracking, controlled operating costs, and continued product investment."}
```

Rerun autoindex and verify generation 2 with four records.

Change the Q2 revenue and narrative in `quarterly.jsonl`, rerun, and verify generation 3. Rename and rerun:

```bash
mv reports/subsidiary.jsonl reports/renamed-subsidiary.jsonl
xerj autoindex ./reports --url http://127.0.0.1:9200 --state-dir ./xerj-state --prefix re2e --no-graph --json
```

Verify generation 4 and confirm the subsidiary document IDs and `ax_file` are unchanged while `ax_path` is `renamed-subsidiary.jsonl`.

Delete and rerun:

```bash
rm reports/renamed-subsidiary.jsonl
xerj autoindex ./reports --url http://127.0.0.1:9200 --state-dir ./xerj-state --prefix re2e --no-graph --json
```

Verify generation 5 with two surviving records, then run the reconciliation aggregate:

```bash
curl -sS -X POST http://127.0.0.1:9200/re2e-jsonl/_search \
  -H 'content-type: application/json' \
  -d '{"size":0,"track_total_hits":true,"query":{"terms":{"ax_file":["SURVIVING_AX_FILE"]}},"aggs":{"time_min":{"min":{"field":"report_date"}},"time_max":{"max":{"field":"report_date"}}}}'
```

The request must return HTTP 200 with two hits and the expected minimum/maximum report dates.

Stop XERJ, restart it against `./xerj-data`, rerun the aggregate, and rerun autoindex. The aggregate must still return HTTP 200 and autoindex must return the existing generation-5 summary without a sixth `sync_commit`.

Inspect the final agent-facing state:

```bash
xerj autoindex status --url http://127.0.0.1:9200 --state-dir ./xerj-state --prefix re2e
xerj autoindex map --url http://127.0.0.1:9200 --prefix re2e --json
```

Expected status:

```text
1 files done, 2 records, FINISHED (generation 5)
```

There must be no graph status line and no graph index.

## Verification status

The exact contribution head `6dd22307ebfd8e48f35dfa3ab9f181e07e7543e1` passed:

- `cargo fmt --all --check`;
- `cargo test -p xerj-autoindex`: 285 passed, 0 failed;
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`;
- `cargo check -p xerj-server`;
- the full ES-YAML gate over 200 files: 1365 passed, 0 failed, 3 skipped;
- the 282-assertion real-XERJ lifecycle proof described above when locally composed with the separate tombstone-only segment fix.

## Claim boundary

This is a correctness, durability, and developer-experience contribution for generated non-graph folder synchronization.

It does **not** claim:

- faster fresh indexing;
- lower memory;
- neural embedding quality;
- PDF extraction improvements;
- FinanceBench retrieval quality;
- the full 368-PDF corpus;
- the `<=600 s` North Star;
- TB-scale operation;
- graph-aware incremental synchronization;
- atomic query snapshots during a foreground generation.