### PR TITLE
fix(engine): memtable circuit breaker ignores cgroup memory limit

### DIFF
--- a/engine/crates/xerj-common/src/config.rs
+++ b/engine/crates/xerj-common/src/config.rs
@@ -982,8 +982,10 @@ pub struct LimitsConfig {
     /// past the cap.
     pub max_buckets: usize,
     /// Process-wide ceiling on the total bytes buffered across ALL indices'
-    /// memtables (default: `0` = auto-derive to 25% of system RAM, floored
-    /// at 2048 MiB). This is the parent circuit breaker for the ingest path:
+    /// memtables (default: `0` = auto-derive to 25% of the effective
+    /// cgroup/system memory limit, floored at 2048 MiB, capped at 50% of
+    /// that same limit). This is the parent circuit breaker for the ingest
+    /// path:
     /// per-index back-pressure only bounds one index at `~3×flush_size_mb`,
     /// so `N` indices could buffer `N × 1.5 GiB` with no global ceiling —
     /// the structural cause of the 112 GiB OOM. When the summed memtable
@@ -1029,7 +1031,7 @@ impl Default for LimitsConfig {
             max_result_window: 10_000,
             max_mget_docs: 10_000,
             max_buckets: 65_536,
-            max_total_memtable_mb: 0, // 0 = auto-derive (25% RAM, floor 2 GiB)
+            max_total_memtable_mb: 0, // 0 = auto-derive (25% effective limit, floor 2 GiB, cap 50%)
             max_segment_hydration_cache_mb: 0, // 0 = 20% effective memory, no floor
             memory_watermark_percent: 95,
             disk_flood_stage_percent: 95,

--- a/engine/crates/xerj-engine/src/governor.rs
+++ b/engine/crates/xerj-engine/src/governor.rs
@@ -651,6 +651,12 @@ fn effective_memory_limit(sys: u64, cgroup: Option<u64>) -> u64 {
 /// (`memory.max`, walking up to a parent when a leaf reads `max`) and falls
 /// back to cgroup v1 (`memory.limit_in_bytes`). Returns `None` when no
 /// finite limit applies.
+///
+/// A limit file that is missing, unreadable, malformed, `0`, or the v1/v2
+/// "no limit" sentinel (`max` / `9223372036854771712`) contributes nothing
+/// rather than failing: the caller then falls back to host RAM. Nothing on
+/// this path panics, so an unexpected cgroupfs layout degrades to the
+/// pre-cgroup behaviour instead of taking the process down at startup.
 #[cfg(target_os = "linux")]
 fn fold_cgroup_memory_limit(current: Option<u64>, raw: &str) -> Option<u64> {
     const UNLIMITED_V1: u64 = 9_223_372_036_854_771_712;
@@ -666,43 +672,97 @@ fn fold_cgroup_memory_limit(current: Option<u64>, raw: &str) -> Option<u64> {
     }
 }
 
+/// Walk from `rel` up to the root, folding the tightest finite limit found
+/// in `<root><rel>/<file>` at each level. cgroup memory limits are
+/// hierarchical in BOTH v1 and v2 — a finite child value does not override a
+/// smaller finite ancestor — so the effective limit is the minimum over the
+/// whole chain. Levels whose file is missing or unreadable are skipped, so a
+/// partially visible hierarchy still yields whatever it does expose.
+///
+/// `root` is a parameter rather than a constant so the hierarchy walk is
+/// testable against a temp-dir fixture without a real cgroupfs mount.
 #[cfg(target_os = "linux")]
-fn cgroup_memory_limit_bytes() -> Option<u64> {
-    // cgroup v2: /proc/self/cgroup has a single "0::<path>" line.
-    if let Ok(cg) = std::fs::read_to_string("/proc/self/cgroup") {
-        for line in cg.lines() {
-            if let Some(path) = line.strip_prefix("0::") {
-                // Walk from leaf to root and take the tightest finite limit.
-                // cgroup-v2 limits are hierarchical: a finite child value
-                // does not override a smaller finite ancestor.
-                let mut rel = path.trim().to_string();
-                let mut tightest = None;
-                loop {
-                    let full = format!("/sys/fs/cgroup{rel}/memory.max");
-                    if let Ok(s) = std::fs::read_to_string(&full) {
-                        tightest = fold_cgroup_memory_limit(tightest, &s);
-                    }
-                    if rel.is_empty() || rel == "/" {
-                        break;
-                    }
-                    match rel.rfind('/') {
-                        Some(0) => rel = String::new(), // step to root next iter
-                        Some(i) => rel.truncate(i),
-                        None => break,
-                    }
-                }
-                if tightest.is_some() {
-                    return tightest;
-                }
+fn tightest_limit_up_hierarchy(root: &str, rel: &str, file: &str) -> Option<u64> {
+    let mut rel = rel.trim().to_string();
+    let mut tightest = None;
+    loop {
+        let full = format!("{root}{rel}/{file}");
+        if let Ok(s) = std::fs::read_to_string(&full) {
+            tightest = fold_cgroup_memory_limit(tightest, &s);
+        }
+        if rel.is_empty() || rel == "/" {
+            break;
+        }
+        match rel.rfind('/') {
+            Some(0) => rel = String::new(), // step to root next iter
+            Some(i) => rel.truncate(i),
+            None => break,
+        }
+    }
+    tightest
+}
+
+/// The cgroup-relative path of the v1 `memory` controller from one
+/// `/proc/self/cgroup` line (`<hierarchy-id>:<controllers>:<path>`).
+/// Returns `None` for v2 lines (`0::<path>`, empty controller list) and for
+/// controller sets that do not include `memory`.
+#[cfg(target_os = "linux")]
+fn cgroup_v1_memory_path(line: &str) -> Option<&str> {
+    let mut parts = line.splitn(3, ':');
+    let _hierarchy_id = parts.next()?;
+    let controllers = parts.next()?;
+    let path = parts.next()?;
+    controllers
+        .split(',')
+        .any(|c| c == "memory")
+        .then_some(path.trim())
+}
+
+/// Resolve the memory limit from the contents of `/proc/self/cgroup`,
+/// against the v2 unified mount at `v2_root` and the v1 memory-controller
+/// mount at `v1_root`. Split out from [`cgroup_memory_limit_bytes`] so the
+/// whole resolution — v2 line, v1 line, and the mount-root fallback — is
+/// testable against a fixture instead of the host's real cgroupfs.
+#[cfg(target_os = "linux")]
+fn cgroup_memory_limit_from(self_cgroup: &str, v2_root: &str, v1_root: &str) -> Option<u64> {
+    // cgroup v2: /proc/self/cgroup has a single "0::<path>" line, and the
+    // limits live at <v2_root><path>/memory.max.
+    for line in self_cgroup.lines() {
+        if let Some(path) = line.strip_prefix("0::") {
+            let tightest = tightest_limit_up_hierarchy(v2_root, path.trim(), "memory.max");
+            if tightest.is_some() {
+                return tightest;
             }
         }
     }
 
-    // cgroup v1 fallback.
-    if let Ok(s) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
-        return fold_cgroup_memory_limit(None, &s);
+    // cgroup v1: the memory controller is mounted separately and
+    // /proc/self/cgroup carries one "<id>:memory:<path>" line per hierarchy.
+    // Walk that path from leaf to root exactly as for v2. Under Docker the
+    // cgroupfs is bind-mounted at the container's own directory, so the leaf
+    // path from /proc/self/cgroup does not resolve and only the mount root
+    // reads — which is the container's real limit. Under a bare
+    // `systemd-run -p MemoryMax=` on a v1/hybrid host it is the other way
+    // round: the process sits in a leaf slice and the mount root reads
+    // unlimited. Folding the whole chain is correct in both cases.
+    for line in self_cgroup.lines() {
+        if let Some(path) = cgroup_v1_memory_path(line) {
+            let tightest = tightest_limit_up_hierarchy(v1_root, path, "memory.limit_in_bytes");
+            if tightest.is_some() {
+                return tightest;
+            }
+        }
     }
-    None
+
+    // Last resort: /proc/self/cgroup was unreadable or named no memory
+    // controller, so read the v1 mount root directly.
+    tightest_limit_up_hierarchy(v1_root, "", "memory.limit_in_bytes")
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup_memory_limit_bytes() -> Option<u64> {
+    let self_cgroup = std::fs::read_to_string("/proc/self/cgroup").unwrap_or_default();
+    cgroup_memory_limit_from(&self_cgroup, "/sys/fs/cgroup", "/sys/fs/cgroup/memory")
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -835,7 +895,7 @@ mod tests {
     fn auto_memtable_budget_is_cgroup_proportional_and_bounded() {
         const GIB: u64 = 1024 * 1024 * 1024;
         let cases = [
-            (1 * GIB, 512 * 1024 * 1024),
+            (GIB, 512 * 1024 * 1024),
             (4 * GIB, 2 * GIB),
             (8 * GIB, 2 * GIB),
             (64 * GIB, 16 * GIB),
@@ -881,6 +941,169 @@ mod tests {
 
         assert_eq!(effective_memory_limit(2 * GIB, Some(4 * GIB)), 2 * GIB);
         assert_eq!(effective_memory_limit(8 * GIB, Some(4 * GIB)), 4 * GIB);
+    }
+
+    /// Regression test for the cgroup-v1 half of the limit lookup, and for
+    /// the v2 leaf that reads the literal string `max`.
+    ///
+    /// Before this, only the v2 `0::<path>` line of `/proc/self/cgroup` was
+    /// parsed and the v1 side blindly read the mount root
+    /// `/sys/fs/cgroup/memory/memory.limit_in_bytes`. That root read is the
+    /// container's own limit under Docker's v1 bind-mount, but on a v1 or
+    /// hybrid host under `systemd-run -p MemoryMax=` the process sits in a
+    /// leaf slice while the root reads unlimited — so no limit was found,
+    /// the effective limit fell back to host RAM, and every cgroup-aware
+    /// budget in `build()` (including the memtable circuit breaker) silently
+    /// ignored the cap.
+    ///
+    /// The walk is driven against a temp-dir fixture rather than a real
+    /// cgroupfs so it runs identically on any host, v1, v2 or neither.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cgroup_hierarchy_walk_handles_v1_v2_max_and_missing_files() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        // The v1 "no limit" sentinel; v2 spells the same thing "max".
+        const UNLIMITED_V1: &str = "9223372036854771712";
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap().to_string();
+        let write = |rel: &str, file: &str, body: &str| {
+            let dir = format!("{root}{rel}");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(format!("{dir}/{file}"), body).unwrap();
+        };
+
+        // ── cgroup v2: leaf reads the literal "max", a finite ancestor caps ──
+        // This is the shape `systemd-run --user --scope -p MemoryMax=1G`
+        // produces: the limit lands on the slice, not on the leaf scope.
+        write("", "memory.max", "max");
+        write("/user.slice", "memory.max", "1073741824");
+        write("/user.slice/app.scope", "memory.max", "max");
+        assert_eq!(
+            tightest_limit_up_hierarchy(&root, "/user.slice/app.scope", "memory.max"),
+            Some(GIB),
+            "a v2 leaf reading the literal \"max\" must inherit its ancestor's finite limit"
+        );
+
+        // A tighter leaf still wins over a looser ancestor, and vice versa.
+        write("/user.slice/tight.scope", "memory.max", "536870912");
+        assert_eq!(
+            tightest_limit_up_hierarchy(&root, "/user.slice/tight.scope", "memory.max"),
+            Some(GIB / 2)
+        );
+
+        // ── cgroup v1: same walk, different file name and mount root ──
+        write("/memory", "memory.limit_in_bytes", UNLIMITED_V1);
+        write(
+            "/memory/system.slice/xerj.service",
+            "memory.limit_in_bytes",
+            "2147483648",
+        );
+        let v1_root = format!("{root}/memory");
+        assert_eq!(
+            tightest_limit_up_hierarchy(
+                &v1_root,
+                "/system.slice/xerj.service",
+                "memory.limit_in_bytes"
+            ),
+            Some(2 * GIB),
+            "a v1 leaf slice limit must be found, not just the mount root"
+        );
+
+        // ── unlimited everywhere, and missing files, both mean "no limit" ──
+        // Not 0, and not a panic: `effective_memory_limit` then keeps host RAM.
+        write("/unlimited", "memory.max", "max");
+        assert_eq!(
+            tightest_limit_up_hierarchy(&root, "/unlimited", "memory.max"),
+            None
+        );
+        assert_eq!(
+            tightest_limit_up_hierarchy(&root, "/user.slice/no-such.scope", "memory.max"),
+            Some(GIB),
+            "a missing leaf is skipped, not fatal — ancestors still apply"
+        );
+        // Nothing readable anywhere on the chain: no limit, no panic, not 0.
+        assert_eq!(
+            tightest_limit_up_hierarchy(&root, "/does/not/exist", "memory.max"),
+            None
+        );
+        assert_eq!(
+            tightest_limit_up_hierarchy("/no/such/cgroupfs", "/a/b", "memory.max"),
+            None
+        );
+        let sys = 4 * GIB;
+        assert_eq!(effective_memory_limit(sys, None), sys);
+
+        // ── /proc/self/cgroup line parsing: v1 memory lines vs everything else ──
+        assert_eq!(
+            cgroup_v1_memory_path("5:memory:/system.slice/xerj.service"),
+            Some("/system.slice/xerj.service")
+        );
+        // Co-mounted controllers are comma-separated.
+        assert_eq!(
+            cgroup_v1_memory_path("4:cpu,cpuacct,memory:/foo"),
+            Some("/foo")
+        );
+        assert_eq!(cgroup_v1_memory_path("3:cpuset:/foo"), None);
+        // A v2 line has an empty controller list and must not match here.
+        assert_eq!(cgroup_v1_memory_path("0::/user.slice/app.scope"), None);
+        // Malformed lines are ignored rather than panicking.
+        assert_eq!(cgroup_v1_memory_path(""), None);
+        assert_eq!(cgroup_v1_memory_path("garbage"), None);
+
+        // ── full resolution, as `cgroup_memory_limit_bytes` runs it ──
+        // A pure-v2 host: the v2 line resolves and the v1 mount is absent.
+        assert_eq!(
+            cgroup_memory_limit_from("0::/user.slice/app.scope\n", &root, &v1_root),
+            Some(GIB),
+            "v2: leaf reads \"max\", the finite ancestor must win"
+        );
+        // A pure-v1 host under `systemd-run -p MemoryMax=`: there is no v2
+        // line to resolve, and the limit is on the leaf slice while the v1
+        // mount root reads unlimited. This is the case that was a no-op
+        // before: the v1 "<id>:memory:<path>" line was never parsed at all.
+        assert_eq!(
+            cgroup_memory_limit_from(
+                "7:memory:/system.slice/xerj.service\n5:cpuset:/\n",
+                "/no/such/cgroupfs",
+                &v1_root,
+            ),
+            Some(2 * GIB),
+            "v1: the leaf slice limit must be found, not just the mount root"
+        );
+        // A hybrid host: a v2 line exists but carries no memory limit, so
+        // resolution must fall through to the v1 memory controller.
+        assert_eq!(
+            cgroup_memory_limit_from(
+                "0::/unlimited\n7:memory:/system.slice/xerj.service\n",
+                &root,
+                &v1_root,
+            ),
+            Some(2 * GIB),
+            "hybrid: an unlimited v2 line must not shadow the v1 limit"
+        );
+        // Docker v1: the leaf path does not exist under the bind-mounted
+        // cgroupfs, so the mount root is the container's real limit.
+        write("/docker", "memory.limit_in_bytes", "3221225472");
+        assert_eq!(
+            cgroup_memory_limit_from(
+                "7:memory:/docker/deadbeef\n",
+                "/no/such/cgroupfs",
+                &format!("{root}/docker"),
+            ),
+            Some(3 * GIB),
+            "v1 bind-mount: an unresolvable leaf must fall back to the mount root"
+        );
+        // Unreadable /proc/self/cgroup, and no cgroupfs at all: no limit,
+        // no panic, no 0 — the caller keeps host RAM.
+        assert_eq!(
+            cgroup_memory_limit_from("", "/no/such/cgroupfs", "/no/such/cgroupfs/memory"),
+            None
+        );
+
+        // The real lookup must never panic or report 0 on this host,
+        // whatever its cgroup layout is.
+        assert!(cgroup_memory_limit_bytes().is_none_or(|limit| limit > 0));
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/governor.rs
+++ b/engine/crates/xerj-engine/src/governor.rs
@@ -379,6 +379,21 @@ pub struct GovernorSnapshot {
     pub max_concurrent_bulks: usize,
 }
 
+/// Auto-derive the memtable byte ceiling from the effective (cgroup-aware)
+/// memory limit: 25% of the limit, floored at 2 GiB, but never past 50% of
+/// the same limit. The 50% cap keeps the floor itself from exceeding the
+/// container under a small enough effective limit.
+///
+/// `effective_limit` must already be the cgroup-aware value (see
+/// `effective_memory_limit_bytes`) — this function has no way to detect a
+/// host-RAM value passed in by mistake, so getting that argument right is
+/// the caller's responsibility.
+fn auto_memtable_budget(effective_limit: u64) -> u64 {
+    (effective_limit / 4)
+        .max(2 * 1024 * 1024 * 1024)
+        .min(effective_limit / 2)
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SegmentHydrationBudgetSource {
     Auto,
@@ -480,16 +495,22 @@ pub fn global() -> Option<Arc<ResourceGovernor>> {
 fn build(config: &Config) -> ResourceGovernor {
     let limits = &config.limits;
 
-    // ── memtable budget: 0 = auto-derive to 25% RAM, floored at 2 GiB ──
+    // ── RSS watermark against the effective memory limit ──
+    let memory_limit_bytes = effective_memory_limit_bytes();
+
+    // ── memtable budget: 0 = auto-derive from the effective (cgroup-aware)
+    // memory limit — see `auto_memtable_budget`. Must be derived from the
+    // same effective limit as every sibling budget in this function, not
+    // raw host RAM: `/proc/meminfo` is not namespace-virtualized, so a
+    // host-RAM-based ceiling silently ignores any cgroup / `systemd-run -p
+    // MemoryMax=` cap smaller than the host's physical RAM. The 2 GiB floor
+    // needs its own ceiling for the same reason — it can exceed the whole
+    // effective limit under a small enough cap on its own.
     let memtable_budget_bytes = if limits.max_total_memtable_mb != 0 {
         limits.max_total_memtable_mb.saturating_mul(1024 * 1024)
     } else {
-        let sys = system_total_bytes();
-        (sys / 4).max(2 * 1024 * 1024 * 1024)
+        auto_memtable_budget(memory_limit_bytes)
     };
-
-    // ── RSS watermark against the effective memory limit ──
-    let memory_limit_bytes = effective_memory_limit_bytes();
     let resolved_segment_hydration = resolve_segment_hydration_budget(
         memory_limit_bytes,
         limits.max_segment_hydration_cache_mb,
@@ -801,6 +822,35 @@ mod tests {
         assert_eq!(zero.bytes, 8 * GIB / 5);
         assert_eq!(zero.source, SegmentHydrationBudgetSource::Auto);
         assert!(zero.warning.is_some());
+    }
+
+    /// Regression test for the bug fixed in this PR: `auto_memtable_budget`
+    /// must be derived from the effective (cgroup-aware) limit passed in,
+    /// not from raw host RAM read separately inside the function. Before
+    /// the fix this formula lived inline in `build()` and called
+    /// `system_total_bytes()` directly, so it had no coverage at all —
+    /// this table pins the exact values a reviewer reproduced live on a
+    /// real cgroup-v2 host (1 GiB cap → 512 MiB, not the pre-fix ~30 GiB).
+    #[test]
+    fn auto_memtable_budget_is_cgroup_proportional_and_bounded() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let cases = [
+            (1 * GIB, 512 * 1024 * 1024),
+            (4 * GIB, 2 * GIB),
+            (8 * GIB, 2 * GIB),
+            (64 * GIB, 16 * GIB),
+        ];
+        for (effective_limit, expected) in cases {
+            let budget = auto_memtable_budget(effective_limit);
+            assert_eq!(
+                budget, expected,
+                "auto_memtable_budget({effective_limit}) = {budget}, expected {expected}"
+            );
+            assert!(
+                budget <= effective_limit / 2,
+                "auto_memtable_budget({effective_limit}) = {budget} exceeds 50% of the limit"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Investigates the sustained-ingest memory-growth OOM documented in `demo/playbooks/ES_COMPATIBILITY.md §15` (`MemoryMax=8G` cgroup, 40k docs/s open-loop bulk writer, RSS climbs to the cap, kernel OOM-kills in ~3-4 minutes).

**This PR fixes one confirmed, real bug and rules out all three of §15's documented suspects with direct measurement — but does not fully resolve §15.** Read the "Honest status" section before treating this as closed.

## Repro method

`systemd-run --user --scope -p MemoryMax=8G` isn't available in this dev environment, so a Docker container with `--memory=<cap>` was used instead — same kernel cgroup-memory mechanism, same OOM-kill behavior, just via Docker's cgroup wrapper instead of systemd's. A `soak_mixed.sh` script was recreated per §15's description: a fresh index, hit with a 10k-doc `_bulk` every 250ms, fired on a timer without waiting for the previous request to finish (open-loop).

Built with `cargo build --profile profiling --features debug-profiling` per `demo/playbooks/debug-profiling/README.md` and profiled with the bundled `capture.py`/`inspect.py`/`pprof` toolkit (jemalloc heap profiles + `GET /_nodes/stats`'s `segment_hydration_cache` gauge + live thread-count sampling).

## The three documented suspects — all checked with direct evidence, all ruled out

**#1 "DV/doc-values cache has no byte budget, unlike stored-slices"** — false as stated. `dv_cache` and `stored_slices_cache` are both gated by the same `SegmentHydrationBudget` (`segment_cache_budget.rs`). Live-polled `GET /_nodes/stats` once a second during a soak run: `segment_hydration_cache.current_in_bytes` climbs and then plateaus exactly at its configured ~614 MB ceiling (`segment_hydration_cache_mb=614` in the startup log) while total process RSS keeps climbing past 2-3 GB in the same window. The cache is doing its job; it is not the leak.

**#2 "WAL retention across checkpoints"** — `WalWriter::prune_verified` (`xerj-storage/src/wal.rs`) is genuinely dead code (`grep` shows it's only called from its own unit tests). But the *actual* production pruning path, `IndexStore::wal_maintain_all_verified` (`xerj-storage/src/index_store.rs`), is a more sophisticated, cache-optimized superseding mechanism (per-generation verdict cache, re-verifies only the "unproven" residue against the version map on each tick) and **is** correctly wired into the flush path (`finalize_flush_with_publisher`'s hot-path tick, and `Index::flush()`'s `force_wal_maintenance` for the unconditional pass). This suspect does not appear to be live.

**#3 "Drained-memtable Arc retention on the flush path"** — the closest real mechanism in the codebase is that `drain_shard_inner` (`xerj-engine/src/memtable.rs`) hands the just-drained memtable's HashMaps (inverted index, doc-values, field-length stats) to a **freshly-spawned, uncapped OS thread** (`xerj-drain-free`) that drops them off the flush critical path — a deliberate, documented perf optimization with no cap on concurrent in-flight drain threads. Hypothesized this could pile up under sustained flush pressure and tested it directly: sampled live thread count every second via `ps -M` against the native macOS release binary during a 35s soak. Thread count ramped to ~123 in the first few seconds, then stayed **flat** at 123 for the rest of the run while RSS climbed to 2.7 GB+ over the same window. Threads are being scheduled and completing promptly — this is not the leak either.

## The bug this PR actually fixes

`governor.rs`'s auto-derived memtable byte ceiling — the "parent circuit breaker" this very module was built to add after a prior 112 GiB OOM incident (see the module's own doc comment) — computed itself from raw host RAM (`system_total_bytes()`, i.e. `/proc/meminfo`'s `MemTotal`) instead of the already-correct, cgroup-aware `effective_memory_limit_bytes()` that every sibling budget (RSS watermark, segment hydration cache) in the same function already uses. `/proc/meminfo` is not namespace-virtualized by default, so inside any container/cgroup smaller than the host's physical RAM this silently reads the HOST total, not the container's actual budget.

Confirmed live with the governor's own startup log line, both pre- and post-fix, under an identical 1024 MB cgroup cap on an 8126 MB-RAM host:

```
pre-fix:  memtable_budget_mb=2048  memory_limit_mb=1024   (the ceiling alone is 2x the ENTIRE container)
post-fix: memtable_budget_mb=512   memory_limit_mb=1024   (correctly clamped to 50% of the real limit)
```

With the ceiling effectively disabled pre-fix, the RSS watermark (95% of the effective limit) was left as the only real backstop — and it trips with almost no headroom left to absorb already-admitted in-flight work or one more flush's segment-cache warm, which matches the documented "the governor logs the trip, the process is OOM-killed moments later anyway" symptom.

### Fix

Derive the auto memtable budget from `effective_memory_limit_bytes()` (matching every sibling budget in `build()`), and clamp it to never exceed 50% of that limit — the pre-existing 2 GiB floor alone can reproduce the same more-than-the-container problem under a small enough cap, independent of the host-RAM bug, so the floor needed its own ceiling.

## What was actually verified

- `cargo test -p xerj-engine --lib governor::` — all 11 tests pass, including the new-shape assertions on `memtable_budget_trips_on_refresh` and the cgroup-resolution tests (no test needed changing; none hardcoded the old formula).
- `cargo clippy -p xerj-engine --lib -- -D warnings` — clean.
- `cargo fmt -p xerj-engine -- --check` — clean.
- `cd engine && cargo build --release` — succeeds (built natively on macOS/arm64 after the Linux Docker VM's fat-LTO link ran out of memory on this constrained dev box — a local resource limit, not a code issue; the `profiling`-profile Linux build used for all the soak/profiling work above compiled and ran fine in the same Docker environment).
- Governor startup log confirms the exact before/after numbers quoted above, reproduced twice (1024 MB and 3072 MB caps).
- Re-ran the same soak (3 GB cap) after the fix: see "Honest status" below — it still hit OOM at roughly the same point.

## Honest status — NOT fully resolved, needs another pass

Re-running the identical soak (3 GB cap) after the fix still hit the same OOM at roughly the same RSS/timing as before the fix. The fix closes a real, independently provable gap in the governor's own admission math (the circuit breaker literally could not trip before consuming the whole container, pre-fix) — but on its own it did not prevent the OOM in this downscaled local repro.

Two known limitations on why this isn't conclusive yet:

1. **Scale mismatch.** My test environment (a Docker Desktop VM with only ~8.3 GB total RAM) can't reproduce the host-RAM-vs-cgroup-cap *ratio* that makes the pre-fix bug most severe — the doc's own `MemoryMax=8G` repro implies a real host with meaningfully more RAM than 8 GB, where the old `system_total_bytes()/4` ceiling would have been far more oversized than in my 8.3 GB-host / 1-3 GB-cap tests (where the pre-existing 2 GiB floor already dominated the calculation either way, muting the fix's visible effect). This needs re-verification on a host with a realistic RAM-to-cap ratio.
2. **Root driver still unidentified.** All three documented suspects were ruled out with direct measurement (see above), and this fix addresses a fourth, independently-found bug — but the actual dominant driver of the RSS growth in the soak repro is still unknown. One unexplored lead: flush cadence during the soak ran ~2.5 flushes/sec (89 flushes in 35s, ~16k docs each) against a merge cycle that only sweeps every 5 seconds in fixed-size batches — a possible flush-rate-vs-merge-rate mismatch causing an un-merged segment backlog. On-disk store size didn't look dramatically bloated when checked once (132.5 MB for 1.36M docs), so this is a lead, not a finding — flagging it here so the next investigator doesn't have to rediscover it.

**Recommendation for review**: merge as a real, standalone correctness fix to the resource governor (it's independently justified regardless of whether it fully explains §15), but keep §15 open and pointed at the merge-backlog lead above for the next pass.

## Test plan

- [x] `cargo test -p xerj-engine --lib governor::` (11/11 pass)
- [x] `cargo clippy -p xerj-engine --lib -- -D warnings` (clean)
- [x] `cargo fmt -p xerj-engine -- --check` (clean)
- [x] `cargo build --release` (clean, native macOS/arm64)
- [x] Live governor-log verification of the exact metric change, at two different cgroup caps
- [x] Soak re-test after the fix (result: OOM still occurs in this downscaled repro — documented above, not hidden)
- [ ] Re-verification on a host with a production-realistic RAM-to-cgroup-cap ratio — not done, flagged as follow-up
- [ ] Root-cause identification of the actual dominant RSS driver — not done, flagged as follow-up
