### PR TITLE
Perf/pdf parse once spool current main

### DIFF
--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -96,9 +96,11 @@ pub fn print_help() {
              Image-only pages need OCR. Page parse failures reject the whole PDF instead\n\
              of silently creating a partial index. XERJ_PDF_WORKER_BIN is a trusted,\n\
              developer-only executable override.\n\
-             Current cost: phase-A sampling parses/materializes each complete PDF, and\n\
-             phase-B indexing parses it again. A framed, early-stop protocol is planned;\n\
-             use fewer --pdf-workers when parent memory is constrained.\n\
+             On a fresh run, phase A parses each PDF once and retains a bounded anonymous\n\
+             extraction artifact; phase B replays it without reparsing. If retention fails\n\
+             or a frozen plan is resumed, phase B safely falls back to parsing again.\n\
+             --pdf-workers bounds both phase-A parser processes and phase-B replay\n\
+             materialization (maximum 4); --workers does not widen that PDF memory gate.\n\
          \n\
          EMBEDDINGS:\n\
              autoindex sends semantic_text to the running server; it does not choose the\n\

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -96,9 +96,12 @@ pub fn print_help() {
              Image-only pages need OCR. Page parse failures reject the whole PDF instead\n\
              of silently creating a partial index. XERJ_PDF_WORKER_BIN is a trusted,\n\
              developer-only executable override.\n\
-             On a fresh run, phase A parses each PDF once and retains a bounded anonymous\n\
-             extraction artifact; phase B replays it without reparsing. If retention fails\n\
-             or a frozen plan is resumed, phase B safely falls back to parsing again.\n\
+             On Linux, fresh runs attempt to retain each validated PDF extraction in\n\
+             bounded anonymous storage under --state-dir. Live admission-time checks\n\
+             attempt to preserve disk and descriptor headroom; refused artifacts are\n\
+             parsed again in phase B and\n\
+             reported under pdf_extraction_reuse. Other platforms currently disable this\n\
+             optimization. Frozen-plan resumes skip phase A and parse unfinished PDFs once.\n\
              --pdf-workers bounds both phase-A parser processes and phase-B replay\n\
              materialization (maximum 4); --workers does not widen that PDF memory gate.\n\
          \n\

--- a/engine/crates/xerj-autoindex/src/extract/pdf.rs
+++ b/engine/crates/xerj-autoindex/src/extract/pdf.rs
@@ -28,6 +28,22 @@ const MAX_EXTRACTED_TEXT: usize = 64 << 20;
 const MAX_WORKER_OUTPUT: usize = 32 << 20;
 const MAX_WORKER_STDERR: u64 = 64 << 10;
 const WORKER_ADDRESS_SPACE: u64 = 1536 << 20;
+// The spool is an optional accelerator on the same filesystem and descriptor
+// table as correctness-critical state. The byte ceiling includes pessimistic
+// 32 MiB reservations held by concurrently serializing PDF responses, not only
+// completed artifact lengths. Hundreds of small retained artifacts plus four
+// in-flight maximum-sized reservations fit while optional pressure stays below
+// the fixed ceiling.
+const MAX_SPOOL_BYTES: u64 = 384 << 20;
+const MAX_SPOOL_HANDLES: u64 = 512;
+// This is an admission-time floor, not a guarantee against other processes
+// consuming filesystem space after the snapshot.
+const MIN_FILESYSTEM_HEADROOM: u64 = 4 << 30;
+const JOURNAL_FILESYSTEM_HEADROOM: u64 = 64 << 20;
+// Preserve a base allowance for the journal/lock/model/runtime plus four
+// descriptors per general and PDF worker for staging, sockets, and pipes.
+const MIN_DESCRIPTOR_HEADROOM: u64 = 64;
+const DESCRIPTOR_HEADROOM_PER_WORKER: u64 = 4;
 
 #[cfg(test)]
 static REPLAY_OBSERVATION_ACTIVE: std::sync::atomic::AtomicUsize =
@@ -123,13 +139,19 @@ pub(crate) fn extract_and_spool(
     source_digest: &str,
     budget: &Arc<ExtractionSpoolBudget>,
     sink: Sink,
-) -> Result<(ExtractStats, Option<ExtractionSpool>, Option<String>)> {
+) -> Result<(ExtractStats, Option<ExtractionSpool>, Option<SpoolFallback>)> {
     let _permit = worker_gate().acquire();
+    budget.record_phase_a_parse();
     let response = spawn_worker(path)?;
     let (spool, fallback) =
         try_spool_response(state_dir, source_size, source_digest, budget, &response);
     let stats = deliver(response, sink);
     Ok((stats, spool, fallback))
+}
+
+pub(crate) struct SpoolFallback {
+    pub(crate) category: &'static str,
+    pub(crate) message: String,
 }
 
 fn try_spool_response(
@@ -138,27 +160,44 @@ fn try_spool_response(
     source_digest: &str,
     budget: &Arc<ExtractionSpoolBudget>,
     response: &WorkerResponse,
-) -> (Option<ExtractionSpool>, Option<String>) {
+) -> (Option<ExtractionSpool>, Option<SpoolFallback>) {
     let reservation = budget.try_reserve(MAX_WORKER_OUTPUT as u64);
     match reservation {
-        Some(reservation) => {
+        Ok(reservation) => {
             match spool_response(state_dir, source_size, source_digest, response, reservation) {
-                Ok(spool) => (Some(spool), None),
-                Err(error) => (
-                    None,
-                    Some(format!(
-                        "could not retain the run-local extraction artifact: {error:#}"
-                    )),
-                ),
+                Ok(spool) => {
+                    budget.record_artifact_accepted(spool.bytes);
+                    (Some(spool), None)
+                }
+                Err(error) => {
+                    budget.record_io_fallback();
+                    budget.record_fallback_category("artifact_io");
+                    budget.record_artifact_rejected();
+                    (
+                        None,
+                        Some(SpoolFallback {
+                            category: "artifact_io",
+                            message: format!(
+                                "could not retain the run-local extraction artifact: {error:#}"
+                            ),
+                        }),
+                    )
+                }
             }
         }
-        None => (
-            None,
-            Some(format!(
-                "the run-local extraction budget is full ({} MiB or {} artifacts)",
-                budget.limit >> 20,
-                budget.max_spools
-            )),
+        Err(category) => (
+            {
+                budget.record_artifact_rejected();
+                budget.record_fallback_category(category);
+                None
+            },
+            Some(SpoolFallback {
+                category,
+                message: format!(
+                    "admission refused ({category}); snapshot headroom or the bounded {} MiB/{}-artifact ceiling would be exceeded",
+                    budget.limit >> 20, budget.max_spools
+                ),
+            }),
         ),
     }
 }
@@ -228,6 +267,46 @@ pub(crate) struct ExtractionSpoolBudget {
     spools: AtomicU64,
     limit: u64,
     max_spools: u64,
+    live_capacity: Option<LiveCapacity>,
+    reservations_started: AtomicU64,
+    cumulative_reserved_bytes: AtomicU64,
+    artifacts_created: AtomicU64,
+    artifacts_not_created: AtomicU64,
+    phase_b_eligible_artifacts: AtomicU64,
+    artifacts_discarded_before_replay: AtomicU64,
+    exact_artifact_bytes: AtomicU64,
+    peak_retained_or_reserved_bytes: AtomicU64,
+    peak_live_artifacts: AtomicU64,
+    phase_a_pdf_parser_calls: AtomicU64,
+    capacity_status: &'static str,
+    capacity_reason: &'static str,
+    fallback_examples: Mutex<Vec<serde_json::Value>>,
+    fallback_examples_total: AtomicU64,
+    fallback_categories: Mutex<std::collections::BTreeMap<&'static str, u64>>,
+    initial_available_bytes: Option<u64>,
+    initial_descriptor_limit: Option<u64>,
+    initial_open_descriptors: Option<u64>,
+    filesystem_headroom: Option<u64>,
+    descriptor_headroom: Option<u64>,
+    capacity_fallbacks: AtomicU64,
+    io_fallbacks: AtomicU64,
+    replay_verified: AtomicU64,
+    replay_integrity_failures: AtomicU64,
+    phase_b_pdf_parses: AtomicU64,
+}
+
+struct LiveCapacity {
+    state_dir: PathBuf,
+    filesystem_headroom: u64,
+    descriptor_headroom: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExtractionSpoolCapacity {
+    bytes: u64,
+    handles: u64,
+    filesystem_headroom: u64,
+    descriptor_headroom: u64,
 }
 
 impl ExtractionSpoolBudget {
@@ -237,31 +316,213 @@ impl ExtractionSpoolBudget {
             spools: AtomicU64::new(0),
             limit,
             max_spools,
+            live_capacity: None,
+            reservations_started: AtomicU64::new(0),
+            cumulative_reserved_bytes: AtomicU64::new(0),
+            artifacts_created: AtomicU64::new(0),
+            artifacts_not_created: AtomicU64::new(0),
+            phase_b_eligible_artifacts: AtomicU64::new(0),
+            artifacts_discarded_before_replay: AtomicU64::new(0),
+            exact_artifact_bytes: AtomicU64::new(0),
+            peak_retained_or_reserved_bytes: AtomicU64::new(0),
+            peak_live_artifacts: AtomicU64::new(0),
+            phase_a_pdf_parser_calls: AtomicU64::new(0),
+            capacity_status: "enabled",
+            capacity_reason: "explicit_budget",
+            fallback_examples: Mutex::new(Vec::new()),
+            fallback_examples_total: AtomicU64::new(0),
+            fallback_categories: Mutex::new(std::collections::BTreeMap::new()),
+            initial_available_bytes: None,
+            initial_descriptor_limit: None,
+            initial_open_descriptors: None,
+            filesystem_headroom: None,
+            descriptor_headroom: None,
+            capacity_fallbacks: AtomicU64::new(0),
+            io_fallbacks: AtomicU64::new(0),
+            replay_verified: AtomicU64::new(0),
+            replay_integrity_failures: AtomicU64::new(0),
+            phase_b_pdf_parses: AtomicU64::new(0),
         })
     }
 
-    fn try_reserve(self: &Arc<Self>, bytes: u64) -> Option<ExtractionSpoolReservation> {
-        self.spools
+    /// Derive an optimization budget from the resources shared with the
+    /// correctness-critical journal, Phase-B staging files, HTTP sockets, and
+    /// worker pipes. If either resource cannot preserve explicit headroom,
+    /// admission is disabled and Phase B uses the existing safe reparse path.
+    pub(crate) fn for_state_dir(
+        state_dir: &Path,
+        workers: usize,
+        pdf_workers: usize,
+        bulk_mb: usize,
+    ) -> (Arc<Self>, Option<String>) {
+        let available_bytes = match available_space_for(state_dir) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                let mut budget = Self::new(0, 0);
+                let inner = Arc::get_mut(&mut budget).expect("new budget has one owner");
+                inner.capacity_status = "disabled";
+                inner.capacity_reason = "free_space_probe_unavailable";
+                return (
+                    budget,
+                    Some(format!(
+                        "disabled because free space under {} could not be measured: {error}",
+                        state_dir.display()
+                    )),
+                );
+            }
+        };
+        let (descriptor_limit, open_descriptors) = descriptor_snapshot_for(state_dir);
+        let capacity = derive_spool_capacity(
+            available_bytes,
+            descriptor_limit,
+            open_descriptors,
+            workers,
+            pdf_workers,
+            bulk_mb,
+        );
+        let warning = if capacity.bytes < MAX_WORKER_OUTPUT as u64 || capacity.handles == 0 {
+            Some(format!(
+                "disabled to preserve {} MiB filesystem and {} descriptor headroom \
+                 ({} MiB free, descriptor limit {})",
+                capacity.filesystem_headroom >> 20,
+                capacity.descriptor_headroom,
+                available_bytes >> 20,
+                descriptor_limit
+                    .map(|limit| limit.to_string())
+                    .unwrap_or_else(|| "unavailable".into())
+            ))
+        } else if capacity.bytes < MAX_SPOOL_BYTES || capacity.handles < MAX_SPOOL_HANDLES {
+            Some(format!(
+                "limited to {} MiB and {} artifacts to preserve {} MiB filesystem and {} \
+                 descriptor headroom",
+                capacity.bytes >> 20,
+                capacity.handles,
+                capacity.filesystem_headroom >> 20,
+                capacity.descriptor_headroom
+            ))
+        } else {
+            None
+        };
+        let capacity_status = if capacity.bytes < MAX_WORKER_OUTPUT as u64 || capacity.handles == 0
+        {
+            "disabled"
+        } else if capacity.bytes < MAX_SPOOL_BYTES || capacity.handles < MAX_SPOOL_HANDLES {
+            "limited"
+        } else {
+            "enabled"
+        };
+        let capacity_reason = if descriptor_limit.is_none() || open_descriptors.is_none() {
+            "descriptor_probe_unavailable"
+        } else if capacity.bytes < MAX_WORKER_OUTPUT as u64 {
+            "filesystem_headroom"
+        } else if capacity.handles == 0 {
+            "descriptor_headroom"
+        } else if capacity_status == "limited" {
+            "resource_share_limited"
+        } else {
+            "full_bounded_capacity"
+        };
+        let budget = Arc::new(Self {
+            used: AtomicU64::new(0),
+            spools: AtomicU64::new(0),
+            limit: capacity.bytes,
+            max_spools: capacity.handles,
+            live_capacity: Some(LiveCapacity {
+                state_dir: state_dir.to_owned(),
+                filesystem_headroom: capacity.filesystem_headroom,
+                descriptor_headroom: capacity.descriptor_headroom,
+            }),
+            reservations_started: AtomicU64::new(0),
+            cumulative_reserved_bytes: AtomicU64::new(0),
+            artifacts_created: AtomicU64::new(0),
+            artifacts_not_created: AtomicU64::new(0),
+            phase_b_eligible_artifacts: AtomicU64::new(0),
+            artifacts_discarded_before_replay: AtomicU64::new(0),
+            exact_artifact_bytes: AtomicU64::new(0),
+            peak_retained_or_reserved_bytes: AtomicU64::new(0),
+            peak_live_artifacts: AtomicU64::new(0),
+            phase_a_pdf_parser_calls: AtomicU64::new(0),
+            capacity_status,
+            capacity_reason,
+            fallback_examples: Mutex::new(Vec::new()),
+            fallback_examples_total: AtomicU64::new(0),
+            fallback_categories: Mutex::new(std::collections::BTreeMap::new()),
+            initial_available_bytes: Some(available_bytes),
+            initial_descriptor_limit: descriptor_limit,
+            initial_open_descriptors: open_descriptors,
+            filesystem_headroom: Some(capacity.filesystem_headroom),
+            descriptor_headroom: Some(capacity.descriptor_headroom),
+            capacity_fallbacks: AtomicU64::new(0),
+            io_fallbacks: AtomicU64::new(0),
+            replay_verified: AtomicU64::new(0),
+            replay_integrity_failures: AtomicU64::new(0),
+            phase_b_pdf_parses: AtomicU64::new(0),
+        });
+        (budget, warning)
+    }
+
+    fn try_reserve(
+        self: &Arc<Self>,
+        bytes: u64,
+    ) -> std::result::Result<ExtractionSpoolReservation, &'static str> {
+        if let Some(live) = &self.live_capacity {
+            let available = available_space_for(&live.state_dir).map_err(|_| {
+                self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
+                "free_space_probe_failed"
+            })?;
+            // `available` already excludes bytes occupied by retained spool
+            // files; adding `used` again would double-count them.
+            if available < live.filesystem_headroom.saturating_add(bytes) {
+                self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
+                return Err("filesystem_admission_floor");
+            }
+            let (Some(limit), Some(open)) = descriptor_snapshot_for(&live.state_dir) else {
+                self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
+                return Err("descriptor_probe_failed");
+            };
+            if open
+                .saturating_add(live.descriptor_headroom)
+                .saturating_add(1)
+                > limit
+            {
+                self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
+                return Err("descriptor_admission_floor");
+            }
+        }
+        let previous_spools = self
+            .spools
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |spools| {
                 (spools < self.max_spools).then_some(spools + 1)
             })
-            .ok()?;
+            .map_err(|_| {
+                self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
+                "artifact_count_ceiling"
+            })?;
+        self.peak_live_artifacts
+            .fetch_max(previous_spools + 1, Ordering::Relaxed);
         let mut used = self.used.load(Ordering::Acquire);
         loop {
             let Some(next) = used.checked_add(bytes) else {
                 self.spools.fetch_sub(1, Ordering::AcqRel);
-                return None;
+                self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
+                return Err("byte_accounting_overflow");
             };
             if next > self.limit {
                 self.spools.fetch_sub(1, Ordering::AcqRel);
-                return None;
+                self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
+                return Err("byte_ceiling");
             }
             match self
                 .used
                 .compare_exchange_weak(used, next, Ordering::AcqRel, Ordering::Acquire)
             {
                 Ok(_) => {
-                    return Some(ExtractionSpoolReservation {
+                    self.reservations_started.fetch_add(1, Ordering::Relaxed);
+                    self.cumulative_reserved_bytes
+                        .fetch_add(bytes, Ordering::Relaxed);
+                    self.peak_retained_or_reserved_bytes
+                        .fetch_max(next, Ordering::Relaxed);
+                    return Ok(ExtractionSpoolReservation {
                         budget: Arc::clone(self),
                         bytes,
                         #[cfg(test)]
@@ -272,6 +533,207 @@ impl ExtractionSpoolBudget {
             }
         }
     }
+
+    pub(crate) fn report(&self) -> serde_json::Value {
+        serde_json::json!({
+            "reservations_started": self.reservations_started.load(Ordering::Relaxed),
+            "cumulative_reserved_bytes": self.cumulative_reserved_bytes.load(Ordering::Relaxed),
+            "artifacts_created": self.artifacts_created.load(Ordering::Relaxed),
+            "artifacts_not_created": self.artifacts_not_created.load(Ordering::Relaxed),
+            "phase_b_eligible_artifacts": self.phase_b_eligible_artifacts.load(Ordering::Relaxed),
+            "artifacts_discarded_before_replay": self.artifacts_discarded_before_replay.load(Ordering::Relaxed),
+            "exact_artifact_bytes": self.exact_artifact_bytes.load(Ordering::Relaxed),
+            "current_retained_or_reserved_bytes": self.used.load(Ordering::Relaxed),
+            "peak_retained_or_reserved_bytes": self.peak_retained_or_reserved_bytes.load(Ordering::Relaxed),
+            "current_live_artifacts": self.spools.load(Ordering::Relaxed),
+            "peak_live_artifacts": self.peak_live_artifacts.load(Ordering::Relaxed),
+            "phase_a_pdf_parser_calls": self.phase_a_pdf_parser_calls.load(Ordering::Relaxed),
+            "capacity_fallbacks": self.capacity_fallbacks.load(Ordering::Relaxed),
+            "io_fallbacks": self.io_fallbacks.load(Ordering::Relaxed),
+            "replay_verified": self.replay_verified.load(Ordering::Relaxed),
+            "replay_integrity_failures": self.replay_integrity_failures.load(Ordering::Relaxed),
+            "phase_b_pdf_parses": self.phase_b_pdf_parses.load(Ordering::Relaxed),
+            "byte_ceiling": self.limit,
+            "artifact_ceiling": self.max_spools,
+            "capacity_status": self.capacity_status,
+            "capacity_reason": self.capacity_reason,
+            "fallback_examples": self.fallback_examples.lock().unwrap().clone(),
+            "fallback_examples_limit": 3,
+            "fallback_examples_truncated": self.fallback_examples_total.load(Ordering::Relaxed) > 3,
+            "fallback_categories": self.fallback_categories.lock().unwrap().clone(),
+            "capacity": {
+                "initial_available_bytes": self.initial_available_bytes,
+                "initial_descriptor_limit": self.initial_descriptor_limit,
+                "initial_open_descriptors": self.initial_open_descriptors,
+                "filesystem_headroom": self.filesystem_headroom,
+                "descriptor_headroom": self.descriptor_headroom,
+            },
+        })
+    }
+
+    pub(crate) fn record_io_fallback(&self) {
+        self.io_fallbacks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_reparse(&self) {
+        self.phase_b_pdf_parses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_fallback_example(
+        &self,
+        path: &str,
+        category: &'static str,
+        message: &str,
+    ) {
+        self.fallback_examples_total.fetch_add(1, Ordering::Relaxed);
+        let mut examples = self.fallback_examples.lock().unwrap();
+        if examples.len() < 3 {
+            examples.push(serde_json::json!({
+                "path": path,
+                "category": category,
+                "message": message,
+            }));
+        }
+    }
+
+    fn record_fallback_category(&self, category: &'static str) {
+        *self
+            .fallback_categories
+            .lock()
+            .unwrap()
+            .entry(category)
+            .or_default() += 1;
+    }
+
+    fn record_phase_a_parse(&self) {
+        self.phase_a_pdf_parser_calls
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_artifact_accepted(&self, bytes: u64) {
+        self.artifacts_created.fetch_add(1, Ordering::Relaxed);
+        self.exact_artifact_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    fn record_artifact_rejected(&self) {
+        self.artifacts_not_created.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_phase_b_eligible(&self) {
+        self.phase_b_eligible_artifacts
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_discarded_before_replay(&self) {
+        self.artifacts_discarded_before_replay
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_source_generation_changed(&self) {
+        self.record_fallback_category("source_generation_changed");
+    }
+}
+
+fn available_space_for(state_dir: &Path) -> std::io::Result<u64> {
+    #[cfg(test)]
+    if let Some(value) = injected_probe_value(state_dir, "available-bytes") {
+        return Ok(value);
+    }
+    fs2::available_space(state_dir)
+}
+
+fn descriptor_snapshot_for(state_dir: &Path) -> (Option<u64>, Option<u64>) {
+    #[cfg(test)]
+    {
+        let limit = injected_probe_value(state_dir, "fd-limit");
+        let open = injected_probe_value(state_dir, "fd-open");
+        if limit.is_some() || open.is_some() {
+            return (limit, open);
+        }
+    }
+    #[cfg(not(test))]
+    let _ = state_dir;
+    (descriptor_soft_limit(), open_descriptor_count())
+}
+
+#[cfg(test)]
+fn injected_probe_value(state_dir: &Path, name: &str) -> Option<u64> {
+    std::fs::read_to_string(state_dir.join(format!(".autoindex-test-pdf-spool-{name}")))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+fn derive_spool_capacity(
+    available_bytes: u64,
+    descriptor_limit: Option<u64>,
+    open_descriptors: Option<u64>,
+    workers: usize,
+    pdf_workers: usize,
+    bulk_mb: usize,
+) -> ExtractionSpoolCapacity {
+    let workers = workers as u64;
+    let pdf_workers = pdf_workers as u64;
+    let bulk_bytes = (bulk_mb as u64).saturating_mul(1 << 20);
+    let filesystem_headroom = MIN_FILESYSTEM_HEADROOM
+        .max(available_bytes / 2)
+        .max(JOURNAL_FILESYSTEM_HEADROOM.saturating_add(workers.saturating_mul(bulk_bytes)));
+    let bytes = MAX_SPOOL_BYTES.min(available_bytes.saturating_sub(filesystem_headroom));
+
+    let descriptor_headroom = MIN_DESCRIPTOR_HEADROOM
+        .saturating_add(workers.saturating_mul(DESCRIPTOR_HEADROOM_PER_WORKER))
+        .saturating_add(pdf_workers.saturating_mul(DESCRIPTOR_HEADROOM_PER_WORKER));
+    let handles = descriptor_limit
+        .zip(open_descriptors)
+        .map(|(limit, open)| {
+            let live_cap = limit.saturating_sub(open.saturating_add(descriptor_headroom));
+            MAX_SPOOL_HANDLES.min(live_cap)
+        })
+        .unwrap_or(0);
+
+    ExtractionSpoolCapacity {
+        bytes,
+        handles,
+        filesystem_headroom,
+        descriptor_headroom,
+    }
+}
+
+#[cfg(unix)]
+fn descriptor_soft_limit() -> Option<u64> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) } != 0 {
+        return None;
+    }
+    if limit.rlim_cur == libc::RLIM_INFINITY {
+        Some(u64::MAX)
+    } else {
+        Some(limit.rlim_cur)
+    }
+}
+
+#[cfg(not(unix))]
+fn descriptor_soft_limit() -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn open_descriptor_count() -> Option<u64> {
+    // Reading this directory temporarily owns one descriptor, so the count is
+    // conservatively one higher than the steady state after this function.
+    std::fs::read_dir("/proc/self/fd")
+        .ok()
+        .and_then(|entries| u64::try_from(entries.count()).ok())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_descriptor_count() -> Option<u64> {
+    None
 }
 
 struct ExtractionSpoolReservation {
@@ -320,7 +782,7 @@ pub(crate) struct ExtractionSpool {
 
 impl ExtractionSpool {
     pub(crate) fn replay(
-        &self,
+        self,
         source_size: u64,
         source_digest: &str,
         sink: Sink,
@@ -329,17 +791,13 @@ impl ExtractionSpool {
     }
 
     fn replay_with_gate(
-        &self,
+        self,
         source_size: u64,
         source_digest: &str,
         sink: Sink,
         gate: &WorkerGate,
         observe_global_replay: bool,
     ) -> Result<ExtractStats> {
-        anyhow::ensure!(
-            source_size == self.source_size && source_digest == self.source_digest,
-            "PDF extraction spool belongs to a different source generation; retry extraction"
-        );
         // JSON decoding materializes a bounded WorkerResponse just like the
         // parser protocol. Share the PDF gate so Phase B cannot multiply that
         // 32 MiB response bound by the general autoindex worker count.
@@ -350,45 +808,73 @@ impl ExtractionSpool {
             .flatten();
         #[cfg(not(test))]
         let _ = observe_global_replay;
-        let mut file = self
-            .file
-            .lock()
-            .map_err(|_| anyhow!("PDF extraction spool lock was poisoned"))?;
-        #[cfg(test)]
-        if CORRUPT_REPLAY_SOURCE_SIZE
-            .compare_exchange(source_size, u64::MAX, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
-        {
-            self._reservation
-                .cleanup_probe
-                .store(true, Ordering::SeqCst);
-            file.set_len(8)
-                .context("inject PDF extraction spool truncation")?;
+        let ExtractionSpool {
+            file,
+            source_size: expected_size,
+            source_digest: expected_digest,
+            bytes,
+            artifact_digest: expected_artifact_digest,
+            _reservation: reservation,
+        } = self;
+        let budget = Arc::clone(&reservation.budget);
+        let decoded = (|| -> Result<WorkerResponse> {
+            anyhow::ensure!(
+                source_size == expected_size && source_digest == expected_digest,
+                "PDF extraction spool belongs to a different source generation; retry extraction"
+            );
+            let mut file = file
+                .into_inner()
+                .map_err(|_| anyhow!("PDF extraction spool lock was poisoned"))?;
+            #[cfg(test)]
+            if CORRUPT_REPLAY_SOURCE_SIZE
+                .compare_exchange(source_size, u64::MAX, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                reservation.cleanup_probe.store(true, Ordering::SeqCst);
+                file.set_len(8)
+                    .context("inject PDF extraction spool truncation")?;
+            }
+            let actual_bytes = file
+                .metadata()
+                .context("measure PDF extraction spool before replay")?
+                .len();
+            anyhow::ensure!(
+                actual_bytes == bytes,
+                "PDF extraction spool length changed (expected {}, found {}); retry extraction",
+                bytes,
+                actual_bytes
+            );
+            let actual_digest = artifact_digest(&mut file, bytes)?;
+            anyhow::ensure!(
+                actual_digest == expected_artifact_digest,
+                "PDF extraction spool content changed; retry extraction"
+            );
+            file.rewind().context("rewind PDF extraction spool")?;
+            let response: WorkerResponse = serde_json::from_reader(BufReader::new(&mut file))
+                .context("PDF extraction spool is malformed or truncated; retry extraction")?;
+            validate_response_identity(&response)?;
+            anyhow::ensure!(
+                file.stream_position()? <= bytes,
+                "PDF extraction spool exceeded its validated boundary"
+            );
+            Ok(response)
+        })();
+        // The optional artifact and its reservation are gone before `deliver`
+        // can expand records into the unbounded correctness-critical stage.
+        // Replay is deliberately one-shot.
+        drop(reservation);
+        match decoded {
+            Ok(response) => {
+                budget.replay_verified.fetch_add(1, Ordering::Relaxed);
+                Ok(deliver(response, sink))
+            }
+            Err(error) => {
+                budget
+                    .replay_integrity_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                Err(error)
+            }
         }
-        let actual_bytes = file
-            .metadata()
-            .context("measure PDF extraction spool before replay")?
-            .len();
-        anyhow::ensure!(
-            actual_bytes == self.bytes,
-            "PDF extraction spool length changed (expected {}, found {}); retry extraction",
-            self.bytes,
-            actual_bytes
-        );
-        let actual_digest = artifact_digest(&mut file, self.bytes)?;
-        anyhow::ensure!(
-            actual_digest == self.artifact_digest,
-            "PDF extraction spool content changed; retry extraction"
-        );
-        file.rewind().context("rewind PDF extraction spool")?;
-        let response: WorkerResponse = serde_json::from_reader(BufReader::new(&mut *file))
-            .context("PDF extraction spool is malformed or truncated; retry extraction")?;
-        validate_response_identity(&response)?;
-        anyhow::ensure!(
-            file.stream_position()? <= self.bytes,
-            "PDF extraction spool exceeded its validated boundary"
-        );
-        Ok(deliver(response, sink))
     }
 }
 
@@ -911,8 +1397,10 @@ fn validate_text_quality(text: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        containment_description, extract_in_process, normalize_legacy_symbol_glyphs,
-        spool_response, try_spool_response, validate_text_quality, WorkerResponse,
+        containment_description, derive_spool_capacity, extract_in_process,
+        normalize_legacy_symbol_glyphs, spool_response, try_spool_response, validate_text_quality,
+        WorkerResponse, JOURNAL_FILESYSTEM_HEADROOM, MAX_SPOOL_BYTES, MAX_SPOOL_HANDLES,
+        MAX_WORKER_OUTPUT, MIN_DESCRIPTOR_HEADROOM, MIN_FILESYSTEM_HEADROOM,
     };
     use crate::infer::{infer_fields, FieldAcc};
     use serde_json::Value;
@@ -1037,8 +1525,16 @@ mod tests {
         let path = source.path().join("quarterly-report.pdf");
         write_prose_pdf(&path);
         let expected = extract_in_process(&path).unwrap();
-        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let budget = super::ExtractionSpoolBudget::new(2 * super::MAX_WORKER_OUTPUT as u64, 2);
         let spool = spool_response(
+            state.path(),
+            123,
+            "axf2-generation-a",
+            &response(expected.clone()),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        let wrong_generation = spool_response(
             state.path(),
             123,
             "axf2-generation-a",
@@ -1064,7 +1560,7 @@ mod tests {
             serde_json::to_value(&expected).unwrap()
         );
 
-        let error = spool
+        let error = wrong_generation
             .replay(123, "axf2-generation-b", &mut |_| true)
             .unwrap_err();
         assert!(error.to_string().contains("different source generation"));
@@ -1102,6 +1598,8 @@ mod tests {
         let mut replayed = Vec::new();
         let replay_stats = spool
             .replay(7, "digest", &mut |record| {
+                assert_eq!(budget.used.load(Ordering::Acquire), 0);
+                assert_eq!(budget.spools.load(Ordering::Acquire), 0);
                 replayed.push(record);
                 replayed.len() < 3
             })
@@ -1118,10 +1616,178 @@ mod tests {
     fn spool_budget_accepts_exact_limit_and_rejects_limit_plus_one() {
         let budget = super::ExtractionSpoolBudget::new(1024, 2);
         let exact = budget.try_reserve(1024).expect("exact limit must fit");
-        assert!(budget.try_reserve(1).is_none());
+        assert!(budget.try_reserve(1).is_err());
         drop(exact);
-        assert!(budget.try_reserve(1025).is_none());
-        assert!(budget.try_reserve(1024).is_some());
+        assert!(budget.try_reserve(1025).is_err());
+        assert!(budget.try_reserve(1024).is_ok());
+    }
+
+    #[test]
+    fn spool_handle_cap_retains_more_than_twelve_small_artifacts() {
+        let budget = super::ExtractionSpoolBudget::new(MAX_SPOOL_BYTES, MAX_SPOOL_HANDLES);
+        let mut retained = Vec::new();
+        for _ in 0..20 {
+            let mut reservation = budget.try_reserve(MAX_WORKER_OUTPUT as u64).unwrap();
+            reservation.shrink_to(1 << 20);
+            retained.push(reservation);
+        }
+        assert_eq!(budget.spools.load(Ordering::Acquire), 20);
+        assert_eq!(budget.used.load(Ordering::Acquire), 20 << 20);
+        drop(retained);
+        assert_eq!(budget.spools.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn many_small_artifacts_plus_four_transient_reservations_fit_384_mib() {
+        const ARTIFACTS: u64 = 360;
+        const EXACT_ARTIFACT_BYTES: u64 = 220 << 20;
+        let budget = super::ExtractionSpoolBudget::new(MAX_SPOOL_BYTES, MAX_SPOOL_HANDLES);
+        let base = EXACT_ARTIFACT_BYTES / ARTIFACTS;
+        let remainder = EXACT_ARTIFACT_BYTES % ARTIFACTS;
+        let mut retained = Vec::new();
+        for index in 0..ARTIFACTS {
+            let mut reservation = budget.try_reserve(MAX_WORKER_OUTPUT as u64).unwrap();
+            reservation.shrink_to(base + u64::from(index < remainder));
+            retained.push(reservation);
+        }
+        let transient: Vec<_> = (0..4)
+            .map(|_| budget.try_reserve(MAX_WORKER_OUTPUT as u64).unwrap())
+            .collect();
+        assert_eq!(
+            budget.used.load(Ordering::Acquire),
+            EXACT_ARTIFACT_BYTES + 4 * MAX_WORKER_OUTPUT as u64
+        );
+        assert!(budget.used.load(Ordering::Acquire) < MAX_SPOOL_BYTES);
+        drop(transient);
+        drop(retained);
+    }
+
+    #[test]
+    fn shared_capacity_preserves_disk_and_descriptor_headroom() {
+        let capacity = derive_spool_capacity(8 << 30, Some(4096), Some(32), 8, 4, 24);
+        assert_eq!(capacity.bytes, MAX_SPOOL_BYTES);
+        assert_eq!(capacity.handles, MAX_SPOOL_HANDLES);
+        assert_eq!(capacity.filesystem_headroom, 4 << 30);
+        assert_eq!(
+            capacity.descriptor_headroom,
+            MIN_DESCRIPTOR_HEADROOM + 8 * 4 + 4 * 4
+        );
+
+        let constrained = derive_spool_capacity(1536 << 20, Some(512), Some(32), 8, 4, 24);
+        assert_eq!(constrained.filesystem_headroom, MIN_FILESYSTEM_HEADROOM);
+        assert_eq!(constrained.bytes, 0);
+        assert_eq!(
+            constrained.handles,
+            512 - 32 - (MIN_DESCRIPTOR_HEADROOM + 8 * 4 + 4 * 4)
+        );
+    }
+
+    #[test]
+    fn shared_capacity_refuses_low_disk_before_staging_headroom_is_spent() {
+        let just_too_small = MIN_FILESYSTEM_HEADROOM + MAX_WORKER_OUTPUT as u64 - 1;
+        let capacity = derive_spool_capacity(just_too_small, Some(4096), Some(16), 8, 4, 24);
+        assert!(capacity.bytes < MAX_WORKER_OUTPUT as u64);
+
+        let exact = derive_spool_capacity(
+            MIN_FILESYSTEM_HEADROOM + MAX_WORKER_OUTPUT as u64,
+            Some(4096),
+            Some(16),
+            8,
+            4,
+            24,
+        );
+        assert_eq!(exact.bytes, MAX_WORKER_OUTPUT as u64);
+
+        let worker_bound = derive_spool_capacity(8 << 30, Some(4096), Some(16), 200, 4, 24);
+        assert_eq!(
+            worker_bound.filesystem_headroom,
+            JOURNAL_FILESYSTEM_HEADROOM + 200 * (24 << 20)
+        );
+    }
+
+    #[test]
+    fn shared_capacity_refuses_low_or_unmeasurable_descriptor_capacity() {
+        let low_limit = derive_spool_capacity(8 << 30, Some(128), Some(16), 8, 4, 24);
+        assert_eq!(low_limit.handles, 0);
+
+        let unknown_limit = derive_spool_capacity(8 << 30, None, Some(16), 8, 4, 24);
+        assert_eq!(unknown_limit.handles, 0);
+
+        let unknown_usage = derive_spool_capacity(8 << 30, Some(4096), None, 8, 4, 24);
+        assert_eq!(unknown_usage.handles, 0);
+    }
+
+    #[test]
+    fn live_admission_uses_injected_disk_and_descriptor_probe_values() {
+        let state = tempfile::tempdir().unwrap();
+        let write_probe = |name: &str, value: u64| {
+            std::fs::write(
+                state
+                    .path()
+                    .join(format!(".autoindex-test-pdf-spool-{name}")),
+                value.to_string(),
+            )
+            .unwrap();
+        };
+        write_probe("available-bytes", 16 << 30);
+        write_probe("fd-limit", 4096);
+        write_probe("fd-open", 16);
+        let (budget, warning) = super::ExtractionSpoolBudget::for_state_dir(state.path(), 8, 4, 24);
+        assert!(warning.is_none());
+
+        write_probe(
+            "available-bytes",
+            MIN_FILESYSTEM_HEADROOM + MAX_WORKER_OUTPUT as u64 - 1,
+        );
+        assert_eq!(
+            budget.try_reserve(MAX_WORKER_OUTPUT as u64).err().unwrap(),
+            "filesystem_admission_floor"
+        );
+
+        write_probe("available-bytes", 16 << 30);
+        write_probe("fd-limit", 128);
+        write_probe("fd-open", 16);
+        assert_eq!(
+            budget.try_reserve(MAX_WORKER_OUTPUT as u64).err().unwrap(),
+            "descriptor_admission_floor"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn low_rlimit_subprocess_disables_optional_spooling() {
+        const CHILD: &str = "XERJ_TEST_LOW_RLIMIT_PDF_SPOOL_CHILD";
+        if std::env::var_os(CHILD).is_some() {
+            let mut limit = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            assert_eq!(
+                unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) },
+                0
+            );
+            limit.rlim_cur = limit.rlim_max.min(96);
+            assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limit) }, 0);
+            let state = tempfile::tempdir().unwrap();
+            let (budget, _) = super::ExtractionSpoolBudget::for_state_dir(state.path(), 8, 4, 24);
+            assert_eq!(budget.report()["capacity_status"], "disabled");
+            assert_eq!(budget.report()["capacity_reason"], "descriptor_headroom");
+            return;
+        }
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "extract::pdf::tests::low_rlimit_subprocess_disables_optional_spooling",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "low-RLIMIT child failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]
@@ -1237,16 +1903,14 @@ mod tests {
         }];
         let spools: Vec<_> = (0..REPLAYS)
             .map(|_| {
-                Arc::new(
-                    spool_response(
-                        state.path(),
-                        7,
-                        "digest",
-                        &response(records.clone()),
-                        budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
-                    )
-                    .unwrap(),
+                spool_response(
+                    state.path(),
+                    7,
+                    "digest",
+                    &response(records.clone()),
+                    budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
                 )
+                .unwrap()
             })
             .collect();
         let gate = Arc::new(super::WorkerGate::new(LIMIT));
@@ -1287,19 +1951,46 @@ mod tests {
     fn spool_budget_is_atomic_and_refunded_on_physical_drop() {
         let budget = super::ExtractionSpoolBudget::new(100, 2);
         let mut first = budget.try_reserve(80).unwrap();
-        assert!(budget.try_reserve(21).is_none());
+        assert!(budget.try_reserve(21).is_err());
         first.shrink_to(40);
         let second = budget.try_reserve(60).unwrap();
-        assert!(budget.try_reserve(1).is_none());
+        assert!(budget.try_reserve(1).is_err());
         drop(second);
-        assert!(budget.try_reserve(60).is_some());
+        assert!(budget.try_reserve(60).is_ok());
         drop(first);
 
         let count_budget = super::ExtractionSpoolBudget::new(1_000, 1);
         let only = count_budget.try_reserve(1).unwrap();
-        assert!(count_budget.try_reserve(1).is_none());
+        assert!(count_budget.try_reserve(1).is_err());
         drop(only);
-        assert!(count_budget.try_reserve(1).is_some());
+        assert!(count_budget.try_reserve(1).is_ok());
+    }
+
+    #[test]
+    fn concurrent_reservations_report_exact_peak_live_artifacts() {
+        const RESERVATIONS: usize = 32;
+        let budget = super::ExtractionSpoolBudget::new(RESERVATIONS as u64, RESERVATIONS as u64);
+        let barrier = Arc::new(Barrier::new(RESERVATIONS + 1));
+        std::thread::scope(|scope| {
+            for _ in 0..RESERVATIONS {
+                let budget = Arc::clone(&budget);
+                let barrier = Arc::clone(&barrier);
+                scope.spawn(move || {
+                    let reservation = budget.try_reserve(1).unwrap();
+                    barrier.wait();
+                    barrier.wait();
+                    drop(reservation);
+                });
+            }
+            barrier.wait();
+            assert_eq!(
+                budget.peak_live_artifacts.load(Ordering::Acquire),
+                RESERVATIONS as u64
+            );
+            assert_eq!(budget.spools.load(Ordering::Acquire), RESERVATIONS as u64);
+            barrier.wait();
+        });
+        assert_eq!(budget.spools.load(Ordering::Acquire), 0);
     }
 
     #[test]
@@ -1314,12 +2005,11 @@ mod tests {
             try_spool_response(&not_a_directory, 7, "digest", &budget, &response);
         assert!(spool.is_none());
         let fallback = fallback.unwrap();
-        assert!(fallback.contains("could not retain"));
-        assert!(fallback.contains("anonymous PDF extraction spool"));
+        assert_eq!(fallback.category, "artifact_io");
+        assert!(fallback.message.contains("could not retain"));
+        assert!(fallback.message.contains("anonymous PDF extraction spool"));
 
         // The failed attempt must not strand either the byte or handle charge.
-        assert!(budget
-            .try_reserve(super::MAX_WORKER_OUTPUT as u64)
-            .is_some());
+        assert!(budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).is_ok());
     }
 }

--- a/engine/crates/xerj-autoindex/src/extract/pdf.rs
+++ b/engine/crates/xerj-autoindex/src/extract/pdf.rs
@@ -12,11 +12,12 @@ use anyhow::{anyhow, Context, Result};
 use pdf_oxide::PdfDocument;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::io::{Read, Write};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Condvar, Mutex, OnceLock};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 const PDF_CAP: u64 = 512 << 20;
@@ -30,6 +31,216 @@ const WORKER_ADDRESS_SPACE: u64 = 1536 << 20;
 pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
     let _permit = worker_gate().acquire();
     let response = spawn_worker(path)?;
+    Ok(deliver(response, sink))
+}
+
+/// Run the isolated parser once and retain its bounded protocol response in an
+/// anonymous, run-local file for Phase B.
+///
+/// The spool is deliberately not durable state. A process restart has a frozen
+/// inference plan but no trusted open handle, so it parses the PDF again. This
+/// avoids coupling extraction cache recovery to the publication journal.
+pub(crate) fn extract_and_spool(
+    path: &Path,
+    state_dir: &Path,
+    source_size: u64,
+    source_digest: &str,
+    budget: &Arc<ExtractionSpoolBudget>,
+    sink: Sink,
+) -> Result<(ExtractStats, Option<ExtractionSpool>, Option<String>)> {
+    let _permit = worker_gate().acquire();
+    let response = spawn_worker(path)?;
+    let (spool, fallback) =
+        try_spool_response(state_dir, source_size, source_digest, budget, &response);
+    let stats = deliver(response, sink);
+    Ok((stats, spool, fallback))
+}
+
+fn try_spool_response(
+    state_dir: &Path,
+    source_size: u64,
+    source_digest: &str,
+    budget: &Arc<ExtractionSpoolBudget>,
+    response: &WorkerResponse,
+) -> (Option<ExtractionSpool>, Option<String>) {
+    let reservation = budget.try_reserve(MAX_WORKER_OUTPUT as u64);
+    match reservation {
+        Some(reservation) => {
+            match spool_response(state_dir, source_size, source_digest, response, reservation) {
+                Ok(spool) => (Some(spool), None),
+                Err(error) => (
+                    None,
+                    Some(format!(
+                        "could not retain the run-local extraction artifact: {error:#}"
+                    )),
+                ),
+            }
+        }
+        None => (
+            None,
+            Some(format!(
+                "the run-local extraction budget is full ({} MiB or {} artifacts)",
+                budget.limit >> 20,
+                budget.max_spools
+            )),
+        ),
+    }
+}
+
+fn spool_response(
+    state_dir: &Path,
+    source_size: u64,
+    source_digest: &str,
+    response: &WorkerResponse,
+    mut reservation: ExtractionSpoolReservation,
+) -> Result<ExtractionSpool> {
+    validate_response_identity(response)?;
+    let mut file = tempfile::tempfile_in(state_dir).with_context(|| {
+        format!(
+            "create anonymous PDF extraction spool under {}",
+            state_dir.display()
+        )
+    })?;
+    {
+        let mut writer = BufWriter::new(&mut file);
+        serde_json::to_writer(&mut writer, &response)
+            .context("serialize validated PDF extraction spool")?;
+        writer.flush().context("flush PDF extraction spool")?;
+    }
+    let bytes = file
+        .stream_position()
+        .context("measure PDF extraction spool")?;
+    if bytes > MAX_WORKER_OUTPUT as u64 {
+        return Err(anyhow!(
+            "validated PDF extraction spool exceeded the {} MiB parent-memory safety limit",
+            MAX_WORKER_OUTPUT >> 20
+        ));
+    }
+    reservation.shrink_to(bytes);
+    file.rewind().context("rewind PDF extraction spool")?;
+    Ok(ExtractionSpool {
+        file: Mutex::new(file),
+        source_size,
+        source_digest: source_digest.to_owned(),
+        bytes,
+        _reservation: reservation,
+    })
+}
+
+pub(crate) struct ExtractionSpoolBudget {
+    used: AtomicU64,
+    spools: AtomicU64,
+    limit: u64,
+    max_spools: u64,
+}
+
+impl ExtractionSpoolBudget {
+    pub(crate) fn new(limit: u64, max_spools: u64) -> Arc<Self> {
+        Arc::new(Self {
+            used: AtomicU64::new(0),
+            spools: AtomicU64::new(0),
+            limit,
+            max_spools,
+        })
+    }
+
+    fn try_reserve(self: &Arc<Self>, bytes: u64) -> Option<ExtractionSpoolReservation> {
+        self.spools
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |spools| {
+                (spools < self.max_spools).then_some(spools + 1)
+            })
+            .ok()?;
+        let mut used = self.used.load(Ordering::Acquire);
+        loop {
+            let Some(next) = used.checked_add(bytes) else {
+                self.spools.fetch_sub(1, Ordering::AcqRel);
+                return None;
+            };
+            if next > self.limit {
+                self.spools.fetch_sub(1, Ordering::AcqRel);
+                return None;
+            }
+            match self
+                .used
+                .compare_exchange_weak(used, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => {
+                    return Some(ExtractionSpoolReservation {
+                        budget: Arc::clone(self),
+                        bytes,
+                    });
+                }
+                Err(actual) => used = actual,
+            }
+        }
+    }
+}
+
+struct ExtractionSpoolReservation {
+    budget: Arc<ExtractionSpoolBudget>,
+    bytes: u64,
+}
+
+impl ExtractionSpoolReservation {
+    fn shrink_to(&mut self, bytes: u64) {
+        debug_assert!(bytes <= self.bytes);
+        let released = self.bytes - bytes;
+        self.bytes = bytes;
+        let previous = self.budget.used.fetch_sub(released, Ordering::AcqRel);
+        debug_assert!(previous >= released);
+    }
+}
+
+impl Drop for ExtractionSpoolReservation {
+    fn drop(&mut self) {
+        let previous = self.budget.used.fetch_sub(self.bytes, Ordering::AcqRel);
+        debug_assert!(previous >= self.bytes);
+        let previous_spools = self.budget.spools.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous_spools > 0);
+    }
+}
+
+/// A validated worker response bound to one inventory generation.
+///
+/// `File` is anonymous and the mutex owns its single seek cursor. Phase A and
+/// Phase B are sequential today, but cursor ownership remains explicit rather
+/// than relying on cloned Unix file descriptors with shared offsets.
+pub(crate) struct ExtractionSpool {
+    file: Mutex<File>,
+    source_size: u64,
+    source_digest: String,
+    bytes: u64,
+    _reservation: ExtractionSpoolReservation,
+}
+
+impl ExtractionSpool {
+    pub(crate) fn replay(
+        &self,
+        source_size: u64,
+        source_digest: &str,
+        sink: Sink,
+    ) -> Result<ExtractStats> {
+        anyhow::ensure!(
+            source_size == self.source_size && source_digest == self.source_digest,
+            "PDF extraction spool belongs to a different source generation; retry extraction"
+        );
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|_| anyhow!("PDF extraction spool lock was poisoned"))?;
+        file.rewind().context("rewind PDF extraction spool")?;
+        let response: WorkerResponse = serde_json::from_reader(BufReader::new(&mut *file))
+            .context("PDF extraction spool is malformed or truncated; retry extraction")?;
+        validate_response_identity(&response)?;
+        anyhow::ensure!(
+            file.stream_position()? <= self.bytes,
+            "PDF extraction spool exceeded its validated boundary"
+        );
+        Ok(deliver(response, sink))
+    }
+}
+
+fn deliver(response: WorkerResponse, sink: Sink) -> ExtractStats {
     let mut stats = ExtractStats::default();
     for record in response.records {
         stats.records += 1;
@@ -37,7 +248,7 @@ pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
             break;
         }
     }
-    Ok(stats)
+    stats
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -186,6 +397,11 @@ fn spawn_worker(path: &Path) -> Result<WorkerResponse> {
             path.display()
         )
     })?;
+    validate_response_identity(&response)?;
+    Ok(response)
+}
+
+fn validate_response_identity(response: &WorkerResponse) -> Result<()> {
     if response.schema != 1 {
         return Err(anyhow!(
             "PDF parser returned unsupported extraction schema {}; update parent and worker together",
@@ -205,7 +421,7 @@ fn spawn_worker(path: &Path) -> Result<WorkerResponse> {
             pdf_oxide::VERSION, response.parser
         ));
     }
-    Ok(response)
+    Ok(())
 }
 
 static WORKER_TIMEOUT_SECS: AtomicU64 = AtomicU64::new(120);
@@ -538,10 +754,14 @@ fn validate_text_quality(text: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_in_process, normalize_legacy_symbol_glyphs, validate_text_quality};
+    use super::{
+        containment_description, extract_in_process, normalize_legacy_symbol_glyphs,
+        spool_response, try_spool_response, validate_text_quality, WorkerResponse,
+    };
     use crate::infer::{infer_fields, FieldAcc};
     use serde_json::Value;
     use std::collections::HashMap;
+    use std::io::{Seek, Write};
 
     fn write_prose_pdf(path: &std::path::Path) {
         let prose = "Quarterly revenue increased because subscription demand remained strong. \
@@ -639,5 +859,139 @@ mod tests {
             first[0].fields.get("body"),
             Some(Value::String(_))
         ));
+    }
+
+    fn response(records: Vec<crate::extract::RawRecord>) -> WorkerResponse {
+        WorkerResponse {
+            schema: 1,
+            extractor: format!("xerj-autoindex/{}", env!("CARGO_PKG_VERSION")),
+            parser: format!("pdf_oxide/{}", pdf_oxide::VERSION),
+            containment: containment_description().to_string(),
+            records,
+        }
+    }
+
+    #[test]
+    fn anonymous_spool_replays_exact_records_and_rejects_another_generation() {
+        let source = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let path = source.path().join("quarterly-report.pdf");
+        write_prose_pdf(&path);
+        let expected = extract_in_process(&path).unwrap();
+        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let spool = spool_response(
+            state.path(),
+            123,
+            "axf2-generation-a",
+            &response(expected.clone()),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+
+        // The artifact exists only as an open handle; it adds no recoverable
+        // path or stale-cache state under the journal directory.
+        assert_eq!(std::fs::read_dir(state.path()).unwrap().count(), 0);
+
+        let mut replayed = Vec::new();
+        let stats = spool
+            .replay(123, "axf2-generation-a", &mut |record| {
+                replayed.push(record);
+                true
+            })
+            .unwrap();
+        assert_eq!(stats.records as usize, expected.len());
+        assert_eq!(
+            serde_json::to_value(&replayed).unwrap(),
+            serde_json::to_value(&expected).unwrap()
+        );
+
+        let error = spool
+            .replay(123, "axf2-generation-b", &mut |_| true)
+            .unwrap_err();
+        assert!(error.to_string().contains("different source generation"));
+    }
+
+    #[test]
+    fn spool_replay_fails_closed_on_truncation_and_wrong_worker_identity() {
+        let source = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let path = source.path().join("quarterly-report.pdf");
+        write_prose_pdf(&path);
+        let records = extract_in_process(&path).unwrap();
+
+        let budget = super::ExtractionSpoolBudget::new(2 * super::MAX_WORKER_OUTPUT as u64, 2);
+        let truncated = spool_response(
+            state.path(),
+            7,
+            "digest",
+            &response(records.clone()),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        truncated.file.lock().unwrap().set_len(8).unwrap();
+        let error = truncated.replay(7, "digest", &mut |_| true).unwrap_err();
+        assert!(format!("{error:#}").contains("malformed or truncated"));
+
+        let wrong_identity = spool_response(
+            state.path(),
+            7,
+            "digest",
+            &response(records.clone()),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        let mut invalid = response(records);
+        invalid.parser = "pdf_oxide/not-the-pinned-parser".into();
+        {
+            let mut file = wrong_identity.file.lock().unwrap();
+            file.rewind().unwrap();
+            file.set_len(0).unwrap();
+            serde_json::to_writer(&mut *file, &invalid).unwrap();
+            file.flush().unwrap();
+        }
+        let error = wrong_identity
+            .replay(7, "digest", &mut |_| true)
+            .unwrap_err();
+        assert!(error.to_string().contains("PDF parser version mismatch"));
+    }
+
+    #[test]
+    fn spool_budget_is_atomic_and_refunded_on_physical_drop() {
+        let budget = super::ExtractionSpoolBudget::new(100, 2);
+        let mut first = budget.try_reserve(80).unwrap();
+        assert!(budget.try_reserve(21).is_none());
+        first.shrink_to(40);
+        let second = budget.try_reserve(60).unwrap();
+        assert!(budget.try_reserve(1).is_none());
+        drop(second);
+        assert!(budget.try_reserve(60).is_some());
+        drop(first);
+
+        let count_budget = super::ExtractionSpoolBudget::new(1_000, 1);
+        let only = count_budget.try_reserve(1).unwrap();
+        assert!(count_budget.try_reserve(1).is_none());
+        drop(only);
+        assert!(count_budget.try_reserve(1).is_some());
+    }
+
+    #[test]
+    fn spool_io_failure_preserves_a_clean_fallback_and_refunds_capacity() {
+        let state = tempfile::tempdir().unwrap();
+        let not_a_directory = state.path().join("regular-file");
+        std::fs::write(&not_a_directory, b"not a directory").unwrap();
+        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let response = response(Vec::new());
+
+        let (spool, fallback) =
+            try_spool_response(&not_a_directory, 7, "digest", &budget, &response);
+        assert!(spool.is_none());
+        let fallback = fallback.unwrap();
+        assert!(fallback.contains("could not retain"));
+        assert!(fallback.contains("anonymous PDF extraction spool"));
+
+        // The failed attempt must not strand either the byte or handle charge.
+        assert!(budget
+            .try_reserve(super::MAX_WORKER_OUTPUT as u64)
+            .is_some());
     }
 }

--- a/engine/crates/xerj-autoindex/src/extract/pdf.rs
+++ b/engine/crates/xerj-autoindex/src/extract/pdf.rs
@@ -19,6 +19,7 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+use xxhash_rust::xxh3::Xxh3;
 
 const PDF_CAP: u64 = 512 << 20;
 const MAX_PAGES: usize = 100_000;
@@ -116,6 +117,7 @@ fn spool_response(
             MAX_WORKER_OUTPUT >> 20
         ));
     }
+    let artifact_digest = artifact_digest(&mut file, bytes)?;
     reservation.shrink_to(bytes);
     file.rewind().context("rewind PDF extraction spool")?;
     Ok(ExtractionSpool {
@@ -123,8 +125,27 @@ fn spool_response(
         source_size,
         source_digest: source_digest.to_owned(),
         bytes,
+        artifact_digest,
         _reservation: reservation,
     })
+}
+
+fn artifact_digest(file: &mut File, bytes: u64) -> Result<u128> {
+    file.rewind().context("rewind PDF extraction spool")?;
+    let mut hash = Xxh3::new();
+    let mut remaining = bytes;
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .context("size PDF extraction spool digest buffer")?;
+        let read = file
+            .read(&mut buffer[..limit])
+            .context("read PDF extraction spool for digest")?;
+        anyhow::ensure!(read > 0, "PDF extraction spool was truncated while hashing");
+        hash.update(&buffer[..read]);
+        remaining -= read as u64;
+    }
+    Ok(hash.digest128())
 }
 
 pub(crate) struct ExtractionSpoolBudget {
@@ -210,6 +231,7 @@ pub(crate) struct ExtractionSpool {
     source_size: u64,
     source_digest: String,
     bytes: u64,
+    artifact_digest: u128,
     _reservation: ExtractionSpoolReservation,
 }
 
@@ -220,14 +242,43 @@ impl ExtractionSpool {
         source_digest: &str,
         sink: Sink,
     ) -> Result<ExtractStats> {
+        self.replay_with_gate(source_size, source_digest, sink, worker_gate())
+    }
+
+    fn replay_with_gate(
+        &self,
+        source_size: u64,
+        source_digest: &str,
+        sink: Sink,
+        gate: &WorkerGate,
+    ) -> Result<ExtractStats> {
         anyhow::ensure!(
             source_size == self.source_size && source_digest == self.source_digest,
             "PDF extraction spool belongs to a different source generation; retry extraction"
         );
+        // JSON decoding materializes a bounded WorkerResponse just like the
+        // parser protocol. Share the PDF gate so Phase B cannot multiply that
+        // 32 MiB response bound by the general autoindex worker count.
+        let _permit = gate.acquire();
         let mut file = self
             .file
             .lock()
             .map_err(|_| anyhow!("PDF extraction spool lock was poisoned"))?;
+        let actual_bytes = file
+            .metadata()
+            .context("measure PDF extraction spool before replay")?
+            .len();
+        anyhow::ensure!(
+            actual_bytes == self.bytes,
+            "PDF extraction spool length changed (expected {}, found {}); retry extraction",
+            self.bytes,
+            actual_bytes
+        );
+        let actual_digest = artifact_digest(&mut file, self.bytes)?;
+        anyhow::ensure!(
+            actual_digest == self.artifact_digest,
+            "PDF extraction spool content changed; retry extraction"
+        );
         file.rewind().context("rewind PDF extraction spool")?;
         let response: WorkerResponse = serde_json::from_reader(BufReader::new(&mut *file))
             .context("PDF extraction spool is malformed or truncated; retry extraction")?;
@@ -660,6 +711,13 @@ struct WorkerGate {
 }
 
 impl WorkerGate {
+    fn new(limit: usize) -> Self {
+        Self {
+            state: Mutex::new((0, limit.clamp(1, 4))),
+            ready: Condvar::new(),
+        }
+    }
+
     fn set_limit(&self, limit: usize) {
         self.state.lock().expect("PDF worker gate poisoned").1 = limit;
         self.ready.notify_all();
@@ -687,15 +745,12 @@ impl Drop for WorkerPermit<'_> {
 
 fn worker_gate() -> &'static WorkerGate {
     static GATE: OnceLock<WorkerGate> = OnceLock::new();
-    GATE.get_or_init(|| WorkerGate {
-        state: Mutex::new((
-            0,
+    GATE.get_or_init(|| {
+        WorkerGate::new(
             std::thread::available_parallelism()
                 .map(|n| n.get())
-                .unwrap_or(4)
-                .min(4),
-        )),
-        ready: Condvar::new(),
+                .unwrap_or(4),
+        )
     })
 }
 
@@ -761,7 +816,10 @@ mod tests {
     use crate::infer::{infer_fields, FieldAcc};
     use serde_json::Value;
     use std::collections::HashMap;
-    use std::io::{Seek, Write};
+    use std::io::{Read, Seek, Write};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
 
     fn write_prose_pdf(path: &std::path::Path) {
         let prose = "Quarterly revenue increased because subscription demand remained strong. \
@@ -912,14 +970,14 @@ mod tests {
     }
 
     #[test]
-    fn spool_replay_fails_closed_on_truncation_and_wrong_worker_identity() {
+    fn spool_replay_verifies_exact_length_and_digest_before_decode() {
         let source = tempfile::tempdir().unwrap();
         let state = tempfile::tempdir().unwrap();
         let path = source.path().join("quarterly-report.pdf");
         write_prose_pdf(&path);
         let records = extract_in_process(&path).unwrap();
 
-        let budget = super::ExtractionSpoolBudget::new(2 * super::MAX_WORKER_OUTPUT as u64, 2);
+        let budget = super::ExtractionSpoolBudget::new(3 * super::MAX_WORKER_OUTPUT as u64, 3);
         let truncated = spool_response(
             state.path(),
             7,
@@ -930,9 +988,9 @@ mod tests {
         .unwrap();
         truncated.file.lock().unwrap().set_len(8).unwrap();
         let error = truncated.replay(7, "digest", &mut |_| true).unwrap_err();
-        assert!(format!("{error:#}").contains("malformed or truncated"));
+        assert!(format!("{error:#}").contains("length changed"));
 
-        let wrong_identity = spool_response(
+        let appended = spool_response(
             state.path(),
             7,
             "digest",
@@ -940,19 +998,100 @@ mod tests {
             budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
         )
         .unwrap();
-        let mut invalid = response(records);
-        invalid.parser = "pdf_oxide/not-the-pinned-parser".into();
         {
-            let mut file = wrong_identity.file.lock().unwrap();
-            file.rewind().unwrap();
-            file.set_len(0).unwrap();
-            serde_json::to_writer(&mut *file, &invalid).unwrap();
+            let mut file = appended.file.lock().unwrap();
+            file.seek(std::io::SeekFrom::End(0)).unwrap();
+            file.write_all(b" ").unwrap();
             file.flush().unwrap();
         }
-        let error = wrong_identity
-            .replay(7, "digest", &mut |_| true)
-            .unwrap_err();
-        assert!(error.to_string().contains("PDF parser version mismatch"));
+        let error = appended.replay(7, "digest", &mut |_| true).unwrap_err();
+        assert!(format!("{error:#}").contains("length changed"));
+
+        let mutated = spool_response(
+            state.path(),
+            7,
+            "digest",
+            &response(records.clone()),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        {
+            let mut file = mutated.file.lock().unwrap();
+            file.rewind().unwrap();
+            let mut first = [0u8; 1];
+            file.read_exact(&mut first).unwrap();
+            file.rewind().unwrap();
+            file.write_all(if first == *b"{" { b"[" } else { b"{" })
+                .unwrap();
+            file.flush().unwrap();
+        }
+        assert_eq!(
+            mutated.file.lock().unwrap().metadata().unwrap().len(),
+            mutated.bytes
+        );
+        let error = mutated.replay(7, "digest", &mut |_| true).unwrap_err();
+        assert!(error.to_string().contains("content changed"));
+    }
+
+    #[test]
+    fn concurrent_spool_replay_never_exceeds_configured_pdf_gate() {
+        const REPLAYS: usize = 8;
+        const LIMIT: usize = 2;
+        let state = tempfile::tempdir().unwrap();
+        let budget = super::ExtractionSpoolBudget::new(
+            REPLAYS as u64 * super::MAX_WORKER_OUTPUT as u64,
+            REPLAYS as u64,
+        );
+        let records = vec![crate::extract::RawRecord {
+            fields: serde_json::Map::new(),
+            locator: "page:1".into(),
+            group: None,
+        }];
+        let spools: Vec<_> = (0..REPLAYS)
+            .map(|_| {
+                Arc::new(
+                    spool_response(
+                        state.path(),
+                        7,
+                        "digest",
+                        &response(records.clone()),
+                        budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+                    )
+                    .unwrap(),
+                )
+            })
+            .collect();
+        let gate = Arc::new(super::WorkerGate::new(LIMIT));
+        let start = Arc::new(Barrier::new(REPLAYS));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|scope| {
+            for spool in spools {
+                let gate = Arc::clone(&gate);
+                let start = Arc::clone(&start);
+                let active = Arc::clone(&active);
+                let maximum = Arc::clone(&maximum);
+                scope.spawn(move || {
+                    start.wait();
+                    spool
+                        .replay_with_gate(
+                            7,
+                            "digest",
+                            &mut |_| {
+                                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                                maximum.fetch_max(now, Ordering::SeqCst);
+                                std::thread::sleep(Duration::from_millis(20));
+                                active.fetch_sub(1, Ordering::SeqCst);
+                                true
+                            },
+                            &gate,
+                        )
+                        .unwrap();
+                });
+            }
+        });
+        assert_eq!(maximum.load(Ordering::SeqCst), LIMIT);
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/extract/pdf.rs
+++ b/engine/crates/xerj-autoindex/src/extract/pdf.rs
@@ -29,6 +29,65 @@ const MAX_WORKER_OUTPUT: usize = 32 << 20;
 const MAX_WORKER_STDERR: u64 = 64 << 10;
 const WORKER_ADDRESS_SPACE: u64 = 1536 << 20;
 
+#[cfg(test)]
+static REPLAY_OBSERVATION_ACTIVE: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static REPLAY_OBSERVATION_MAXIMUM: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static REPLAY_OBSERVATION_DELAY_MS: AtomicU64 = AtomicU64::new(0);
+#[cfg(test)]
+static REPLAY_OBSERVATION_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(test)]
+pub(crate) fn reset_replay_concurrency_observation(delay_ms: u64) {
+    REPLAY_OBSERVATION_ENABLED.store(false, Ordering::SeqCst);
+    REPLAY_OBSERVATION_DELAY_MS.store(delay_ms, Ordering::SeqCst);
+    if delay_ms == 0 {
+        return;
+    }
+    assert_eq!(
+        REPLAY_OBSERVATION_ACTIVE.load(Ordering::SeqCst),
+        0,
+        "a previous PDF replay observation is still active"
+    );
+    REPLAY_OBSERVATION_MAXIMUM.store(0, Ordering::SeqCst);
+    REPLAY_OBSERVATION_ENABLED.store(true, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn replay_concurrency_maximum() -> usize {
+    REPLAY_OBSERVATION_MAXIMUM.load(Ordering::SeqCst)
+}
+
+#[cfg(test)]
+struct ReplayObservation;
+
+#[cfg(test)]
+impl ReplayObservation {
+    fn begin() -> Option<Self> {
+        if !REPLAY_OBSERVATION_ENABLED.load(Ordering::SeqCst) {
+            return None;
+        }
+        let active = REPLAY_OBSERVATION_ACTIVE.fetch_add(1, Ordering::SeqCst) + 1;
+        REPLAY_OBSERVATION_MAXIMUM.fetch_max(active, Ordering::SeqCst);
+        let delay_ms = REPLAY_OBSERVATION_DELAY_MS.load(Ordering::SeqCst);
+        if delay_ms > 0 {
+            std::thread::sleep(Duration::from_millis(delay_ms));
+        }
+        Some(Self)
+    }
+}
+
+#[cfg(test)]
+impl Drop for ReplayObservation {
+    fn drop(&mut self) {
+        REPLAY_OBSERVATION_ACTIVE.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
     let _permit = worker_gate().acquire();
     let response = spawn_worker(path)?;
@@ -242,7 +301,7 @@ impl ExtractionSpool {
         source_digest: &str,
         sink: Sink,
     ) -> Result<ExtractStats> {
-        self.replay_with_gate(source_size, source_digest, sink, worker_gate())
+        self.replay_with_gate(source_size, source_digest, sink, worker_gate(), true)
     }
 
     fn replay_with_gate(
@@ -251,6 +310,7 @@ impl ExtractionSpool {
         source_digest: &str,
         sink: Sink,
         gate: &WorkerGate,
+        observe_global_replay: bool,
     ) -> Result<ExtractStats> {
         anyhow::ensure!(
             source_size == self.source_size && source_digest == self.source_digest,
@@ -260,6 +320,12 @@ impl ExtractionSpool {
         // parser protocol. Share the PDF gate so Phase B cannot multiply that
         // 32 MiB response bound by the general autoindex worker count.
         let _permit = gate.acquire();
+        #[cfg(test)]
+        let _observation = observe_global_replay
+            .then(ReplayObservation::begin)
+            .flatten();
+        #[cfg(not(test))]
+        let _ = observe_global_replay;
         let mut file = self
             .file
             .lock()
@@ -1086,6 +1152,7 @@ mod tests {
                                 true
                             },
                             &gate,
+                            false,
                         )
                         .unwrap();
                 });

--- a/engine/crates/xerj-autoindex/src/extract/pdf.rs
+++ b/engine/crates/xerj-autoindex/src/extract/pdf.rs
@@ -40,6 +40,11 @@ static REPLAY_OBSERVATION_DELAY_MS: AtomicU64 = AtomicU64::new(0);
 #[cfg(test)]
 static REPLAY_OBSERVATION_ENABLED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+#[cfg(test)]
+static CORRUPT_REPLAY_SOURCE_SIZE: AtomicU64 = AtomicU64::new(u64::MAX);
+#[cfg(test)]
+static CORRUPTED_REPLAY_RESERVATION_DROPPED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 #[cfg(test)]
 pub(crate) fn reset_replay_concurrency_observation(delay_ms: u64) {
@@ -60,6 +65,17 @@ pub(crate) fn reset_replay_concurrency_observation(delay_ms: u64) {
 #[cfg(test)]
 pub(crate) fn replay_concurrency_maximum() -> usize {
     REPLAY_OBSERVATION_MAXIMUM.load(Ordering::SeqCst)
+}
+
+#[cfg(test)]
+pub(crate) fn corrupt_replay_for_source_size(source_size: u64) {
+    CORRUPTED_REPLAY_RESERVATION_DROPPED.store(false, Ordering::SeqCst);
+    CORRUPT_REPLAY_SOURCE_SIZE.store(source_size, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn corrupted_replay_reservation_was_dropped() -> bool {
+    CORRUPTED_REPLAY_RESERVATION_DROPPED.load(Ordering::SeqCst)
 }
 
 #[cfg(test)]
@@ -248,6 +264,8 @@ impl ExtractionSpoolBudget {
                     return Some(ExtractionSpoolReservation {
                         budget: Arc::clone(self),
                         bytes,
+                        #[cfg(test)]
+                        cleanup_probe: std::sync::atomic::AtomicBool::new(false),
                     });
                 }
                 Err(actual) => used = actual,
@@ -259,6 +277,8 @@ impl ExtractionSpoolBudget {
 struct ExtractionSpoolReservation {
     budget: Arc<ExtractionSpoolBudget>,
     bytes: u64,
+    #[cfg(test)]
+    cleanup_probe: std::sync::atomic::AtomicBool,
 }
 
 impl ExtractionSpoolReservation {
@@ -277,6 +297,10 @@ impl Drop for ExtractionSpoolReservation {
         debug_assert!(previous >= self.bytes);
         let previous_spools = self.budget.spools.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(previous_spools > 0);
+        #[cfg(test)]
+        if self.cleanup_probe.load(Ordering::SeqCst) {
+            CORRUPTED_REPLAY_RESERVATION_DROPPED.store(true, Ordering::SeqCst);
+        }
     }
 }
 
@@ -330,6 +354,17 @@ impl ExtractionSpool {
             .file
             .lock()
             .map_err(|_| anyhow!("PDF extraction spool lock was poisoned"))?;
+        #[cfg(test)]
+        if CORRUPT_REPLAY_SOURCE_SIZE
+            .compare_exchange(source_size, u64::MAX, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self._reservation
+                .cleanup_probe
+                .store(true, Ordering::SeqCst);
+            file.set_len(8)
+                .context("inject PDF extraction spool truncation")?;
+        }
         let actual_bytes = file
             .metadata()
             .context("measure PDF extraction spool before replay")?
@@ -1033,6 +1068,93 @@ mod tests {
             .replay(123, "axf2-generation-b", &mut |_| true)
             .unwrap_err();
         assert!(error.to_string().contains("different source generation"));
+    }
+
+    #[test]
+    fn spool_replay_early_stop_matches_direct_delivery() {
+        let state = tempfile::tempdir().unwrap();
+        let records: Vec<_> = (0..5)
+            .map(|index| crate::extract::RawRecord {
+                fields: serde_json::Map::from_iter([(
+                    "ordinal".into(),
+                    serde_json::Value::from(index),
+                )]),
+                locator: format!("p1-s{index}"),
+                group: None,
+            })
+            .collect();
+        let expected = response(records.clone());
+        let mut direct = Vec::new();
+        let direct_stats = super::deliver(expected, &mut |record| {
+            direct.push(record);
+            direct.len() < 3
+        });
+
+        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let spool = spool_response(
+            state.path(),
+            7,
+            "digest",
+            &response(records),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        let mut replayed = Vec::new();
+        let replay_stats = spool
+            .replay(7, "digest", &mut |record| {
+                replayed.push(record);
+                replayed.len() < 3
+            })
+            .unwrap();
+
+        assert_eq!(replay_stats.records, direct_stats.records);
+        assert_eq!(
+            serde_json::to_value(replayed).unwrap(),
+            serde_json::to_value(direct).unwrap()
+        );
+    }
+
+    #[test]
+    fn spool_budget_accepts_exact_limit_and_rejects_limit_plus_one() {
+        let budget = super::ExtractionSpoolBudget::new(1024, 2);
+        let exact = budget.try_reserve(1024).expect("exact limit must fit");
+        assert!(budget.try_reserve(1).is_none());
+        drop(exact);
+        assert!(budget.try_reserve(1025).is_none());
+        assert!(budget.try_reserve(1024).is_some());
+    }
+
+    #[test]
+    fn multi_megabyte_spool_replays_with_exact_integrity() {
+        const BODY_BYTES: usize = 2 * 1024 * 1024;
+        let state = tempfile::tempdir().unwrap();
+        let body = "quarterly-results ".repeat(BODY_BYTES / "quarterly-results ".len());
+        let record = crate::extract::RawRecord {
+            fields: serde_json::Map::from_iter([("body".into(), body.clone().into())]),
+            locator: "p1-s0".into(),
+            group: None,
+        };
+        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let spool = spool_response(
+            state.path(),
+            7,
+            "digest",
+            &response(vec![record]),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        assert!(spool.bytes >= BODY_BYTES as u64);
+        assert!(spool.bytes < super::MAX_WORKER_OUTPUT as u64);
+
+        let mut replayed_body = None;
+        let stats = spool
+            .replay(7, "digest", &mut |record| {
+                replayed_body = record.fields["body"].as_str().map(ToOwned::to_owned);
+                true
+            })
+            .unwrap();
+        assert_eq!(stats.records, 1);
+        assert_eq!(replayed_body.as_deref(), Some(body.as_str()));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/extract/pdf.rs
+++ b/engine/crates/xerj-autoindex/src/extract/pdf.rs
@@ -46,42 +46,10 @@ const MIN_DESCRIPTOR_HEADROOM: u64 = 64;
 const DESCRIPTOR_HEADROOM_PER_WORKER: u64 = 4;
 
 #[cfg(test)]
-static REPLAY_OBSERVATION_ACTIVE: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-#[cfg(test)]
-static REPLAY_OBSERVATION_MAXIMUM: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-#[cfg(test)]
-static REPLAY_OBSERVATION_DELAY_MS: AtomicU64 = AtomicU64::new(0);
-#[cfg(test)]
-static REPLAY_OBSERVATION_ENABLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-#[cfg(test)]
 static CORRUPT_REPLAY_SOURCE_SIZE: AtomicU64 = AtomicU64::new(u64::MAX);
 #[cfg(test)]
 static CORRUPTED_REPLAY_RESERVATION_DROPPED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
-
-#[cfg(test)]
-pub(crate) fn reset_replay_concurrency_observation(delay_ms: u64) {
-    REPLAY_OBSERVATION_ENABLED.store(false, Ordering::SeqCst);
-    REPLAY_OBSERVATION_DELAY_MS.store(delay_ms, Ordering::SeqCst);
-    if delay_ms == 0 {
-        return;
-    }
-    assert_eq!(
-        REPLAY_OBSERVATION_ACTIVE.load(Ordering::SeqCst),
-        0,
-        "a previous PDF replay observation is still active"
-    );
-    REPLAY_OBSERVATION_MAXIMUM.store(0, Ordering::SeqCst);
-    REPLAY_OBSERVATION_ENABLED.store(true, Ordering::SeqCst);
-}
-
-#[cfg(test)]
-pub(crate) fn replay_concurrency_maximum() -> usize {
-    REPLAY_OBSERVATION_MAXIMUM.load(Ordering::SeqCst)
-}
 
 #[cfg(test)]
 pub(crate) fn corrupt_replay_for_source_size(source_size: u64) {
@@ -92,32 +60,6 @@ pub(crate) fn corrupt_replay_for_source_size(source_size: u64) {
 #[cfg(test)]
 pub(crate) fn corrupted_replay_reservation_was_dropped() -> bool {
     CORRUPTED_REPLAY_RESERVATION_DROPPED.load(Ordering::SeqCst)
-}
-
-#[cfg(test)]
-struct ReplayObservation;
-
-#[cfg(test)]
-impl ReplayObservation {
-    fn begin() -> Option<Self> {
-        if !REPLAY_OBSERVATION_ENABLED.load(Ordering::SeqCst) {
-            return None;
-        }
-        let active = REPLAY_OBSERVATION_ACTIVE.fetch_add(1, Ordering::SeqCst) + 1;
-        REPLAY_OBSERVATION_MAXIMUM.fetch_max(active, Ordering::SeqCst);
-        let delay_ms = REPLAY_OBSERVATION_DELAY_MS.load(Ordering::SeqCst);
-        if delay_ms > 0 {
-            std::thread::sleep(Duration::from_millis(delay_ms));
-        }
-        Some(Self)
-    }
-}
-
-#[cfg(test)]
-impl Drop for ReplayObservation {
-    fn drop(&mut self) {
-        REPLAY_OBSERVATION_ACTIVE.fetch_sub(1, Ordering::SeqCst);
-    }
 }
 
 pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
@@ -141,8 +83,10 @@ pub(crate) fn extract_and_spool(
     sink: Sink,
 ) -> Result<(ExtractStats, Option<ExtractionSpool>, Option<SpoolFallback>)> {
     let _permit = worker_gate().acquire();
-    budget.record_phase_a_parse();
     let response = spawn_worker(path)?;
+    // Count completed parser protocol calls, not attempts that failed before
+    // producing a response which Phase A could use.
+    budget.record_phase_a_parse();
     let (spool, fallback) =
         try_spool_response(state_dir, source_size, source_digest, budget, &response);
     let stats = deliver(response, sink);
@@ -263,6 +207,7 @@ fn artifact_digest(file: &mut File, bytes: u64) -> Result<u128> {
 }
 
 pub(crate) struct ExtractionSpoolBudget {
+    admission: Mutex<()>,
     used: AtomicU64,
     spools: AtomicU64,
     limit: u64,
@@ -312,6 +257,7 @@ struct ExtractionSpoolCapacity {
 impl ExtractionSpoolBudget {
     pub(crate) fn new(limit: u64, max_spools: u64) -> Arc<Self> {
         Arc::new(Self {
+            admission: Mutex::new(()),
             used: AtomicU64::new(0),
             spools: AtomicU64::new(0),
             limit,
@@ -423,6 +369,7 @@ impl ExtractionSpoolBudget {
             "full_bounded_capacity"
         };
         let budget = Arc::new(Self {
+            admission: Mutex::new(()),
             used: AtomicU64::new(0),
             spools: AtomicU64::new(0),
             limit: capacity.bytes,
@@ -489,6 +436,10 @@ impl ExtractionSpoolBudget {
                 return Err("descriptor_admission_floor");
             }
         }
+        // Serialize the tiny accounting transition so a handle claim that is
+        // subsequently rejected by the byte ceiling cannot inflate the
+        // advertised live-artifact peak.
+        let _admission = self.admission.lock().unwrap();
         let previous_spools = self
             .spools
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |spools| {
@@ -498,8 +449,6 @@ impl ExtractionSpoolBudget {
                 self.capacity_fallbacks.fetch_add(1, Ordering::Relaxed);
                 "artifact_count_ceiling"
             })?;
-        self.peak_live_artifacts
-            .fetch_max(previous_spools + 1, Ordering::Relaxed);
         let mut used = self.used.load(Ordering::Acquire);
         loop {
             let Some(next) = used.checked_add(bytes) else {
@@ -517,6 +466,8 @@ impl ExtractionSpoolBudget {
                 .compare_exchange_weak(used, next, Ordering::AcqRel, Ordering::Acquire)
             {
                 Ok(_) => {
+                    self.peak_live_artifacts
+                        .fetch_max(previous_spools + 1, Ordering::Relaxed);
                     self.reservations_started.fetch_add(1, Ordering::Relaxed);
                     self.cumulative_reserved_bytes
                         .fetch_add(bytes, Ordering::Relaxed);
@@ -577,6 +528,23 @@ impl ExtractionSpoolBudget {
 
     pub(crate) fn record_reparse(&self) {
         self.phase_b_pdf_parses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_replay_fallback(&self, path: &str, error: &anyhow::Error) {
+        self.record_io_fallback();
+        self.record_fallback_category("replay_verification");
+        self.record_fallback_example(
+            path,
+            "replay_verification",
+            &format!(
+                "run-local PDF extraction artifact could not be verified; reparsed source: \
+                 {error:#}"
+            ),
+        );
+    }
+
+    pub(crate) fn platform_reuse_is_unavailable(&self) -> bool {
+        self.capacity_status == "disabled" && self.capacity_reason == "descriptor_probe_unavailable"
     }
 
     pub(crate) fn record_fallback_example(
@@ -796,18 +764,12 @@ impl ExtractionSpool {
         source_digest: &str,
         sink: Sink,
         gate: &WorkerGate,
-        observe_global_replay: bool,
+        _observe_global_replay: bool,
     ) -> Result<ExtractStats> {
         // JSON decoding materializes a bounded WorkerResponse just like the
         // parser protocol. Share the PDF gate so Phase B cannot multiply that
         // 32 MiB response bound by the general autoindex worker count.
         let _permit = gate.acquire();
-        #[cfg(test)]
-        let _observation = observe_global_replay
-            .then(ReplayObservation::begin)
-            .flatten();
-        #[cfg(not(test))]
-        let _ = observe_global_replay;
         let ExtractionSpool {
             file,
             source_size: expected_size,
@@ -853,10 +815,6 @@ impl ExtractionSpool {
             let response: WorkerResponse = serde_json::from_reader(BufReader::new(&mut file))
                 .context("PDF extraction spool is malformed or truncated; retry extraction")?;
             validate_response_identity(&response)?;
-            anyhow::ensure!(
-                file.stream_position()? <= bytes,
-                "PDF extraction spool exceeded its validated boundary"
-            );
             Ok(response)
         })();
         // The optional artifact and its reservation are gone before `deliver`
@@ -1620,6 +1578,56 @@ mod tests {
         drop(exact);
         assert!(budget.try_reserve(1025).is_err());
         assert!(budget.try_reserve(1024).is_ok());
+
+        let rejected = super::ExtractionSpoolBudget::new(0, 1);
+        assert!(rejected.try_reserve(1).is_err());
+        assert_eq!(
+            rejected
+                .peak_live_artifacts
+                .load(std::sync::atomic::Ordering::Acquire),
+            0,
+            "a byte-refused provisional handle is not a live artifact"
+        );
+    }
+
+    #[test]
+    fn fallback_examples_are_exactly_bounded_and_report_truncation() {
+        let budget = super::ExtractionSpoolBudget::new(0, 0);
+        for index in 0..4 {
+            budget.record_fallback_example(
+                &format!("report-{index}.pdf"),
+                "test_fallback",
+                "injected",
+            );
+        }
+        let report = budget.report();
+        assert_eq!(report["fallback_examples"].as_array().unwrap().len(), 3);
+        assert_eq!(report["fallback_examples_limit"], 3);
+        assert_eq!(report["fallback_examples_truncated"], true);
+        assert_eq!(report["fallback_examples"][0]["path"], "report-0.pdf");
+        assert_eq!(report["fallback_examples"][2]["path"], "report-2.pdf");
+    }
+
+    #[test]
+    fn failed_worker_protocol_call_is_not_reported_as_a_completed_phase_a_parse() {
+        let source = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let missing = source.path().join("missing.pdf");
+        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let error = match super::extract_and_spool(
+            &missing,
+            state.path(),
+            0,
+            "digest",
+            &budget,
+            &mut |_| true,
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("a missing PDF cannot produce a worker response"),
+        };
+        assert!(!format!("{error:#}").is_empty());
+        assert_eq!(budget.report()["phase_a_pdf_parser_calls"], 0);
+        assert_eq!(budget.report()["reservations_started"], 0);
     }
 
     #[test]
@@ -1769,6 +1777,13 @@ mod tests {
             limit.rlim_cur = limit.rlim_max.min(96);
             assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limit) }, 0);
             let state = tempfile::tempdir().unwrap();
+            std::fs::write(
+                state
+                    .path()
+                    .join(".autoindex-test-pdf-spool-available-bytes"),
+                (16_u64 << 30).to_string(),
+            )
+            .unwrap();
             let (budget, _) = super::ExtractionSpoolBudget::for_state_dir(state.path(), 8, 4, 24);
             assert_eq!(budget.report()["capacity_status"], "disabled");
             assert_eq!(budget.report()["capacity_reason"], "descriptor_headroom");
@@ -1885,6 +1900,75 @@ mod tests {
         );
         let error = mutated.replay(7, "digest", &mut |_| true).unwrap_err();
         assert!(error.to_string().contains("content changed"));
+    }
+
+    fn rewrite_spool_and_reseal(
+        spool: &mut super::ExtractionSpool,
+        rewrite: impl FnOnce(&mut Vec<u8>),
+    ) {
+        let mut file = spool.file.lock().unwrap();
+        file.rewind().unwrap();
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).unwrap();
+        rewrite(&mut bytes);
+        file.set_len(0).unwrap();
+        file.rewind().unwrap();
+        file.write_all(&bytes).unwrap();
+        file.flush().unwrap();
+        spool.bytes = bytes.len() as u64;
+        spool.artifact_digest = super::artifact_digest(&mut file, spool.bytes).unwrap();
+        file.rewind().unwrap();
+    }
+
+    #[test]
+    fn replay_rejects_malformed_json_after_physical_integrity_passes() {
+        let state = tempfile::tempdir().unwrap();
+        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let mut spool = spool_response(
+            state.path(),
+            7,
+            "digest",
+            &response(Vec::new()),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        rewrite_spool_and_reseal(&mut spool, |bytes| bytes[0] = b'[');
+
+        let error = spool.replay(7, "digest", &mut |_| true).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("malformed or truncated"),
+            "{error:#}"
+        );
+        assert_eq!(budget.report()["replay_integrity_failures"], 1);
+    }
+
+    #[test]
+    fn replay_rejects_worker_protocol_mismatch_after_integrity_passes() {
+        let state = tempfile::tempdir().unwrap();
+        let budget = super::ExtractionSpoolBudget::new(super::MAX_WORKER_OUTPUT as u64, 1);
+        let mut spool = spool_response(
+            state.path(),
+            7,
+            "digest",
+            &response(Vec::new()),
+            budget.try_reserve(super::MAX_WORKER_OUTPUT as u64).unwrap(),
+        )
+        .unwrap();
+        rewrite_spool_and_reseal(&mut spool, |bytes| {
+            let needle = b"xerj-autoindex/";
+            let offset = bytes
+                .windows(needle.len())
+                .position(|window| window == needle)
+                .unwrap();
+            bytes[offset] = b'X';
+        });
+
+        let error = spool.replay(7, "digest", &mut |_| true).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("extractor version mismatch"),
+            "{error:#}"
+        );
+        assert_eq!(budget.report()["replay_integrity_failures"], 1);
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -24,7 +24,20 @@ impl Drop for PdfWorkerEnvGuard {
     fn drop(&mut self) {
         std::env::remove_var("XERJ_PDF_WORKER_BIN");
         std::env::remove_var("XERJ_TEST_PDF_COUNT");
-        crate::extract::pdf::reset_replay_concurrency_observation(0);
+    }
+}
+
+fn inject_pdf_spool_capacity(state_dir: &Path) {
+    for (name, value) in [
+        ("available-bytes", 16_u64 << 30),
+        ("fd-limit", 4096),
+        ("fd-open", 16),
+    ] {
+        fs::write(
+            state_dir.join(format!(".autoindex-test-pdf-spool-{name}")),
+            value.to_string(),
+        )
+        .unwrap();
     }
 }
 
@@ -858,6 +871,7 @@ fn fresh_pdf_is_parsed_once_and_failed_publication_retry_reparses_once() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
+    inject_pdf_spool_capacity(state_dir.path());
     let tools = tempfile::tempdir().unwrap();
     let pdf = corpus.path().join("quarterly-report.pdf");
     fs::write(
@@ -978,7 +992,7 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
 
 #[cfg(unix)]
 #[test]
-fn same_size_source_change_preserves_prior_fallback_and_adds_typed_diagnostic() {
+fn refused_spool_does_not_pay_a_second_phase_a_source_hash() {
     use std::os::unix::fs::PermissionsExt;
 
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
@@ -1017,7 +1031,7 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
     let budget = crate::extract::pdf::ExtractionSpoolBudget::new(0, 0);
     let scan = scan_file(&pdf, size, &digest, state_dir.path(), &budget, 100, 1);
     assert!(scan.pdf_spool.is_none());
-    assert_eq!(scan.pdf_spool_fallbacks.len(), 2);
+    assert_eq!(scan.pdf_spool_fallbacks.len(), 1);
     for fallback in &scan.pdf_spool_fallbacks {
         budget.record_fallback_example(
             "quarterly-report.pdf",
@@ -1030,15 +1044,9 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
     assert_eq!(report["phase_b_eligible_artifacts"], 0);
     assert_eq!(report["artifacts_discarded_before_replay"], 0);
     assert_eq!(report["fallback_categories"]["artifact_count_ceiling"], 1);
-    assert_eq!(
-        report["fallback_categories"]["source_generation_changed"],
-        1
-    );
-    assert!(report["fallback_examples"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|example| example["category"] == "source_generation_changed"));
+    assert!(report["fallback_categories"]
+        .get("source_generation_changed")
+        .is_none());
 }
 
 #[cfg(unix)]
@@ -1049,6 +1057,7 @@ fn verified_but_junk_pdf_spool_is_created_then_discarded_not_eligible() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
+    inject_pdf_spool_capacity(state_dir.path());
     let tools = tempfile::tempdir().unwrap();
     let pdf = corpus.path().join("empty-report.pdf");
     fs::write(&pdf, b"%PDF-1.4\nempty test input\n").unwrap();
@@ -1087,12 +1096,13 @@ fn verified_but_junk_pdf_spool_is_created_then_discarded_not_eligible() {
 
 #[cfg(unix)]
 #[test]
-fn multi_pdf_run_index_bounds_phase_b_replay_by_pdf_workers_not_general_workers() {
+fn multi_pdf_run_reuses_every_artifact_and_reports_exact_success_counters() {
     use std::os::unix::fs::PermissionsExt;
 
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
+    inject_pdf_spool_capacity(state_dir.path());
     let tools = tempfile::tempdir().unwrap();
     const PDFS: usize = 6;
     for index in 0..PDFS {
@@ -1124,36 +1134,57 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
     std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
     std::env::set_var("XERJ_TEST_PDF_COUNT", &count);
     let _env = PdfWorkerEnvGuard;
-    crate::extract::pdf::reset_replay_concurrency_observation(40);
-
-    assert_eq!(run_index(config).unwrap(), 0);
+    let (code, report) = run_index_report(config).unwrap();
+    assert_eq!(code, 0);
     assert_eq!(
         fs::read_to_string(&count).unwrap().lines().count(),
         PDFS,
         "each unique PDF must be parsed once in Phase A and replayed in Phase B"
     );
-    assert_eq!(
-        crate::extract::pdf::replay_concurrency_maximum(),
-        2,
-        "eight general workers must not widen the two-worker PDF replay gate"
-    );
     assert_eq!(endpoint.state.lock().unwrap().docs.len(), PDFS);
+    let reuse = report.unwrap()["pdf_extraction_reuse"].clone();
+    assert_eq!(reuse["reservations_started"], PDFS);
+    assert_eq!(
+        reuse["cumulative_reserved_bytes"],
+        PDFS as u64 * (32_u64 << 20)
+    );
+    assert_eq!(reuse["artifacts_created"], PDFS);
+    assert_eq!(reuse["artifacts_not_created"], 0);
+    assert_eq!(reuse["phase_b_eligible_artifacts"], PDFS);
+    assert_eq!(reuse["artifacts_discarded_before_replay"], 0);
+    assert!(reuse["exact_artifact_bytes"].as_u64().unwrap() > 0);
+    assert_eq!(reuse["current_retained_or_reserved_bytes"], 0);
+    assert!(reuse["peak_retained_or_reserved_bytes"].as_u64().unwrap() > 0);
+    assert_eq!(reuse["current_live_artifacts"], 0);
+    assert!(reuse["peak_live_artifacts"].as_u64().unwrap() > 0);
+    assert_eq!(reuse["phase_a_pdf_parser_calls"], PDFS);
+    assert_eq!(reuse["capacity_fallbacks"], 0);
+    assert_eq!(reuse["io_fallbacks"], 0);
+    assert_eq!(reuse["replay_verified"], PDFS);
+    assert_eq!(reuse["replay_integrity_failures"], 0);
+    assert_eq!(reuse["phase_b_pdf_parses"], 0);
+    assert_eq!(reuse["fallback_examples"].as_array().unwrap().len(), 0);
+    assert_eq!(reuse["fallback_examples_truncated"], false);
+    assert_eq!(reuse["fallback_categories"].as_object().unwrap().len(), 0);
 }
 
 #[cfg(unix)]
 #[test]
-fn corrupted_pdf_replay_fails_closed_and_releases_spool_budget() {
+fn corrupted_pdf_replay_reparses_without_blaming_the_source_or_backend() {
     use std::os::unix::fs::PermissionsExt;
 
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
+    inject_pdf_spool_capacity(state_dir.path());
     let tools = tempfile::tempdir().unwrap();
     let pdf = corpus.path().join("report.pdf");
     fs::write(&pdf, b"%PDF-1.4\ntest worker input\n").unwrap();
     let worker = tools.path().join("pdf-worker");
+    let count = tools.path().join("worker-count");
     let worker_script = String::from_utf8(
         br#"#!/bin/sh
+printf 'parse\n' >> "$XERJ_TEST_PDF_COUNT"
 printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"body":"Quarterly revenue increased while operating margin improved."},"locator":"p1-s0","group":null}]}'
 "#
         .to_vec(),
@@ -1166,14 +1197,28 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
     let endpoint = MockEndpoint::start(0);
     let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
     std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
+    std::env::set_var("XERJ_TEST_PDF_COUNT", &count);
     let _env = PdfWorkerEnvGuard;
     crate::extract::pdf::corrupt_replay_for_source_size(fs::metadata(&pdf).unwrap().len());
 
-    let error = run_index(config).unwrap_err();
-    assert!(format!("{error:#}").contains("spool length changed"));
-    assert!(endpoint.state.lock().unwrap().docs.is_empty());
-    assert_eq!(file_done_count(state_dir.path()), 0);
+    let (code, report) = run_index_report(config).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(fs::read_to_string(&count).unwrap().lines().count(), 2);
+    assert_eq!(endpoint.state.lock().unwrap().docs.len(), 1);
+    assert_eq!(file_done_count(state_dir.path()), 1);
     assert!(crate::extract::pdf::corrupted_replay_reservation_was_dropped());
+    let reuse = report.unwrap()["pdf_extraction_reuse"].clone();
+    assert_eq!(reuse["replay_verified"], 0);
+    assert_eq!(reuse["replay_integrity_failures"], 1);
+    assert_eq!(reuse["io_fallbacks"], 1);
+    assert_eq!(reuse["phase_b_pdf_parses"], 1);
+    assert_eq!(reuse["current_live_artifacts"], 0);
+    assert_eq!(reuse["current_retained_or_reserved_bytes"], 0);
+    assert_eq!(reuse["fallback_categories"]["replay_verification"], 1);
+    assert_eq!(
+        reuse["fallback_examples"][0]["category"],
+        "replay_verification"
+    );
 }
 
 #[test]
@@ -1201,7 +1246,10 @@ fn junk_scan_drops_its_spool_before_indexable_spools_are_retained() {
     assert_eq!(drops.load(Ordering::SeqCst), 1);
     let report = budget.report();
     assert_eq!(report["artifacts_discarded_before_replay"], 1);
-    assert_eq!(report["phase_b_eligible_artifacts"], 1);
+    assert_eq!(
+        report["phase_b_eligible_artifacts"], 0,
+        "eligibility is recorded only after the final todo set is known"
+    );
     drop(retained);
     assert_eq!(drops.load(Ordering::SeqCst), 2);
 }

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -959,3 +959,65 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
     );
     assert_eq!(endpoint.state.lock().unwrap().docs.len(), PDFS);
 }
+
+#[cfg(unix)]
+#[test]
+fn corrupted_pdf_replay_fails_closed_and_releases_spool_budget() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let tools = tempfile::tempdir().unwrap();
+    let pdf = corpus.path().join("report.pdf");
+    fs::write(&pdf, b"%PDF-1.4\ntest worker input\n").unwrap();
+    let worker = tools.path().join("pdf-worker");
+    let worker_script = String::from_utf8(
+        br#"#!/bin/sh
+printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"body":"Quarterly revenue increased while operating margin improved."},"locator":"p1-s0","group":null}]}'
+"#
+        .to_vec(),
+    )
+    .unwrap()
+    .replace("__XERJ_VERSION__", env!("CARGO_PKG_VERSION"));
+    fs::write(&worker, worker_script).unwrap();
+    fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let endpoint = MockEndpoint::start(0);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
+    let _env = PdfWorkerEnvGuard;
+    crate::extract::pdf::corrupt_replay_for_source_size(fs::metadata(&pdf).unwrap().len());
+
+    let error = run_index(config).unwrap_err();
+    assert!(format!("{error:#}").contains("spool length changed"));
+    assert!(endpoint.state.lock().unwrap().docs.is_empty());
+    assert_eq!(file_done_count(state_dir.path()), 0);
+    assert!(crate::extract::pdf::corrupted_replay_reservation_was_dropped());
+}
+
+#[test]
+fn junk_scan_drops_its_spool_before_indexable_spools_are_retained() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct DropProbe(Arc<AtomicUsize>);
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut junk = Some(DropProbe(Arc::clone(&drops)));
+    assert!(take_pdf_spool_if_indexable(&mut junk, true).is_none());
+    assert!(junk.is_none());
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    let mut indexable = Some(DropProbe(Arc::clone(&drops)));
+    let retained = take_pdf_spool_if_indexable(&mut indexable, false);
+    assert!(retained.is_some());
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    drop(retained);
+    assert_eq!(drops.load(Ordering::SeqCst), 2);
+}

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -16,6 +16,17 @@ use std::thread;
 
 static FAILPOINT_TEST_LOCK: Mutex<()> = Mutex::new(());
 
+#[cfg(unix)]
+struct PdfWorkerEnvGuard;
+
+#[cfg(unix)]
+impl Drop for PdfWorkerEnvGuard {
+    fn drop(&mut self) {
+        std::env::remove_var("XERJ_PDF_WORKER_BIN");
+        std::env::remove_var("XERJ_TEST_PDF_COUNT");
+    }
+}
+
 #[derive(Default)]
 struct MockState {
     docs: HashMap<String, Value>,
@@ -836,4 +847,57 @@ fn partial_file_done_is_rolled_back_before_another_worker_commits() {
             .as_str()
             .is_some_and(|value| value.ends_with("-new"))
     }));
+}
+
+#[cfg(unix)]
+#[test]
+fn fresh_pdf_is_parsed_once_and_failed_publication_retry_reparses_once() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let tools = tempfile::tempdir().unwrap();
+    let pdf = corpus.path().join("quarterly-report.pdf");
+    fs::write(
+        &pdf,
+        b"%PDF-1.4\nfake bytes consumed by the isolated test worker\n",
+    )
+    .unwrap();
+    fs::copy(&pdf, corpus.path().join("quarterly-report-copy.pdf")).unwrap();
+
+    let count = tools.path().join("worker-count");
+    let worker = tools.path().join("pdf-worker");
+    fs::write(
+        &worker,
+        br#"#!/bin/sh
+printf 'parse\n' >> "$XERJ_TEST_PDF_COUNT"
+printf '%s' '{"schema":1,"extractor":"xerj-autoindex/1.0.0-rc.5","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"title":"quarterly-report","page":1,"body":"Quarterly revenue increased while operating margin improved.","pdf_pages_total":1,"pdf_pages_with_text":1,"pdf_pages_omitted":0},"locator":"p1-s0","group":null}]}'
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let endpoint = MockEndpoint::start(1);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
+    std::env::set_var("XERJ_TEST_PDF_COUNT", &count);
+    let _env = PdfWorkerEnvGuard;
+
+    let first = run_index(config.clone()).unwrap_err();
+    assert!(format!("{first:#}").contains("bulk backend failed"));
+    assert_eq!(
+        fs::read_to_string(&count).unwrap().lines().count(),
+        1,
+        "Phase A's extraction must be replayed in Phase B, not parsed again"
+    );
+    assert_eq!(file_done_count(state_dir.path()), 0);
+
+    // The process-local spool is intentionally not journal state. A retry has
+    // a frozen plan, performs exactly one fresh extraction in Phase B, and
+    // commits only after the backend accepts it.
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(fs::read_to_string(&count).unwrap().lines().count(), 2);
+    assert_eq!(file_done_count(state_dir.path()), 1);
+    assert_eq!(endpoint.state.lock().unwrap().docs.len(), 1);
 }

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -869,14 +869,16 @@ fn fresh_pdf_is_parsed_once_and_failed_publication_retry_reparses_once() {
 
     let count = tools.path().join("worker-count");
     let worker = tools.path().join("pdf-worker");
-    fs::write(
-        &worker,
+    let worker_script = String::from_utf8(
         br#"#!/bin/sh
 printf 'parse\n' >> "$XERJ_TEST_PDF_COUNT"
-printf '%s' '{"schema":1,"extractor":"xerj-autoindex/1.0.0-rc.5","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"title":"quarterly-report","page":1,"body":"Quarterly revenue increased while operating margin improved.","pdf_pages_total":1,"pdf_pages_with_text":1,"pdf_pages_omitted":0},"locator":"p1-s0","group":null}]}'
-"#,
+printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"title":"quarterly-report","page":1,"body":"Quarterly revenue increased while operating margin improved.","pdf_pages_total":1,"pdf_pages_with_text":1,"pdf_pages_omitted":0},"locator":"p1-s0","group":null}]}'
+"#
+        .to_vec(),
     )
-    .unwrap();
+    .unwrap()
+    .replace("__XERJ_VERSION__", env!("CARGO_PKG_VERSION"));
+    fs::write(&worker, worker_script).unwrap();
     fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
 
     let endpoint = MockEndpoint::start(1);
@@ -923,14 +925,16 @@ fn multi_pdf_run_index_bounds_phase_b_replay_by_pdf_workers_not_general_workers(
 
     let count = tools.path().join("worker-count");
     let worker = tools.path().join("pdf-worker");
-    fs::write(
-        &worker,
+    let worker_script = String::from_utf8(
         br#"#!/bin/sh
 printf 'parse\n' >> "$XERJ_TEST_PDF_COUNT"
-printf '%s' '{"schema":1,"extractor":"xerj-autoindex/1.0.0-rc.5","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"title":"quarterly-report","page":1,"body":"Quarterly revenue increased while operating margin improved.","pdf_pages_total":1,"pdf_pages_with_text":1,"pdf_pages_omitted":0},"locator":"p1-s0","group":null}]}'
-"#,
+printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"title":"quarterly-report","page":1,"body":"Quarterly revenue increased while operating margin improved.","pdf_pages_total":1,"pdf_pages_with_text":1,"pdf_pages_omitted":0},"locator":"p1-s0","group":null}]}'
+"#
+        .to_vec(),
     )
-    .unwrap();
+    .unwrap()
+    .replace("__XERJ_VERSION__", env!("CARGO_PKG_VERSION"));
+    fs::write(&worker, worker_script).unwrap();
     fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
 
     let endpoint = MockEndpoint::start(0);

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -907,6 +907,186 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
 
 #[cfg(unix)]
 #[test]
+fn refused_pdf_spool_reparses_and_reports_fallback_without_weakening_publication() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let tools = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("quarterly-report.pdf"),
+        b"%PDF-1.4\nfake bytes consumed by the isolated test worker\n",
+    )
+    .unwrap();
+    fs::write(
+        state_dir
+            .path()
+            .join(".autoindex-test-pdf-spool-available-bytes"),
+        ((4_u64 << 30) + (32 << 20) - 1).to_string(),
+    )
+    .unwrap();
+    fs::write(
+        state_dir.path().join(".autoindex-test-pdf-spool-fd-limit"),
+        "4096",
+    )
+    .unwrap();
+    fs::write(
+        state_dir.path().join(".autoindex-test-pdf-spool-fd-open"),
+        "16",
+    )
+    .unwrap();
+
+    let count = tools.path().join("worker-count");
+    let worker = tools.path().join("pdf-worker");
+    let worker_script = String::from_utf8(
+        br#"#!/bin/sh
+printf 'parse\n' >> "$XERJ_TEST_PDF_COUNT"
+printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"title":"quarterly-report","page":1,"body":"Quarterly revenue increased while operating margin improved.","pdf_pages_total":1,"pdf_pages_with_text":1,"pdf_pages_omitted":0},"locator":"p1-s0","group":null}]}'
+"#
+        .to_vec(),
+    )
+    .unwrap()
+    .replace("__XERJ_VERSION__", env!("CARGO_PKG_VERSION"));
+    fs::write(&worker, worker_script).unwrap();
+    fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let endpoint = MockEndpoint::start(0);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
+    std::env::set_var("XERJ_TEST_PDF_COUNT", &count);
+    let _env = PdfWorkerEnvGuard;
+
+    let (code, report) = run_index_report(config).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(fs::read_to_string(&count).unwrap().lines().count(), 2);
+    assert_eq!(file_done_count(state_dir.path()), 1);
+    assert_eq!(endpoint.state.lock().unwrap().docs.len(), 1);
+    let reuse = report.unwrap()["pdf_extraction_reuse"].clone();
+    assert_eq!(reuse["reservations_started"], 0);
+    assert_eq!(reuse["capacity_fallbacks"], 1);
+    assert_eq!(reuse["phase_b_pdf_parses"], 1);
+    assert_eq!(reuse["replay_verified"], 0);
+    assert_eq!(reuse["artifacts_not_created"], 1);
+    assert_eq!(reuse["phase_a_pdf_parser_calls"], 1);
+    assert_eq!(reuse["capacity_status"], "disabled");
+    assert_eq!(
+        reuse["fallback_examples"][0]["path"],
+        "quarterly-report.pdf"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn same_size_source_change_preserves_prior_fallback_and_adds_typed_diagnostic() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let tools = tempfile::tempdir().unwrap();
+    let pdf = corpus.path().join("quarterly-report.pdf");
+    fs::write(&pdf, b"%PDF-1.4\nsame-size-source-generation\n").unwrap();
+    let size = fs::metadata(&pdf).unwrap().len();
+    let digest = content::resolve(vec![crate::walk::FileEntry {
+        path: pdf.clone(),
+        rel: "quarterly-report.pdf".into(),
+        rel_id: "quarterly-report.pdf".into(),
+        is_symlink: false,
+        size,
+    }])
+    .unwrap()
+    .digests
+    .remove(0);
+
+    let worker = tools.path().join("pdf-worker");
+    let worker_script = String::from_utf8(
+        br#"#!/bin/sh
+printf 'Z' | dd of="$2" bs=1 seek=10 conv=notrunc 2>/dev/null
+printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"body":"Quarterly revenue increased while operating margin improved."},"locator":"p1-s0","group":null}]}'
+"#
+        .to_vec(),
+    )
+    .unwrap()
+    .replace("__XERJ_VERSION__", env!("CARGO_PKG_VERSION"));
+    fs::write(&worker, worker_script).unwrap();
+    fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
+    std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
+    let _env = PdfWorkerEnvGuard;
+
+    let budget = crate::extract::pdf::ExtractionSpoolBudget::new(0, 0);
+    let scan = scan_file(&pdf, size, &digest, state_dir.path(), &budget, 100, 1);
+    assert!(scan.pdf_spool.is_none());
+    assert_eq!(scan.pdf_spool_fallbacks.len(), 2);
+    for fallback in &scan.pdf_spool_fallbacks {
+        budget.record_fallback_example(
+            "quarterly-report.pdf",
+            fallback.category,
+            &fallback.message,
+        );
+    }
+    let report = budget.report();
+    assert_eq!(report["artifacts_created"], 0);
+    assert_eq!(report["phase_b_eligible_artifacts"], 0);
+    assert_eq!(report["artifacts_discarded_before_replay"], 0);
+    assert_eq!(report["fallback_categories"]["artifact_count_ceiling"], 1);
+    assert_eq!(
+        report["fallback_categories"]["source_generation_changed"],
+        1
+    );
+    assert!(report["fallback_examples"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|example| example["category"] == "source_generation_changed"));
+}
+
+#[cfg(unix)]
+#[test]
+fn verified_but_junk_pdf_spool_is_created_then_discarded_not_eligible() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let tools = tempfile::tempdir().unwrap();
+    let pdf = corpus.path().join("empty-report.pdf");
+    fs::write(&pdf, b"%PDF-1.4\nempty test input\n").unwrap();
+    let size = fs::metadata(&pdf).unwrap().len();
+    let digest = content::resolve(vec![crate::walk::FileEntry {
+        path: pdf.clone(),
+        rel: "empty-report.pdf".into(),
+        rel_id: "empty-report.pdf".into(),
+        is_symlink: false,
+        size,
+    }])
+    .unwrap()
+    .digests
+    .remove(0);
+    let worker = tools.path().join("pdf-worker");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s' '{{\"schema\":1,\"extractor\":\"xerj-autoindex/{}\",\"parser\":\"pdf_oxide/0.3.75\",\"containment\":\"test worker\",\"records\":[]}}'\n",
+        env!("CARGO_PKG_VERSION")
+    );
+    fs::write(&worker, script).unwrap();
+    fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
+    std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
+    let _env = PdfWorkerEnvGuard;
+
+    let (budget, _) =
+        crate::extract::pdf::ExtractionSpoolBudget::for_state_dir(state_dir.path(), 1, 1, 8);
+    let mut scan = scan_file(&pdf, size, &digest, state_dir.path(), &budget, 100, 1);
+    assert!(scan.junk.is_some());
+    assert!(scan.pdf_spool.is_some());
+    assert!(take_pdf_spool_if_indexable(&mut scan.pdf_spool, true, &budget).is_none());
+    let report = budget.report();
+    assert_eq!(report["artifacts_created"], 1);
+    assert_eq!(report["artifacts_discarded_before_replay"], 1);
+    assert_eq!(report["phase_b_eligible_artifacts"], 0);
+}
+
+#[cfg(unix)]
+#[test]
 fn multi_pdf_run_index_bounds_phase_b_replay_by_pdf_workers_not_general_workers() {
     use std::os::unix::fs::PermissionsExt;
 
@@ -1009,15 +1189,19 @@ fn junk_scan_drops_its_spool_before_indexable_spools_are_retained() {
     }
 
     let drops = Arc::new(AtomicUsize::new(0));
+    let budget = crate::extract::pdf::ExtractionSpoolBudget::new(1, 1);
     let mut junk = Some(DropProbe(Arc::clone(&drops)));
-    assert!(take_pdf_spool_if_indexable(&mut junk, true).is_none());
+    assert!(take_pdf_spool_if_indexable(&mut junk, true, &budget).is_none());
     assert!(junk.is_none());
     assert_eq!(drops.load(Ordering::SeqCst), 1);
 
     let mut indexable = Some(DropProbe(Arc::clone(&drops)));
-    let retained = take_pdf_spool_if_indexable(&mut indexable, false);
+    let retained = take_pdf_spool_if_indexable(&mut indexable, false, &budget);
     assert!(retained.is_some());
     assert_eq!(drops.load(Ordering::SeqCst), 1);
+    let report = budget.report();
+    assert_eq!(report["artifacts_discarded_before_replay"], 1);
+    assert_eq!(report["phase_b_eligible_artifacts"], 1);
     drop(retained);
     assert_eq!(drops.load(Ordering::SeqCst), 2);
 }

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -24,6 +24,7 @@ impl Drop for PdfWorkerEnvGuard {
     fn drop(&mut self) {
         std::env::remove_var("XERJ_PDF_WORKER_BIN");
         std::env::remove_var("XERJ_TEST_PDF_COUNT");
+        crate::extract::pdf::reset_replay_concurrency_observation(0);
     }
 }
 
@@ -900,4 +901,57 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/1.0.0-rc.5","parser":"pdf_o
     assert_eq!(fs::read_to_string(&count).unwrap().lines().count(), 2);
     assert_eq!(file_done_count(state_dir.path()), 1);
     assert_eq!(endpoint.state.lock().unwrap().docs.len(), 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn multi_pdf_run_index_bounds_phase_b_replay_by_pdf_workers_not_general_workers() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let tools = tempfile::tempdir().unwrap();
+    const PDFS: usize = 6;
+    for index in 0..PDFS {
+        fs::write(
+            corpus.path().join(format!("quarterly-report-{index}.pdf")),
+            format!("%PDF-1.4\nunique isolated worker input {index}\n"),
+        )
+        .unwrap();
+    }
+
+    let count = tools.path().join("worker-count");
+    let worker = tools.path().join("pdf-worker");
+    fs::write(
+        &worker,
+        br#"#!/bin/sh
+printf 'parse\n' >> "$XERJ_TEST_PDF_COUNT"
+printf '%s' '{"schema":1,"extractor":"xerj-autoindex/1.0.0-rc.5","parser":"pdf_oxide/0.3.75","containment":"test worker","records":[{"fields":{"title":"quarterly-report","page":1,"body":"Quarterly revenue increased while operating margin improved.","pdf_pages_total":1,"pdf_pages_with_text":1,"pdf_pages_omitted":0},"locator":"p1-s0","group":null}]}'
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&worker, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let endpoint = MockEndpoint::start(0);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    config.workers = 8;
+    config.pdf_workers = 2;
+    std::env::set_var("XERJ_PDF_WORKER_BIN", &worker);
+    std::env::set_var("XERJ_TEST_PDF_COUNT", &count);
+    let _env = PdfWorkerEnvGuard;
+    crate::extract::pdf::reset_replay_concurrency_observation(40);
+
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(
+        fs::read_to_string(&count).unwrap().lines().count(),
+        PDFS,
+        "each unique PDF must be parsed once in Phase A and replayed in Phase B"
+    );
+    assert_eq!(
+        crate::extract::pdf::replay_concurrency_maximum(),
+        2,
+        "eight general workers must not widen the two-worker PDF replay gate"
+    );
+    assert_eq!(endpoint.state.lock().unwrap().docs.len(), PDFS);
 }

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -68,8 +68,6 @@ pub fn run_cli() -> i32 {
 const GB: u64 = 1 << 30;
 const SAMPLE_LIMIT_BYTES: u64 = 4 << 20;
 const SQLDUMP_SAMPLE_LIMIT: u64 = 64 << 20;
-const PDF_EXTRACTION_SPOOL_BUDGET: u64 = 2 << 30;
-const PDF_EXTRACTION_SPOOL_COUNT: u64 = 512;
 
 #[cfg(test)]
 static REPLACEMENT_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
@@ -185,14 +183,24 @@ struct FileScan {
     /// Run-local PDF extraction produced during sampling. This is consumed by
     /// Phase B only when it is bound to the same full-content generation.
     pdf_spool: Option<extract::pdf::ExtractionSpool>,
-    pdf_spool_fallback: Option<String>,
+    pdf_spool_fallbacks: Vec<extract::pdf::SpoolFallback>,
 }
 
-fn take_pdf_spool_if_indexable<T>(spool: &mut Option<T>, is_junk: bool) -> Option<T> {
+fn take_pdf_spool_if_indexable<T>(
+    spool: &mut Option<T>,
+    is_junk: bool,
+    budget: &extract::pdf::ExtractionSpoolBudget,
+) -> Option<T> {
     if is_junk {
+        if spool.is_some() {
+            budget.record_discarded_before_replay();
+        }
         spool.take();
         None
     } else {
+        if spool.is_some() {
+            budget.record_phase_b_eligible();
+        }
         spool.take()
     }
 }
@@ -211,7 +219,7 @@ fn scan_file(
         sketches: Vec::new(),
         junk: None,
         pdf_spool: None,
-        pdf_spool_fallback: None,
+        pdf_spool_fallbacks: Vec::new(),
     };
     let sn = match sniff::sniff(path) {
         Ok(s) => s,
@@ -286,12 +294,20 @@ fn scan_file(
                 match content::verify(path, size, digest) {
                     Ok(()) => {
                         out.pdf_spool = spool;
-                        out.pdf_spool_fallback = fallback;
+                        out.pdf_spool_fallbacks.extend(fallback);
                     }
                     Err(error) => {
-                        out.pdf_spool_fallback = Some(format!(
-                            "source generation changed after extraction: {error:#}"
-                        ));
+                        if spool.is_some() {
+                            pdf_spool_budget.record_discarded_before_replay();
+                        }
+                        pdf_spool_budget.record_source_generation_changed();
+                        out.pdf_spool_fallbacks.extend(fallback);
+                        out.pdf_spool_fallbacks.push(extract::pdf::SpoolFallback {
+                            category: "source_generation_changed",
+                            message: format!(
+                                "source generation changed after extraction: {error:#}"
+                            ),
+                        });
                     }
                 }
                 Ok(stats)
@@ -715,10 +731,13 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     let mut clusters_rt: Option<Vec<dataset::Cluster>> = None;
     let mut pdf_spools: Vec<Option<extract::pdf::ExtractionSpool>> =
         (0..files.len()).map(|_| None).collect();
-    let pdf_spool_budget = extract::pdf::ExtractionSpoolBudget::new(
-        PDF_EXTRACTION_SPOOL_BUDGET,
-        PDF_EXTRACTION_SPOOL_COUNT,
-    );
+    let (pdf_spool_budget, pdf_spool_capacity_warning) =
+        extract::pdf::ExtractionSpoolBudget::for_state_dir(
+            &state_dir,
+            cfg.workers,
+            cfg.pdf_workers,
+            cfg.bulk_mb,
+        );
     let plan: Plan = if let Some(p) = journal.plan.clone() {
         p
     } else {
@@ -741,18 +760,26 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             })
             .collect();
 
-        let pdf_reparse_reasons: Vec<&str> = scans
-            .iter()
-            .filter_map(|scan| scan.pdf_spool_fallback.as_deref())
-            .collect();
+        let mut pdf_reparse_reasons: Vec<(&str, &extract::pdf::SpoolFallback)> = Vec::new();
+        for (index, scan) in scans.iter().enumerate() {
+            for fallback in &scan.pdf_spool_fallbacks {
+                pdf_reparse_reasons.push((files[index].rel.as_str(), fallback));
+            }
+        }
+        for (path, fallback) in &pdf_reparse_reasons {
+            pdf_spool_budget.record_fallback_example(path, fallback.category, &fallback.message);
+        }
         if !pdf_reparse_reasons.is_empty() && !cfg.quiet {
             eprintln!(
                 "phase A: {} PDF extraction(s) could not retain a bounded run-local artifact; \
                  phase B will parse them again safely",
                 pdf_reparse_reasons.len()
             );
-            for reason in pdf_reparse_reasons.iter().take(3) {
-                eprintln!("  PDF reuse fallback: {reason}");
+            if let Some(warning) = pdf_spool_capacity_warning.as_deref() {
+                eprintln!("  PDF reuse capacity: {warning}");
+            }
+            for (path, fallback) in pdf_reparse_reasons.iter().take(3) {
+                eprintln!("  PDF reuse fallback for {path}: {}", fallback.message);
             }
             if pdf_reparse_reasons.len() > 3 {
                 eprintln!(
@@ -771,7 +798,11 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 .as_ref()
                 .map(|s| s.family)
                 .unwrap_or(Family::Binary);
-            pdf_spools[i] = take_pdf_spool_if_indexable(&mut sc.pdf_spool, sc.junk.is_some());
+            pdf_spools[i] = take_pdf_spool_if_indexable(
+                &mut sc.pdf_spool,
+                sc.junk.is_some(),
+                &pdf_spool_budget,
+            );
             if let Some((status, reason)) = sc.junk {
                 junk_files.push(JunkFile {
                     file_key: keys[i].clone(),
@@ -1163,7 +1194,16 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         }
     }
 
-    let queue = Mutex::new(todo);
+    // Move each optional artifact into its sole Phase-B job. A replay cannot
+    // be retried or retained accidentally after staging begins.
+    let queue = Mutex::new(
+        todo.into_iter()
+            .map(|index| {
+                let spool = pdf_spools[index].take();
+                (index, spool)
+            })
+            .collect::<Vec<_>>(),
+    );
     let mut paths_by_key: HashMap<String, Vec<String>> = files
         .iter()
         .zip(keys.iter())
@@ -1188,8 +1228,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         for _ in 0..cfg.workers.min(n_todo.max(1)) {
             scope.spawn(|| {
                 loop {
-                    let i = match queue.lock().unwrap().pop() {
-                        Some(i) => i,
+                    let (i, pdf_spool) = match queue.lock().unwrap().pop() {
+                        Some(job) => job,
                         None => break,
                     };
                     let f = &files[i];
@@ -1381,9 +1421,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             true
                         };
                         let res = if sn.family == Family::Pdf {
-                            match pdf_spools[i].as_ref() {
+                            match pdf_spool {
                                 Some(spool) => spool.replay(f.size, expected_digest, &mut sink),
-                                None => extract::extract(&f.path, &sn, None, &mut sink),
+                                None => {
+                                    pdf_spool_budget.record_reparse();
+                                    extract::extract(&f.path, &sn, None, &mut sink)
+                                }
                             }
                         } else {
                             extract::extract(&f.path, &sn, None, &mut sink)
@@ -1945,6 +1988,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         "wall_seconds": (wall * 10.0).round() / 10.0,
         "workers": cfg.workers,
         "semantic": !cfg.no_semantic,
+        "pdf_extraction_reuse": pdf_spool_budget.report(),
     });
     if let Some(g) = &graph_summary {
         run_doc["graph"] = g.clone();

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -188,6 +188,15 @@ struct FileScan {
     pdf_spool_fallback: Option<String>,
 }
 
+fn take_pdf_spool_if_indexable<T>(spool: &mut Option<T>, is_junk: bool) -> Option<T> {
+    if is_junk {
+        spool.take();
+        None
+    } else {
+        spool.take()
+    }
+}
+
 fn scan_file(
     path: &Path,
     size: u64,
@@ -757,12 +766,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         let mut sketches = Vec::new();
         let mut junk_files = Vec::new();
         for (i, mut sc) in scans.into_iter().enumerate() {
-            pdf_spools[i] = sc.pdf_spool.take();
             let family = sc
                 .sniffed
                 .as_ref()
                 .map(|s| s.family)
                 .unwrap_or(Family::Binary);
+            pdf_spools[i] = take_pdf_spool_if_indexable(&mut sc.pdf_spool, sc.junk.is_some());
             if let Some((status, reason)) = sc.junk {
                 junk_files.push(JunkFile {
                     file_key: keys[i].clone(),

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -68,6 +68,8 @@ pub fn run_cli() -> i32 {
 const GB: u64 = 1 << 30;
 const SAMPLE_LIMIT_BYTES: u64 = 4 << 20;
 const SQLDUMP_SAMPLE_LIMIT: u64 = 64 << 20;
+const PDF_EXTRACTION_SPOOL_BUDGET: u64 = 2 << 30;
+const PDF_EXTRACTION_SPOOL_COUNT: u64 = 512;
 
 #[cfg(test)]
 static REPLACEMENT_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
@@ -180,13 +182,27 @@ struct FileScan {
     /// group → (field accs, sampled record count)
     sketches: Vec<(Option<String>, HashMap<String, infer::FieldAcc>, u64)>,
     junk: Option<(String, String)>, // (status, reason)
+    /// Run-local PDF extraction produced during sampling. This is consumed by
+    /// Phase B only when it is bound to the same full-content generation.
+    pdf_spool: Option<extract::pdf::ExtractionSpool>,
+    pdf_spool_fallback: Option<String>,
 }
 
-fn scan_file(path: &Path, size: u64, sample: usize, max_file_gb: u64) -> FileScan {
+fn scan_file(
+    path: &Path,
+    size: u64,
+    digest: &str,
+    state_dir: &Path,
+    pdf_spool_budget: &std::sync::Arc<extract::pdf::ExtractionSpoolBudget>,
+    sample: usize,
+    max_file_gb: u64,
+) -> FileScan {
     let mut out = FileScan {
         sniffed: None,
         sketches: Vec::new(),
         junk: None,
+        pdf_spool: None,
+        pdf_spool_fallback: None,
     };
     let sn = match sniff::sniff(path) {
         Ok(s) => s,
@@ -245,7 +261,38 @@ fn scan_file(path: &Path, size: u64, sample: usize, max_file_gb: u64) -> FileSca
             (entry.1 as usize) < sample
         }
     };
-    match extract::extract(path, &sn, limit, &mut sink) {
+    let extraction = if sn.family == Family::Pdf {
+        match extract::pdf::extract_and_spool(
+            path,
+            state_dir,
+            size,
+            digest,
+            pdf_spool_budget,
+            &mut sink,
+        ) {
+            Ok((stats, spool, fallback)) => {
+                // The inventory digest was computed before Phase A. Only hand
+                // bytes to Phase B when the source still matches that exact
+                // generation after the parser has finished reading it.
+                match content::verify(path, size, digest) {
+                    Ok(()) => {
+                        out.pdf_spool = spool;
+                        out.pdf_spool_fallback = fallback;
+                    }
+                    Err(error) => {
+                        out.pdf_spool_fallback = Some(format!(
+                            "source generation changed after extraction: {error:#}"
+                        ));
+                    }
+                }
+                Ok(stats)
+            }
+            Err(error) => Err(error),
+        }
+    } else {
+        extract::extract(path, &sn, limit, &mut sink)
+    };
+    match extraction {
         Ok(stats) => {
             if groups.is_empty() {
                 out.junk = Some((
@@ -657,6 +704,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     // ── Phase A: inference (skipped when a frozen plan exists) ──────────
     let mut clusters_rt: Option<Vec<dataset::Cluster>> = None;
+    let mut pdf_spools: Vec<Option<extract::pdf::ExtractionSpool>> =
+        (0..files.len()).map(|_| None).collect();
+    let pdf_spool_budget = extract::pdf::ExtractionSpoolBudget::new(
+        PDF_EXTRACTION_SPOOL_BUDGET,
+        PDF_EXTRACTION_SPOOL_COUNT,
+    );
     let plan: Plan = if let Some(p) = journal.plan.clone() {
         p
     } else {
@@ -665,13 +718,46 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         }
         let scans: Vec<FileScan> = files
             .par_iter()
-            .map(|f| scan_file(&f.path, f.size, cfg.sample, cfg.max_file_gb))
+            .zip(digests.par_iter())
+            .map(|(f, digest)| {
+                scan_file(
+                    &f.path,
+                    f.size,
+                    digest,
+                    &state_dir,
+                    &pdf_spool_budget,
+                    cfg.sample,
+                    cfg.max_file_gb,
+                )
+            })
             .collect();
+
+        let pdf_reparse_reasons: Vec<&str> = scans
+            .iter()
+            .filter_map(|scan| scan.pdf_spool_fallback.as_deref())
+            .collect();
+        if !pdf_reparse_reasons.is_empty() && !cfg.quiet {
+            eprintln!(
+                "phase A: {} PDF extraction(s) could not retain a bounded run-local artifact; \
+                 phase B will parse them again safely",
+                pdf_reparse_reasons.len()
+            );
+            for reason in pdf_reparse_reasons.iter().take(3) {
+                eprintln!("  PDF reuse fallback: {reason}");
+            }
+            if pdf_reparse_reasons.len() > 3 {
+                eprintln!(
+                    "  … and {} more PDF reuse fallback(s)",
+                    pdf_reparse_reasons.len() - 3
+                );
+            }
+        }
 
         let rels: Vec<String> = files.iter().map(|f| f.rel.clone()).collect();
         let mut sketches = Vec::new();
         let mut junk_files = Vec::new();
-        for (i, sc) in scans.into_iter().enumerate() {
+        for (i, mut sc) in scans.into_iter().enumerate() {
+            pdf_spools[i] = sc.pdf_spool.take();
             let family = sc
                 .sniffed
                 .as_ref()
@@ -1051,11 +1137,21 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // start first and can't serialize the end of the run.
     todo.sort_by_key(|&i| files[i].size);
     let n_todo = todo.len();
+    let n_pdf_spools = todo
+        .iter()
+        .filter(|&&index| pdf_spools[index].is_some())
+        .count();
     if !cfg.quiet {
         eprintln!(
             "phase B: indexing {} files with {} workers → {}",
             n_todo, cfg.workers, cfg.url
         );
+        if n_pdf_spools > 0 {
+            eprintln!(
+                "phase B: reusing {n_pdf_spools} run-local PDF extraction(s); these PDFs will not \
+                 be parsed a second time"
+            );
+        }
     }
 
     let queue = Mutex::new(todo);
@@ -1275,7 +1371,14 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             }
                             true
                         };
-                        let res = extract::extract(&f.path, &sn, None, &mut sink);
+                        let res = if sn.family == Family::Pdf {
+                            match pdf_spools[i].as_ref() {
+                                Some(spool) => spool.replay(f.size, expected_digest, &mut sink),
+                                None => extract::extract(&f.path, &sn, None, &mut sink),
+                            }
+                        } else {
+                            extract::extract(&f.path, &sn, None, &mut sink)
+                        };
                         match res {
                             Ok(stats) => {
                                 file_junk += stats.junk;

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -198,9 +198,6 @@ fn take_pdf_spool_if_indexable<T>(
         spool.take();
         None
     } else {
-        if spool.is_some() {
-            budget.record_phase_b_eligible();
-        }
         spool.take()
     }
 }
@@ -291,23 +288,30 @@ fn scan_file(
                 // The inventory digest was computed before Phase A. Only hand
                 // bytes to Phase B when the source still matches that exact
                 // generation after the parser has finished reading it.
-                match content::verify(path, size, digest) {
-                    Ok(()) => {
-                        out.pdf_spool = spool;
-                        out.pdf_spool_fallbacks.extend(fallback);
-                    }
-                    Err(error) => {
-                        if spool.is_some() {
-                            pdf_spool_budget.record_discarded_before_replay();
+                // If no reusable artifact exists, avoid a second full-file
+                // read: Phase B performs the authoritative generation check
+                // immediately before its ordinary reparse.
+                if spool.is_none() {
+                    out.pdf_spool_fallbacks.extend(fallback);
+                } else {
+                    match content::verify(path, size, digest) {
+                        Ok(()) => {
+                            out.pdf_spool = spool;
+                            out.pdf_spool_fallbacks.extend(fallback);
                         }
-                        pdf_spool_budget.record_source_generation_changed();
-                        out.pdf_spool_fallbacks.extend(fallback);
-                        out.pdf_spool_fallbacks.push(extract::pdf::SpoolFallback {
-                            category: "source_generation_changed",
-                            message: format!(
-                                "source generation changed after extraction: {error:#}"
-                            ),
-                        });
+                        Err(error) => {
+                            if spool.is_some() {
+                                pdf_spool_budget.record_discarded_before_replay();
+                            }
+                            pdf_spool_budget.record_source_generation_changed();
+                            out.pdf_spool_fallbacks.extend(fallback);
+                            out.pdf_spool_fallbacks.push(extract::pdf::SpoolFallback {
+                                category: "source_generation_changed",
+                                message: format!(
+                                    "source generation changed after extraction: {error:#}"
+                                ),
+                            });
+                        }
                     }
                 }
                 Ok(stats)
@@ -769,7 +773,15 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         for (path, fallback) in &pdf_reparse_reasons {
             pdf_spool_budget.record_fallback_example(path, fallback.category, &fallback.message);
         }
-        if !pdf_reparse_reasons.is_empty() && !cfg.quiet {
+        if !pdf_reparse_reasons.is_empty()
+            && !cfg.quiet
+            && pdf_spool_budget.platform_reuse_is_unavailable()
+        {
+            eprintln!(
+                "phase A: run-local PDF extraction reuse is unavailable on this platform; \
+                 phase B will use the normal parser"
+            );
+        } else if !pdf_reparse_reasons.is_empty() && !cfg.quiet {
             eprintln!(
                 "phase A: {} PDF extraction(s) could not retain a bounded run-local artifact; \
                  phase B will parse them again safely",
@@ -1011,6 +1023,18 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         // created in this process can prove that its first publication is
         // genuinely fresh and skip the delete round trip.
         cleanup_required.extend(todo.iter().map(|&i| keys[i].clone()));
+    }
+    let todo_set: std::collections::HashSet<usize> = todo.iter().copied().collect();
+    for (index, spool) in pdf_spools.iter_mut().enumerate() {
+        if spool.is_none() {
+            continue;
+        }
+        if todo_set.contains(&index) {
+            pdf_spool_budget.record_phase_b_eligible();
+        } else {
+            pdf_spool_budget.record_discarded_before_replay();
+            spool.take();
+        }
     }
     // Every publication, including a fresh one, receives durable intent
     // before its first bulk. A failed fresh publication therefore skips the
@@ -1422,7 +1446,29 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                         };
                         let res = if sn.family == Family::Pdf {
                             match pdf_spool {
-                                Some(spool) => spool.replay(f.size, expected_digest, &mut sink),
+                                Some(spool) => {
+                                    match spool.replay(f.size, expected_digest, &mut sink) {
+                                        Ok(stats) => Ok(stats),
+                                        Err(replay_error) => {
+                                            // Replay verifies the complete
+                                            // artifact before `deliver`
+                                            // invokes the sink, so falling
+                                            // back here cannot duplicate a
+                                            // partially staged record stream.
+                                            pdf_spool_budget
+                                                .record_replay_fallback(&f.rel, &replay_error);
+                                            pdf_spool_budget.record_reparse();
+                                            extract::extract(&f.path, &sn, None, &mut sink)
+                                                .with_context(|| {
+                                                    format!(
+                                                        "reparse {} after run-local PDF artifact \
+                                                         verification failed: {replay_error:#}",
+                                                        f.rel
+                                                    )
+                                                })
+                                        }
+                                    }
+                                }
                                 None => {
                                     pdf_spool_budget.record_reparse();
                                     extract::extract(&f.path, &sn, None, &mut sink)


### PR DESCRIPTION
## Summary

This change makes fresh PDF autoindexing reuse the complete Phase-A extraction result during Phase B instead of launching the PDF parser a second time. The optimization is transparent: users keep running the ordinary `xerj autoindex <folder>` command, and constrained or unsupported environments automatically fall back to the existing Phase-B parse path.

The implementation treats reuse as an optional bounded acceleration, not as correctness-critical state. It verifies the source generation, physical artifact length, digest, worker protocol identity, and JSON payload before replay. A failed verification publishes no records and no `file_done` marker.

## Why

Before this change, every accepted PDF was parsed once for discovery/inference and again for indexing. Real financial reports make PDF extraction material enough that this duplicated work dominates a meaningful part of foreground autoindex latency.

The goal is narrowly algorithmic: remove the redundant parser invocation while preserving the same extracted records, index mapping, restart behavior, unchanged-rescan behavior, and safe recovery path.

## User experience

No new command or setup step is required.

```console
xerj autoindex ./reports --url http://localhost:9200 --workers 1 --pdf-workers 4
```

When bounded reuse is available, autoindex retains verified anonymous extraction artifacts between its discovery and indexing phases. When disk or descriptor capacity cannot be measured conservatively, capacity is insufficient, an artifact cannot be created, or an I/O operation fails, autoindex records a typed diagnostic and reparses that PDF using the established path.

The final `--json` result includes `pdf_extraction_reuse` counters so agents and operators can see parser calls, verified replays, fallback categories, exact retained bytes, and current/peak ownership without inferring behavior from timing.

## Design

- Retain complete PDF worker responses in anonymous temporary files after Phase A.
- Bound retained plus in-flight responses to 384 MiB and independently cap artifact handles from live descriptor capacity.
- Preserve a 4 GiB-or-half-free filesystem floor for correctness-critical journal and Phase-B staging work.
- Recheck Linux filesystem and descriptor snapshots at every admission using the actual general-worker, PDF-worker, and bulk settings.
- Consume each artifact exactly once and physically close/refund it before unbounded Phase-B staging proceeds.
- Verify generation, length, digest, protocol identity, and JSON before delivering any replayed record.
- Keep corruption fail-closed; capacity and ordinary I/O limitations use the existing reparse path.
- Expose bounded, claim-safe counters and at most three path examples.

Linux provides the live `/proc` and `RLIMIT_NOFILE` probes used for conservative admission. Other platforms retain correct indexing behavior by declining this optional optimization when equivalent live descriptor evidence is unavailable.

## Repeated real-document result

The preregistered campaign used the canonical FinanceBench-20 corpus: 20 paths, 19 unique accepted PDFs, and 6,641 indexed page records. Both arms used fresh isolated data/state/ports, `--workers 1 --pdf-workers 4 --bulk-mb 1`, and the same explicitly enabled ONNX model and tokenizer. The counterbalanced order was candidate, baseline, baseline, candidate.

| Arm | External wall: immediately before autoindex through fresh-run map | Product-reported autoindex wall |
|---|---:|---:|
| Candidate 1 | 130.342 s | 129.4 s |
| Baseline 1 | 157.084 s | 156.2 s |
| Baseline 2 | 162.629 s | 161.7 s |
| Candidate 2 | 128.972 s | 128.2 s |

The candidate improved external wall time by 17.02% and 20.70% in the two pairs; the median paired improvement was 18.86%. Product-reported improvements were 17.16% and 20.72%; the median paired improvement was 18.94%.

Both candidate runs reported 19 Phase-A PDF parser calls, zero Phase-B PDF parses, 19 verified replays, zero integrity failures, zero capacity fallbacks, zero I/O fallbacks, and zero retained artifacts/bytes after completion. Exact artifact content totaled 12,103,569 bytes. Peak retained/reserved ownership was 44,706,658 and 44,527,534 bytes.

Every arm retained exactly 6,641 documents and the same mapping. Every non-vector source field, document ID, restart snapshot, and unchanged-rescan snapshot matched. Both candidate unchanged rescans invoked the PDF parser zero times.

## Exact serialization result and quality audit

The preregistered byte-level source gate failed and is intentionally not rewritten as a pass. JSON-decoded vector values differed below `f32` precision across arms, and similar variation also occurred between repeated runs of the same arm.

A follow-up quantitative audit compared 4,915 vectors and 1,887,360 scalar coordinates. Zero coordinates differed after conversion to the intended `f32` representation. The largest JSON-decoded absolute delta was `1.3234889800848443e-23`; mean cosine similarity was 1.0 and minimum cosine similarity was 0.9999999999999998. All 15 semantic probes returned the exact same ordered top-10 IDs, scores, and passage provenance.

Therefore the honest result is: the preregistered exact serialized-JSON gate failed, while the quantitative vector and retrieval quality audit is a GO. The variation is not uniquely attributable to parse-once because it also appears within baseline repeats and within candidate repeats.

## Correctness and failure coverage

The focused suite covers:

- exact-limit and limit-plus-one admission;
- concurrent reservation and replay bounds;
- actual low-`RLIMIT_NOFILE` fallback on Linux;
- injected disk and descriptor pressure;
- multi-megabyte artifacts;
- I/O refusal and capacity fallback accounting;
- same-size source mutation;
- source-generation mismatch;
- physical length and digest mismatch;
- worker protocol mismatch;
- replay JSON corruption;
- verified-but-junk PDFs;
- publication retry and restart;
- cleanup and current/peak ownership accounting.

## Final gates at exact head

Head: `6c8ada8e6537783fe3259996b6a68456034047e7`

Base: `76d8bb02bc1f1aa9dffcf2eb41ccd8d4c9bee6d6` (`origin/main` at final validation)

- `cargo fmt --all --check`: pass
- `cargo clippy -p xerj-autoindex --all-targets --all-features -- -D warnings`: pass
- `cargo test -p xerj-autoindex --all-features`: 230 passed, 0 failed
- ES-YAML conformance against the exact-head server: 1,365 passed, 0 failed, 3 skipped
- `git diff --check origin/main...HEAD`: pass

All local validation used non-fat development/test builds. The conformance server was the sealed exact-head candidate binary with SHA-256 `60bc9a863aac2275a2ed1c75968cf38da1c50be9871756d83bb45455070bf761`.

## Scope

The branch changes only:

- `engine/crates/xerj-autoindex/src/cli.rs`
- `engine/crates/xerj-autoindex/src/extract/pdf.rs`
- `engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs`
- `engine/crates/xerj-autoindex/src/lib.rs`

It does not change PDF extraction semantics, embedding models, query ranking, default embedding mode, server indexing APIs, or the journal’s correctness contract.

## Evidence

The local evidence bundle contains the preregistration, per-arm raw commands/stdout/stderr/server logs, monotonic timing windows, stable per-ID/per-field snapshots, restart/rescan evidence, compact campaign summary, and vector-quality audit:

`/workspace/north-star-evidence/pdf-parse-once-ab-v1/claim-grade-fb20/`
root@Xerj-Audit:/workspace# cat user-feedback/PDF_PARSE_ONCE_PR_BODY.md
## Summary

This change makes fresh PDF autoindexing reuse the complete Phase-A extraction result during Phase B instead of launching the PDF parser a second time. The optimization is transparent: users keep running the ordinary `xerj autoindex <folder>` command, and constrained or unsupported environments automatically fall back to the existing Phase-B parse path.

The implementation treats reuse as an optional bounded acceleration, not as correctness-critical state. It verifies the source generation, physical artifact length, digest, worker protocol identity, and JSON payload before replay. A failed verification publishes no records and no `file_done` marker.

## Why

Before this change, every accepted PDF was parsed once for discovery/inference and again for indexing. Real financial reports make PDF extraction material enough that this duplicated work dominates a meaningful part of foreground autoindex latency.

The goal is narrowly algorithmic: remove the redundant parser invocation while preserving the same extracted records, index mapping, restart behavior, unchanged-rescan behavior, and safe recovery path.

## User experience

No new command or setup step is required.

```console
xerj autoindex ./reports --url http://localhost:9200 --workers 1 --pdf-workers 4
```

When bounded reuse is available, autoindex retains verified anonymous extraction artifacts between its discovery and indexing phases. When disk or descriptor capacity cannot be measured conservatively, capacity is insufficient, an artifact cannot be created, or an I/O operation fails, autoindex records a typed diagnostic and reparses that PDF using the established path.

The final `--json` result includes `pdf_extraction_reuse` counters so agents and operators can see parser calls, verified replays, fallback categories, exact retained bytes, and current/peak ownership without inferring behavior from timing.

## Design

- Retain complete PDF worker responses in anonymous temporary files after Phase A.
- Bound retained plus in-flight responses to 384 MiB and independently cap artifact handles from live descriptor capacity.
- Preserve a 4 GiB-or-half-free filesystem floor for correctness-critical journal and Phase-B staging work.
- Recheck Linux filesystem and descriptor snapshots at every admission using the actual general-worker, PDF-worker, and bulk settings.
- Consume each artifact exactly once and physically close/refund it before unbounded Phase-B staging proceeds.
- Verify generation, length, digest, protocol identity, and JSON before delivering any replayed record.
- Keep corruption fail-closed; capacity and ordinary I/O limitations use the existing reparse path.
- Expose bounded, claim-safe counters and at most three path examples.

Linux provides the live `/proc` and `RLIMIT_NOFILE` probes used for conservative admission. Other platforms retain correct indexing behavior by declining this optional optimization when equivalent live descriptor evidence is unavailable.

## Repeated real-document result

The preregistered campaign used the canonical FinanceBench-20 corpus: 20 paths, 19 unique accepted PDFs, and 6,641 indexed page records. Both arms used fresh isolated data/state/ports, `--workers 1 --pdf-workers 4 --bulk-mb 1`, and the same explicitly enabled ONNX model and tokenizer. The counterbalanced order was candidate, baseline, baseline, candidate.

| Arm | External wall: immediately before autoindex through fresh-run map | Product-reported autoindex wall |
|---|---:|---:|
| Candidate 1 | 130.342 s | 129.4 s |
| Baseline 1 | 157.084 s | 156.2 s |
| Baseline 2 | 162.629 s | 161.7 s |
| Candidate 2 | 128.972 s | 128.2 s |

The candidate improved external wall time by 17.02% and 20.70% in the two pairs; the median paired improvement was 18.86%. Product-reported improvements were 17.16% and 20.72%; the median paired improvement was 18.94%.

Both candidate runs reported 19 Phase-A PDF parser calls, zero Phase-B PDF parses, 19 verified replays, zero integrity failures, zero capacity fallbacks, zero I/O fallbacks, and zero retained artifacts/bytes after completion. Exact artifact content totaled 12,103,569 bytes. Peak retained/reserved ownership was 44,706,658 and 44,527,534 bytes.

Every arm retained exactly 6,641 documents and the same mapping. Every non-vector source field, document ID, restart snapshot, and unchanged-rescan snapshot matched. Both candidate unchanged rescans invoked the PDF parser zero times.

## Exact serialization result and quality audit

The preregistered byte-level source gate failed and is intentionally not rewritten as a pass. JSON-decoded vector values differed below `f32` precision across arms, and similar variation also occurred between repeated runs of the same arm.

A follow-up quantitative audit compared 4,915 vectors and 1,887,360 scalar coordinates. Zero coordinates differed after conversion to the intended `f32` representation. The largest JSON-decoded absolute delta was `1.3234889800848443e-23`; mean cosine similarity was 1.0 and minimum cosine similarity was 0.9999999999999998. All 15 semantic probes returned the exact same ordered top-10 IDs, scores, and passage provenance.

Therefore the honest result is: the preregistered exact serialized-JSON gate failed, while the quantitative vector and retrieval quality audit is a GO. The variation is not uniquely attributable to parse-once because it also appears within baseline repeats and within candidate repeats.

## Correctness and failure coverage

The focused suite covers:

- exact-limit and limit-plus-one admission;
- concurrent reservation and replay bounds;
- actual low-`RLIMIT_NOFILE` fallback on Linux;
- injected disk and descriptor pressure;
- multi-megabyte artifacts;
- I/O refusal and capacity fallback accounting;
- same-size source mutation;
- source-generation mismatch;
- physical length and digest mismatch;
- worker protocol mismatch;
- replay JSON corruption;
- verified-but-junk PDFs;
- publication retry and restart;
- cleanup and current/peak ownership accounting.

## Final gates at exact head

Head: `6c8ada8e6537783fe3259996b6a68456034047e7`

Base: `76d8bb02bc1f1aa9dffcf2eb41ccd8d4c9bee6d6` (`origin/main` at final validation)

- `cargo fmt --all --check`: pass
- `cargo clippy -p xerj-autoindex --all-targets --all-features -- -D warnings`: pass
- `cargo test -p xerj-autoindex --all-features`: 230 passed, 0 failed
- ES-YAML conformance against the exact-head server: 1,365 passed, 0 failed, 3 skipped
- `git diff --check origin/main...HEAD`: pass

All local validation used non-fat development/test builds. The conformance server was the sealed exact-head candidate binary with SHA-256 `60bc9a863aac2275a2ed1c75968cf38da1c50be9871756d83bb45455070bf761`.

## Scope

The branch changes only:

- `engine/crates/xerj-autoindex/src/cli.rs`
- `engine/crates/xerj-autoindex/src/extract/pdf.rs`
- `engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs`
- `engine/crates/xerj-autoindex/src/lib.rs`

It does not change PDF extraction semantics, embedding models, query ranking, default embedding mode, server indexing APIs, or the journal’s correctness contract.

## Evidence

The local evidence bundle contains the preregistration, per-arm raw commands/stdout/stderr/server logs, monotonic timing windows, stable per-ID/per-field snapshots, restart/rescan evidence, compact campaign summary, and vector-quality audit:

`/workspace/north-star-evidence/pdf-parse-once-ab-v1/claim-grade-fb20/`