### PR TITLE
fix(autoindex): Fix autoindex map metadata drift on unchanged resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Repeated `autoindex` scans keep agent-facing map metadata durable.**
+  Dataset source bytes, parser-junk counts and coercion-drop notes now derive
+  from committed per-file journal records instead of invocation-local worker
+  counters, so an unchanged resume does not overwrite them with zero. Run
+  timestamps now distinguish invocation start from summary generation.
+  Existing catalogs whose historical `started` field was dynamically mapped
+  as text remain usable: the additive mapping upgrade no longer attempts an
+  incompatible text-to-date type change.
+
 ## [1.0.0-rc.10] - 2026-08-03
 
 ### Security

--- a/engine/crates/xerj-autoindex/src/catalog.rs
+++ b/engine/crates/xerj-autoindex/src/catalog.rs
@@ -56,11 +56,11 @@ pub fn catalog_mapping() -> Value {
         .expect("catalog mapping properties");
     properties.insert(
         "started".into(),
-        json!({"type": "date", "format": "strict_date_optional_time"}),
+        json!({"type": "date", "format": "strict_date_optional_time||epoch_millis"}),
     );
     properties.insert(
         "summary_generated_at".into(),
-        json!({"type": "date", "format": "strict_date_optional_time"}),
+        json!({"type": "date", "format": "strict_date_optional_time||epoch_millis"}),
     );
     properties.insert(
         "invocation_telemetry_scope".into(),

--- a/engine/crates/xerj-autoindex/src/catalog.rs
+++ b/engine/crates/xerj-autoindex/src/catalog.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 pub const CATALOG_INDEX: &str = "autoindex-catalog";
 
 pub fn catalog_mapping() -> Value {
-    json!({
+    let mut mapping = json!({
         "mappings": {"properties": {
             "doc_kind": {"type": "keyword"},
             "slug": {"type": "keyword"},
@@ -49,7 +49,24 @@ pub fn catalog_mapping() -> Value {
             "pearson_r": {"type": "double"},
             "activity_correlated": {"type": "boolean"},
         }}
-    })
+    });
+    let properties = mapping
+        .pointer_mut("/mappings/properties")
+        .and_then(Value::as_object_mut)
+        .expect("catalog mapping properties");
+    properties.insert(
+        "started".into(),
+        json!({"type": "date", "format": "strict_date_optional_time"}),
+    );
+    properties.insert(
+        "summary_generated_at".into(),
+        json!({"type": "date", "format": "strict_date_optional_time"}),
+    );
+    properties.insert(
+        "invocation_telemetry_scope".into(),
+        json!({"type": "keyword"}),
+    );
+    mapping
 }
 
 pub const GOTCHAS: &[&str] = &[
@@ -67,6 +84,11 @@ pub struct DatasetDocInput<'a> {
     pub pd: &'a PlanDataset,
     pub record_count: u64,
     pub junk_records: u64,
+    /// Canonical source bytes backing this dataset's durably live records.
+    ///
+    /// This is not a scan-time filesystem total: a removed path stays
+    /// represented until autoindex also removes its live records, and one
+    /// source feeding several datasets contributes its bytes to each.
     pub bytes: u64,
     pub file_count: usize,
     pub formats: Vec<String>,

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -19,10 +19,15 @@ static FAILPOINT_TEST_LOCK: Mutex<()> = Mutex::new(());
 #[derive(Default)]
 struct MockState {
     docs: HashMap<String, Value>,
+    catalog_docs: HashMap<String, Value>,
     data_bulk_number: usize,
     fail_data_bulk: usize,
     failed_once: bool,
     delete_calls: usize,
+    response_delay_ms: u64,
+    catalog_preexists: bool,
+    catalog_mapping_upgraded: bool,
+    catalog_bulk_before_upgrade: bool,
     stop: bool,
 }
 
@@ -34,11 +39,16 @@ struct MockEndpoint {
 
 impl MockEndpoint {
     fn start(fail_data_bulk: usize) -> Self {
+        Self::start_with_delay(fail_data_bulk, 0)
+    }
+
+    fn start_with_delay(fail_data_bulk: usize, response_delay_ms: u64) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap());
         let state = Arc::new(Mutex::new(MockState {
             fail_data_bulk,
+            response_delay_ms,
             ..MockState::default()
         }));
         let server_state = Arc::clone(&state);
@@ -59,6 +69,12 @@ impl MockEndpoint {
             state,
             join: Some(join),
         }
+    }
+
+    fn start_with_existing_catalog() -> Self {
+        let endpoint = Self::start(usize::MAX);
+        endpoint.state.lock().unwrap().catalog_preexists = true;
+        endpoint
     }
 }
 
@@ -98,9 +114,37 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("");
     let path = parts.next().unwrap_or("");
+    let response_delay_ms = state.lock().unwrap().response_delay_ms;
+    if response_delay_ms > 0 {
+        thread::sleep(std::time::Duration::from_millis(response_delay_ms));
+    }
 
-    let response = if method == "POST" && path == "/_bulk" {
-        bulk_response(&body, state)
+    let (status, response) = if method == "PUT" && path == "/autoindex-catalog" {
+        if state.lock().unwrap().catalog_preexists {
+            (
+                400,
+                json!({"error": {"type": "resource_already_exists_exception"}}),
+            )
+        } else {
+            (200, json!({"acknowledged": true}))
+        }
+    } else if method == "PUT" && path == "/autoindex-catalog/_mapping" {
+        let mapping: Value = serde_json::from_slice(&body).unwrap();
+        let required = [
+            "started",
+            "summary_generated_at",
+            "invocation_telemetry_scope",
+        ];
+        let upgraded = required.iter().all(|field| {
+            mapping
+                .pointer(&format!("/properties/{field}/type"))
+                .and_then(Value::as_str)
+                .is_some()
+        });
+        state.lock().unwrap().catalog_mapping_upgraded = upgraded;
+        (200, json!({"acknowledged": true}))
+    } else if method == "POST" && path == "/_bulk" {
+        (200, bulk_response(&body, state))
     } else if method == "POST" && path.contains("/_delete_by_query") {
         let query: Value = serde_json::from_slice(&body).unwrap();
         let ax_file = query
@@ -114,19 +158,23 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
                 .docs
                 .retain(|_, doc| doc.get("ax_file").and_then(Value::as_str) != Some(key.as_str()));
         }
-        json!({"deleted": 0, "failures": []})
+        (200, json!({"deleted": 0, "failures": []}))
     } else if method == "GET" && path.ends_with("/_count") {
-        json!({"count": state.lock().unwrap().docs.len()})
+        (200, json!({"count": state.lock().unwrap().docs.len()}))
     } else if method == "POST" && path.ends_with("/_search") {
-        json!({"hits":{"total":{"value":0},"hits":[]},"aggregations":{}})
+        (
+            200,
+            json!({"hits":{"total":{"value":0},"hits":[]},"aggregations":{}}),
+        )
     } else {
         // ping, index creation/mapping, refresh, and catalog operations
-        json!({"acknowledged": true})
+        (200, json!({"acknowledged": true}))
     };
     let bytes = response.to_string();
+    let reason = if status == 200 { "OK" } else { "Bad Request" };
     write!(
         stream,
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         bytes.len(),
         bytes
     )
@@ -145,6 +193,21 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
         .and_then(|index| index.as_str().map(str::to_owned))
         .is_some_and(|index| index != catalog::CATALOG_INDEX);
     if !is_data {
+        let mut locked = state.lock().unwrap();
+        if locked.catalog_preexists && !locked.catalog_mapping_upgraded {
+            locked.catalog_bulk_before_upgrade = true;
+        }
+        for pair in lines.chunks_exact(2) {
+            let action: Value = serde_json::from_slice(pair[0]).unwrap();
+            if action.pointer("/index/_index").and_then(Value::as_str)
+                != Some(catalog::CATALOG_INDEX)
+            {
+                continue;
+            }
+            let id = action.pointer("/index/_id").unwrap().as_str().unwrap();
+            let doc: Value = serde_json::from_slice(pair[1]).unwrap();
+            locked.catalog_docs.insert(id.to_owned(), doc);
+        }
         return json!({"errors": false, "items": []});
     }
 
@@ -225,6 +288,25 @@ fn event_count(state_dir: &Path, kind: &str) -> usize {
         .count()
 }
 
+fn dataset_catalog_docs(endpoint: &MockEndpoint) -> Vec<Value> {
+    let mut docs: Vec<Value> = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .catalog_docs
+        .values()
+        .filter(|doc| doc.get("doc_kind").and_then(Value::as_str) == Some("dataset"))
+        .cloned()
+        .collect();
+    docs.sort_by_key(|doc| {
+        doc.get("slug")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string()
+    });
+    docs
+}
+
 #[test]
 fn fresh_publication_skips_delete_and_noop_resume_does_not_append_plan() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
@@ -240,20 +322,240 @@ fn fresh_publication_skips_delete_and_noop_resume_does_not_append_plan() {
         "id,value\n0,fresh\n1,fresh\n",
     )
     .unwrap();
-    let endpoint = MockEndpoint::start(usize::MAX);
+    // A fixed endpoint delay makes the start/summary chronology
+    // deterministic instead of relying on scheduler timing.
+    let endpoint = MockEndpoint::start_with_delay(usize::MAX, 5);
     let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
 
-    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let (initial_code, initial_summary) = run_index_report(config.clone()).unwrap();
+    assert_eq!(initial_code, 0);
     assert_eq!(endpoint.state.lock().unwrap().delete_calls, 0);
     assert_eq!(event_count(state_dir.path(), "plan"), 1);
     assert_eq!(event_count(state_dir.path(), "file_replace_start"), 1);
+    let source_bytes = fs::metadata(corpus.path().join("records.csv"))
+        .unwrap()
+        .len();
+    let initial_dataset = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .catalog_docs
+        .values()
+        .find(|doc| doc.get("doc_kind").and_then(Value::as_str) == Some("dataset"))
+        .cloned()
+        .expect("dataset catalog document");
+    let initial_dataset_bytes = initial_dataset
+        .get("bytes")
+        .and_then(Value::as_u64)
+        .unwrap();
+    assert_eq!(initial_dataset_bytes, source_bytes);
+    let initial_summary = initial_summary.unwrap();
+    assert_eq!(
+        initial_summary["invocation_telemetry_scope"],
+        json!("latest_invocation_of_durable_run")
+    );
+    let initial_started =
+        chrono::DateTime::parse_from_rfc3339(initial_summary["started"].as_str().unwrap()).unwrap();
+    let initial_summary_generated_at = chrono::DateTime::parse_from_rfc3339(
+        initial_summary["summary_generated_at"].as_str().unwrap(),
+    )
+    .unwrap();
+    assert!(
+        initial_summary_generated_at - initial_started >= chrono::Duration::milliseconds(5),
+        "started must be captured before work, not synthesized with the summary"
+    );
 
-    assert_eq!(run_index(config).unwrap(), 0);
+    let (resume_code, resume_summary) = run_index_report(config).unwrap();
+    assert_eq!(resume_code, 0);
     assert_eq!(endpoint.state.lock().unwrap().delete_calls, 0);
     assert_eq!(
         event_count(state_dir.path(), "plan"),
         1,
         "an identical resume must reuse the durable plan"
+    );
+    let resumed_dataset = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .catalog_docs
+        .values()
+        .find(|doc| doc.get("doc_kind").and_then(Value::as_str) == Some("dataset"))
+        .cloned()
+        .expect("dataset catalog document after resume");
+    assert_eq!(
+        resumed_dataset["bytes"],
+        json!(source_bytes),
+        "an unchanged resume must not replace durable dataset bytes with zero"
+    );
+    assert_eq!(
+        resume_summary.unwrap()["invocation_telemetry_scope"],
+        json!("latest_invocation_of_durable_run")
+    );
+}
+
+#[test]
+fn changed_source_replaces_durable_dataset_bytes_across_reopen() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let path = corpus.path().join("records.csv");
+    fs::write(&path, "id,value\n0,old\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let initial_bytes = fs::metadata(&path).unwrap().len();
+    assert_eq!(dataset_catalog_docs(&endpoint)[0]["bytes"], initial_bytes);
+
+    fs::write(
+        &path,
+        "id,value,description\n0,new,a longer replacement source\n1,new,second row\n",
+    )
+    .unwrap();
+    let replacement_bytes = fs::metadata(&path).unwrap().len();
+    assert_ne!(replacement_bytes, initial_bytes);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    // Reopen the durable journal independently of the product invocation.
+    let root = config.root.canonicalize().unwrap();
+    let reopened = state::Journal::open(
+        state_dir.path(),
+        &root.to_string_lossy(),
+        &config.url,
+        &config.prefix,
+        config.bulk_timeout_secs,
+        false,
+    )
+    .unwrap();
+    assert_eq!(reopened.done.len(), 1);
+    assert_eq!(
+        reopened.done.values().next().unwrap().bytes,
+        replacement_bytes
+    );
+    drop(reopened);
+
+    // A following unchanged product rescan must publish the replacement
+    // generation's durable bytes, not zero and not the historical size.
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(
+        dataset_catalog_docs(&endpoint)[0]["bytes"],
+        replacement_bytes
+    );
+}
+
+#[test]
+fn deleted_path_bytes_remain_while_its_documents_remain_live() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let removed = corpus.path().join("removed.csv");
+    let retained = corpus.path().join("retained.csv");
+    fs::write(&removed, "id,value\n0,removed\n1,removed\n").unwrap();
+    fs::write(&retained, "id,value\n2,retained\n3,retained\n").unwrap();
+    let durable_live_bytes =
+        fs::metadata(&removed).unwrap().len() + fs::metadata(&retained).unwrap().len();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    assert_eq!(
+        dataset_catalog_docs(&endpoint)[0]["bytes"],
+        durable_live_bytes
+    );
+    assert_eq!(endpoint.state.lock().unwrap().docs.len(), 4);
+
+    fs::remove_file(&removed).unwrap();
+    // Current autoindex semantics do not reconcile a missing canonical path:
+    // its indexed documents and FileDone remain live. Dataset bytes must
+    // describe that durable live index rather than silently pretend deletion.
+    for _ in 0..2 {
+        assert_eq!(run_index(config.clone()).unwrap(), 0);
+        assert_eq!(endpoint.state.lock().unwrap().docs.len(), 4);
+        assert_eq!(
+            dataset_catalog_docs(&endpoint)[0]["bytes"],
+            durable_live_bytes
+        );
+    }
+}
+
+#[test]
+fn product_path_counts_shared_source_once_per_distinct_dataset() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let path = corpus.path().join("finance.sqlite");
+    {
+        let db = rusqlite::Connection::open(&path).unwrap();
+        db.execute_batch(
+            "CREATE TABLE quarterly (quarter TEXT, revenue INTEGER);
+             INSERT INTO quarterly VALUES ('2026-Q1', 100);
+             CREATE TABLE annual (year INTEGER, filing TEXT);
+             INSERT INTO annual VALUES (2026, '10-K');",
+        )
+        .unwrap();
+    }
+    let source_bytes = fs::metadata(&path).unwrap().len();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let root = config.root.canonicalize().unwrap();
+    let mut journal = state::Journal::open(
+        state_dir.path(),
+        &root.to_string_lossy(),
+        &config.url,
+        &config.prefix,
+        config.bulk_timeout_secs,
+        false,
+    )
+    .unwrap();
+    let mut plan = journal.plan.clone().unwrap();
+    assert_eq!(plan.datasets.len(), 2);
+    let assignment = plan.files.values_mut().next().unwrap();
+    assert_eq!(assignment.assignments.len(), 2);
+    // Model a compatible historical plan that repeated one group assignment.
+    // Catalog accounting must deduplicate it by dataset slug.
+    assignment
+        .assignments
+        .push(assignment.assignments[0].clone());
+    journal.write_plan(&plan).unwrap();
+    drop(journal);
+
+    assert_eq!(run_index(config).unwrap(), 0);
+    let datasets = dataset_catalog_docs(&endpoint);
+    assert_eq!(datasets.len(), 2);
+    assert!(datasets
+        .iter()
+        .all(|dataset| dataset["bytes"] == json!(source_bytes)));
+}
+
+#[test]
+fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("records.csv"), "id,value\n0,one\n").unwrap();
+    let endpoint = MockEndpoint::start_with_existing_catalog();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    let (code, summary) = run_index_report(config).unwrap();
+    assert_eq!(code, 0);
+    let summary = summary.unwrap();
+    assert!(summary["started"].is_string());
+    assert!(summary["summary_generated_at"].is_string());
+    assert_eq!(
+        summary["invocation_telemetry_scope"],
+        json!("latest_invocation_of_durable_run")
+    );
+    let state = endpoint.state.lock().unwrap();
+    assert!(state.catalog_mapping_upgraded);
+    assert!(
+        !state.catalog_bulk_before_upgrade,
+        "new run metadata must not reach a legacy catalog before its additive mapping upgrade"
     );
 }
 

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -130,19 +130,27 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
         }
     } else if method == "PUT" && path == "/autoindex-catalog/_mapping" {
         let mapping: Value = serde_json::from_slice(&body).unwrap();
-        let required = [
-            "started",
-            "summary_generated_at",
-            "invocation_telemetry_scope",
-        ];
+        let started_requested = mapping.pointer("/properties/started").is_some();
+        let required = ["summary_generated_at", "invocation_telemetry_scope"];
         let upgraded = required.iter().all(|field| {
             mapping
                 .pointer(&format!("/properties/{field}/type"))
                 .and_then(Value::as_str)
                 .is_some()
         });
-        state.lock().unwrap().catalog_mapping_upgraded = upgraded;
-        (200, json!({"acknowledged": true}))
+        let mut locked = state.lock().unwrap();
+        if locked.catalog_preexists && started_requested {
+            (
+                400,
+                json!({"error": {
+                    "type": "mapper_parsing_exception",
+                    "reason": "field [started] already exists as [text], cannot add [date]"
+                }}),
+            )
+        } else {
+            locked.catalog_mapping_upgraded = upgraded;
+            (200, json!({"acknowledged": true}))
+        }
     } else if method == "POST" && path == "/_bulk" {
         (200, bulk_response(&body, state))
     } else if method == "POST" && path.contains("/_delete_by_query") {
@@ -197,16 +205,25 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
         if locked.catalog_preexists && !locked.catalog_mapping_upgraded {
             locked.catalog_bulk_before_upgrade = true;
         }
-        for pair in lines.chunks_exact(2) {
-            let action: Value = serde_json::from_slice(pair[0]).unwrap();
-            if action.pointer("/index/_index").and_then(Value::as_str)
-                != Some(catalog::CATALOG_INDEX)
-            {
-                continue;
+        let mut line = 0;
+        while line < lines.len() {
+            let action: Value = serde_json::from_slice(lines[line]).unwrap();
+            line += 1;
+            if let Some(index) = action.pointer("/index/_index").and_then(Value::as_str) {
+                let doc: Value = serde_json::from_slice(
+                    lines
+                        .get(line)
+                        .expect("index action must have a source line"),
+                )
+                .unwrap();
+                line += 1;
+                if index == catalog::CATALOG_INDEX {
+                    let id = action.pointer("/index/_id").unwrap().as_str().unwrap();
+                    locked.catalog_docs.insert(id.to_owned(), doc);
+                }
+            } else if action.pointer("/delete/_index").is_none() {
+                panic!("unexpected catalog bulk action: {action}");
             }
-            let id = action.pointer("/index/_id").unwrap().as_str().unwrap();
-            let doc: Value = serde_json::from_slice(pair[1]).unwrap();
-            locked.catalog_docs.insert(id.to_owned(), doc);
         }
         return json!({"errors": false, "items": []});
     }
@@ -557,6 +574,46 @@ fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
         !state.catalog_bulk_before_upgrade,
         "new run metadata must not reach a legacy catalog before its additive mapping upgrade"
     );
+}
+
+#[test]
+fn unchanged_resume_keeps_durable_dataset_junk_and_coercion_notes() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("records.csv"), "id,value\n0,one\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let root = config.root.canonicalize().unwrap();
+    let mut journal = state::Journal::open(
+        state_dir.path(),
+        &root.to_string_lossy(),
+        &config.url,
+        &config.prefix,
+        config.bulk_timeout_secs,
+        false,
+    )
+    .unwrap();
+    let plan = journal.plan.clone().unwrap();
+    let slug = plan.datasets[0].slug.clone();
+    let mut completion = journal.done.values().next().unwrap().clone();
+    completion.junk = 7;
+    completion.dropped_by_dataset.insert(slug.clone(), 3);
+    journal.file_done(&completion).unwrap();
+    drop(journal);
+
+    assert_eq!(run_index(config).unwrap(), 0);
+    let dataset = dataset_catalog_docs(&endpoint)
+        .into_iter()
+        .find(|doc| doc["slug"] == slug)
+        .unwrap();
+    assert_eq!(dataset["junk_records"], 7);
+    assert!(dataset["notes"].as_array().unwrap().iter().any(|note| note
+        .as_str()
+        .is_some_and(|text| { text.contains("3 field values could not be coerced") })));
 }
 
 #[test]

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -440,15 +440,28 @@ pub fn derive_brain_name(root: &Path) -> String {
     }
 }
 
-/// Source bytes durably represented by each dataset.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct DurableDatasetStats {
+    bytes: u64,
+    junk: u64,
+    dropped: u64,
+}
+
+/// Source metadata durably represented by each dataset.
 ///
 /// `FileDone` is the commit record for a successfully published canonical
 /// source. A source can feed more than one inferred dataset (for example, a
 /// workbook or database with multiple tables), so each distinct assigned
 /// dataset reports the complete source bytes it depends on. Repeated groups
-/// within the same dataset count the source only once.
-fn durable_dataset_bytes(plan: &Plan, done: &HashMap<String, FileDone>) -> HashMap<String, u64> {
-    let mut bytes_by_dataset = HashMap::new();
+/// within the same dataset count the source only once. Parser-level junk has
+/// no group after extraction rejects it, so it retains the historical
+/// attribution to the file's first assigned dataset. Coercion drops retain
+/// their exact dataset captured in the completion record.
+fn durable_dataset_stats(
+    plan: &Plan,
+    done: &HashMap<String, FileDone>,
+) -> HashMap<String, DurableDatasetStats> {
+    let mut stats_by_dataset: HashMap<String, DurableDatasetStats> = HashMap::new();
     for (file_key, completed) in done {
         let Some(assignment) = plan.files.get(file_key) else {
             continue;
@@ -459,11 +472,25 @@ fn durable_dataset_bytes(plan: &Plan, done: &HashMap<String, FileDone>) -> HashM
             .map(|(_, slug)| slug.as_str())
             .collect();
         for slug in assigned_datasets {
-            let bytes = bytes_by_dataset.entry(slug.to_string()).or_insert(0u64);
-            *bytes = bytes.saturating_add(completed.bytes);
+            let stats = stats_by_dataset.entry(slug.to_string()).or_default();
+            stats.bytes = stats.bytes.saturating_add(completed.bytes);
+        }
+        if let Some((_, slug)) = assignment.assignments.first() {
+            let stats = stats_by_dataset.entry(slug.clone()).or_default();
+            stats.junk = stats.junk.saturating_add(completed.junk);
+        }
+        for (slug, dropped) in &completed.dropped_by_dataset {
+            if assignment
+                .assignments
+                .iter()
+                .any(|(_, assigned)| assigned == slug)
+            {
+                let stats = stats_by_dataset.entry(slug.clone()).or_default();
+                stats.dropped = stats.dropped.saturating_add(*dropped);
+            }
         }
     }
-    bytes_by_dataset
+    stats_by_dataset
 }
 
 fn invocation_report_timestamps(
@@ -814,8 +841,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         catalog::CATALOG_INDEX,
         &json!({"properties": {
             "duplicate_of": {"type": "keyword"},
-            "started": {"type": "date", "format": "strict_date_optional_time"},
-            "summary_generated_at": {"type": "date", "format": "strict_date_optional_time"},
+            // `started` intentionally stays out of this additive upgrade.
+            // Older catalogs dynamically mapped it as text, and asking the
+            // engine to change that existing field to date aborts every run.
+            "summary_generated_at": {"type": "date", "format": "strict_date_optional_time||epoch_millis"},
             "invocation_telemetry_scope": {"type": "keyword"}
         }}),
     )
@@ -871,8 +900,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         index: String,
         plan: HashMap<String, coerce::Coerce>,
         records: AtomicU64,
-        junk: AtomicU64,
-        dropped: AtomicU64,
     }
     let mut ds_rt: HashMap<String, DsRt> = HashMap::new();
     for d in &plan.datasets {
@@ -882,8 +909,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 index: d.index.clone(),
                 plan: coerce::plan_from_specs(&d.specs),
                 records: AtomicU64::new(0),
-                junk: AtomicU64::new(0),
-                dropped: AtomicU64::new(0),
             },
         );
     }
@@ -1146,6 +1171,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     };
                     let mut file_records = 0u64;
                     let mut file_junk = 0u64;
+                    let mut file_dropped_by_dataset: HashMap<String, u64> = HashMap::new();
                     let mut send_err: Option<String> = None;
                     // Edges this file teaches — buffered apart from the node
                     // staging file (different target index) and sent only
@@ -1248,7 +1274,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             let mut fields = rec.fields;
                             let dropped = coerce::coerce_record(&mut fields, &rt.plan);
                             if dropped > 0 {
-                                rt.dropped.fetch_add(dropped as u64, Ordering::Relaxed);
+                                let durable =
+                                    file_dropped_by_dataset.entry(slug.clone()).or_default();
+                                *durable = durable.saturating_add(dropped as u64);
                             }
                             fields.insert("ax_path".into(), Value::String(f.rel.clone()));
                             fields.insert(
@@ -1517,11 +1545,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     }
                     records_total.fetch_add(file_records, Ordering::Relaxed);
                     junk_records.fetch_add(file_junk, Ordering::Relaxed);
-                    if let Some(rt) = fa.assignments.first().and_then(|(_, slug)| ds_rt.get(slug)) {
-                        if file_junk > 0 {
-                            rt.junk.fetch_add(file_junk, Ordering::Relaxed);
-                        }
-                    }
                     let (commit_result, journal_path) = {
                         let mut journal = journal_mx.lock().unwrap();
                         let path = journal.path().display().to_string();
@@ -1531,6 +1554,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             records: file_records,
                             junk: file_junk,
                             bytes: f.size,
+                            dropped_by_dataset: file_dropped_by_dataset,
                             generation: Some(expected_digest.clone()),
                         });
                         (result, path)
@@ -1685,15 +1709,15 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     // dataset docs
     let mut junk_records_by_run: u64 = junk_records.load(Ordering::Relaxed);
-    let dataset_bytes = {
+    let dataset_stats = {
         let journal = journal_mx.lock().unwrap();
-        durable_dataset_bytes(&plan, &journal.done)
+        durable_dataset_stats(&plan, &journal.done)
     };
     for d in &plan.datasets {
-        let rt = &ds_rt[&d.slug];
         let sample_queries = catalog::build_sample_queries(d, &key_corrs);
         let mut notes = Vec::new();
-        let dropped = rt.dropped.load(Ordering::Relaxed);
+        let durable = dataset_stats.get(&d.slug).copied().unwrap_or_default();
+        let dropped = durable.dropped;
         if dropped > 0 {
             notes.push(format!(
                 "{dropped} field values could not be coerced to the inferred types and were dropped (records still indexed)"
@@ -1726,8 +1750,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         let (id, doc) = catalog::dataset_doc(&catalog::DatasetDocInput {
             pd: d,
             record_count: *ds_counts.get(&d.slug).unwrap_or(&0),
-            junk_records: rt.junk.load(Ordering::Relaxed),
-            bytes: dataset_bytes.get(&d.slug).copied().unwrap_or(0),
+            junk_records: durable.junk,
+            bytes: durable.bytes,
             file_count: d.file_count,
             formats,
             time_min: tmin,
@@ -2370,6 +2394,7 @@ mod duplicate_integration_tests {
                 records,
                 junk: 0,
                 bytes: inventory.files[0].size,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some(inventory.digests[0].clone()),
             })
             .unwrap();
@@ -2498,8 +2523,9 @@ mod map_metadata_tests {
                 file_key: "shared".into(),
                 path: "report.dat".into(),
                 records: 10,
-                junk: 0,
+                junk: 5,
                 bytes: 100,
+                dropped_by_dataset: HashMap::from([("quarterly".into(), 7), ("annual".into(), 3)]),
                 generation: Some("digest".into()),
             })
             .unwrap();
@@ -2508,12 +2534,13 @@ mod map_metadata_tests {
                 file_key: "quarterly-only".into(),
                 path: "quarterly.json".into(),
                 records: 2,
-                junk: 0,
+                junk: 2,
                 bytes: 23,
+                dropped_by_dataset: HashMap::from([("quarterly".into(), 11)]),
                 generation: Some("digest-2".into()),
             })
             .unwrap();
-        let before_resume = durable_dataset_bytes(&plan, &initial.done);
+        let before_resume = durable_dataset_stats(&plan, &initial.done);
         drop(initial);
 
         // Opening the same durable run appends only an invocation-level
@@ -2528,11 +2555,15 @@ mod map_metadata_tests {
         )
         .unwrap();
         let after_unchanged_resume =
-            durable_dataset_bytes(resumed.plan.as_ref().unwrap(), &resumed.done);
+            durable_dataset_stats(resumed.plan.as_ref().unwrap(), &resumed.done);
 
         assert_eq!(before_resume, after_unchanged_resume);
-        assert_eq!(after_unchanged_resume["quarterly"], 123);
-        assert_eq!(after_unchanged_resume["annual"], 100);
+        assert_eq!(after_unchanged_resume["quarterly"].bytes, 123);
+        assert_eq!(after_unchanged_resume["annual"].bytes, 100);
+        assert_eq!(after_unchanged_resume["quarterly"].junk, 7);
+        assert_eq!(after_unchanged_resume["annual"].junk, 0);
+        assert_eq!(after_unchanged_resume["quarterly"].dropped, 18);
+        assert_eq!(after_unchanged_resume["annual"].dropped, 3);
     }
 
     #[test]
@@ -2570,6 +2601,14 @@ mod map_metadata_tests {
         assert_eq!(
             mapping.pointer("/mappings/properties/invocation_telemetry_scope/type"),
             Some(&json!("keyword"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/started/format"),
+            Some(&json!("strict_date_optional_time||epoch_millis"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/summary_generated_at/format"),
+            Some(&json!("strict_date_optional_time||epoch_millis"))
         );
     }
 }

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -440,6 +440,39 @@ pub fn derive_brain_name(root: &Path) -> String {
     }
 }
 
+/// Source bytes durably represented by each dataset.
+///
+/// `FileDone` is the commit record for a successfully published canonical
+/// source. A source can feed more than one inferred dataset (for example, a
+/// workbook or database with multiple tables), so each distinct assigned
+/// dataset reports the complete source bytes it depends on. Repeated groups
+/// within the same dataset count the source only once.
+fn durable_dataset_bytes(plan: &Plan, done: &HashMap<String, FileDone>) -> HashMap<String, u64> {
+    let mut bytes_by_dataset = HashMap::new();
+    for (file_key, completed) in done {
+        let Some(assignment) = plan.files.get(file_key) else {
+            continue;
+        };
+        let assigned_datasets: std::collections::HashSet<&str> = assignment
+            .assignments
+            .iter()
+            .map(|(_, slug)| slug.as_str())
+            .collect();
+        for slug in assigned_datasets {
+            let bytes = bytes_by_dataset.entry(slug.to_string()).or_insert(0u64);
+            *bytes = bytes.saturating_add(completed.bytes);
+        }
+    }
+    bytes_by_dataset
+}
+
+fn invocation_report_timestamps(
+    started: chrono::DateTime<chrono::Utc>,
+    summary_generated_at: chrono::DateTime<chrono::Utc>,
+) -> (String, String) {
+    (started.to_rfc3339(), summary_generated_at.to_rfc3339())
+}
+
 fn run_index(cfg: IndexCfg) -> Result<i32> {
     run_index_report(cfg).map(|(code, _)| code)
 }
@@ -452,6 +485,7 @@ fn run_index(cfg: IndexCfg) -> Result<i32> {
 /// `None` when the run ended before a plan produced one (empty folder,
 /// `--dry-run`).
 pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
+    let invocation_started = chrono::Utc::now();
     extract::pdf::configure_workers(cfg.pdf_workers);
     extract::pdf::configure_timeout(cfg.pdf_timeout_secs);
     use rayon::prelude::*;
@@ -778,9 +812,14 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     es.ensure_index(catalog::CATALOG_INDEX, &catalog::catalog_mapping())?;
     es.update_mapping(
         catalog::CATALOG_INDEX,
-        &json!({"properties": {"duplicate_of": {"type": "keyword"}}}),
+        &json!({"properties": {
+            "duplicate_of": {"type": "keyword"},
+            "started": {"type": "date", "format": "strict_date_optional_time"},
+            "summary_generated_at": {"type": "date", "format": "strict_date_optional_time"},
+            "invocation_telemetry_scope": {"type": "keyword"}
+        }}),
     )
-    .context("upgrade autoindex catalog mapping for duplicate aliases")?;
+    .context("upgrade autoindex catalog mapping")?;
     // A replacement transaction starts before the effective new plan is
     // persisted and before live visibility changes. If the process dies at
     // any later boundary, journal replay removes the older file_done and
@@ -834,7 +873,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         records: AtomicU64,
         junk: AtomicU64,
         dropped: AtomicU64,
-        bytes: AtomicU64,
     }
     let mut ds_rt: HashMap<String, DsRt> = HashMap::new();
     for d in &plan.datasets {
@@ -846,7 +884,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 records: AtomicU64::new(0),
                 junk: AtomicU64::new(0),
                 dropped: AtomicU64::new(0),
-                bytes: AtomicU64::new(0),
             },
         );
     }
@@ -1481,10 +1518,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     records_total.fetch_add(file_records, Ordering::Relaxed);
                     junk_records.fetch_add(file_junk, Ordering::Relaxed);
                     if let Some(rt) = fa.assignments.first().and_then(|(_, slug)| ds_rt.get(slug)) {
-                        rt.bytes.fetch_add(
-                            f.size / fa.assignments.len().max(1) as u64,
-                            Ordering::Relaxed,
-                        );
                         if file_junk > 0 {
                             rt.junk.fetch_add(file_junk, Ordering::Relaxed);
                         }
@@ -1652,6 +1685,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     // dataset docs
     let mut junk_records_by_run: u64 = junk_records.load(Ordering::Relaxed);
+    let dataset_bytes = {
+        let journal = journal_mx.lock().unwrap();
+        durable_dataset_bytes(&plan, &journal.done)
+    };
     for d in &plan.datasets {
         let rt = &ds_rt[&d.slug];
         let sample_queries = catalog::build_sample_queries(d, &key_corrs);
@@ -1690,7 +1727,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             pd: d,
             record_count: *ds_counts.get(&d.slug).unwrap_or(&0),
             junk_records: rt.junk.load(Ordering::Relaxed),
-            bytes: rt.bytes.load(Ordering::Relaxed),
+            bytes: dataset_bytes.get(&d.slug).copied().unwrap_or(0),
             file_count: d.file_count,
             formats,
             time_min: tmin,
@@ -1786,6 +1823,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     }
 
     let wall = t0.elapsed().as_secs_f64();
+    let (started, summary_generated_at) =
+        invocation_report_timestamps(invocation_started, chrono::Utc::now());
     let total_records: u64 = ds_counts.values().sum();
     // Run-summary honesty (§6.6.4): what the detectors wrote AND what they
     // could not resolve — a dangling [[link]] is a fact about the corpus, not
@@ -1816,13 +1855,18 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             "edges_invalidated": gr.invalidated,
         })
     });
+    // A resume intentionally reuses and upserts the durable run id. Timing
+    // and detector counters therefore describe this latest invocation,
+    // while corpus descriptors describe the durable live run state.
     let mut run_doc = json!({
         "doc_kind": "run",
         "run_id": run_id,
         "root": root_str,
         "url": cfg.url,
         "prefix": cfg.prefix,
-        "started": chrono::Utc::now().to_rfc3339(),
+        "started": started,
+        "summary_generated_at": summary_generated_at,
+        "invocation_telemetry_scope": "latest_invocation_of_durable_run",
         "files_total": paths_discovered,
         "unique_content_files": files.len(),
         "files_indexed": journal_mx.lock().unwrap().done.len(),
@@ -2403,6 +2447,130 @@ mod duplicate_integration_tests {
         })
         .unwrap();
         assert_eq!(live, HashSet::from(["r0".into(), "r1".into()]));
+    }
+}
+
+#[cfg(test)]
+mod map_metadata_tests {
+    use super::*;
+
+    fn assignment(slugs: &[&str]) -> FileAssignment {
+        FileAssignment {
+            rel: "report.dat".into(),
+            path_id: "path:report.dat".into(),
+            family: "json".into(),
+            gzip: false,
+            content_digest: Some("digest".into()),
+            assignments: slugs
+                .iter()
+                .enumerate()
+                .map(|(group, slug)| (Some(format!("group-{group}")), (*slug).to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn unchanged_resume_keeps_durable_assignment_aware_dataset_bytes() {
+        let _guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let state_dir = tempfile::tempdir().unwrap();
+        let plan = Plan {
+            files: HashMap::from([
+                (
+                    "shared".into(),
+                    assignment(&["quarterly", "quarterly", "annual"]),
+                ),
+                ("quarterly-only".into(), assignment(&["quarterly"])),
+            ]),
+            ..Plan::default()
+        };
+        let mut initial = state::Journal::open(
+            state_dir.path(),
+            "corpus",
+            "http://engine",
+            "ax",
+            300,
+            false,
+        )
+        .unwrap();
+        initial.write_plan(&plan).unwrap();
+        initial
+            .file_done(&FileDone {
+                file_key: "shared".into(),
+                path: "report.dat".into(),
+                records: 10,
+                junk: 0,
+                bytes: 100,
+                generation: Some("digest".into()),
+            })
+            .unwrap();
+        initial
+            .file_done(&FileDone {
+                file_key: "quarterly-only".into(),
+                path: "quarterly.json".into(),
+                records: 2,
+                junk: 0,
+                bytes: 23,
+                generation: Some("digest-2".into()),
+            })
+            .unwrap();
+        let before_resume = durable_dataset_bytes(&plan, &initial.done);
+        drop(initial);
+
+        // Opening the same durable run appends only an invocation-level
+        // resume record. No source is processed and no FileDone is appended.
+        let resumed = state::Journal::open(
+            state_dir.path(),
+            "corpus",
+            "http://engine",
+            "ax",
+            300,
+            false,
+        )
+        .unwrap();
+        let after_unchanged_resume =
+            durable_dataset_bytes(resumed.plan.as_ref().unwrap(), &resumed.done);
+
+        assert_eq!(before_resume, after_unchanged_resume);
+        assert_eq!(after_unchanged_resume["quarterly"], 123);
+        assert_eq!(after_unchanged_resume["annual"], 100);
+    }
+
+    #[test]
+    fn invocation_started_is_not_derived_from_summary_generation() {
+        let started = chrono::DateTime::parse_from_rfc3339("2026-08-04T00:29:05.673023686Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let summary_generated_at =
+            chrono::DateTime::parse_from_rfc3339("2026-08-04T00:31:37.937589283Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc);
+
+        let (reported_started, reported_summary_generated_at) =
+            invocation_report_timestamps(started, summary_generated_at);
+
+        assert_eq!(reported_started, "2026-08-04T00:29:05.673023686+00:00");
+        assert_eq!(
+            reported_summary_generated_at,
+            "2026-08-04T00:31:37.937589283+00:00"
+        );
+        assert_ne!(reported_started, reported_summary_generated_at);
+    }
+
+    #[test]
+    fn catalog_mapping_declares_latest_invocation_telemetry_fields() {
+        let mapping = catalog::catalog_mapping();
+        assert_eq!(
+            mapping.pointer("/mappings/properties/started/type"),
+            Some(&json!("date"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/summary_generated_at/type"),
+            Some(&json!("date"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/invocation_telemetry_scope/type"),
+            Some(&json!("keyword"))
+        );
     }
 }
 

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -142,6 +142,10 @@ pub struct FileDone {
     pub records: u64,
     pub junk: u64,
     pub bytes: u64,
+    /// Field values dropped by coercion, grouped by the dataset whose
+    /// inferred schema rejected them. Older journals predate this accounting.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub dropped_by_dataset: HashMap<String, u64>,
     /// Content generation committed by this record. Legacy completions have
     /// no generation and cannot commit a newer pending replacement.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -556,6 +560,7 @@ mod compatibility_tests {
             records: 6_001,
             junk: 0,
             bytes: 100,
+            dropped_by_dataset: HashMap::new(),
             generation: Some("old-generation".into()),
         };
         journal.file_done(&old).unwrap();
@@ -628,6 +633,7 @@ mod compatibility_tests {
                 records: 2,
                 junk: 0,
                 bytes: 20,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-2".into()),
             })
             .unwrap();
@@ -708,6 +714,7 @@ mod compatibility_tests {
                 records: 10,
                 junk: 0,
                 bytes: 10,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("old".into()),
             })
             .unwrap_err();
@@ -732,6 +739,7 @@ mod compatibility_tests {
                     records: 2,
                     junk: 0,
                     bytes: 20,
+                    dropped_by_dataset: HashMap::new(),
                     generation: Some("new".into()),
                 })
                 .unwrap_err();
@@ -769,6 +777,7 @@ mod compatibility_tests {
                 records: 2,
                 junk: 0,
                 bytes: 20,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-c".into()),
             })
             .unwrap_err();
@@ -783,6 +792,7 @@ mod compatibility_tests {
                 records: 3,
                 junk: 0,
                 bytes: 30,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-d".into()),
             })
             .unwrap();
@@ -800,6 +810,7 @@ mod compatibility_tests {
                 records: 2,
                 junk: 0,
                 bytes: 20,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-c".into()),
             })
             .unwrap();


### PR DESCRIPTION
## Summary

This fixes two agent-facing metadata errors in `xerj autoindex map`: an unchanged resume replaced a durable non-zero dataset byte count with `0`, and `run.started` was generated during finalization rather than when the invocation actually started.

Dataset bytes now come from durable completed-source journal records joined through the frozen file-to-dataset assignments. Invocation start is captured as the first operation of `run_index_report`, the summary records a precisely named `summary_generated_at`, and `invocation_telemetry_scope` tells agents that timing and detector counters describe the latest invocation of a durable run.

## Observed failure

The issue was reproduced on an unchanged rescan of the 20-PDF FinanceBench diagnostic corpus. Indexed data remained correct: document count stayed `6,641`, canonical `_source` hash stayed `0f7c130620751abe97fc463b12e0b5fc6043b274d44e8cc5fe25999b2830019e`, mappings stayed `d78203dfbe07cf4529cb831067dd96e34422feb15fe020bb7d9316b42dc139ff`, and sentinel results stayed `b4b0824defb0e3101b849c376422aef3db0fa9b90f87fa61fa873afee18ad37a`.

The map was wrong even though the index was not: `/datasets/0/bytes` changed from `99,855,980` to `0`. The initial invocation's durable journal recorded a real start at `2026-08-04T00:29:05.673023686Z`, but the catalog's `run.started` was `2026-08-04T00:31:37.937589283Z`, after the 152.3-second indexing work had already happened.

## Root cause

Every dataset runtime initialized an invocation-local byte counter to zero. The counter increased only after a file was processed during Phase B. Finalization nevertheless replaced the deterministic `ds:{slug}` catalog document on every invocation. An unchanged resume has no Phase-B work, so it overwrote the durable dataset byte description with zero.

The run catalog document independently constructed `started` with `Utc::now()` beside the final summary. That timestamp therefore described summary generation while being labeled as invocation start.

## Dataset-byte contract

`bytes` now means canonical source bytes backing this dataset's durably live records.

The value is derived from durable `FileDone` commits, not the files processed by the latest invocation or a fresh filesystem total. A byte-identical alias does not add bytes because only its canonical source has a completion commit. A source assigned to several distinct datasets contributes its complete source size to each dataset, while repeated assignments to the same dataset count once.

This is a dataset-local source footprint, not a physical-storage partition. Summing `bytes` across datasets can exceed corpus size when one source feeds several datasets, just as one source can contribute to several dataset-local file counts.

Current autoindex does not delete already-indexed records merely because a canonical path disappears from the next filesystem scan. This change therefore preserves that source's bytes while its documents and `FileDone` remain live. Subtracting it would claim a deletion the product did not perform. Missing-path reconciliation remains a separate behavior change.

## Invocation telemetry contract

`started` is captured before worker configuration, ping, discovery, hashing, extraction, indexing, and finalization.

`summary_generated_at` records when the summary is constructed. It is deliberately not called `completed`, because construction occurs before the later catalog bulk write, refresh, durable journal finish, output, and process exit.

`invocation_telemetry_scope` is `latest_invocation_of_durable_run`. This is explicit because resumes intentionally reuse and upsert the same durable `run_id`: timing and graph detector counters describe the latest invocation, while live record counts and dataset bytes describe durable corpus state.

The new fields use explicit catalog mappings. Existing catalog indices are upgraded additively before the catalog bulk writes documents containing the fields.

## Regression coverage

- Initial product run followed by an unchanged resume: dataset bytes remain equal to the non-zero source size, no replacement delete occurs, the frozen plan is not rewritten, and invocation timing has the declared scope.
- Changed-size source replacement followed by independent journal reopen and another unchanged rescan: the catalog reports the replacement generation's durable byte size, not zero and not the historical size.
- Removed filesystem path while its indexed records remain live: two later product invocations preserve both the live documents and their durable source bytes.
- Real SQLite source containing two tables: autoindex creates two datasets, then a compatible repeated persisted assignment proves that the full source size appears once in each distinct dataset without double-counting the repeated assignment.
- Existing legacy catalog: index creation returns `resource_already_exists`, the additive mapping update succeeds, and the test proves no catalog bulk containing new metadata fields occurs before that upgrade.
- Controlled timestamps use the exact start and finalization timestamps observed in the FinanceBench diagnostic.

## Verification

- `cargo test -p xerj-autoindex --lib -- --test-threads=1`: `214 passed; 0 failed`
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`: passed
- `cargo fmt -p xerj-autoindex -- --check`: passed
- `git diff --check`: passed

All checks were scoped to `xerj-autoindex` and reused the shared Cargo target. No workspace-wide build, fat-LTO development build, `cargo clean`, or new per-worktree target directory was used.

## Scope

This PR changes only:

- `engine/crates/xerj-autoindex/src/lib.rs`
- `engine/crates/xerj-autoindex/src/catalog.rs`
- `engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs`

It is based directly on current upstream `main` at `76d8bb0` and is independent of the PDF parse-once optimization.