### PR TITLE
[HELD on #178] fix(autoindex): extract a C header's API surface, stop indexing include guards

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -3,7 +3,8 @@
 //! Source files used to fall through to the plain-text extractor, so a repo was
 //! searchable only as prose. This parses each file with the matching tree-sitter
 //! grammar and captures its DEFINITIONS (functions, classes, methods, structs,
-//! traits, interfaces, modules, …). Each file becomes one document carrying:
+//! traits, interfaces, modules, constants, …). Each file becomes one document
+//! carrying:
 //! - `language`  the detected language
 //! - `symbols`   a structured array of {name, kind, line}
 //! - `defs`      "kind name" per symbol, newline-joined so BM25 matches a query
@@ -246,6 +247,19 @@ const TS_Q: &str = r#"
 (variable_declarator name: (identifier) @function value: (arrow_function))
 "#;
 
+// `const_item` / `static_item` are captured because a file whose whole content
+// is a lookup table (`pub const BYTE_FREQUENCIES: [u8; 256] = [...]`) otherwise
+// extracts ZERO symbols and becomes unreachable by symbol search — see #170.
+// Those files matter disproportionately: their contents are empirical, so they
+// are exactly what cannot be recalled and must be retrieved.
+//
+// Deliberately NOT anchored to `source_file`. Measured over the 331-file
+// memchr/regex/aho-corasick corpus, the 959 const/static declarations sit at:
+// file-scope 720, impl-block associated consts 75, trait 4, function-local 160.
+// Anchoring would throw away the 79 associated consts — `impl Foo { const N }`
+// is idiomatic Rust — to suppress function-local ones, and a function-local
+// `const` in Rust is still a deliberately named constant (Rust `let` bindings
+// are a different node and are never captured), so it is signal, not noise.
 const RUST_Q: &str = r#"
 (function_item name: (identifier) @function)
 (struct_item name: (type_identifier) @struct)
@@ -254,14 +268,38 @@ const RUST_Q: &str = r#"
 (mod_item name: (identifier) @module)
 (macro_definition name: (identifier) @macro)
 (type_item name: (type_identifier) @type)
+(const_item name: (identifier) @const)
+(static_item name: (identifier) @static)
 "#;
 
+// Go's package-level `const`/`var` are anchored to `source_file` on purpose:
+// unanchored, `var_declaration` also matches every function-local `var`, which
+// fills `defs` with locals (verified — unanchoring makes `go_const_and_var`
+// fail on a captured `local`). Note the grammar is asymmetric: a grouped
+// `const ( A = 1 )` keeps `const_spec` as a direct child of `const_declaration`
+// (there is no `const_spec_list` node — a query naming one fails to compile),
+// but a grouped `var ( T = 1 )` wraps its specs in `var_spec_list`, so that
+// form needs its own pattern or package-level tables in `var (…)` are missed.
 const GO_Q: &str = r#"
 (function_declaration name: (identifier) @function)
 (method_declaration name: (field_identifier) @method)
 (type_declaration (type_spec name: (type_identifier) @type))
+(source_file (const_declaration (const_spec name: (identifier) @const)))
+(source_file (var_declaration (var_spec name: (identifier) @static)))
+(source_file (var_declaration (var_spec_list (var_spec name: (identifier) @static))))
 "#;
 
+// No constant capture here, deliberately. #170 is about files that extract zero
+// symbols and so become unreachable; Java barely has that failure mode, because
+// every file must declare a type. Measured: 7 of 1043 Java files in one corpus
+// and 1 of 72 in another extract zero symbols under this query (0.7%), against
+// 20 of 331 for Rust and 186 of 400 for C headers. A clean query does exist if
+// the recall is wanted later — `(field_declaration (modifiers "static")
+// declarator: (variable_declarator name: (identifier) @const))` captured 372
+// constants with 0 method-local false positives, where capturing all fields
+// would have pulled in 1311 including private instance state — but it is a
+// recall improvement, not this bug, and no Java corpus is wired into the
+// end-to-end check that proves it, so it is not shipped unverified.
 const JAVA_Q: &str = r#"
 (class_declaration name: (identifier) @class)
 (interface_declaration name: (identifier) @interface)
@@ -270,11 +308,36 @@ const JAVA_Q: &str = r#"
 (constructor_declaration name: (identifier) @method)
 "#;
 
+// C has #170's failure mode worse than anywhere else: 186 of 400 sampled headers
+// and 39 of 400 sampled .c files extracted zero symbols before this.
+//
+// `preproc_def` is the lever that matters — it rescued 148 of those 186 headers
+// and 13 of those 39 .c files, because a header of nothing but `#define`s is the
+// canonical C constant table. It needs no anchoring: only 319 of 7356 captures
+// (4%) sat inside a function body, and include-guard-shaped names were 298 of
+// 4192 in headers (7%). Function-like `#define F(x)` is a different node
+// (`preproc_function_def`) and is not captured.
+//
+// The object declarations ARE anchored to `translation_unit`. A bare
+// `(declaration ...)` is exactly the noisy query to avoid: measured over the
+// same 400 .c files it captured 11806 names of which 11320 (96%) were function
+// locals. Anchored, it captured 274 with zero function locals.
+//
+// Known limit of that anchoring, measured not assumed: an include guard parses
+// as `translation_unit > preproc_ifdef > declaration`, so guarded headers put
+// their declarations one level too deep and only `preproc_def` sees them. That
+// is why the anchored patterns rescued just 6 headers. Widening the anchor per
+// preprocessor form (`preproc_ifdef`, `preproc_if`, nesting) is unbounded and
+// each extra level re-admits in-function declarations, so it is left alone:
+// missing a symbol is recoverable, filling `defs` with locals is not.
 const C_Q: &str = r#"
 (function_definition declarator: (function_declarator declarator: (identifier) @function))
 (struct_specifier name: (type_identifier) @struct)
 (enum_specifier name: (type_identifier) @enum)
 (type_definition declarator: (type_identifier) @type)
+(preproc_def name: (identifier) @const)
+(translation_unit (declaration declarator: (init_declarator declarator: (identifier) @static)))
+(translation_unit (declaration declarator: (init_declarator declarator: (array_declarator declarator: (identifier) @static))))
 "#;
 
 const CPP_Q: &str = r#"
@@ -301,6 +364,11 @@ const PHP_Q: &str = r#"
 (trait_declaration name: (name) @trait)
 "#;
 
+// Also no constant capture, for a blunter reason than Java: there were 4 C#
+// files on the machine this was measured on, so there is no corpus to measure a
+// candidate query's precision against. Shipping one would be a guess, and the
+// C numbers above show how wrong that guess can be (96% locals from a node type
+// that looks perfectly reasonable on paper).
 const CSHARP_Q: &str = r#"
 (class_declaration name: (identifier) @class)
 (interface_declaration name: (identifier) @interface)
@@ -377,6 +445,57 @@ mod tests {
         assert!(has(&s, "T", "trait"));
         assert!(has(&s, "m", "module"));
     }
+    /// A file that is nothing but a lookup table must still yield symbols.
+    /// Without `const_item`/`static_item` in RUST_Q this extracts zero, and the
+    /// file becomes unreachable by symbol search (#170) — which is exactly the
+    /// content that cannot be recalled and therefore most needs retrieving.
+    #[test]
+    fn rust_const_and_static() {
+        let s = syms(
+            "rust",
+            "pub const BYTE_FREQUENCIES: [u8; 256] = [1, 2];\nstatic TABLE: [u8; 2] = [3, 4];\n",
+        );
+        assert!(has(&s, "BYTE_FREQUENCIES", "const"), "got {s:?}");
+        assert!(has(&s, "TABLE", "static"), "got {s:?}");
+    }
+    /// Associated consts are why RUST_Q is not anchored to `source_file`; if a
+    /// future edit anchors it to suppress function-local consts, this fails.
+    #[test]
+    fn rust_associated_const() {
+        let s = syms(
+            "rust",
+            "struct S;\nimpl S { pub const LANES: usize = 8; }\ntrait T { const NAME: &'static str; }\n",
+        );
+        assert!(has(&s, "LANES", "const"), "got {s:?}");
+        assert!(has(&s, "NAME", "const"), "got {s:?}");
+    }
+    #[test]
+    fn go_const_and_var() {
+        let s = syms(
+            "go",
+            "package p\nconst Limit = 10\nvar Table = []byte{1}\nfunc F(){ var local = 1; _ = local }\n",
+        );
+        assert!(has(&s, "Limit", "const"), "got {s:?}");
+        assert!(has(&s, "Table", "static"), "got {s:?}");
+        // Function-local `var` must NOT be captured, or defs fills with locals.
+        assert!(!has(&s, "local", "static"), "captured a local: {s:?}");
+    }
+    /// Grouped `const (…)` / `var (…)` are how Go actually writes lookup tables.
+    /// They parse differently from each other — grouped `var` interposes a
+    /// `var_spec_list` node, grouped `const` does not — so the anchored form
+    /// silently misses `var (…)` unless that case is matched explicitly.
+    #[test]
+    fn go_grouped_const_and_var() {
+        let s = syms(
+            "go",
+            "package p\nconst (\n Alpha = 1\n Beta = 2\n)\nvar (\n Grouped = []byte{1}\n)\nfunc F(){ var loc = 1; const lc = 2; _ = loc; _ = lc }\n",
+        );
+        assert!(has(&s, "Alpha", "const"), "got {s:?}");
+        assert!(has(&s, "Beta", "const"), "got {s:?}");
+        assert!(has(&s, "Grouped", "static"), "got {s:?}");
+        assert!(!has(&s, "loc", "static"), "captured a local: {s:?}");
+        assert!(!has(&s, "lc", "const"), "captured a local const: {s:?}");
+    }
     #[test]
     fn go() {
         let s = syms(
@@ -403,6 +522,28 @@ mod tests {
         assert!(has(&s, "f", "function"));
         assert!(has(&s, "S", "struct"));
         assert!(has(&s, "E", "enum"));
+    }
+    /// C's table file: `#define`s plus file-scope arrays, and NOT the locals
+    /// inside a function — an unanchored `(declaration …)` captured 96% locals
+    /// on a real 400-file sample, so the anchoring is the whole point.
+    #[test]
+    fn c_const_and_file_scope() {
+        let s = syms(
+            "c",
+            "#define MAX_LEN 256\nstatic const unsigned char BYTE_FREQUENCIES[256] = {1,2};\nint g_count = 7;\nvoid f(void){ int local = 1; const int lc = 2; (void)local; (void)lc; }\n",
+        );
+        assert!(has(&s, "MAX_LEN", "const"), "got {s:?}");
+        assert!(has(&s, "BYTE_FREQUENCIES", "static"), "got {s:?}");
+        assert!(has(&s, "g_count", "static"), "got {s:?}");
+        assert!(!has(&s, "local", "static"), "captured a local: {s:?}");
+        assert!(!has(&s, "lc", "static"), "captured a local: {s:?}");
+    }
+    /// Function-like macros are a different node and must stay out of `defs`.
+    #[test]
+    fn c_function_macro_not_captured() {
+        let s = syms("c", "#define MIN(a,b) ((a)<(b)?(a):(b))\n#define LIMIT 4\n");
+        assert!(has(&s, "LIMIT", "const"), "got {s:?}");
+        assert!(!has(&s, "MIN", "const"), "captured a function macro: {s:?}");
     }
     #[test]
     fn cpp() {

--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -330,14 +330,67 @@ const JAVA_Q: &str = r#"
 // preprocessor form (`preproc_ifdef`, `preproc_if`, nesting) is unbounded and
 // each extra level re-admits in-function declarations, so it is left alone:
 // missing a symbol is recoverable, filling `defs` with locals is not.
+//
+// ── #172: the header API surface. Measured over valkey + memcached at
+// /home/claude/.xerj-code/corpora/kv-oss (547 .c, 360 .h). "in-body" below
+// counts captures with a `compound_statement` ancestor, i.e. the locals trap.
+//
+// Prototypes (`int do_thing(int);`) are `declaration` + `function_declarator`,
+// a different node from `function_definition`, so none were captured — a C
+// library's whole callable API was missing from `defs`. These two patterns are
+// deliberately NOT anchored to `translation_unit`, against the shape of the
+// rest of this query, because real headers are guarded: anchored, the prototype
+// pattern captures 689 names (176 in headers); unanchored it captures 3871
+// (3285 in headers). Unanchoring is safe HERE and nowhere else in C, because
+// the pattern demands a `function_declarator` — declaring a function inside a
+// function body is legal but vanishingly rare: 14 of 3871 (0.4%) were in-body,
+// and of those 9 are a macro misparse (`JEMALLOC_CC_SILENCE_INIT`) and the rest
+// are genuine local prototypes. Contrast the bare `(declaration declarator:
+// (identifier))` that #170 measured: 6666 captures, 6033 (90%) in-body.
+// The `pointer_declarator` variant is separate because `char *f(void);` wraps
+// the `function_declarator` one level deeper: 652 more (546 in headers), 0
+// in-body. Two levels (`char **f(void);`) is 10 captures corpus-wide and is not
+// worth a third pattern. The same wrapper gap existed on `function_definition`,
+// where it was costing 1477 pointer-returning function definitions (4 in-body,
+// all macro misparses of real top-level functions).
+//
+// `extern int global_counter;` has no initialiser, so the `init_declarator`
+// patterns above never saw it. The `extern` keyword itself is the precision
+// filter — it is an anonymous token inside `storage_class_specifier`, and
+// matching it lets these three stay unanchored (so guarded headers work) at
+// 153 + 28 + 20 = 201 captures with 2 in-body, both genuine `extern` statements
+// declaring globals inside a function. Without the keyword the same shape is
+// the 90%-locals trap above. `static int x;` at file scope (no initialiser) is
+// still missed; it needs an anchored pattern and is not this bug.
+//
+// `preproc_def` now requires a `value:` — an include guard's `#define FOO_H`
+// has an EMPTY replacement list and so no `value` child, while `#define
+// MAX_ITEMS 128` has `value: (preproc_arg)` (verified in the grammar, not
+// assumed). That drops 564 of 5255 `#define` captures: 284 are `_H`-suffixed
+// guard names, the rest are valueless build knobs (`LUA_CORE`, `_GNU_SOURCE`,
+// `LTTNG_UST_TRACEPOINT_DEFINE`). The cost is real and was measured: 21 files
+// lose their last symbol and go back to zero-symbol (#170's failure mode), but
+// in 14 of them the lost symbol was the file's own include guard and in the
+// other 7 a build knob, so no file lost a constant anyone would search for.
+// Whole-corpus zero-symbol files still improve on the pre-#172 query for
+// headers via the prototype patterns: .c 9→17, .h 10→17 zero, against 6201
+// newly captured API names. A name-shape regex (`#not-match?` on `FOO_H`) was
+// the alternative; it would keep the build knobs but it is a heuristic on
+// spelling, and it misses guards like `MATH_C_`, so the grammar-level rule won.
 const C_Q: &str = r#"
 (function_definition declarator: (function_declarator declarator: (identifier) @function))
+(function_definition declarator: (pointer_declarator declarator: (function_declarator declarator: (identifier) @function)))
+(declaration declarator: (function_declarator declarator: (identifier) @function))
+(declaration declarator: (pointer_declarator declarator: (function_declarator declarator: (identifier) @function)))
 (struct_specifier name: (type_identifier) @struct)
 (enum_specifier name: (type_identifier) @enum)
 (type_definition declarator: (type_identifier) @type)
-(preproc_def name: (identifier) @const)
+(preproc_def name: (identifier) @const value: (preproc_arg))
 (translation_unit (declaration declarator: (init_declarator declarator: (identifier) @static)))
 (translation_unit (declaration declarator: (init_declarator declarator: (array_declarator declarator: (identifier) @static))))
+(declaration (storage_class_specifier "extern") declarator: (identifier) @static)
+(declaration (storage_class_specifier "extern") declarator: (pointer_declarator declarator: (identifier) @static))
+(declaration (storage_class_specifier "extern") declarator: (array_declarator declarator: (identifier) @static))
 "#;
 
 const CPP_Q: &str = r#"
@@ -544,6 +597,101 @@ mod tests {
         let s = syms("c", "#define MIN(a,b) ((a)<(b)?(a):(b))\n#define LIMIT 4\n");
         assert!(has(&s, "LIMIT", "const"), "got {s:?}");
         assert!(!has(&s, "MIN", "const"), "captured a function macro: {s:?}");
+    }
+
+    /// The header probe from #172, unguarded. A header is prototypes and
+    /// `extern`s; before this both were invisible, so a C library's callable
+    /// API never reached `defs` and `do_thing` could not be found.
+    #[test]
+    fn c_header_api_surface() {
+        let s = syms(
+            "c",
+            "#define MAX_ITEMS 128\n\
+             extern int global_counter;\n\
+             extern char *global_name;\n\
+             extern struct thing global_table[];\n\
+             struct thing { int x; };\n\
+             int do_thing(int a);\n\
+             char *dup_thing(const char *s);\n",
+        );
+        assert!(has(&s, "do_thing", "function"), "got {s:?}");
+        assert!(has(&s, "dup_thing", "function"), "got {s:?}");
+        assert!(has(&s, "global_counter", "static"), "got {s:?}");
+        assert!(has(&s, "global_name", "static"), "got {s:?}");
+        assert!(has(&s, "global_table", "static"), "got {s:?}");
+        assert!(has(&s, "MAX_ITEMS", "const"), "got {s:?}");
+        assert!(has(&s, "thing", "struct"), "got {s:?}");
+    }
+
+    /// The same header behind an include guard. Everything sits one level
+    /// deeper (`translation_unit > preproc_ifdef > …`), which is why the
+    /// prototype and `extern` patterns are unanchored — and the guard's own
+    /// `#define` must NOT become a constant, which is what it used to do.
+    #[test]
+    fn c_include_guard_is_not_a_constant() {
+        let s = syms(
+            "c",
+            "#ifndef GUARDED_H\n\
+             #define GUARDED_H\n\
+             #define MAX_ITEMS 128\n\
+             extern int global_counter;\n\
+             struct thing { int x; };\n\
+             int do_thing(int a);\n\
+             #endif\n",
+        );
+        assert!(!has(&s, "GUARDED_H", "const"), "captured a guard: {s:?}");
+        assert!(has(&s, "MAX_ITEMS", "const"), "got {s:?}");
+        assert!(has(&s, "do_thing", "function"), "got {s:?}");
+        assert!(has(&s, "global_counter", "static"), "got {s:?}");
+        assert!(has(&s, "thing", "struct"), "got {s:?}");
+    }
+
+    /// The precision half of the prototype/`extern` patterns. Unanchoring them
+    /// is only safe because each demands a shape a local cannot have; a bare
+    /// declaration inside a function body must stay out of `defs` (measured at
+    /// 90% locals if it does not — #170).
+    #[test]
+    fn c_locals_still_excluded() {
+        let s = syms(
+            "c",
+            "int do_thing(int a);\n\
+             void f(void) {\n\
+                 int local;\n\
+                 char *ptr;\n\
+                 int table[4];\n\
+                 struct thing *node;\n\
+                 (void)local; (void)ptr; (void)table; (void)node;\n\
+             }\n",
+        );
+        assert!(has(&s, "do_thing", "function"), "got {s:?}");
+        assert!(has(&s, "f", "function"), "got {s:?}");
+        assert!(!has(&s, "local", "static"), "captured a local: {s:?}");
+        assert!(!has(&s, "ptr", "static"), "captured a local: {s:?}");
+        assert!(!has(&s, "table", "static"), "captured a local: {s:?}");
+        assert!(!has(&s, "node", "static"), "captured a local: {s:?}");
+    }
+
+    /// A pointer-returning function wraps its `function_declarator` in a
+    /// `pointer_declarator`, so it needs its own pattern — 1477 definitions and
+    /// 652 prototypes in the measured corpus went missing without it.
+    #[test]
+    fn c_pointer_returning_functions() {
+        let s = syms(
+            "c",
+            "char *sdsnew(const char *init);\nchar *sdsdup(char *s) { return s; }\n",
+        );
+        assert!(has(&s, "sdsnew", "function"), "got {s:?}");
+        assert!(has(&s, "sdsdup", "function"), "got {s:?}");
+    }
+
+    /// The deliberate cost of the empty-replacement-list rule: a valueless
+    /// build knob is dropped along with the guards. Documented as a test so a
+    /// future reader sees it was a choice, not an oversight.
+    #[test]
+    fn c_valueless_define_is_dropped() {
+        let s = syms("c", "#define LUA_CORE\n#define LIMIT 4\n");
+        assert!(has(&s, "LIMIT", "const"), "got {s:?}");
+        assert!(!has(&s, "LUA_CORE", "const"), "got {s:?}");
     }
     #[test]
     fn cpp() {

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -319,8 +319,11 @@ mod clustering_key_tests {
         let dir = std::env::temp_dir().join("xerj-ax-178-key");
         std::fs::create_dir_all(&dir).unwrap();
 
-        // `const` is invisible to the shipped Rust query, so this file parses
-        // to zero symbols — exactly the case #170 improves.
+        // #170 now captures the `const`, so this file parses to one symbol and
+        // GAINS a `defs` field — the case #170 improves. The point of this test
+        // survives that change: the newly-captured extractor name must still be
+        // kept out of the clustering key (#180), so a const-only file and a
+        // fn/struct file still land in ONE dataset rather than re-homing apart.
         let table = scan(
             &dir,
             "table.rs",
@@ -337,7 +340,8 @@ mod clustering_key_tests {
                 s.sketches[0].key_fields
             );
         }
-        assert!(!table.sketches[0].fields.contains_key("defs"));
+        // #170: the const is now captured, so the table file has `defs` too.
+        assert!(table.sketches[0].fields.contains_key("defs"));
         assert!(code.sketches[0].fields.contains_key("defs"));
 
         // …so the two land in one dataset instead of one dataset each.


### PR DESCRIPTION
Closes #172.

A `.h` file is where a C library's public interface lives, and `C_Q` could not see most of it: prototypes and `extern`s were invisible, while every guarded header contributed one junk constant.

**Stacking note:** this branch is cut from the unmerged #170 fix, so it carries two commits — `5712f28` is that fix (const/static/`#define`), `addb9f8` is this one. Review the second commit; the first should land on its own or with this PR.

Everything below is measured over the valkey + memcached corpus at `/home/claude/.xerj-code/corpora/kv-oss` (547 `.c`, 360 `.h`). "in-body" means the capture has a `compound_statement` ancestor — the function-locals trap that made #170's bare `(declaration …)` unusable.

## Shipped

| Defect | Pattern | Captures | In-body | Precision |
|---|---|---|---|---|
| 1. prototypes | `(declaration declarator: (function_declarator declarator: (identifier) @function))` | **3871** (3285 in `.h`) | 14 | 99.6% |
| 1. prototypes returning a pointer | same, wrapped in `pointer_declarator` | **652** (546 in `.h`) | 0 | 100% |
| 2. `extern` object | `(declaration (storage_class_specifier "extern") declarator: (identifier) @static)` | **153** | 0 | 100% |
| 2. `extern` pointer / array | same, `pointer_declarator` / `array_declarator` | **28 / 20** | 2 / 0 | 96% / 100% |
| 3. include guards | `(preproc_def name: (identifier) @const value: (preproc_arg))` | **−564 of 5255** | — | 284 dropped names are `_H`-suffixed guards |
| (also) pointer-returning **definitions** | `(function_definition declarator: (pointer_declarator …))` | **1477** | 4 | 99.7% |

The 14 in-body prototype captures are 9 instances of a `JEMALLOC_CC_SILENCE_INIT` macro misparse plus genuine local prototypes; the 2 in-body `extern`s are real `extern` statements declaring globals inside a function; the 4 in-body definitions are macro misparses of real top-level functions. Corpus totals: **21611 → 27248 captures**.

The last row is not one of the issue's three defects. `char *foo(void) {…}` wraps its `function_declarator` in a `pointer_declarator`, so the pre-existing `function_definition` pattern was already missing 1477 function definitions in `.c` files — the same node-shape bug, one line away, so it is fixed here rather than filed. Called out so it is not an undisclosed behaviour change.

### On anchoring — this contradicts the issue's suggested direction, with numbers

The issue suggests anchoring the new patterns to `translation_unit`, as #170 did. Measured, that is the wrong call **for these two patterns**: real headers are guarded, and a guard puts the whole file under `preproc_ifdef`, one level too deep. Anchored, the prototype pattern captures **689** names (176 in headers). Unanchored it captures **3871** (3285 in headers) at 99.6% precision.

Unanchoring is safe here and nowhere else in C, because each pattern demands a shape a local cannot cheaply have — a `function_declarator`, or the `extern` keyword. The shape #170 rejected is untouched and still rejected: `(declaration declarator: (identifier))` measures **6666 captures, 6033 (90%) function locals**.

### On include guards — the grammar rule, verified before use

`#define GUARDED_H` parses to `(preproc_def name: (identifier))`; `#define MAX_ITEMS 128` parses to `(preproc_def name: (identifier) value: (preproc_arg))`. The empty-replacement-list distinction holds, so requiring `value:` needs no name heuristic.

**Its cost, measured:** 564 of 5255 `#define` captures go away — 284 `_H`-suffixed guards, the rest valueless build knobs (`LUA_CORE`, `_GNU_SOURCE`, `LTTNG_UST_TRACEPOINT_DEFINE`). **21 files lose their last symbol** and return to #170's zero-symbol state. In 14 of them the lost symbol was the file's own include guard, in the other 7 a build knob; no file lost a constant anyone would search for. Whole-corpus zero-symbol files: `.c` 9→17, `.h` 10→17, against 6201 newly captured API names.

The alternative — a `#not-match?` regex on guard-shaped names — would keep the build knobs, but it is a heuristic on spelling and it misses real guards like `MATH_C_` and `_CRC16_TABLE_H__`. The grammar-level rule won.

## Not shipped

- **Double-pointer returns** (`char **f(void);`): 10 captures corpus-wide. Not worth a third pattern; tree-sitter queries cannot express "any depth of wrapper".
- **File-scope pointer globals** (`static char *p = "x";` — the `init_declarator` sits inside a `pointer_declarator`): 104 captures measured, 0 in-body, so a clean win is available. It is #170's territory, not this bug, so it is left for a follow-up rather than smuggled in.
- **`static int x;` at file scope with no initialiser**: still missed. It needs an anchored pattern (no keyword to key on that a local lacks — `static` is legal on locals), which the guarded-header problem then defeats. Not attempted.
- **Function-like macros** (`preproc_function_def`): several of the 21 newly zero-symbol headers are macro-only (`ql.h`, `qr.h`, `typed_list.h`), and their macros ARE their API. Capturing them as `@macro` would restore those files, but it is a recall change of unmeasured volume and a new symbol kind, so it is a separate issue.

## Verification

Five new tests, each asserting on **captured names** — a tree-sitter query with a wrong node name compiles fine and captures nothing, which is how #170 stayed hidden. All five fail against the previous query (checked by reverting `C_Q` and re-running), and `all_queries_compile` alone would not have caught any of this:

- `c_header_api_surface` — the issue's unguarded probe; before: `[MAX_ITEMS, thing]`.
- `c_include_guard_is_not_a_constant` — the guarded probe; asserts `GUARDED_H` is absent *and* that the prototype/`extern`/`struct` are present through the guard.
- `c_locals_still_excluded` — `int local; char *ptr; int table[4];` in a function body stay out of `defs`.
- `c_pointer_returning_functions`, `c_valueless_define_is_dropped` (the last documents the deliberate cost).

`cargo test -p xerj-autoindex`: 225 passed. `cargo clippy --all-targets` and `cargo fmt --check` clean.

End to end against a live server (`xerj autoindex … --no-graph --fresh`), the issue's two-file probe now indexes identically whether or not it is guarded:

```
before:  plain.h    symbols=2  defs='const MAX_ITEMS\nstruct thing'
         guarded.h  symbols=3  defs='const GUARDED_H\nconst MAX_ITEMS\nstruct thing'

after:   plain.h    symbols=4  defs='const MAX_ITEMS\nstatic global_counter\nstruct thing\nfunction do_thing'
         guarded.h  symbols=4  defs='const MAX_ITEMS\nstatic global_counter\nstruct thing\nfunction do_thing'
```

And on real code — indexing memcached, `assoc.h` goes from **0 symbols to 11**, and a `function assoc_insert` symbol search returns `assoc.h` (5.06) ahead of `assoc.c` (4.26), which is the retrieval this bug was costing.
