### PR TITLE
[BLOCKED: data loss] fix(autoindex): extract const/static/#define, and sweep superseded records

### DIFF
--- a/engine/crates/xerj-autoindex/src/esclient.rs
+++ b/engine/crates/xerj-autoindex/src/esclient.rs
@@ -318,12 +318,16 @@ impl Es {
     /// locator set alongside the replacement. The server executes ONE bounded
     /// search-and-delete pass per call (size-capped at 10k docs), so a single
     /// response is not complete removal: repeat until a pass deletes nothing.
-    pub fn delete_by_query(&self, index: &str, query: &Value) -> Result<()> {
+    /// Returns the total number of documents removed across the passes.
+    pub fn delete_by_query(&self, index: &str, query: &Value) -> Result<u64> {
         const MAX_PASSES: usize = 1_000;
+        let mut removed = 0u64;
         for _ in 0..MAX_PASSES {
-            if self.delete_by_query_pass(index, query)? == 0 {
-                return Ok(());
+            let pass = self.delete_by_query_pass(index, query)?;
+            if pass == 0 {
+                return Ok(removed);
             }
+            removed += pass;
         }
         Err(anyhow!(
             "POST /{index}/_delete_by_query still reported deletions after {MAX_PASSES} passes; \

--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -3,7 +3,8 @@
 //! Source files used to fall through to the plain-text extractor, so a repo was
 //! searchable only as prose. This parses each file with the matching tree-sitter
 //! grammar and captures its DEFINITIONS (functions, classes, methods, structs,
-//! traits, interfaces, modules, …). Each file becomes one document carrying:
+//! traits, interfaces, modules, constants, …). Each file becomes one document
+//! carrying:
 //! - `language`  the detected language
 //! - `symbols`   a structured array of {name, kind, line}
 //! - `defs`      "kind name" per symbol, newline-joined so BM25 matches a query
@@ -242,6 +243,19 @@ const TS_Q: &str = r#"
 (variable_declarator name: (identifier) @function value: (arrow_function))
 "#;
 
+// `const_item` / `static_item` are captured because a file whose whole content
+// is a lookup table (`pub const BYTE_FREQUENCIES: [u8; 256] = [...]`) otherwise
+// extracts ZERO symbols and becomes unreachable by symbol search — see #170.
+// Those files matter disproportionately: their contents are empirical, so they
+// are exactly what cannot be recalled and must be retrieved.
+//
+// Deliberately NOT anchored to `source_file`. Measured over the 331-file
+// memchr/regex/aho-corasick corpus, the 959 const/static declarations sit at:
+// file-scope 720, impl-block associated consts 75, trait 4, function-local 160.
+// Anchoring would throw away the 79 associated consts — `impl Foo { const N }`
+// is idiomatic Rust — to suppress function-local ones, and a function-local
+// `const` in Rust is still a deliberately named constant (Rust `let` bindings
+// are a different node and are never captured), so it is signal, not noise.
 const RUST_Q: &str = r#"
 (function_item name: (identifier) @function)
 (struct_item name: (type_identifier) @struct)
@@ -250,14 +264,38 @@ const RUST_Q: &str = r#"
 (mod_item name: (identifier) @module)
 (macro_definition name: (identifier) @macro)
 (type_item name: (type_identifier) @type)
+(const_item name: (identifier) @const)
+(static_item name: (identifier) @static)
 "#;
 
+// Go's package-level `const`/`var` are anchored to `source_file` on purpose:
+// unanchored, `var_declaration` also matches every function-local `var`, which
+// fills `defs` with locals (verified — unanchoring makes `go_const_and_var`
+// fail on a captured `local`). Note the grammar is asymmetric: a grouped
+// `const ( A = 1 )` keeps `const_spec` as a direct child of `const_declaration`
+// (there is no `const_spec_list` node — a query naming one fails to compile),
+// but a grouped `var ( T = 1 )` wraps its specs in `var_spec_list`, so that
+// form needs its own pattern or package-level tables in `var (…)` are missed.
 const GO_Q: &str = r#"
 (function_declaration name: (identifier) @function)
 (method_declaration name: (field_identifier) @method)
 (type_declaration (type_spec name: (type_identifier) @type))
+(source_file (const_declaration (const_spec name: (identifier) @const)))
+(source_file (var_declaration (var_spec name: (identifier) @static)))
+(source_file (var_declaration (var_spec_list (var_spec name: (identifier) @static))))
 "#;
 
+// No constant capture here, deliberately. #170 is about files that extract zero
+// symbols and so become unreachable; Java barely has that failure mode, because
+// every file must declare a type. Measured: 7 of 1043 Java files in one corpus
+// and 1 of 72 in another extract zero symbols under this query (0.7%), against
+// 20 of 331 for Rust and 186 of 400 for C headers. A clean query does exist if
+// the recall is wanted later — `(field_declaration (modifiers "static")
+// declarator: (variable_declarator name: (identifier) @const))` captured 372
+// constants with 0 method-local false positives, where capturing all fields
+// would have pulled in 1311 including private instance state — but it is a
+// recall improvement, not this bug, and no Java corpus is wired into the
+// end-to-end check that proves it, so it is not shipped unverified.
 const JAVA_Q: &str = r#"
 (class_declaration name: (identifier) @class)
 (interface_declaration name: (identifier) @interface)
@@ -266,11 +304,36 @@ const JAVA_Q: &str = r#"
 (constructor_declaration name: (identifier) @method)
 "#;
 
+// C has #170's failure mode worse than anywhere else: 186 of 400 sampled headers
+// and 39 of 400 sampled .c files extracted zero symbols before this.
+//
+// `preproc_def` is the lever that matters — it rescued 148 of those 186 headers
+// and 13 of those 39 .c files, because a header of nothing but `#define`s is the
+// canonical C constant table. It needs no anchoring: only 319 of 7356 captures
+// (4%) sat inside a function body, and include-guard-shaped names were 298 of
+// 4192 in headers (7%). Function-like `#define F(x)` is a different node
+// (`preproc_function_def`) and is not captured.
+//
+// The object declarations ARE anchored to `translation_unit`. A bare
+// `(declaration ...)` is exactly the noisy query to avoid: measured over the
+// same 400 .c files it captured 11806 names of which 11320 (96%) were function
+// locals. Anchored, it captured 274 with zero function locals.
+//
+// Known limit of that anchoring, measured not assumed: an include guard parses
+// as `translation_unit > preproc_ifdef > declaration`, so guarded headers put
+// their declarations one level too deep and only `preproc_def` sees them. That
+// is why the anchored patterns rescued just 6 headers. Widening the anchor per
+// preprocessor form (`preproc_ifdef`, `preproc_if`, nesting) is unbounded and
+// each extra level re-admits in-function declarations, so it is left alone:
+// missing a symbol is recoverable, filling `defs` with locals is not.
 const C_Q: &str = r#"
 (function_definition declarator: (function_declarator declarator: (identifier) @function))
 (struct_specifier name: (type_identifier) @struct)
 (enum_specifier name: (type_identifier) @enum)
 (type_definition declarator: (type_identifier) @type)
+(preproc_def name: (identifier) @const)
+(translation_unit (declaration declarator: (init_declarator declarator: (identifier) @static)))
+(translation_unit (declaration declarator: (init_declarator declarator: (array_declarator declarator: (identifier) @static))))
 "#;
 
 const CPP_Q: &str = r#"
@@ -297,6 +360,11 @@ const PHP_Q: &str = r#"
 (trait_declaration name: (name) @trait)
 "#;
 
+// Also no constant capture, for a blunter reason than Java: there were 4 C#
+// files on the machine this was measured on, so there is no corpus to measure a
+// candidate query's precision against. Shipping one would be a guess, and the
+// C numbers above show how wrong that guess can be (96% locals from a node type
+// that looks perfectly reasonable on paper).
 const CSHARP_Q: &str = r#"
 (class_declaration name: (identifier) @class)
 (interface_declaration name: (identifier) @interface)
@@ -373,6 +441,57 @@ mod tests {
         assert!(has(&s, "T", "trait"));
         assert!(has(&s, "m", "module"));
     }
+    /// A file that is nothing but a lookup table must still yield symbols.
+    /// Without `const_item`/`static_item` in RUST_Q this extracts zero, and the
+    /// file becomes unreachable by symbol search (#170) — which is exactly the
+    /// content that cannot be recalled and therefore most needs retrieving.
+    #[test]
+    fn rust_const_and_static() {
+        let s = syms(
+            "rust",
+            "pub const BYTE_FREQUENCIES: [u8; 256] = [1, 2];\nstatic TABLE: [u8; 2] = [3, 4];\n",
+        );
+        assert!(has(&s, "BYTE_FREQUENCIES", "const"), "got {s:?}");
+        assert!(has(&s, "TABLE", "static"), "got {s:?}");
+    }
+    /// Associated consts are why RUST_Q is not anchored to `source_file`; if a
+    /// future edit anchors it to suppress function-local consts, this fails.
+    #[test]
+    fn rust_associated_const() {
+        let s = syms(
+            "rust",
+            "struct S;\nimpl S { pub const LANES: usize = 8; }\ntrait T { const NAME: &'static str; }\n",
+        );
+        assert!(has(&s, "LANES", "const"), "got {s:?}");
+        assert!(has(&s, "NAME", "const"), "got {s:?}");
+    }
+    #[test]
+    fn go_const_and_var() {
+        let s = syms(
+            "go",
+            "package p\nconst Limit = 10\nvar Table = []byte{1}\nfunc F(){ var local = 1; _ = local }\n",
+        );
+        assert!(has(&s, "Limit", "const"), "got {s:?}");
+        assert!(has(&s, "Table", "static"), "got {s:?}");
+        // Function-local `var` must NOT be captured, or defs fills with locals.
+        assert!(!has(&s, "local", "static"), "captured a local: {s:?}");
+    }
+    /// Grouped `const (…)` / `var (…)` are how Go actually writes lookup tables.
+    /// They parse differently from each other — grouped `var` interposes a
+    /// `var_spec_list` node, grouped `const` does not — so the anchored form
+    /// silently misses `var (…)` unless that case is matched explicitly.
+    #[test]
+    fn go_grouped_const_and_var() {
+        let s = syms(
+            "go",
+            "package p\nconst (\n Alpha = 1\n Beta = 2\n)\nvar (\n Grouped = []byte{1}\n)\nfunc F(){ var loc = 1; const lc = 2; _ = loc; _ = lc }\n",
+        );
+        assert!(has(&s, "Alpha", "const"), "got {s:?}");
+        assert!(has(&s, "Beta", "const"), "got {s:?}");
+        assert!(has(&s, "Grouped", "static"), "got {s:?}");
+        assert!(!has(&s, "loc", "static"), "captured a local: {s:?}");
+        assert!(!has(&s, "lc", "const"), "captured a local const: {s:?}");
+    }
     #[test]
     fn go() {
         let s = syms(
@@ -399,6 +518,28 @@ mod tests {
         assert!(has(&s, "f", "function"));
         assert!(has(&s, "S", "struct"));
         assert!(has(&s, "E", "enum"));
+    }
+    /// C's table file: `#define`s plus file-scope arrays, and NOT the locals
+    /// inside a function — an unanchored `(declaration …)` captured 96% locals
+    /// on a real 400-file sample, so the anchoring is the whole point.
+    #[test]
+    fn c_const_and_file_scope() {
+        let s = syms(
+            "c",
+            "#define MAX_LEN 256\nstatic const unsigned char BYTE_FREQUENCIES[256] = {1,2};\nint g_count = 7;\nvoid f(void){ int local = 1; const int lc = 2; (void)local; (void)lc; }\n",
+        );
+        assert!(has(&s, "MAX_LEN", "const"), "got {s:?}");
+        assert!(has(&s, "BYTE_FREQUENCIES", "static"), "got {s:?}");
+        assert!(has(&s, "g_count", "static"), "got {s:?}");
+        assert!(!has(&s, "local", "static"), "captured a local: {s:?}");
+        assert!(!has(&s, "lc", "static"), "captured a local: {s:?}");
+    }
+    /// Function-like macros are a different node and must stay out of `defs`.
+    #[test]
+    fn c_function_macro_not_captured() {
+        let s = syms("c", "#define MIN(a,b) ((a)<(b)?(a):(b))\n#define LIMIT 4\n");
+        assert!(has(&s, "LIMIT", "const"), "got {s:?}");
+        assert!(!has(&s, "MIN", "const"), "captured a function macro: {s:?}");
     }
     #[test]
     fn cpp() {

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -297,6 +297,87 @@ fn build_mapping(specs: &[infer::FieldSpec]) -> Value {
     json!({"mappings": {"properties": props}})
 }
 
+/// Live indices under `{prefix}-` — the ones a run could inherit records from.
+fn indices_under_prefix(es: &Es, prefix: &str) -> Result<Vec<String>> {
+    let pattern = format!("{prefix}-");
+    Ok(es
+        .cat_indices()
+        .context("list the live indices under this prefix")?
+        .into_iter()
+        .map(|(name, _)| name)
+        .filter(|name| name.starts_with(&pattern))
+        .collect())
+}
+
+/// One `ax_file` key set per `_delete_by_query`. The sweep issues
+/// `inherited indices × ceil(keys / this)` requests, so a bigger batch is
+/// cheaper, but the terms list travels in the request body and the server holds
+/// it while it scans, so it is not free to make unbounded.
+const SWEEP_KEY_BATCH: usize = 512;
+
+/// Enforce one invariant: no index under this prefix may hold records of a file
+/// that this plan assigns to a DIFFERENT index. Returns how many documents that
+/// removed.
+///
+/// `ids::doc_id` mixes the dataset slug in, so when a file lands in a different
+/// inferred schema group than it did last run — exactly what happens when an
+/// extractor upgrade gives it a field it did not have before — its records are
+/// written under a NEW `_id` in a NEW index, and nothing overwrites the copy in
+/// the old one. Phase B's delete-before-replace cannot reach it either: it
+/// clears only the indices in the file's CURRENT assignment, and a `--fresh`
+/// run begins with an empty journal so it does not treat the file as a
+/// replacement at all.
+///
+/// The discriminator is the plan's own assignment, not the `ax_run` stamp:
+/// run ids are `run-{UTC second}-{pid}`, so two runs from one process inside
+/// one second share an id and a stamp comparison would silently keep the stale
+/// copy (observed — it is what the first cut of this sweep did).
+///
+/// Scoping to this corpus's own file keys is load-bearing, not caution: the
+/// default prefix is `ax`, so unrelated corpora routinely share one prefix, and
+/// a sweep phrased as "delete anything that is not mine" would destroy them.
+fn sweep_migrated_records(es: &Es, plan: &Plan, inherited_indices: &[String]) -> Result<u64> {
+    if inherited_indices.is_empty() {
+        return Ok(0);
+    }
+    let index_by_slug: HashMap<&str, &str> = plan
+        .datasets
+        .iter()
+        .map(|d| (d.slug.as_str(), d.index.as_str()))
+        .collect();
+    let mut homes: Vec<(&str, Vec<&str>)> = plan
+        .files
+        .iter()
+        .map(|(key, assignment)| {
+            let mut indices: Vec<&str> = assignment
+                .assignments
+                .iter()
+                .filter_map(|(_, slug)| index_by_slug.get(slug.as_str()).copied())
+                .collect();
+            indices.sort_unstable();
+            indices.dedup();
+            (key.as_str(), indices)
+        })
+        .collect();
+    homes.sort_unstable();
+    let mut removed = 0u64;
+    for index in inherited_indices {
+        let strangers: Vec<&str> = homes
+            .iter()
+            .filter(|(_, assigned)| !assigned.iter().any(|home| home == index))
+            .map(|(key, _)| *key)
+            .collect();
+        for batch in strangers.chunks(SWEEP_KEY_BATCH) {
+            removed += es
+                .delete_by_query(index, &json!({"terms": {"ax_file": batch}}))
+                .with_context(|| {
+                    format!("remove records that moved out of {index} into another dataset")
+                })?;
+        }
+    }
+    Ok(removed)
+}
+
 // ─── the main run ────────────────────────────────────────────────────────
 
 fn select_resume_plan_keys(
@@ -778,6 +859,36 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             identity.resumable,
             identity.non_resumable_reason.as_deref(),
         )?;
+    }
+
+    // Which indices this run INHERITED, sampled before it creates any of its
+    // own. An index this run created cannot hold a record this run did not
+    // write, so a first publication into an empty prefix sweeps nothing and
+    // pays nothing.
+    let inherited_indices = indices_under_prefix(&es, &cfg.prefix).unwrap_or_else(|error| {
+        eprintln!(
+            "warning: could not list the existing indices under {}-*: {error:#}. Records left in \
+             a dataset that this run's files have moved out of cannot be cleaned up; a file \
+             indexed under an earlier schema may stay searchable twice.",
+            cfg.prefix
+        );
+        Vec::new()
+    });
+    if cfg.fresh && !inherited_indices.is_empty() && !cfg.quiet {
+        // Not fixed here, and not caused by the dataset sweep below: `ax_file`
+        // is derived from CONTENT, so `--fresh` — which throws the journal away
+        // and recomputes every key from scratch — gives an edited file a new
+        // key, and its pre-edit records are no longer anything this corpus
+        // claims. Measured on a 284-file corpus with one file edited between
+        // two --fresh runs: 518 -> 519 live records, the same on the unpatched
+        // build. Resuming (no --fresh) has no such gap: the resume plan carries
+        // the old key forward and the edited file replaces itself in place.
+        eprintln!(
+            "note: --fresh re-keys every file by content, so any file EDITED since the last run \
+             of this prefix leaves its pre-edit records live. Only its dataset moves are cleaned \
+             up. Delete the {}-* indices first for a guaranteed-clean rebuild.",
+            cfg.prefix
+        );
     }
 
     // ── create indices with explicit mappings ────────────────────────────
@@ -1558,6 +1669,33 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         es.refresh(&gr.edges_index).ok();
     }
 
+    // Records left behind in a dataset a file has moved out of are removed only
+    // here, after every file has been published and every bulk confirmed.
+    // Doing it earlier would let a run that dies mid-way delete records it has
+    // not written the replacement for yet, turning a duplicate — which a rerun
+    // repairs — into a hole.
+    let superseded_removed =
+        sweep_migrated_records(&es, &plan, &inherited_indices).unwrap_or_else(|error| {
+            // A failed sweep leaves the duplicates that were there before this
+            // fix, so it must not fail a run whose records are all live. It
+            // must not be silent either.
+            eprintln!(
+                "warning: could not remove records that moved between datasets: {error:#}. \
+                 Files whose inferred dataset changed since the last run are indexed twice; \
+                 rerun autoindex to retry the cleanup."
+            );
+            0
+        });
+    if superseded_removed > 0 {
+        if !cfg.quiet {
+            eprintln!(
+                "removed {superseded_removed} superseded record(s): their files moved to a \
+                 different inferred dataset since the last run of this prefix"
+            );
+        }
+        es.refresh(&format!("{}-*", cfg.prefix)).ok();
+    }
+
     // live per-dataset counts + time ranges (every claim traces to a run)
     let mut ds_counts: HashMap<String, u64> = HashMap::new();
     let mut ds_timerange: HashMap<String, (Option<String>, Option<String>)> = HashMap::new();
@@ -1845,6 +1983,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         "files_junk": all_junk.len(),
         "records_total": total_records,
         "junk_records_total": junk_records_by_run,
+        "superseded_records_removed": superseded_removed,
         "wall_seconds": (wall * 10.0).round() / 10.0,
         "workers": cfg.workers,
         "semantic": !cfg.no_semantic,
@@ -2423,3 +2562,6 @@ mod duplicate_integration_tests {
 
 #[cfg(test)]
 mod failure_resume_http_tests;
+
+#[cfg(test)]
+mod reindex_migration_tests;

--- a/engine/crates/xerj-autoindex/src/reindex_migration_tests.rs
+++ b/engine/crates/xerj-autoindex/src/reindex_migration_tests.rs
@@ -1,0 +1,410 @@
+//! Re-indexing a prefix in place must not leave a second copy behind.
+//!
+//! `ids::doc_id` mixes the dataset slug in, so a file that lands in a different
+//! inferred dataset than it did last run is written under a NEW `_id` in a NEW
+//! index. Nothing overwrites the old copy, and the per-file delete-before-replace
+//! cannot reach it because it only clears the file's CURRENT assignment. The
+//! mock endpoint here keys documents by `(index, _id)` — exactly the identity
+//! the real backend uses — because a mock keyed by `_id` alone would silently
+//! merge the two copies and pass.
+
+use super::*;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+#[derive(Default)]
+struct MockState {
+    /// (index, _id) → source. Keyed the way a real cluster keys documents.
+    docs: HashMap<(String, String), Value>,
+    stop: bool,
+}
+
+impl MockState {
+    fn live_under(&self, prefix: &str) -> usize {
+        let pattern = format!("{prefix}-");
+        self.docs
+            .keys()
+            .filter(|(index, _)| index.starts_with(&pattern))
+            .count()
+    }
+
+    /// Every live copy of one source path, as (index, ax_run) pairs.
+    fn copies_of(&self, prefix: &str, path: &str) -> Vec<(String, String)> {
+        let pattern = format!("{prefix}-");
+        let mut out: Vec<(String, String)> = self
+            .docs
+            .iter()
+            .filter(|((index, _), doc)| {
+                index.starts_with(&pattern)
+                    && doc.get("ax_path").and_then(Value::as_str) == Some(path)
+            })
+            .map(|((index, _), doc)| {
+                (
+                    index.clone(),
+                    doc.get("ax_run")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                )
+            })
+            .collect();
+        out.sort();
+        out
+    }
+
+    fn indices(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.docs.keys().map(|(index, _)| index.clone()).collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+}
+
+struct MockEndpoint {
+    url: String,
+    state: Arc<Mutex<MockState>>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl MockEndpoint {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let state = Arc::new(Mutex::new(MockState::default()));
+        let server_state = Arc::clone(&state);
+        let join = thread::spawn(move || loop {
+            match listener.accept() {
+                Ok((stream, _)) => handle(stream, &server_state),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if server_state.lock().unwrap().stop {
+                        break;
+                    }
+                    thread::yield_now();
+                }
+                Err(error) => panic!("mock endpoint accept failed: {error}"),
+            }
+        });
+        Self {
+            url,
+            state,
+            join: Some(join),
+        }
+    }
+}
+
+impl Drop for MockEndpoint {
+    fn drop(&mut self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.stop = true;
+        }
+        // Wake the nonblocking listener even on heavily loaded test hosts.
+        let _ = TcpStream::connect(self.url.trim_start_matches("http://"));
+        // Deliberately not unwrapped: a failing assertion unwinds through this
+        // drop, and a panicking destructor aborts the process and hides the
+        // assertion message that says what actually broke.
+        let _ = self.join.take().unwrap().join();
+    }
+}
+
+/// The query shapes autoindex actually sends to `_delete_by_query`: a bare
+/// `term`, a `terms` set, and `bool` with `must`/`filter`/`must_not`.
+fn matches(query: &Value, doc: &Value) -> bool {
+    if let Some(term) = query.get("term").and_then(Value::as_object) {
+        return term
+            .iter()
+            .all(|(field, want)| doc.get(field) == Some(want));
+    }
+    if let Some(terms) = query.get("terms").and_then(Value::as_object) {
+        return terms.iter().all(|(field, wanted)| {
+            let Some(value) = doc.get(field) else {
+                return false;
+            };
+            wanted
+                .as_array()
+                .is_some_and(|options| options.contains(value))
+        });
+    }
+    if let Some(bool_query) = query.get("bool").and_then(Value::as_object) {
+        let clauses = |name: &str| -> Vec<Value> {
+            bool_query
+                .get(name)
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+        };
+        return clauses("must").iter().all(|c| matches(c, doc))
+            && clauses("filter").iter().all(|c| matches(c, doc))
+            && !clauses("must_not").iter().any(|c| matches(c, doc));
+    }
+    panic!("mock endpoint got an unsupported query shape: {query}");
+}
+
+fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
+    let clone = stream.try_clone().unwrap();
+    let mut reader = BufReader::new(clone);
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).unwrap() == 0 {
+        return;
+    }
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        if line == "\r\n" || line.is_empty() {
+            break;
+        }
+        if let Some(value) = line
+            .to_ascii_lowercase()
+            .strip_prefix("content-length:")
+            .map(str::trim)
+        {
+            content_length = value.parse().unwrap();
+        }
+    }
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body).unwrap();
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("");
+
+    // `_cat/indices` is plain text, not JSON — the real endpoint ignores
+    // ?format=json, and `Es::cat_indices` parses columns positionally.
+    if method == "GET" && path.starts_with("/_cat/indices") {
+        let locked = state.lock().unwrap();
+        let mut text = String::new();
+        for index in locked.indices() {
+            let docs = locked
+                .docs
+                .keys()
+                .filter(|(name, _)| *name == index)
+                .count();
+            text.push_str(&format!(
+                "green open {index} uuid-{index} 1 0 {docs} 0 1kb 1kb 1kb\n"
+            ));
+        }
+        drop(locked);
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            text.len(),
+            text
+        )
+        .unwrap();
+        return;
+    }
+
+    let response = if method == "POST" && path == "/_bulk" {
+        let mut locked = state.lock().unwrap();
+        let lines: Vec<&[u8]> = body
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .collect();
+        let mut i = 0;
+        while i < lines.len() {
+            let action: Value = serde_json::from_slice(lines[i]).unwrap();
+            if let Some(target) = action.get("delete") {
+                let index = target.get("_index").and_then(Value::as_str).unwrap();
+                let id = target.get("_id").and_then(Value::as_str).unwrap();
+                locked.docs.remove(&(index.to_string(), id.to_string()));
+                i += 1;
+                continue;
+            }
+            let target = action.get("index").expect("index or delete action");
+            let index = target.get("_index").and_then(Value::as_str).unwrap();
+            let id = target.get("_id").and_then(Value::as_str).unwrap();
+            let doc: Value = serde_json::from_slice(lines[i + 1]).unwrap();
+            locked.docs.insert((index.to_string(), id.to_string()), doc);
+            i += 2;
+        }
+        json!({"errors": false, "items": []})
+    } else if method == "POST" && path.contains("/_delete_by_query") {
+        let index = path
+            .trim_start_matches('/')
+            .split('/')
+            .next()
+            .unwrap()
+            .to_string();
+        let request: Value = serde_json::from_slice(&body).unwrap();
+        let query = request.get("query").cloned().unwrap_or(json!({}));
+        let mut locked = state.lock().unwrap();
+        let doomed: Vec<(String, String)> = locked
+            .docs
+            .iter()
+            .filter(|((name, _), doc)| *name == index && matches(&query, doc))
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in &doomed {
+            locked.docs.remove(key);
+        }
+        json!({"deleted": doomed.len(), "failures": []})
+    } else if method == "POST" && path.ends_with("/_search") {
+        let index = path
+            .trim_start_matches('/')
+            .split('/')
+            .next()
+            .unwrap()
+            .to_string();
+        let locked = state.lock().unwrap();
+        let total = locked
+            .docs
+            .keys()
+            .filter(|(name, _)| *name == index)
+            .count();
+        json!({"hits": {"total": {"value": total}, "hits": []}, "aggregations": {}})
+    } else {
+        // ping, index creation, mapping upgrades, refresh
+        json!({"acknowledged": true})
+    };
+    let bytes = response.to_string();
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        bytes.len(),
+        bytes
+    )
+    .unwrap();
+}
+
+fn cfg(root: &Path, state_dir: &Path, url: &str) -> IndexCfg {
+    IndexCfg {
+        root: root.to_owned(),
+        url: url.to_owned(),
+        api_key: None,
+        workers: 1,
+        pdf_workers: 1,
+        pdf_timeout_secs: 30,
+        bulk_mb: 64,
+        bulk_timeout_secs: 3_600,
+        prefix: "reindex-test".into(),
+        state_dir: Some(state_dir.to_owned()),
+        fresh: false,
+        follow_symlinks: false,
+        max_file_gb: 1,
+        sample: 50,
+        no_semantic: true,
+        brain: None,
+        no_graph: true,
+        dry_run: false,
+        json: false,
+        quiet: true,
+    }
+}
+
+/// Re-inferring the plan for a prefix that already holds records must leave one
+/// copy of every file, even when a file's inferred dataset changed.
+///
+/// The migration is provoked the way the real one happens — by changing what
+/// the corpus infers to. `d/a.jsonl` alone owns the base slug `d`; adding a
+/// second file with a disjoint field set splits `d` into two single-file
+/// clusters, and collision resolution renames both after their file stem. So
+/// `a.jsonl` moves from `reindex-test-d` to `reindex-test-d-a`, which is the
+/// same mechanism an extractor upgrade triggers when it gives a file a field it
+/// did not have before (issue #170's `defs`).
+#[test]
+fn in_place_reindex_after_a_dataset_migration_does_not_duplicate() {
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::create_dir(corpus.path().join("d")).unwrap();
+    fs::write(
+        corpus.path().join("d/a.jsonl"),
+        "{\"alpha\": 1, \"beta\": \"one\"}\n{\"alpha\": 2, \"beta\": \"two\"}\n",
+    )
+    .unwrap();
+
+    let endpoint = MockEndpoint::start();
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    let after_first = endpoint.state.lock().unwrap().live_under(&config.prefix);
+    assert_eq!(after_first, 2, "first run publishes both records");
+    let first_copies = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .copies_of(&config.prefix, "d/a.jsonl");
+    assert_eq!(first_copies.len(), 2);
+    let first_index = first_copies[0].0.clone();
+    let first_run = first_copies[0].1.clone();
+
+    // Second file, disjoint schema — splits the cluster and renames both slugs.
+    fs::write(
+        corpus.path().join("d/b.jsonl"),
+        "{\"gamma\": 3, \"delta\": \"three\"}\n",
+    )
+    .unwrap();
+    // A frozen resume plan skips new files AND never re-extracts old ones, so
+    // --fresh is the only way to pick up a re-inference (or an upgraded
+    // extractor) on an existing prefix. It is what `xc-index.sh … --fresh` runs.
+    config.fresh = true;
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    let locked = endpoint.state.lock().unwrap();
+    let copies = locked.copies_of(&config.prefix, "d/a.jsonl");
+    assert_eq!(
+        copies.len(),
+        2,
+        "a.jsonl must keep exactly its 2 records, one copy each; got {copies:?}"
+    );
+    assert!(
+        copies.iter().all(|(index, _)| *index != first_index),
+        "the migration under test did not happen — a.jsonl never left {first_index}, \
+         so this test would pass even with the leak open"
+    );
+    // Not asserted on `ax_run`: run ids are `run-{UTC second}-{pid}`, so two
+    // in-process runs inside one second share one — which is exactly why the
+    // sweep discriminates on the plan's assignment and not on the stamp.
+    let _ = first_run;
+    assert_eq!(
+        locked.live_under(&config.prefix),
+        3,
+        "3 records in the corpus, 3 live documents; indices: {:?}",
+        locked.indices()
+    );
+}
+
+/// The sweep is scoped to the running corpus's own file keys because the
+/// default prefix is `ax` — every corpus indexed without `--prefix` shares it.
+/// A second corpus re-indexed under the same prefix must not delete the first.
+#[test]
+fn reindex_leaves_another_corpus_under_the_same_prefix_alone() {
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let first_state = tempfile::tempdir().unwrap();
+    let second_state = tempfile::tempdir().unwrap();
+    fs::write(
+        first.path().join("keep.jsonl"),
+        "{\"alpha\": 1, \"beta\": \"one\"}\n",
+    )
+    .unwrap();
+    fs::write(
+        second.path().join("other.jsonl"),
+        "{\"gamma\": 2, \"delta\": \"two\"}\n",
+    )
+    .unwrap();
+
+    let endpoint = MockEndpoint::start();
+    assert_eq!(
+        run_index(cfg(first.path(), first_state.path(), &endpoint.url)).unwrap(),
+        0
+    );
+    assert_eq!(
+        run_index(cfg(second.path(), second_state.path(), &endpoint.url)).unwrap(),
+        0
+    );
+    let mut third = cfg(second.path(), second_state.path(), &endpoint.url);
+    third.fresh = true;
+    assert_eq!(run_index(third.clone()).unwrap(), 0);
+
+    let locked = endpoint.state.lock().unwrap();
+    assert_eq!(
+        locked.copies_of(&third.prefix, "keep.jsonl").len(),
+        1,
+        "the unrelated corpus sharing this prefix lost its record"
+    );
+    assert_eq!(locked.live_under(&third.prefix), 2);
+}


### PR DESCRIPTION
Closes #170.

Two commits. The first is the extractor fix for #170 itself; the second closes
the re-index hazard that an independent verifier found in it, which was the one
thing blocking this from being mergeable.

## 1. `5712f28` — extract const/static/#define

A source file whose entire content is a lookup table extracted ZERO symbols, so
it got no `defs`, and searching for the constant it defines returned the files
that merely *consume* it and never the file that declares it. Those files are
the worst ones to lose: a table's contents are empirical, exactly what cannot be
recalled from memory and must be retrieved.

`RUST_Q` now captures `const_item`/`static_item`, `GO_Q` captures package-level
`const`/`var` anchored to `source_file`, `C_Q` captures `preproc_def` plus
`translation_unit`-anchored declarations. Java and C# are deliberately left
alone. The anchoring decisions and the measurements behind each one are in the
commit body; the short version:

| | |
|---|---|
| rust records with no `defs` | 28 → 9 |
| `aho-corasick/src/util/byte_frequencies.rs` | no defs → `const BYTE_FREQUENCIES` |
| search "BYTE_FREQUENCIES" — defining file | rank 5 → top pair (ties `rank.rs`, which declares the same constant) |

## 2. `35b93b0` — the blocker: in-place re-index duplicated records

**Reproduced first, not taken on trust.** Corpus: memchr 2.8.3, regex 1.13.1,
regex-automata 0.4.16, regex-syntax 0.8.11, aho-corasick 1.1.4 — 298 paths, 284
unique-content files. Indexed with the pre-#170 extractor, then re-indexed into
the SAME prefix with `--fresh` and the #170 extractor:

```
live documents under the prefix     518 -> 538
the run's own summary still said    "518 records live"
```

`regex-syntax/src/unicode_tables/general_category.rs` — a pure lookup table, the
class of file #170 exists for — ended with two live copies, in two indices, from
two runs. The whole `regex-syntax-src` dataset dissolved and its index was left
live holding 20 orphaned documents that no dataset in the new plan pointed at.

Three parts had to line up:

1. `ids::doc_id` mixes the dataset slug in, so a file that moves schema group is
   written under a new `_id` in a new index; nothing overwrites the old copy.
2. Phase B's delete-before-replace clears only the file's CURRENT assignment, so
   it cannot see the dataset the file just left.
3. `--fresh` starts from an empty journal, so `cleanup_required` is empty and
   that delete does not run at all.

And `--fresh` was not avoidable. Measured on the same corpus: re-running WITHOUT
it is a complete no-op — the frozen resume plan is reused, every file is already
`file_done`, the upgraded extractor never runs, and the prefix keeps its 518
pre-fix records. **The only path that delivered #170's benefit on an existing
index was the one that duplicated.**

### The fix

One invariant, enforced once per run: no index under this prefix may hold
records of a file that this plan assigns to a different index. After every file
is published and every bulk confirmed, each index the run *inherited* — sampled
from `_cat/indices` before the run creates any of its own — gets a
`_delete_by_query` for the `ax_file` keys this plan homes elsewhere.

Same corpus, same two runs, with the fix:

```
live documents under the prefix     518 -> 518
the run reports                     "removed 20 superseded record(s)"
general_category.rs                 1 live copy
byte_frequencies.rs                 1 live copy, defs "const BYTE_FREQUENCIES"
3rd and 4th --fresh run             518, 518 — no drift
first run into an unused prefix     518, sweep skipped, nothing extra
```

Scale check, because the sweep batches keys 512 at a time and the corpus above
never crossed one batch. 700 single-record files whose dataset slug changes for
all 700 at once (`d/dee/*` renamed to `d/eff/*`, content untouched so every
`ax_file` key is unchanged), re-indexed in place with `--fresh`:

```
unpatched build   700 -> 1400 live documents   (an exact doubling; both indices live)
this branch       700 ->  700 live documents   ("removed 700 superseded record(s)")
                  whole run, sweep included:   0.64 s wall
```

Three decisions worth stating:

* **`ax_run` is not the discriminator**, though every document carries it. Run
  ids are `run-{UTC second}-{pid}`, so two runs from one process inside one
  second share one. The first cut of this sweep compared stamps and silently
  kept the stale copy; the new test caught it. The plan's own assignment cannot
  collide.
* **Scoped to this corpus's file keys**, not "everything that is not mine". The
  default prefix is `ax`, so unrelated corpora routinely share one prefix and an
  unscoped sweep would delete them. A test pins that.
* **Runs after publication, not before.** A run that dies mid-way then leaves a
  duplicate, which a rerun repairs, rather than a hole, which nothing does. And
  the sweep is not gated on the plan being freshly inferred, so the repair
  actually happens. Exercised for real — 4000 files, all migrating, `--fresh`
  run `kill -9`ed after publication but before the sweep, then resumed normally:

  ```
  after the kill      8000 live documents (4000 old + 4000 new, both indices)
  after the resume    "removed 4000 superseded record(s)" -> 4000 live
  ```

  Gating the sweep on a freshly inferred plan would have left those 4000
  duplicates permanently, since a resume reuses the frozen plan.

Cost: zero requests when nothing was inherited — a first publication into an
unused prefix pays nothing. Otherwise one delete-by-query per inherited index
per 512 keys, measured at **0.2 ms each** when it matches nothing (50 calls,
512-term filter, live server), so even a re-index with 50 inherited indices and
10k files is well under a second of added round trips. It cannot be collapsed
into a single wildcard call: verified against a live server, both `prefix-*` and
`a,b` return 404 `index_not_found_exception` from `_delete_by_query`.

### Tests

`crates/xerj-autoindex/src/reindex_migration_tests.rs`, against a mock endpoint
that keys documents by `(index, _id)` — a mock keyed by `_id` alone merges the
two copies and passes with the bug open.

* `in_place_reindex_after_a_dataset_migration_does_not_duplicate` — provokes the
  migration the way the real one happens (a second file with a disjoint field
  set splits the cluster and renames both slugs), re-indexes in place with
  `--fresh`, asserts the document count does not grow and that the file actually
  left its original index, so the test cannot pass vacuously. **Verified failing
  without the sweep: 4 live copies of a 2-record file instead of 2.**
* `reindex_leaves_another_corpus_under_the_same_prefix_alone` — a second corpus
  sharing the prefix keeps its records.

Full suite: `cargo test -p xerj-autoindex` 222 passed, 0 failed. `cargo fmt
--check` and `cargo clippy --all-targets -- -D warnings` clean. `cargo check -p
xerj-server` passes (`Es::delete_by_query` now returns the number of documents
removed).

### Known limits, disclosed rather than papered over

* `ax_file` is derived from CONTENT, so `--fresh` gives an EDITED file a new key
  and its pre-edit records are no longer anything the corpus claims. Measured
  with one file edited between two `--fresh` runs: **518 → 519, identical on the
  unpatched build** — pre-existing, not introduced here, and not fixed here.
  `autoindex` now prints this as a `note:` whenever `--fresh` runs against a
  prefix that already has indices, and points at deleting the `{prefix}-*`
  indices for a guaranteed-clean rebuild. Resuming (no `--fresh`) has no such
  gap: the resume plan carries the old key forward and the file replaces itself
  in place.
* Same shape, same reason: a file the new plan classifies as junk (oversized,
  unparseable) is not in `plan.files` either, so its earlier records also stay.
  Sweeping `plan.junk_files` keys instead would be actively unsafe — a
  key-collision divert records the *owner's* key in `junk_files`, so it would
  delete the legitimate owner's records.
* An index the sweep empties stays live at 0 documents. Autoindex has no
  delete-index path and adding one is a larger, destructive change.
* The catalog's `ds:{slug}` document for a dissolved dataset also survives with
  a stale `run_id`. It sits outside `{prefix}-*` so it affects no document
  count, and the catalog id is global across prefixes, so cleaning it needs its
  own design.
