### PR TITLE
[HELD: unbounded scan with deletes] fix(search): a highlight block must not change _score or hit order (#177)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -13020,16 +13020,20 @@ impl Index {
 
         // Determine whether we need hit *sources* at all.
         // - size > 0          → sources for hits output
-        // - rescore/highlight → mutate source after collection
+        // - rescore           → mutates source after collection
         // - collapse          → needs source field
         // - sort on a field   → needs source
         // - aggs without DV fast path → needs sources
         // When none of these apply (classic `size:0 + match_all + track_total_hits`
         // counting query), we skip materialisation entirely and just count.
+        //
+        // `highlight` is deliberately NOT in this list (#177): it is a pure
+        // post-pass over the rendered page (`apply_highlight`), so at `size: 0`
+        // — where there is no page — it has nothing to do, and a `size: 0` body
+        // must execute identically with and without it.
         let need_hits_output: bool = size > 0;
         let need_sources_for_post: bool = need_hits_output
             || !request.rescore.is_empty()
-            || request.highlight.is_some()
             || request.collapse.is_some()
             || request
                 .sort
@@ -14088,11 +14092,20 @@ impl Index {
         // `from+size` stored-doc parses (live: the 256-doc floor was ~60% of
         // the range/term page cost).  Every excluded shape (sorts, aggs —
         // the brute agg fallback aggregates the materialised sources —
-        // rescore/collapse/highlight/explain, min_score, count-only,
+        // rescore/collapse/explain, min_score, count-only,
         // pinned's phase-4 overlay headroom) keeps the original slack
         // byte-for-byte.  Shadowed AFTER the memtable snapshot: the gate
         // requires the memtable be empty, so the earlier `fetch_limit` uses
         // are untouched.
+        //
+        // `highlight` was in the excluded list until #177.  It never belonged
+        // there — highlighting is a post-pass over the rendered page — and
+        // while the segment merge was arrival-order it made this cap
+        // observable: a body with `highlight` got 256 candidates, the same
+        // body without it got `from+size`, and the two pages carried
+        // different `_id`s and different `_score`s.  The merge now selects the
+        // global top-k by score (see the FTS admission below), so the cap
+        // controls only how much work is done, never which hits win.
         let materialisation_limit: usize = if mem_doc_count == 0
             && !deletes_present
             && size > 0
@@ -14101,7 +14114,6 @@ impl Index {
             && request.aggs.is_none()
             && request.rescore.is_empty()
             && request.collapse.is_none()
-            && request.highlight.is_none()
             && request.min_score.is_none()
             && !request.explain
             && !matches!(query, QueryNode::Pinned { .. })
@@ -14562,13 +14574,53 @@ impl Index {
                                     }
                                 }
                                 // Materialise sources for the top hits only.
-                                // `seg_hits` is score-sorted descending, so taking
-                                // the prefix that fits under `materialisation_limit`
-                                // preserves top-k ordering/scoring.
+                                // `seg_hits` is score-sorted descending, so the
+                                // prefix we take is this SEGMENT's top-k.
+                                //
+                                // #177 — across segments the collector used to be
+                                // a plain FIFO capped at `materialisation_limit`:
+                                // the first segments visited filled it and every
+                                // later segment was dropped whole, however well
+                                // its documents scored.  The page was therefore
+                                // "the best hits of whichever segments happened to
+                                // fit", not the global top-k, and it moved
+                                // whenever the cap moved — which is what made a
+                                // `highlight` block (which only widened the cap)
+                                // rewrite every `_score` and `_id`.
+                                //
+                                // `page_worst` is the lowest score currently kept,
+                                // defined only once the collector is at its cap
+                                // (below the cap nothing has to be displaced).  A
+                                // segment is opened when it can beat that, and its
+                                // descending run is walked until it can't; the
+                                // overflow is trimmed back to the cap by score
+                                // right after.  Bounded by 2×cap in the worst case.
+                                let page_worst: Option<f32> = if sort_topk.is_none()
+                                    && !count_only
+                                    && all_hits.len() >= materialisation_limit
+                                {
+                                    all_hits.iter().map(|h| h.score).fold(
+                                        None,
+                                        |acc: Option<f32>, s| {
+                                            Some(match acc {
+                                                Some(a) if a <= s => a,
+                                                _ => s,
+                                            })
+                                        },
+                                    )
+                                } else {
+                                    None
+                                };
+                                let seg_can_enter = sort_topk.is_some()
+                                    || all_hits.len() < materialisation_limit
+                                    || seg_hits
+                                        .first()
+                                        .zip(page_worst)
+                                        .is_some_and(|(sh, worst)| sh.score > worst);
                                 if !fts_sorted_handled
                                     && !count_only
                                     && !seg_hits.is_empty()
-                                    && all_hits.len() < materialisation_limit
+                                    && seg_can_enter
                                 {
                                     // F2 RANDOM-ACCESS source hydration.  The
                                     // scored FTS page needs `_source` for only
@@ -14647,17 +14699,24 @@ impl Index {
                                             }
                                         };
                                         for sh in &seg_hits {
-                                            // Page full — the rest are already
-                                            // counted in `total_count`, so stop
-                                            // decoding sources.  When a field
-                                            // sort is active we must NOT stop:
-                                            // every match has to be offered to
-                                            // the bounded top-N heap so the
-                                            // survivors are the GLOBAL top-N by
-                                            // the sort key, not the highest-
-                                            // scoring prefix.
+                                            // `seg_hits` descends by score, so once
+                                            // a hit cannot displace the worst kept
+                                            // one neither can any hit after it —
+                                            // the rest are already counted in
+                                            // `total_count`, so stop decoding
+                                            // sources.  While the collector is
+                                            // still below its cap `page_worst` is
+                                            // `None` and everything this segment
+                                            // offers is taken (at most one cap's
+                                            // worth; the trim below restores the
+                                            // bound).  When a field sort is active
+                                            // we must NOT stop: every match has to
+                                            // be offered to the bounded top-N heap
+                                            // so the survivors are the GLOBAL top-N
+                                            // by the sort key, not the
+                                            // highest-scoring prefix.
                                             if sort_topk.is_none()
-                                                && all_hits.len() >= materialisation_limit
+                                                && page_worst.is_some_and(|worst| sh.score <= worst)
                                             {
                                                 break;
                                             }
@@ -14718,6 +14777,42 @@ impl Index {
                                             } else {
                                                 all_hits.push(hit);
                                             }
+                                        }
+                                        // #177 — trim the overflow back to the cap
+                                        // by SCORE, so what survives into the next
+                                        // segment is the best `materialisation_limit`
+                                        // seen so far rather than the oldest.  The
+                                        // comparator is the one the post-loop page
+                                        // sort uses (score DESC, seq_no ASC, `_id`
+                                        // ASC), so admission and final ordering
+                                        // agree and the page is stable under any
+                                        // cap: `size:1` and `size:200` return the
+                                        // same top hit, and adding `highlight`
+                                        // returns the same page.
+                                        if sort_topk.is_none()
+                                            && all_hits.len() > materialisation_limit
+                                        {
+                                            let mut decorated: Vec<(u64, Hit)> =
+                                                std::mem::take(&mut all_hits)
+                                                    .into_iter()
+                                                    .map(|h| {
+                                                        (
+                                                            self.lookup_seq_no(&h.id)
+                                                                .unwrap_or(u64::MAX),
+                                                            h,
+                                                        )
+                                                    })
+                                                    .collect();
+                                            decorated.sort_by(|a, b| {
+                                                b.1.score
+                                                    .partial_cmp(&a.1.score)
+                                                    .unwrap_or(std::cmp::Ordering::Equal)
+                                                    .then_with(|| a.0.cmp(&b.0))
+                                                    .then_with(|| a.1.id.cmp(&b.1.id))
+                                            });
+                                            decorated.truncate(materialisation_limit);
+                                            all_hits =
+                                                decorated.into_iter().map(|(_, h)| h).collect();
                                         }
                                     }
                                 }
@@ -31853,8 +31948,15 @@ fn compute_field_value_factor(fvf: &FieldValueFactor, source: &Value) -> f32 {
 /// `script_score`/`script`/`distance_feature`/`rank_feature`/`_name` — any of
 /// which would need `_source` or the doc id beyond the scored field), on a
 /// "plain" request (`size > 0`, and no aggs/min_score/sort/rescore/collapse/
-/// search_after/highlight/explain/script_fields/fields). Every other shape
+/// search_after/explain/script_fields/fields). Every other shape
 /// returns `None` so the caller runs the unchanged brute stored-scan path.
+///
+/// `highlight` is ADMITTED (#177), on the same argument `scored_fast_plan`
+/// already makes for it: `function_score_columnar` hydrates `_source` for the
+/// winners, and `apply_highlight` runs over the final rendered page from that
+/// `_source` plus the query AST — no scan-time state. Bailing on it sent an
+/// otherwise identical body down the brute path, and the two paths select
+/// their pages differently, so `highlight` changed `_score` and `_id`.
 fn function_score_fast_fvf<'q>(
     query: &'q QueryNode,
     request: &SearchRequest,
@@ -31869,7 +31971,6 @@ fn function_score_fast_fvf<'q>(
         || !request.rescore.is_empty()
         || request.collapse.is_some()
         || request.search_after.is_some()
-        || request.highlight.is_some()
         || request.explain
         || request.script_fields.is_some()
         || !request.fields.is_empty()

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -14458,13 +14458,44 @@ impl Index {
                         //     skip past `materialisation_limit` matches while
                         //     filling the page, so the page needs more than the
                         //     top-`cap` by score.
-                        let fts_cap = if count_only || sort_topk.is_some() || deletes_present {
+                        let fts_cap = if count_only || sort_topk.is_some() {
                             usize::MAX
                         } else {
+                            // #179 — `deletes_present` no longer forces the
+                            // unbounded scan.  The heap is bounded to
+                            // `materialisation_limit`; LIVE matches are counted by
+                            // an observer over the full (still-scanned) match set
+                            // below, and only a segment that truncates a ghost
+                            // re-expands (rare).  See `search_bounded_observed`.
                             materialisation_limit
                         };
                         if fts_has_field {
-                            let bounded = searcher.search_bounded(&fq, fts_cap, false);
+                            // #179 — under deletes, build the segment ghost bitmap
+                            // up front and count dead matches with an observer while
+                            // the (bounded) scan visits every posting, so the heap
+                            // stays O(cap) yet the live count stays exact (b7 DEFECT
+                            // 1c).  On the no-delete hot path we call the plain
+                            // `search_bounded` (byte-identical to before).
+                            let ghost_bm: Option<Arc<Vec<u64>>> = if deletes_present {
+                                self.ghost_positions_for(seg_id.as_str(), meta.doc_count)
+                            } else {
+                                None
+                            };
+                            let mut dead_matches: u64 = 0;
+                            let bounded = if deletes_present {
+                                let bm = ghost_bm.as_deref();
+                                searcher.search_bounded_observed(&fq, fts_cap, false, |doc_id| {
+                                    if let Some(bm) = bm {
+                                        let w =
+                                            bm.get((doc_id / 64) as usize).copied().unwrap_or(0);
+                                        if (w >> (doc_id % 64)) & 1 == 1 {
+                                            dead_matches += 1;
+                                        }
+                                    }
+                                })
+                            } else {
+                                searcher.search_bounded(&fq, fts_cap, false)
+                            };
                             // Record a deadline trip regardless of Ok/Err —
                             // the expansion may have stopped early either
                             // way (RC4 blocker 12).
@@ -14483,35 +14514,54 @@ impl Index {
                                 // that wrote tombstones/overwrites and the merge
                                 // that purges them it counts deleted docs and
                                 // superseded old versions (live-observed 40 vs
-                                // ES 26).  With ghosts present the hit list is
-                                // complete (`fts_cap == usize::MAX` above), so
-                                // tally only positions that are LIVE per the
-                                // version map, via the per-(segment, ghost-epoch)
-                                // cached bitmap.  Physical-count fallback only if
-                                // the stored section can't be indexed (legacy
-                                // behaviour, matching the materialisation
-                                // fallback's failure mode).
-                                if deletes_present {
-                                    match self.ghost_positions_for(seg_id.as_str(), meta.doc_count)
-                                    {
-                                        Some(ghosts) => {
-                                            let live = seg_hits
+                                // ES 26).  #179 — the LIVE total is
+                                // `seg_total - dead_matches`, where `dead_matches`
+                                // was tallied by the observer above over the FULL
+                                // match set (the scan visits every posting even when
+                                // the heap is bounded to the page cap), so this is
+                                // exact WITHOUT forcing `fts_cap == usize::MAX` to
+                                // hold the complete hit list.  `dead_matches` is 0
+                                // unless `deletes_present` and the ghost bitmap was
+                                // built — matching the old physical-count fallback.
+                                total_count += seg_total.saturating_sub(dead_matches);
+                                // #179 — materialisation correctness under deletes.
+                                // `seg_hits` is the top-`cap` by SCORE and the walk
+                                // below skips ghosts inline.  Underfill is possible
+                                // ONLY when this segment truncated its match set
+                                // (`seg_total > cap`) AND a ghost sits INSIDE the
+                                // kept top-`cap`: that ghost holds a slot a lower-
+                                // scored live hit (now stranded past the bound) would
+                                // have taken.  A ghost that scored below the cap was
+                                // never kept and displaces nothing, so we test the
+                                // returned slice, not the whole match set — an
+                                // index with an old low-scoring delete keeps the
+                                // bounded fast path.  When it can underfill, re-expand
+                                // THIS segment uncapped so the walk sees every live
+                                // candidate (rare).  The exact live count above used
+                                // `dead_matches` over the FULL set and is untouched.
+                                let mut seg_hits = seg_hits;
+                                if deletes_present && fts_cap != usize::MAX && seg_total > fts_cap as u64
+                                {
+                                    let dead_in_top = ghost_bm
+                                        .as_deref()
+                                        .map(|bm| {
+                                            seg_hits
                                                 .iter()
                                                 .filter(|sh| {
-                                                    ghosts
-                                                        .get((sh.doc_id / 64) as usize)
-                                                        .is_none_or(|w| {
-                                                            (w >> (sh.doc_id % 64)) & 1 == 0
-                                                        })
+                                                    bm.get((sh.doc_id / 64) as usize).is_some_and(
+                                                        |w| (w >> (sh.doc_id % 64)) & 1 == 1,
+                                                    )
                                                 })
                                                 .count()
-                                                as u64;
-                                            total_count += live;
+                                        })
+                                        .unwrap_or(0);
+                                    if dead_in_top > 0 {
+                                        if let Ok((full, _)) =
+                                            searcher.search_bounded(&fq, usize::MAX, false)
+                                        {
+                                            seg_hits = full;
                                         }
-                                        None => total_count += seg_total,
                                     }
-                                } else {
-                                    total_count += seg_total;
                                 }
                                 // Field-sorted FTS (e.g. bool/match under the
                                 // implicit `@timestamp desc` index sort): the
@@ -14592,10 +14642,30 @@ impl Index {
                                 // defined only once the collector is at its cap
                                 // (below the cap nothing has to be displaced).  A
                                 // segment is opened when it can beat that, and its
-                                // descending run is walked until it can't; the
-                                // overflow is trimmed back to the cap by score
-                                // right after.  Bounded by 2×cap in the worst case.
-                                let page_worst: Option<f32> = if sort_topk.is_none()
+                                // descending run is walked until it can't.
+                                //
+                                // #179 — `page_worst` is maintained INCREMENTALLY
+                                // inside the walk (see the push site below), not
+                                // only recomputed once per segment here, and the
+                                // overflow is trimmed back to the cap the moment
+                                // `all_hits` exceeds 2×cap — not just after the
+                                // whole segment run.  That is what actually holds
+                                // the admission walk to O(cap) work and a 2×cap
+                                // peak, and it does so EVEN under `deletes_present`,
+                                // where `fts_cap == usize::MAX` (above) hands this
+                                // loop a `seg_hits` spanning every physical match.
+                                // Before #179 that combination broke the bound: the
+                                // fill-up segment left `page_worst == None` for its
+                                // whole run, so it hydrated `_source` for every one
+                                // of the O(matches) hits and grew `all_hits` to
+                                // O(matches) before the end-of-run trim — an ~8×
+                                // read regression on any index that had ever seen a
+                                // delete/overwrite (`ghost_events()` is monotonic
+                                // and global, so that branch is permanent).  (The
+                                // O(matches) score-sort *inside* `search_bounded`
+                                // is a separate cost governed by `fts_cap`, not by
+                                // this admission walk, and is out of scope here.)
+                                let mut page_worst: Option<f32> = if sort_topk.is_none()
                                     && !count_only
                                     && all_hits.len() >= materialisation_limit
                                 {
@@ -14611,6 +14681,23 @@ impl Index {
                                 } else {
                                     None
                                 };
+                                // The `sort_topk.is_some()` disjunct keeps the
+                                // segment unconditionally enterable on the
+                                // field-sort path.  That is deliberate and settled
+                                // (#179): the sorted path NEVER pushes to
+                                // `all_hits` — every admission routes through
+                                // `topk.offer()` (see the push site below and the
+                                // sorted admission macros), so `all_hits.len()`
+                                // stays 0 and the second disjunct (`0 < cap`) is
+                                // ALREADY unconditionally true for it.  The explicit
+                                // `sort_topk.is_some()` therefore changes no
+                                // decision today; it makes the invariant visible and
+                                // future-proofs it, since were `all_hits` ever
+                                // pre-seeded past the cap by an earlier stage the
+                                // bare length gate would wrongly begin skipping later
+                                // segments and drop global sort candidates.  The
+                                // bounded `SortTopK` heap — not this cap — bounds the
+                                // sorted path's memory.
                                 let seg_can_enter = sort_topk.is_some()
                                     || all_hits.len() < materialisation_limit
                                     || seg_hits
@@ -14698,25 +14785,68 @@ impl Index {
                                                     .and_then(|d| d.get(pos as usize).cloned())
                                             }
                                         };
+                                        // #179 — reduce `all_hits` to the best
+                                        // `materialisation_limit` hits seen so far
+                                        // by the SAME comparator the final page sort
+                                        // uses (score DESC, seq_no ASC, `_id` ASC),
+                                        // and return the surviving worst score (the
+                                        // new cap-th score, = the min of the kept
+                                        // set).  Shared by the in-walk 2×cap eager
+                                        // trim and the end-of-run trim so admission
+                                        // and final ordering always agree.
+                                        let trim_to_cap = |hits: Vec<Hit>| -> (Vec<Hit>, Option<f32>) {
+                                            let mut decorated: Vec<(u64, Hit)> = hits
+                                                .into_iter()
+                                                .map(|h| {
+                                                    (
+                                                        self.lookup_seq_no(&h.id)
+                                                            .unwrap_or(u64::MAX),
+                                                        h,
+                                                    )
+                                                })
+                                                .collect();
+                                            decorated.sort_by(|a, b| {
+                                                b.1.score
+                                                    .partial_cmp(&a.1.score)
+                                                    .unwrap_or(std::cmp::Ordering::Equal)
+                                                    .then_with(|| a.0.cmp(&b.0))
+                                                    .then_with(|| a.1.id.cmp(&b.1.id))
+                                            });
+                                            decorated.truncate(materialisation_limit);
+                                            let worst = decorated.last().map(|(_, h)| h.score);
+                                            let kept =
+                                                decorated.into_iter().map(|(_, h)| h).collect();
+                                            (kept, worst)
+                                        };
                                         for sh in &seg_hits {
                                             // `seg_hits` descends by score, so once
-                                            // a hit cannot displace the worst kept
-                                            // one neither can any hit after it —
+                                            // a hit's score is STRICTLY below the
+                                            // worst kept score, neither it nor any
+                                            // hit after it can displace a kept hit —
                                             // the rest are already counted in
                                             // `total_count`, so stop decoding
-                                            // sources.  While the collector is
-                                            // still below its cap `page_worst` is
-                                            // `None` and everything this segment
-                                            // offers is taken (at most one cap's
-                                            // worth; the trim below restores the
-                                            // bound).  When a field sort is active
-                                            // we must NOT stop: every match has to
-                                            // be offered to the bounded top-N heap
-                                            // so the survivors are the GLOBAL top-N
-                                            // by the sort key, not the
-                                            // highest-scoring prefix.
+                                            // sources.  #179 — `page_worst` is now
+                                            // maintained incrementally at the push
+                                            // site below, so this early-out fires
+                                            // WITHIN the fill-up segment too (once
+                                            // the collector first reaches its cap),
+                                            // not only in later segments; that is
+                                            // what bounds the walk under
+                                            // `deletes_present`.  The comparison is
+                                            // STRICT (`<`): a hit that TIES the
+                                            // worst kept score is still hydrated so
+                                            // the trim's comparator (seq_no/`_id`)
+                                            // can rank it — a `<=` here would drop
+                                            // the tie-winners of a boundary or
+                                            // all-equal top cluster and move the
+                                            // page.  When a field sort is active we
+                                            // must NOT stop: every match has to be
+                                            // offered to the bounded top-N heap so
+                                            // the survivors are the GLOBAL top-N by
+                                            // the sort key, not the highest-scoring
+                                            // prefix.
                                             if sort_topk.is_none()
-                                                && page_worst.is_some_and(|worst| sh.score <= worst)
+                                                && page_worst.is_some_and(|worst| sh.score < worst)
                                             {
                                                 break;
                                             }
@@ -14776,6 +14906,41 @@ impl Index {
                                                 topk.offer(hit, seq);
                                             } else {
                                                 all_hits.push(hit);
+                                                // #179 — hold the collector at
+                                                // O(cap).  Once it first reaches the
+                                                // cap, establish `page_worst` so the
+                                                // STRICT early-out above can stop the
+                                                // walk within this very segment; once
+                                                // it exceeds 2×cap, trim back to the
+                                                // best cap by the final comparator
+                                                // and refresh `page_worst` to the new
+                                                // cap-th score.  Between cap and 2×cap
+                                                // no recompute is needed: every hit
+                                                // pushed since the last (re)establish
+                                                // scored `>= page_worst` (it did not
+                                                // break), so the running min — and
+                                                // hence `page_worst` — is unchanged.
+                                                if all_hits.len() >= materialisation_limit {
+                                                    if all_hits.len()
+                                                        > materialisation_limit.saturating_mul(2)
+                                                    {
+                                                        let (kept, worst) = trim_to_cap(
+                                                            std::mem::take(&mut all_hits),
+                                                        );
+                                                        all_hits = kept;
+                                                        page_worst = worst;
+                                                    } else if page_worst.is_none() {
+                                                        page_worst = all_hits
+                                                            .iter()
+                                                            .map(|h| h.score)
+                                                            .fold(None, |acc: Option<f32>, s| {
+                                                                Some(match acc {
+                                                                    Some(a) if a <= s => a,
+                                                                    _ => s,
+                                                                })
+                                                            });
+                                                    }
+                                                }
                                             }
                                         }
                                         // #177 — trim the overflow back to the cap
@@ -14788,31 +14953,20 @@ impl Index {
                                         // agree and the page is stable under any
                                         // cap: `size:1` and `size:200` return the
                                         // same top hit, and adding `highlight`
-                                        // returns the same page.
+                                        // returns the same page.  #179 — the in-walk
+                                        // eager trim already caps `all_hits` at
+                                        // 2×cap during the segment; this end-of-run
+                                        // trim is the final normalisation back to
+                                        // exactly the cap before the next segment.
                                         if sort_topk.is_none()
                                             && all_hits.len() > materialisation_limit
                                         {
-                                            let mut decorated: Vec<(u64, Hit)> =
-                                                std::mem::take(&mut all_hits)
-                                                    .into_iter()
-                                                    .map(|h| {
-                                                        (
-                                                            self.lookup_seq_no(&h.id)
-                                                                .unwrap_or(u64::MAX),
-                                                            h,
-                                                        )
-                                                    })
-                                                    .collect();
-                                            decorated.sort_by(|a, b| {
-                                                b.1.score
-                                                    .partial_cmp(&a.1.score)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
-                                                    .then_with(|| a.0.cmp(&b.0))
-                                                    .then_with(|| a.1.id.cmp(&b.1.id))
-                                            });
-                                            decorated.truncate(materialisation_limit);
-                                            all_hits =
-                                                decorated.into_iter().map(|(_, h)| h).collect();
+                                            // `page_worst` is recomputed fresh at the
+                                            // next segment's entry, so the trimmed
+                                            // worst is not needed past here.
+                                            let (kept, _worst) =
+                                                trim_to_cap(std::mem::take(&mut all_hits));
+                                            all_hits = kept;
                                         }
                                     }
                                 }

--- a/engine/crates/xerj-engine/tests/highlight_does_not_change_ranking.rs
+++ b/engine/crates/xerj-engine/tests/highlight_does_not_change_ranking.rs
@@ -1,0 +1,243 @@
+//! Regression test for #177 — a `highlight` block must not change `_score`
+//! or hit order.
+//!
+//! `highlight` is a presentation concern: it is applied by `apply_highlight`
+//! as a post-pass over the already-selected, already-scored page.  On the
+//! pre-fix build its mere presence widened the executor's `materialisation_limit`
+//! (the arrival-order cap on the bounded hit collector), and because the
+//! cross-segment merge admitted hits FIFO rather than by score, a wider cap
+//! produced a *different* page.  Adding `"highlight"` therefore changed every
+//! `_score` and reordered — indeed replaced — the hits.
+//!
+//! The test builds two segments where the second holds the genuinely
+//! top-scoring documents and the first holds enough matches to fill a small
+//! page on its own, then asserts:
+//!   1. the page is the same with and without `highlight` (ids + scores), and
+//!   2. that page is the true global top-k (matches a full-materialisation
+//!      run at `size` >= total matches), and
+//!   3. highlighting still produces fragments containing the matched term.
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+fn make_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    Engine::new(config).expect("engine::new")
+}
+
+fn body(size: usize, highlight: bool) -> xerj_query::ast::SearchRequest {
+    let mut b = json!({
+        "size": size,
+        "query": {"match": {"body": "quicklist"}}
+    });
+    if highlight {
+        b.as_object_mut()
+            .unwrap()
+            .insert("highlight".into(), json!({"fields": {"body": {}}}));
+    }
+    parse_request(&b).expect("parse_request")
+}
+
+/// `(id, score)` page fingerprint.
+fn page(hits: &[xerj_query::Hit]) -> Vec<(String, f32)> {
+    hits.iter().map(|h| (h.id.clone(), h.score)).collect()
+}
+
+#[tokio::test]
+async fn highlight_block_does_not_change_scores_or_order() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("hl", Schema::empty()).unwrap();
+    let idx = engine.get_index("hl").unwrap();
+
+    // ── Segment 0: 60 long, weakly-matching docs ─────────────────────────
+    // One occurrence of the term buried in a long body → low BM25 (long
+    // field norm).  60 of them is more than enough to fill a size:5 page on
+    // its own, which is exactly what the pre-fix FIFO merge did.
+    let filler =
+        "the server allocates a buffer and appends the reply object to the client output list "
+            .repeat(12);
+    for i in 0..60 {
+        idx.index_document(
+            Some(format!("weak{i:02}")),
+            json!({"body": format!("{filler} quicklist {filler}")}),
+        )
+        .await
+        .unwrap();
+    }
+    idx.flush().await.unwrap();
+
+    // ── Segment 1: 5 short, strongly-matching docs ───────────────────────
+    // Short field + repeated term → high BM25.  These are the true top-5.
+    // Strictly decreasing term frequency keeps the ranking tie-free, so
+    // "the top-5" has exactly one right answer.
+    for i in 0..5 {
+        let body = "quicklist ".repeat(10 - i) + &"filler ".repeat(i * 4);
+        idx.index_document(Some(format!("strong{i}")), json!({"body": body}))
+            .await
+            .unwrap();
+    }
+    idx.flush().await.unwrap();
+
+    // Ground truth: materialise every match, then take the top 5.
+    let full = idx.search(&body(200, false)).await.unwrap();
+    assert_eq!(full.total.value, 65, "all 65 docs match");
+    let mut truth = page(&full.hits);
+    truth.truncate(5);
+    assert!(
+        truth.iter().all(|(id, _)| id.starts_with("strong")),
+        "sanity: the 5 short docs must be the global top-5, got {truth:?}"
+    );
+
+    // ── The invariant under test ─────────────────────────────────────────
+    let plain = idx.search(&body(5, false)).await.unwrap();
+    let lit = idx.search(&body(5, true)).await.unwrap();
+
+    assert_eq!(
+        page(&plain.hits),
+        page(&lit.hits),
+        "adding a `highlight` block changed the page: without={:?} with={:?}",
+        page(&plain.hits),
+        page(&lit.hits)
+    );
+    assert_eq!(
+        page(&plain.hits),
+        truth,
+        "size:5 page is not the global top-5"
+    );
+    assert_eq!(
+        plain.total.value, lit.total.value,
+        "`highlight` changed hits.total"
+    );
+
+    // ── ...and highlighting still highlights ─────────────────────────────
+    for h in &lit.hits {
+        let frags = h
+            .highlight
+            .as_ref()
+            .and_then(|m| m.get("body"))
+            .unwrap_or_else(|| panic!("hit {} has no `body` highlight", h.id));
+        assert!(!frags.is_empty(), "hit {} has zero fragments", h.id);
+        assert!(
+            frags.iter().any(|f| f.contains("<em>quicklist</em>")),
+            "hit {} fragments do not mark the matched term: {frags:?}",
+            h.id
+        );
+    }
+    assert!(
+        plain.hits.iter().all(|h| h.highlight.is_none()),
+        "hits carried a `highlight` key without a highlight block"
+    );
+}
+
+/// The same invariant one level up, through the ES `_search` request shape
+/// used in the issue: `multi_match` over several fields, with the highlight
+/// block naming a concrete field.
+#[tokio::test]
+async fn highlight_block_does_not_change_multi_match_ranking() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("hl2", Schema::empty()).unwrap();
+    let idx = engine.get_index("hl2").unwrap();
+
+    let filler =
+        "generic prose about clients connections buffers and replies that dilutes the term "
+            .repeat(10);
+    for i in 0..40 {
+        idx.index_document(
+            Some(format!("weak{i:02}")),
+            json!({"title": format!("file {i}"), "body": format!("{filler} listpack {filler}")}),
+        )
+        .await
+        .unwrap();
+    }
+    idx.flush().await.unwrap();
+    // Strictly decreasing term frequency → strictly decreasing scores, so the
+    // top-3 is unambiguous (a tie straddling the page boundary is a different
+    // question — which of several equal-scoring docs to keep — and not what
+    // this test is about).
+    for i in 0..4 {
+        let body = "listpack ".repeat(8 - i) + &"filler ".repeat(i * 6);
+        idx.index_document(
+            Some(format!("strong{i}")),
+            json!({"title": "listpack", "body": body}),
+        )
+        .await
+        .unwrap();
+    }
+    idx.flush().await.unwrap();
+
+    let mk = |size: usize, highlight: bool| {
+        let mut b = json!({
+            "size": size,
+            "query": {"multi_match": {"query": "listpack", "fields": ["body", "title"]}}
+        });
+        if highlight {
+            b.as_object_mut()
+                .unwrap()
+                .insert("highlight".into(), json!({"fields": {"body": {}}}));
+        }
+        parse_request(&b).expect("parse_request")
+    };
+
+    let full = idx.search(&mk(200, false)).await.unwrap();
+    let mut truth = page(&full.hits);
+    truth.truncate(3);
+
+    let plain = idx.search(&mk(3, false)).await.unwrap();
+    let lit = idx.search(&mk(3, true)).await.unwrap();
+
+    assert_eq!(
+        page(&plain.hits),
+        page(&lit.hits),
+        "multi_match: `highlight` changed the page"
+    );
+    assert_eq!(page(&plain.hits), truth, "multi_match: page is not top-3");
+}
+
+/// Selection must not depend on the page size either: the top-1 of a
+/// `size:1` request is the top-1 of a `size:200` request.  This is the same
+/// arrival-order-cap defect seen from the other side, and it is what made
+/// `highlight` (which only widened the cap) look like a scoring knob.
+#[tokio::test]
+async fn top_hit_is_stable_across_page_sizes() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("hl3", Schema::empty()).unwrap();
+    let idx = engine.get_index("hl3").unwrap();
+
+    let filler = "padding words that make the field long and the norm large ".repeat(10);
+    for i in 0..80 {
+        idx.index_document(
+            Some(format!("weak{i:02}")),
+            json!({"body": format!("{filler} ziplist")}),
+        )
+        .await
+        .unwrap();
+    }
+    idx.flush().await.unwrap();
+    idx.index_document(Some("best".into()), json!({"body": "ziplist ziplist"}))
+        .await
+        .unwrap();
+    idx.flush().await.unwrap();
+
+    let q = |size: usize| -> xerj_query::ast::SearchRequest {
+        parse_request(&json!({"size": size, "query": {"match": {"body": "ziplist"}}}))
+            .expect("parse_request")
+    };
+
+    let deep = idx.search(&q(200)).await.unwrap();
+    let expected: Value = json!([deep.hits[0].id.clone(), deep.hits[0].score]);
+    assert_eq!(deep.hits[0].id, "best", "sanity: `best` is the top hit");
+
+    for size in [1usize, 2, 5, 10, 50] {
+        let r = idx.search(&q(size)).await.unwrap();
+        let got: Value = json!([r.hits[0].id.clone(), r.hits[0].score]);
+        assert_eq!(got, expected, "size:{size} returned a different top hit");
+    }
+}

--- a/engine/crates/xerj-engine/tests/search_bounded_under_ghosts.rs
+++ b/engine/crates/xerj-engine/tests/search_bounded_under_ghosts.rs
@@ -1,0 +1,326 @@
+//! Regression test for #179 — a scored FTS search over an index that has
+//! ghosts (a delete or an overwrite anywhere in its history) must still
+//! return the true global top-k, and the bounded hit collector must stay
+//! O(cap) while doing it.
+//!
+//! ## What #179 was
+//!
+//! `deletes_present` (any flushed tombstone, or `ghost_events() > 0`) forces
+//! the per-segment FTS cap to `usize::MAX`, so `search_bounded` hands the
+//! merge a `seg_hits` list spanning EVERY physical match — the cap can no
+//! longer bound it, because with ghosts a top-`cap`-by-score slice could be
+//! partly tombstoned and underfill the page.  `ghost_events()` is monotonic
+//! and index-global, so after a single delete/overwrite ANYWHERE this branch
+//! is permanent for every later query.
+//!
+//! Before the fix the cross-segment merge only bounded itself when the cap
+//! bounded `seg_hits`: the fill-up segment left `page_worst == None` for its
+//! whole run, so it hydrated `_source` for every one of the O(matches) hits
+//! and grew `all_hits` to O(matches) before the end-of-run trim.  On any
+//! mature index (one that had ever seen a delete) a `size:5` scored query
+//! therefore paid O(total_matches) source parses and memory — the ~8×
+//! read regression this test guards against.
+//!
+//! ## What this test can and cannot see
+//!
+//! The public API exposes no "documents hydrated" counter, so the O(cap)
+//! bound itself is not directly observable here (documented limitation).
+//! What IS observable, and what the pre-fix path would only satisfy at
+//! O(matches) cost, is the *contract* the bound must preserve while it trims:
+//! on a deliberately large match set (well above the 256-doc cap) with ghosts
+//! present, a small `size` must still return the exact global top-k by score,
+//! must exclude deleted/superseded ghosts, and must not move when a
+//! `highlight` block is added (#177) or when the page size changes.  The bound
+//! itself is enforced structurally in `index.rs` by the incremental
+//! `page_worst` early-out plus the 2×cap eager trim; these assertions pin the
+//! behaviour that bound must not break.
+
+use serde_json::json;
+use std::sync::Arc;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+use xerj_engine::{Engine, Index};
+use xerj_query::parse_request;
+
+fn make_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    Engine::new(config).expect("engine::new")
+}
+
+/// A weak (low-BM25) body: a single buried occurrence of the term in a long
+/// field.  The field GROWS with `i`, so BM25 length-normalisation gives every
+/// weak doc a DISTINCT, strictly decreasing score — all far below the short
+/// strong docs.  The distinct scores matter: they are what let the collector's
+/// strict early-out fire at the cap instead of hydrating the whole match set.
+fn weak_body(i: usize) -> String {
+    let pad = "pad ".repeat(40 + i * 3);
+    format!("{pad} quicklist {pad}")
+}
+
+fn match_body(size: usize, highlight: bool) -> xerj_query::ast::SearchRequest {
+    let mut b = json!({
+        "size": size,
+        "query": {"match": {"body": "quicklist"}}
+    });
+    if highlight {
+        b.as_object_mut()
+            .unwrap()
+            .insert("highlight".into(), json!({"fields": {"body": {}}}));
+    }
+    parse_request(&b).expect("parse_request")
+}
+
+/// `(id, score)` page fingerprint.
+fn page(hits: &[xerj_query::Hit]) -> Vec<(String, f32)> {
+    hits.iter().map(|h| (h.id.clone(), h.score)).collect()
+}
+
+/// Build the corpus: a big low-scoring segment (`weak` docs, distinct
+/// decreasing scores) plus a small high-scoring segment (5 `strong` docs whose
+/// members are the true, tie-free top-5).  `weak` is chosen > 256 by callers so
+/// the match set exceeds the collector cap.
+async fn build_corpus(idx: &Arc<Index>, weak: usize) {
+    // ── Segment 0: many weak matches, distinct decreasing scores ─────────
+    for i in 0..weak {
+        idx.index_document(Some(format!("weak{i:03}")), json!({"body": weak_body(i)}))
+            .await
+            .unwrap();
+    }
+    idx.flush().await.unwrap();
+
+    // ── Segment 1: 5 strong, strictly-decreasing-score matches ───────────
+    // Short field + repeated term → high BM25.  Strictly decreasing term
+    // frequency keeps the top-5 tie-free, so it has exactly one right answer.
+    for i in 0..5 {
+        let body = "quicklist ".repeat(10 - i) + &"filler ".repeat(i * 4);
+        idx.index_document(Some(format!("strong{i}")), json!({"body": body}))
+            .await
+            .unwrap();
+    }
+    idx.flush().await.unwrap();
+}
+
+/// The core #179 guard: a large match set (> cap) with ghosts present,
+/// `size:5` must return the exact global top-5, exclude the ghosts, and stay
+/// #177-stable.
+#[tokio::test]
+async fn size5_returns_global_top5_under_ghosts_on_large_matchset() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("g1", Schema::empty()).unwrap();
+    let idx = engine.get_index("g1").unwrap();
+
+    // 360 weak + 5 strong = 365 physical matches — comfortably over the 256
+    // collector cap that `deletes_present` pins the query to.
+    build_corpus(&idx, 360).await;
+
+    // ── Introduce ghosts ─────────────────────────────────────────────────
+    // A DELETE (tombstone) and an OVERWRITE (superseded old version) — both
+    // land in already-flushed segment 0, so their stale copies are ghosts the
+    // scan must skip, and either one alone flips `deletes_present` (hence
+    // `fts_cap == usize::MAX`) permanently for every query below.
+    assert!(
+        idx.delete_document("weak000").await.unwrap(),
+        "weak000 should have existed to delete"
+    );
+    // Overwrite weak001: its live version moves to the memtable, its segment-0
+    // copy becomes a superseded ghost that the scan must not double-count.
+    idx.index_document(Some("weak001".into()), json!({"body": weak_body(1)}))
+        .await
+        .unwrap();
+
+    // Live matches: 360 weak - 1 deleted = 359 (weak001 overwritten, still
+    // matches) + 5 strong = 364.
+    let expected_total: u64 = 364;
+
+    // ── Ground truth: full materialisation, then the top 5 ───────────────
+    let full = idx.search(&match_body(500, false)).await.unwrap();
+    assert_eq!(
+        full.total.value, expected_total,
+        "live total wrong under ghosts (deleted/superseded copies leaked into the count)"
+    );
+    let mut truth = page(&full.hits);
+    truth.truncate(5);
+    assert!(
+        truth.iter().all(|(id, _)| id.starts_with("strong")),
+        "sanity: the 5 short docs must be the global top-5, got {truth:?}"
+    );
+    assert!(
+        full.hits.iter().all(|h| h.id != "weak000"),
+        "deleted doc weak000 leaked into results"
+    );
+    assert!(
+        full.hits.iter().filter(|h| h.id == "weak001").count() <= 1,
+        "overwritten doc weak001 returned as a duplicate (stale ghost not skipped)"
+    );
+
+    // ── The #179 assertion: the bounded `size:5` page == the true top-5 ──
+    // On the pre-fix code this same answer required hydrating all 364 live
+    // matches; the bound must produce it while trimming to O(cap).
+    let small = idx.search(&match_body(5, false)).await.unwrap();
+    assert_eq!(
+        small.total.value, expected_total,
+        "size:5 reported a different total than the full run under ghosts"
+    );
+    assert_eq!(
+        page(&small.hits),
+        truth,
+        "size:5 page is not the global top-5 under ghosts"
+    );
+
+    // ── #177 must still hold on the deletes-present path ─────────────────
+    let lit = idx.search(&match_body(5, true)).await.unwrap();
+    assert_eq!(
+        page(&small.hits),
+        page(&lit.hits),
+        "adding `highlight` changed the page under ghosts: without={:?} with={:?}",
+        page(&small.hits),
+        page(&lit.hits)
+    );
+    for h in &lit.hits {
+        let frags = h
+            .highlight
+            .as_ref()
+            .and_then(|m| m.get("body"))
+            .unwrap_or_else(|| panic!("hit {} has no `body` highlight", h.id));
+        assert!(
+            frags.iter().any(|f| f.contains("<em>quicklist</em>")),
+            "hit {} fragments do not mark the matched term: {frags:?}",
+            h.id
+        );
+    }
+}
+
+/// The #179 re-expand path, exercised end to end: a page that reaches PAST the
+/// strong docs and INTO the big, truncated, ghost-bearing segment.  Under the
+/// observer fix that segment is scanned bounded (heap = cap) but re-expands
+/// uncapped because it truncated (`seg_total > cap`) AND holds ghosts
+/// (`dead_matches > 0`), so the walk still sees every live candidate.  Without
+/// the re-expand the top-`cap`-by-score slice — whose highest members here are
+/// the very docs that were deleted/overwritten — would drop live hits and the
+/// page would be wrong.  Asserted black-box against a full-materialisation
+/// ground truth, so it holds whatever the exact BM25 order turns out to be.
+#[tokio::test]
+async fn page_reaching_into_truncated_ghost_segment_is_exact() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("g3", Schema::empty()).unwrap();
+    let idx = engine.get_index("g3").unwrap();
+
+    // 360 weak (distinct DECREASING scores: weak000 is the highest-scoring
+    // weak doc) + 5 strong.  Match set 365 > 256 cap.
+    build_corpus(&idx, 360).await;
+
+    // Ghost the TWO highest-scoring weak docs — exactly the ones a bounded
+    // top-cap slice keeps first, so a broken bound would surface them.
+    assert!(idx.delete_document("weak000").await.unwrap());
+    idx.index_document(Some("weak001".into()), json!({"body": weak_body(1)}))
+        .await
+        .unwrap();
+
+    let expected_total: u64 = 364;
+
+    // Ground truth: full materialisation.
+    let full = idx.search(&match_body(500, false)).await.unwrap();
+    assert_eq!(full.total.value, expected_total, "live total wrong under ghosts");
+
+    // Pages that reach well into the weak segment must equal the ground-truth
+    // prefix — this is the assertion the re-expand exists to satisfy.
+    for size in [10usize, 25, 50, 100] {
+        let mut truth = page(&full.hits);
+        truth.truncate(size);
+        let r = idx.search(&match_body(size, false)).await.unwrap();
+        assert_eq!(r.total.value, expected_total, "size:{size} total drifted under ghosts");
+        assert_eq!(
+            page(&r.hits),
+            truth,
+            "size:{size} page reaching into the truncated ghost segment != global order"
+        );
+        assert!(
+            r.hits.iter().all(|h| h.id != "weak000"),
+            "size:{size}: deleted weak000 leaked into the page"
+        );
+        assert!(
+            r.hits.iter().filter(|h| h.id == "weak001").count() <= 1,
+            "size:{size}: overwritten weak001 returned as a duplicate (stale ghost not skipped)"
+        );
+    }
+}
+
+/// Cap-independence must hold on the `deletes_present` path too: the top hit of
+/// a `size:1` request is the top hit of a `size:200` request, unchanged by the
+/// presence of ghosts.  This is the incremental `page_worst` doing its job — a
+/// worst-kept score frozen at segment entry would let the fill-up segment's
+/// arrival order leak into small pages.
+#[tokio::test]
+async fn top_hit_stable_across_page_sizes_under_ghosts() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("g2", Schema::empty()).unwrap();
+    let idx = engine.get_index("g2").unwrap();
+
+    build_corpus(&idx, 300).await;
+
+    // One delete → `deletes_present` is now permanently true.
+    assert!(idx.delete_document("weak100").await.unwrap());
+
+    let deep = idx.search(&match_body(400, false)).await.unwrap();
+    let expected_top = (deep.hits[0].id.clone(), deep.hits[0].score);
+    assert_eq!(
+        expected_top.0, "strong0",
+        "sanity: strong0 is the global top hit"
+    );
+
+    for size in [1usize, 2, 5, 10, 50, 100] {
+        let r = idx.search(&match_body(size, false)).await.unwrap();
+        let got = (r.hits[0].id.clone(), r.hits[0].score);
+        assert_eq!(
+            got, expected_top,
+            "size:{size} returned a different top hit under ghosts (bounded merge lost the global top-k)"
+        );
+    }
+}
+
+/// Stress guard for the re-expand fallback at scale: a big single segment
+/// (well over the cap) whose HIGHEST-scoring doc is a ghost, so every page that
+/// reaches the top must skip it via an uncapped re-expand and still return the
+/// exact global order.  This is the large-match-set analogue of
+/// `page_reaching_into_truncated_ghost_segment_is_exact`; it exists because the
+/// bounded scan sheds the pre-#179 full-set sort/allocation here — the win that
+/// grows with the match-set size — and this pins the correctness that shedding
+/// must preserve.
+#[tokio::test]
+async fn large_single_segment_with_top_ghost_returns_exact_order() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("g4", Schema::empty()).unwrap();
+    let idx = engine.get_index("g4").unwrap();
+
+    // 1500 distinct-scoring matches in ONE segment; weak0000 is the top.
+    let n = 1500usize;
+    for i in 0..n {
+        idx.index_document(Some(format!("weak{i:04}")), json!({"body": weak_body(i)}))
+            .await
+            .unwrap();
+    }
+    idx.flush().await.unwrap();
+
+    // Delete the top-scorer (inside the kept top-cap → forces the re-expand)
+    // and overwrite the runner-up (superseded ghost).
+    assert!(idx.delete_document("weak0000").await.unwrap());
+    idx.index_document(Some("weak0001".into()), json!({"body": weak_body(1)}))
+        .await
+        .unwrap();
+
+    let full = idx.search(&match_body(500, false)).await.unwrap();
+    assert_eq!(full.total.value, (n as u64) - 1, "live total wrong under a top ghost");
+    for size in [10usize, 50, 200] {
+        let mut truth = page(&full.hits);
+        truth.truncate(size);
+        let r = idx.search(&match_body(size, false)).await.unwrap();
+        assert_eq!(page(&r.hits), truth, "size:{size} order wrong with a top-scoring ghost");
+        assert!(r.hits.iter().all(|h| h.id != "weak0000"), "deleted top-scorer leaked");
+    }
+}

--- a/engine/crates/xerj-fts/src/search.rs
+++ b/engine/crates/xerj-fts/src/search.rs
@@ -506,9 +506,37 @@ impl FtsSearcher {
         cap: usize,
         explain: bool,
     ) -> Result<(Vec<ScoredHit>, u64)> {
+        // The no-op observer monomorphises away, so this stays byte-identical to
+        // the pre-#179 bounded search on the hot (no-delete) path.
+        self.search_bounded_observed(query, cap, explain, |_| {})
+    }
+
+    /// Like [`Self::search_bounded`], but invokes `observe(doc_id)` once for
+    /// EVERY match in the full match set — before the `cap` is applied — so a
+    /// caller can derive an exact per-match statistic without materialising the
+    /// whole hit list.  The returned total is the exact physical match count
+    /// regardless of `cap` ([`TopN`] counts every push).
+    ///
+    /// #179: the delete-present read path uses this to tally LIVE matches (via
+    /// the segment ghost bitmap) during a BOUNDED scan, instead of forcing
+    /// `cap == usize::MAX` purely to hold the complete hit list for the count.
+    /// The scan already visits every posting on the bounded path, so the
+    /// observer is free; the win is shedding the full-set sort and the
+    /// O(matches) `Vec` that the unbounded path built on any index that had ever
+    /// seen a delete.
+    pub fn search_bounded_observed<F: FnMut(u32)>(
+        &self,
+        query: &Query,
+        cap: usize,
+        explain: bool,
+        mut observe: F,
+    ) -> Result<(Vec<ScoredHit>, u64)> {
         if cap == usize::MAX {
             let mut hits = self.execute(query, explain)?;
             let total = hits.len() as u64;
+            for h in &hits {
+                observe(h.doc_id);
+            }
             hits.sort_unstable();
             return Ok((hits, total));
         }
@@ -516,11 +544,15 @@ impl FtsSearcher {
         let mut top = TopN::new(cap);
         match query {
             // Streaming leaf: push each scored posting directly into the heap.
-            Query::Term(tq) => self.collect_term(tq, explain, &mut top)?,
+            Query::Term(tq) => self.scan_term(tq, explain, |h| {
+                observe(h.doc_id);
+                top.push(h);
+            })?,
             // Compound / positional arms: reuse the exact hit-set builder, then
             // drain into the bounded heap (the sort is what we shed here).
             _ => {
                 for hit in self.execute(query, explain)? {
+                    observe(hit.doc_id);
                     top.push(hit);
                 }
             }
@@ -550,17 +582,12 @@ impl FtsSearcher {
         Ok(hits)
     }
 
-    /// Streaming variant of [`Self::execute_term`] for the bounded search path:
-    /// each scored posting is offered straight to the `TopN` heap, so a keyword
-    /// term matching tens of thousands of docs never materialises the full hit
-    /// `Vec` for a size:10 request.
-    fn collect_term(&self, tq: &TermQuery, explain: bool, top: &mut TopN) -> Result<()> {
-        self.scan_term(tq, explain, |h| top.push(h))
-    }
-
-    /// Shared scoring scan used by both [`Self::execute_term`] (Vec) and
-    /// [`Self::collect_term`] (bounded heap).  Emits one `ScoredHit` per
-    /// matching posting in ascending doc_id order.
+    /// Shared scoring scan used by both [`Self::execute_term`] (Vec) and the
+    /// bounded [`Self::search_bounded_observed`] path (which offers each scored
+    /// posting straight to the `TopN` heap, so a keyword term matching tens of
+    /// thousands of docs never materialises the full hit `Vec` for a size:10
+    /// request).  Emits one `ScoredHit` per matching posting in ascending
+    /// doc_id order.
     fn scan_term<F: FnMut(ScoredHit)>(
         &self,
         tq: &TermQuery,


### PR DESCRIPTION
Fixes #177.

## Reproduction (before this PR)

rc.11 build, valkey+memcached corpus, index `xc-kv-oss-valkey-deps-3`, 616 matches:

```
Q = {"multi_match":{"query":"addReplyNull null bulk string reply",
                    "fields":["body","defs","title"]}}

A  size:5, no highlight        12.6832  11.8398  11.4218  11.3757  11.2564
B  size:5, + highlight.body    20.4350  19.9605  19.8379  19.1846  17.2884
T  size:700 (all 616), top-5   20.4350  19.9605  19.8379  19.1846  17.2884
```

Every score differs, the hit sets are disjoint, and `A` is not the global
top-5 — `B` is. So the *default* page was the wrong one, and asking for
snippets accidentally corrected it.

The same defect is visible with no highlight anywhere in the body: on that
corpus `size:100` reports a top hit of `12.6832` and `size:155` reports
`20.4350`.

## Mechanism

`engine/crates/xerj-engine/src/index.rs`.

1. `highlight` was one of the shapes excluded from the page-cap gate
   (`let materialisation_limit: usize = if mem_doc_count == 0 && …`), so a
   `size:5` body got a cap of `from+size = 5` without it and `256` with it.

2. That should not have been observable. It was, because the cross-segment
   merge was arrival-order. `search_bounded` returns each segment's top-k by
   score; the merge pushed them into `all_hits` with a plain
   `if all_hits.len() >= materialisation_limit { break }` and an outer
   `all_hits.len() < materialisation_limit` guard. The first segments visited
   filled the cap and every later segment was dropped whole, regardless of
   score. The page was "the best hits of whichever segments happened to fit".

So the cap decided which hits won, and `highlight` decided the cap.

## Fix

**The merge now selects the global top-k by score.** `page_worst` is the
lowest score currently held (defined only once the collector is at its cap —
below the cap nothing has to be displaced). A segment is opened when its best
hit beats that; its descending run is walked until a hit cannot; the overflow
is trimmed back to the cap with the comparator the final page sort already
uses (score DESC, `seq_no` ASC, `_id` ASC), so admission and final ordering
agree. Memory stays O(cap), 2×cap transiently. A segment that cannot beat the
worst kept hit is skipped exactly as before — the common "first segments
dominate" case does no extra work.

**`highlight` is removed from all three execution gates**, so a body now runs
the *same plan* with and without it rather than a different plan that happens
to agree:

| gate | why it was wrong |
|---|---|
| page-cap `materialisation_limit` | highlighting is a post-pass; it has no bearing on how many candidates the scan needs |
| `need_sources_for_post` | at `size:0` there is no page to highlight, so it should not force source materialisation |
| `function_score_fast_fvf` | `function_score_columnar` hydrates `_source` for the winners, which is all `apply_highlight` reads — the same argument `scored_fast_plan` already makes for admitting `highlight` |

## Tests

`engine/crates/xerj-engine/tests/highlight_does_not_change_ranking.rs`, three
tests. Each builds two segments where the second holds the genuinely
top-scoring documents and the first holds enough matches to fill a small page
on its own.

* `highlight_block_does_not_change_scores_or_order` — same body twice, once
  with a highlight block; asserts identical `(_id, _score)` pairs in identical
  order, identical `hits.total`, that the page equals the full-materialisation
  top-5, that the highlighted run returns fragments containing
  `<em>quicklist</em>`, and that the plain run carries no `highlight` key.
* `highlight_block_does_not_change_multi_match_ranking` — the issue's
  `multi_match` shape.
* `top_hit_is_stable_across_page_sizes` — `size:1/2/5/10/50` must all return
  the `size:200` top hit. This is the same defect seen from the other side.

All three FAIL on `main` and pass here:

```
main:  0 passed; 3 failed
  top_hit_is_stable_across_page_sizes
    left:  ["weak03", 0.07465832680463791]      right: ["best", 0.39556291699409485]
  highlight_block_does_not_change_multi_match_ranking
    left:  [("weak03",0.0873), ("weak04",0.0873), ("weak08",0.0873)]
    right: [("strong0",0.5503), ("strong1",0.5448), ("strong2",0.5311)]
  highlight_block_does_not_change_scores_or_order
    left:  [("weak55",0.2899), ("weak03",0.0877), …]
    right: [("strong0",0.5696), ("strong1",0.5622), …]

this branch:  3 passed; 0 failed
```

Rest of the suite: `cargo test -p xerj-engine --no-fail-fast` — 412 unit tests
and every integration binary green, 0 failures. `cargo fmt` clean,
`cargo clippy -p xerj-engine --all-targets` clean.

## Live verification

Two servers on the same corpus (a copy of the `xc-kv-oss-*` data dir): rc.11
`main` build vs this build.

```
                       A==B    A == size:700 top-5
before (main)          false   false
after  (this branch)   true    true
```

Across 9 query shapes — `multi_match`, `match`, `match_phrase`, `bool should`,
`bool must+filter`, `dis_max`, `prefix`, `query_string`, `match_all` —
`highlight` changed the page on **3 of 9 before, 0 of 9 after**. `hits.total`
is unchanged on all 9. Highlighting still works: 3 fragments returned, all 3
carrying `<em>`-marked matches, e.g.

```
"...* if we need to convert a listpack to a quicklist. Note that we only check
 <em>string</em>\n * encoded objects as their string length can be queried..."
```

Warm median latency for the issue's query (9 samples after 3 warm-ups):

| | before | after |
|---|---|---|
| no highlight | 163.1 ms | 32.5 ms |
| with highlight | 27.2 ms | 30.5 ms |

The plain path got faster because it no longer takes the narrow-cap route that
reopened segments to no purpose; both shapes now run the same plan, so they
land on the same number.

## Known limits — not fixed here

* This PR makes the `size:5` page equal the `size:700` top-5 for `multi_match`,
  `match` and `match_phrase` (it did not before). Five of the nine shapes —
  `bool should`, `bool must+filter`, `dis_max`, `prefix`, `query_string` —
  still do not, **both before and after** this change. Those go through other
  executor arms (stored-doc scan, columnar scored family) whose selection this
  PR does not touch. `match_all` was already correct.
* `bool should` additionally scores the *same document* differently at
  different page sizes (`5cfb36ea…` scores 1.2497 at `size:5` and 4.8065 at
  `size:700`, on the unmodified `main` build). That is a separate pre-existing
  defect — the bool IDF rescore runs over the materialised window — and since
  this PR changes which hits that window holds, that query's page moves. Its
  top-1 becomes the global top-1; the rest of its page is not comparable across
  cap values while the score itself depends on the cap.
* Which of several *exactly tied* documents survives a top-k truncation is
  still decided by arrival, not by `seq_no`. Ties are strictly not displaced
  (`sh.score > worst`), matching Lucene's "lowest doc id wins a tie" only when
  segments are visited in doc-id order. The new tests deliberately use
  tie-free rankings so they assert selection, not tie-break.
