### PR TITLE
fix(api): _field_caps and _mapping/field report the declared numeric type

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -17887,8 +17887,9 @@ pub async fn field_caps(
             }
 
             let native_es_type = native_type_to_es_str(&field.field_type);
-            let es_type =
-                declared_flattened_type(&properties, &field.name).unwrap_or(native_es_type);
+            let es_type = declared_flattened_type(&properties, &field.name)
+                .or_else(|| declared_numeric_type(&properties, &field.name))
+                .unwrap_or(native_es_type);
             let searchable = field.is_searchable();
             let aggregatable = field.is_aggregatable();
 
@@ -18018,6 +18019,46 @@ fn declared_flattened_type<'a>(properties: &'a Value, field_name: &str) -> Optio
     None
 }
 
+/// Look up `field_name` (a possibly dotted path) in a mapping `properties`
+/// tree and return its declared ES type string ONLY if it's one of the
+/// numeric aliases that collapse onto a coarser native `FieldType` — the
+/// engine schema has only `Long`/`Double`, so `byte`/`short`/`integer`/
+/// `unsigned_long` all become `FieldType::Long`, and `float`/`half_float`/
+/// `scaled_float` all become `FieldType::Double` (see the ES-type-string →
+/// `FieldType` mapping in `engine.rs`). `GET _mapping` reads the stored
+/// mapping directly and round-trips the declared type correctly; before
+/// this, `_field_caps`/`_mapping/field` derived their type from the
+/// native schema instead and always reported `long`/`double` regardless
+/// of what was actually declared — a client that looked up
+/// `field_caps[name][mapped_type]` (a reasonable pattern, and what ES/OS's
+/// own docs show) got a silently empty result for every non-`long`/
+/// non-`double` numeric field, with no error.
+fn declared_numeric_type<'a>(properties: &'a Value, field_name: &str) -> Option<&'a str> {
+    let mut current = properties;
+    let segments: Vec<&str> = field_name.split('.').collect();
+    for (i, seg) in segments.iter().enumerate() {
+        let def = current.as_object()?.get(*seg)?;
+        if i == segments.len() - 1 {
+            let t = def.get("type").and_then(Value::as_str)?;
+            return matches!(
+                t,
+                "byte"
+                    | "short"
+                    | "integer"
+                    | "long"
+                    | "unsigned_long"
+                    | "half_float"
+                    | "float"
+                    | "scaled_float"
+                    | "double"
+            )
+            .then_some(t);
+        }
+        current = def.get("properties")?;
+    }
+    None
+}
+
 fn native_type_to_es_str(ft: &FieldType) -> &'static str {
     match ft {
         FieldType::Text => "text",
@@ -18097,6 +18138,44 @@ mod flat_object_field_caps_tests {
         assert_eq!(declared_flattened_type(&props, "missing"), None);
     }
 
+    #[test]
+    fn declared_numeric_type_finds_every_integer_and_float_alias() {
+        for t in [
+            "byte",
+            "short",
+            "integer",
+            "long",
+            "unsigned_long",
+            "half_float",
+            "float",
+            "scaled_float",
+            "double",
+        ] {
+            let props = json!({"n": {"type": t}});
+            assert_eq!(declared_numeric_type(&props, "n"), Some(t));
+        }
+    }
+
+    #[test]
+    fn declared_numeric_type_walks_dotted_nested_path() {
+        let props = json!({
+            "obj": {"type": "object", "properties": {"price": {"type": "float"}}}
+        });
+        assert_eq!(declared_numeric_type(&props, "obj.price"), Some("float"));
+    }
+
+    #[test]
+    fn declared_numeric_type_returns_none_for_non_numeric_types() {
+        let props = json!({"name": {"type": "keyword"}});
+        assert_eq!(declared_numeric_type(&props, "name"), None);
+    }
+
+    #[test]
+    fn declared_numeric_type_returns_none_for_missing_field() {
+        let props = json!({"price": {"type": "float"}});
+        assert_eq!(declared_numeric_type(&props, "missing"), None);
+    }
+
     fn test_state() -> AppState {
         let dir = tempfile::tempdir().expect("tempdir").keep();
         let mut config = Config::default();
@@ -18150,6 +18229,71 @@ mod flat_object_field_caps_tests {
             response["fields"]["attrs"].get("object").is_none(),
             "attrs should not ALSO be reported as a generic object: {response}"
         );
+    }
+
+    /// Regression test for a real bug found live: `GET _mapping` correctly
+    /// round-trips `float`/`integer` (it returns the stored mapping JSON
+    /// verbatim), but `_field_caps` derived its reported type from the
+    /// native schema — which has only `Long`/`Double` — so every `float`
+    /// field was keyed `double` and every `integer` field was keyed `long`.
+    /// A client doing `field_caps[name][mapped_type]` (a reasonable
+    /// pattern) got a silently empty result for both, with no error.
+    #[tokio::test]
+    async fn field_caps_reports_declared_numeric_type_not_native_storage_type() {
+        let router = crate::router::build_es_compat_router(test_state());
+
+        let create_response = router
+            .clone()
+            .oneshot(
+                Request::put("/numeric-caps-e2e")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"mappings": {"properties": {
+                            "price": {"type": "float"},
+                            "quantity": {"type": "integer"},
+                            "big_count": {"type": "long"},
+                            "score": {"type": "double"},
+                        }}})
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("create response");
+        assert!(create_response.status().is_success());
+
+        let caps_response = router
+            .oneshot(
+                Request::get("/numeric-caps-e2e/_field_caps?fields=price,quantity,big_count,score")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("field_caps response");
+        assert!(caps_response.status().is_success());
+
+        let bytes = to_bytes(caps_response.into_body(), usize::MAX)
+            .await
+            .expect("response bytes");
+        let response: Value = serde_json::from_slice(&bytes).expect("JSON response");
+
+        for (field, mapped_type) in [
+            ("price", "float"),
+            ("quantity", "integer"),
+            ("big_count", "long"),
+            ("score", "double"),
+        ] {
+            assert!(
+                response["fields"][field][mapped_type]["searchable"]
+                    .as_bool()
+                    .unwrap_or(false),
+                "expected _field_caps[{field}][{mapped_type}] to exist, got: {response}"
+            );
+        }
+        // The pre-fix behavior: both price and quantity collapsed onto the
+        // native storage type instead of the declared one.
+        assert!(response["fields"]["price"].get("double").is_none());
+        assert!(response["fields"]["quantity"].get("long").is_none());
     }
 }
 
@@ -26638,8 +26782,9 @@ pub async fn global_field_caps(
             }
 
             let native_es_type = native_type_to_es_str(&field.field_type);
-            let es_type =
-                declared_flattened_type(&properties, &field.name).unwrap_or(native_es_type);
+            let es_type = declared_flattened_type(&properties, &field.name)
+                .or_else(|| declared_numeric_type(&properties, &field.name))
+                .unwrap_or(native_es_type);
             let searchable = field.is_searchable();
             let aggregatable = field.is_aggregatable();
 
@@ -26737,8 +26882,9 @@ pub async fn get_mapping_field(
                 .get("type")
                 .and_then(Value::as_str)
                 .unwrap_or("object");
-            let es_type =
-                declared_flattened_type(&stored_properties, field_name).unwrap_or(native_es_type);
+            let es_type = declared_flattened_type(&stored_properties, field_name)
+                .or_else(|| declared_numeric_type(&stored_properties, field_name))
+                .unwrap_or(native_es_type);
             mapping_result.insert(
                 field_name.clone(),
                 json!({


### PR DESCRIPTION
## Summary

`_field_caps` (and `GET /{index}/_mapping/field/{field}`) report the wrong type key for numeric fields: a field mapped `float` is keyed `double`, a field mapped `integer` is keyed `long`. `GET _mapping` on the same index correctly reports `float`/`integer`.

## Bug report (as received, translated from Italian)

> Symptom: for a field mapped float/integer, `_mapping` correctly reports the declared type, but `_field_caps` keys the capability object with a different type (double/long) instead of repeating the mapped type.
>
> Repro with exact curl commands (mapping vs field_caps side-by-side) on index `soak-mixed-1785794882-69951`, XERJ v1.0.0-rc.9 instance in `--compat-distribution opensearch --compat-version 2.11.0` mode.
>
> Suspected cause (unverified, no source access): XERJ probably normalizes numerics internally to f64/i64, and `_field_caps` exposes that internal storage type instead of the declared mapping type.
>
> Impact: a client doing `field_caps[name][mapped_type]` (a reasonable pattern) gets a silent empty result on every float/integer field — no error, just a slightly-wrong boolean that's easy to miss (exactly what happened on my end).
>
> Stated limitation: couldn't compare against a real Elasticsearch/OpenSearch on this machine (every Kibana/OSD container here points at XERJ processes, not a real cluster) — flagged explicitly as something to verify in triage, not presented as absolute certainty.

Reproduced independently before touching any code:

```
PUT /fc-test {"mappings":{"properties":{"price":{"type":"float"},"quantity":{"type":"integer"}}}}

GET /fc-test/_mapping     → price: {"type": "float"}, quantity: {"type": "integer"}   (correct)
GET /fc-test/_field_caps  → price: {"double": {...}}, quantity: {"long": {...}}       (wrong key)
```

## Root cause — confirmed exactly as the reporter suspected

`FieldType` (`xerj-engine`'s native schema enum) has only `Long` and `Double` for numerics. `engine.rs`'s mapping-type-string → `FieldType` conversion collapses `byte`/`short`/`integer`/`long`/`unsigned_long` onto `Long`, and `half_float`/`float`/`scaled_float`/`double` onto `Double`:

```rust
"long" | "integer" | "short" | "byte" | "unsigned_long" => FieldType::Long,
"double" | "float" | "half_float" | "scaled_float" => FieldType::Double,
```

`GET _mapping` is unaffected because it returns the stored mapping JSON verbatim. `_field_caps` and `GET _mapping/field/{field}` both instead derive their reported type from that lossy native schema (`native_type_to_es_str`), so every numeric field silently reported its coarser native type.

The exact same class of bug — a native-schema type collapse leaking into `_field_caps` — was already fixed once before, for `flattened`/`flat_object` (both collapse onto the generic `FieldType::Object`), via a small `declared_flattened_type` override that consults the stored mapping JSON directly. That fix's scope was Object-only, so the identical numeric-precision collapse was missed.

## Fix

Added `declared_numeric_type`, following the exact same pattern as `declared_flattened_type`, covering all 9 ES numeric aliases. Chained it in after the existing flattened-type check at all three affected call sites — `field_caps`, `global_field_caps`, and `GET /{index}/_mapping/field/{field}` (a third occurrence of the identical bug, found while fixing the first two).

## What was verified

- New unit tests for `declared_numeric_type`: all 9 aliases, dotted nested paths, non-numeric and missing-field negatives — mirrors the existing `declared_flattened_type` coverage.
- New end-to-end test `field_caps_reports_declared_numeric_type_not_native_storage_type`: builds a real index via the HTTP router with `float`/`integer`/`long`/`double` fields, asserts `_field_caps` keys each by its declared type, and explicitly asserts the pre-fix wrong keys are gone.
- `cargo test -p xerj-api --lib` — **159/159 pass**, no regressions.
- `cargo clippy -p xerj-api --lib -- -D warnings` — clean.
- `cargo fmt -p xerj-api -- --check` — clean.
- **Live manual repro** against a rebuilt release binary with `--compat-distribution opensearch --compat-version 2.11.0` (matching the report's exact mode): `_mapping`, `_field_caps`, and `_mapping/field` now all agree.
- **Functional regression check**: `avg`/`sum` aggregations on the affected fields still return correct values post-fix — this is a reporting-layer-only change; the underlying storage/query path (already built on the native Long/Double representation) is untouched.

## Scope — what this does and doesn't change

Fixes the reported symptom for every plain numeric field, and the same bug in a third endpoint (`_mapping/field`) not mentioned in the original report. Does **not** change how numerics are stored or queried — `float` vs `double`, `integer` vs `long` remain the same native representation; only the type *string* reported by `_field_caps`/`_mapping/field` now matches what `_mapping` already said.

Multi-field numeric aliases (e.g. `"price": {"type": "float", "fields": {"exact": {"type": "double"}}}`) were never affected — `collect_multi_fields` already reads the declared type straight from the mapping JSON, not through the native-schema path.

The reporter's stated limitation (no real ES/OS available locally to diff against) doesn't affect confidence in this fix: the correct behavior is unambiguous from `_mapping`'s own contract (report the declared type) and from `_field_caps`'s existing, already-fixed handling of the identical `flattened`/`flat_object` collapse — this PR just extends that same precedent to numerics.

## Test plan

- [x] `cargo test -p xerj-api --lib` (159/159)
- [x] `cargo clippy -p xerj-api --lib -- -D warnings`
- [x] `cargo fmt -p xerj-api -- --check`
- [x] Live repro in the reporter's exact compat mode, before and after the fix
- [x] Functional regression check on aggregations over the affected fields
