### PR TITLE
fix(ci): restore `cargo fmt` cleanliness on main

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -14540,7 +14540,9 @@ impl Index {
                                 // candidate (rare).  The exact live count above used
                                 // `dead_matches` over the FULL set and is untouched.
                                 let mut seg_hits = seg_hits;
-                                if deletes_present && fts_cap != usize::MAX && seg_total > fts_cap as u64
+                                if deletes_present
+                                    && fts_cap != usize::MAX
+                                    && seg_total > fts_cap as u64
                                 {
                                     let dead_in_top = ghost_bm
                                         .as_deref()
@@ -14794,30 +14796,31 @@ impl Index {
                                         // set).  Shared by the in-walk 2×cap eager
                                         // trim and the end-of-run trim so admission
                                         // and final ordering always agree.
-                                        let trim_to_cap = |hits: Vec<Hit>| -> (Vec<Hit>, Option<f32>) {
-                                            let mut decorated: Vec<(u64, Hit)> = hits
-                                                .into_iter()
-                                                .map(|h| {
-                                                    (
-                                                        self.lookup_seq_no(&h.id)
-                                                            .unwrap_or(u64::MAX),
-                                                        h,
-                                                    )
-                                                })
-                                                .collect();
-                                            decorated.sort_by(|a, b| {
-                                                b.1.score
-                                                    .partial_cmp(&a.1.score)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
-                                                    .then_with(|| a.0.cmp(&b.0))
-                                                    .then_with(|| a.1.id.cmp(&b.1.id))
-                                            });
-                                            decorated.truncate(materialisation_limit);
-                                            let worst = decorated.last().map(|(_, h)| h.score);
-                                            let kept =
-                                                decorated.into_iter().map(|(_, h)| h).collect();
-                                            (kept, worst)
-                                        };
+                                        let trim_to_cap =
+                                            |hits: Vec<Hit>| -> (Vec<Hit>, Option<f32>) {
+                                                let mut decorated: Vec<(u64, Hit)> = hits
+                                                    .into_iter()
+                                                    .map(|h| {
+                                                        (
+                                                            self.lookup_seq_no(&h.id)
+                                                                .unwrap_or(u64::MAX),
+                                                            h,
+                                                        )
+                                                    })
+                                                    .collect();
+                                                decorated.sort_by(|a, b| {
+                                                    b.1.score
+                                                        .partial_cmp(&a.1.score)
+                                                        .unwrap_or(std::cmp::Ordering::Equal)
+                                                        .then_with(|| a.0.cmp(&b.0))
+                                                        .then_with(|| a.1.id.cmp(&b.1.id))
+                                                });
+                                                decorated.truncate(materialisation_limit);
+                                                let worst = decorated.last().map(|(_, h)| h.score);
+                                                let kept =
+                                                    decorated.into_iter().map(|(_, h)| h).collect();
+                                                (kept, worst)
+                                            };
                                         for sh in &seg_hits {
                                             // `seg_hits` descends by score, so once
                                             // a hit's score is STRICTLY below the

--- a/engine/crates/xerj-engine/tests/search_bounded_under_ghosts.rs
+++ b/engine/crates/xerj-engine/tests/search_bounded_under_ghosts.rs
@@ -224,7 +224,10 @@ async fn page_reaching_into_truncated_ghost_segment_is_exact() {
 
     // Ground truth: full materialisation.
     let full = idx.search(&match_body(500, false)).await.unwrap();
-    assert_eq!(full.total.value, expected_total, "live total wrong under ghosts");
+    assert_eq!(
+        full.total.value, expected_total,
+        "live total wrong under ghosts"
+    );
 
     // Pages that reach well into the weak segment must equal the ground-truth
     // prefix — this is the assertion the re-expand exists to satisfy.
@@ -232,7 +235,10 @@ async fn page_reaching_into_truncated_ghost_segment_is_exact() {
         let mut truth = page(&full.hits);
         truth.truncate(size);
         let r = idx.search(&match_body(size, false)).await.unwrap();
-        assert_eq!(r.total.value, expected_total, "size:{size} total drifted under ghosts");
+        assert_eq!(
+            r.total.value, expected_total,
+            "size:{size} total drifted under ghosts"
+        );
         assert_eq!(
             page(&r.hits),
             truth,
@@ -315,12 +321,23 @@ async fn large_single_segment_with_top_ghost_returns_exact_order() {
         .unwrap();
 
     let full = idx.search(&match_body(500, false)).await.unwrap();
-    assert_eq!(full.total.value, (n as u64) - 1, "live total wrong under a top ghost");
+    assert_eq!(
+        full.total.value,
+        (n as u64) - 1,
+        "live total wrong under a top ghost"
+    );
     for size in [10usize, 50, 200] {
         let mut truth = page(&full.hits);
         truth.truncate(size);
         let r = idx.search(&match_body(size, false)).await.unwrap();
-        assert_eq!(page(&r.hits), truth, "size:{size} order wrong with a top-scoring ghost");
-        assert!(r.hits.iter().all(|h| h.id != "weak0000"), "deleted top-scorer leaked");
+        assert_eq!(
+            page(&r.hits),
+            truth,
+            "size:{size} order wrong with a top-scoring ghost"
+        );
+        assert!(
+            r.hits.iter().all(|h| h.id != "weak0000"),
+            "deleted top-scorer leaked"
+        );
     }
 }


### PR DESCRIPTION
## main is red

`main` has been red since 2026-08-06. The **Format + Clippy** job fails on six rustfmt diffs that landed with merge 8a6fa38 (the #179/#177 delete-present FTS work):

- `engine/crates/xerj-engine/src/index.rs:14540, 14794`
- `engine/crates/xerj-engine/tests/search_bounded_under_ghosts.rs:224, 232, 315, 322`

Every open PR inherits the red check, so no contribution can be judged on its own merits until this is fixed — and it blocks the next release cut.

## What this is

`cargo fmt --all` output and nothing else:

- the two hunks in `index.rs` wrap a long `if` condition and a closure body;
- the four in the test file wrap `assert!` / `assert_eq!` arguments.

No logic is touched. `git diff -w` shows only line reflow.

## Verification

`cargo fmt --all -- --check` is clean after this change.