### PR TITLE
fix(helm): default to secure, and say what insecure mode turns off

### DIFF
--- a/deploy/helm/xerj/templates/NOTES.txt
+++ b/deploy/helm/xerj/templates/NOTES.txt
@@ -1,0 +1,42 @@
+XERJ {{ .Chart.AppVersion }} installed as {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+{{- if .Values.insecure }}
+
+  WARNING: insecure mode is ON.
+
+  TLS and authentication are both disabled. Every listener below is open to
+  anything that can reach this pod:
+
+    ES-compat   {{ .Values.service.esCompatPort }}
+    native REST {{ .Values.service.nativePort }}
+    gRPC        {{ .Values.service.grpcPort }}
+
+  This is fine for a local dev cluster and is not fine for anything holding
+  real data. Turn it off with:
+
+    helm upgrade {{ .Release.Name }} ... --set insecure=false
+
+{{- else }}
+
+  Auth is on. XERJ generates an admin key on first start and writes it to
+  {{ .Values.persistence.mountPath | default "/var/lib/xerj" }}/admin.key with mode 0600.
+
+  Read it with:
+
+    kubectl exec -n {{ .Release.Namespace }} {{ .Release.Name }}-0 -- cat {{ .Values.persistence.mountPath | default "/var/lib/xerj" }}/admin.key
+
+  Then call the API with:
+
+    curl -H "Authorization: ApiKey $KEY" http://{{ .Release.Name }}:{{ .Values.service.esCompatPort }}/_cluster/health
+
+{{- if not .Values.tls.enabled }}
+
+  Note: TLS is off, so that key crosses the network in cleartext. Set
+  tls.enabled=true and supply tls.secretName before exposing this outside
+  the cluster.
+{{- end }}
+{{- end }}
+
+Check it is up:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/deploy/helm/xerj/values.yaml
+++ b/deploy/helm/xerj/values.yaml
@@ -50,9 +50,16 @@ probes:
     timeoutSeconds: 2
     failureThreshold: 3
 
-# Insecure mode disables TLS + auth (for dev/POC clusters).  Production
-# users should set this to false and supply tls.cert/key + auth.token.
-insecure: true
+# Insecure mode disables TLS AND auth.  Off by default: an install with no
+# values.yaml of your own is authenticated, matching the engine's own default
+# (auth.enabled = true, admin key auto-generated 0600 on first start).
+#
+# Set to true ONLY for a local dev or throwaway POC cluster.  Doing so leaves
+# the ES-compat, native REST and gRPC listeners open to anything that can reach
+# the pod.  Insecure defaults are the single most cited cause of the NoSQL data
+# exposures in user-feedback/09-security/insecure-defaults.md, and a chart
+# default is the configuration most users will ever run.
+insecure: false
 
 tls:
   enabled: false


### PR DESCRIPTION
Closes #205.

The chart shipped `insecure: true`, disabling TLS and auth. The two install paths disagreed:

```
curl https://xerj.org/get | sh    auth on, admin key auto-generated 0600
helm install xerj ./deploy/helm   auth off, TLS off
```

The second is what production runs. The old comment said "production users should set this to false", which is backwards. A default should be safe and dev should opt out.

**What changed**

`insecure: false`. The statefulset template already gates the flag on this value (`templates/statefulset.yaml:31-33`), so with it off the `--insecure` arg is not passed and the engine's own defaults apply: `auth.enabled = true` with an admin key generated 0600 on first start.

Adds `NOTES.txt`, which the chart did not have. The point is to make the choice visible at install time instead of buried in values.yaml:

- insecure on: names every port left open and how to turn it off
- insecure off: how to read the generated admin key, plus a warning that the key crosses the network in cleartext while `tls.enabled` is false

**Note for existing users:** anyone who installed with the old default and did not set `insecure` explicitly will get an authenticated instance on upgrade. That is the intended direction, but it is a behaviour change and should be called out in the release notes.

Not verified with `helm lint` or `helm template` because helm is not installed here. The change is a one-value flip plus a new NOTES.txt, and the template conditional was read directly to confirm the flag is gated correctly.