### PR TITLE
fix(deps): clear 13 Dependabot advisories in engine/Cargo.lock

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -430,9 +430,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64urlsafedata"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f7f6be94fa637132933fd0a68b9140bcb60e3d46164cb68e82a2bb8d102b3a"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
 dependencies = [
  "base64 0.21.7",
  "pastey",
@@ -678,6 +678,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1886,11 +1897,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1903,6 +1912,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -3112,15 +3122,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3153,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3357,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3591,7 +3600,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror 1.0.69",
 ]
 
@@ -3737,12 +3745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
 name = "protox"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,14 +3847,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3901,9 +3904,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3918,6 +3921,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3959,6 +3973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3966,6 +3986,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4276,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5172,7 +5201,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.7",
  "slab",
  "tokio",
  "tokio-util",
@@ -5852,9 +5881,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-attestation-ca"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafcf13f7dc1fb292ed4aea22cdd3757c285d7559e9748950ee390249da4da6b"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
 dependencies = [
  "base64urlsafedata",
  "openssl",
@@ -5866,9 +5895,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b24d082d3360258fefb6ffe56123beef7d6868c765c779f97b7a2fcf06727f8"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
 dependencies = [
  "base64urlsafedata",
  "serde",
@@ -5880,9 +5909,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15784340a24c170ce60567282fb956a0938742dbfbf9eff5df793a686a009b8b"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -5907,9 +5936,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1fb2580ce73baa42d3011a24de2ceab0d428de1879ece06e02e8c416e497c"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -6450,7 +6479,7 @@ dependencies = [
  "crc32fast",
  "futures",
  "hmac",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6511,7 +6540,7 @@ dependencies = [
  "hmac",
  "http-body-util",
  "openssl",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6655,7 +6684,7 @@ dependencies = [
  "pprof",
  "prost 0.13.5",
  "protox",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rayon",
  "rcgen",
  "reqwest",
@@ -6723,7 +6752,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc32fast",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rayon",
  "serde",
  "serde_json",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -80,8 +80,16 @@ aws-config = "1"
 # TLS
 rustls = "0.23"
 rcgen = "0.13"
-# Metrics
-prometheus = "0.13"
+# Metrics. `default-features = false` drops the optional `protobuf` feature,
+# which is the ONLY thing that pulled protobuf 2.28.0 into the tree
+# (GHSA-2gh3-rmm4-6rq5, uncontrolled recursion when PARSING protobuf). We only
+# ever ENCODE, and only to the text exposition format: `TextEncoder`, `Encoder`
+# and `proto::MetricFamily` are all available without the feature (`proto` is
+# then backed by prometheus's pure-Rust `src/plain_model.rs`). Only
+# `ProtobufEncoder`/`PROTOBUF_FORMAT` are gated off, and nothing here uses them.
+# Removing the dependency beats upgrading it — there is no protobuf parser left
+# to be recursed into. Same reasoning as the `tonic` line below.
+prometheus = { version = "0.13", default-features = false }
 # gRPC (XerjSearch service on :8081). Default features only — the `tls`
 # feature is intentionally OFF so tonic pulls no crypto backend (no
 # aws-lc-rs / vendored OpenSSL); the gRPC listener speaks plaintext h2c,

--- a/engine/crates/xerj-common/src/metrics.rs
+++ b/engine/crates/xerj-common/src/metrics.rs
@@ -493,6 +493,58 @@ mod tests {
         assert!(text.contains("xerj_docs_indexed_total"));
     }
 
+    /// `/metrics` must emit the Prometheus text exposition format exactly:
+    /// a `# HELP` line, a `# TYPE` line, then the sample.
+    ///
+    /// This pins the wire contract independently of which `proto` backend the
+    /// `prometheus` crate was compiled with. We build with
+    /// `default-features = false`, which drops the optional `protobuf` feature
+    /// (and with it protobuf 2.x, GHSA-2gh3-rmm4-6rq5); `proto::MetricFamily`
+    /// is then prometheus's pure-Rust `plain_model` rather than generated
+    /// protobuf code. The text output is required to be byte-identical either
+    /// way, and a scrape breaking silently is exactly the regression that
+    /// feature flip could cause.
+    #[test]
+    fn gather_text_emits_prometheus_exposition_format() {
+        let m = Metrics::new().unwrap();
+        m.docs_indexed.inc_by(3);
+        let text = m.gather_text().unwrap();
+
+        assert!(
+            text.contains(
+                "# HELP xerj_docs_indexed_total Total number of documents successfully indexed"
+            ),
+            "missing/incorrect HELP line:\n{text}"
+        );
+        assert!(
+            text.contains("# TYPE xerj_docs_indexed_total counter"),
+            "missing/incorrect TYPE line:\n{text}"
+        );
+        assert!(
+            text.lines().any(|l| l == "xerj_docs_indexed_total 3"),
+            "missing unlabelled sample line:\n{text}"
+        );
+    }
+
+    /// Labelled series must survive the same encoder path — label rendering is
+    /// the other place a `proto` backend swap could diverge.
+    #[test]
+    fn gather_text_renders_labelled_series() {
+        let m = Metrics::new().unwrap();
+        m.record_docs_indexed("my-index", 2);
+        let text = m.gather_text().unwrap();
+
+        assert!(
+            text.contains("# TYPE xerj_docs_indexed_by_index_total counter"),
+            "missing TYPE line for labelled counter:\n{text}"
+        );
+        assert!(
+            text.lines()
+                .any(|l| l == "xerj_docs_indexed_by_index_total{index=\"my-index\"} 2"),
+            "missing/incorrect labelled sample line:\n{text}"
+        );
+    }
+
     #[test]
     fn isolated_registries_do_not_conflict() {
         // Two Metrics instances must not share state


### PR DESCRIPTION
Closes every open Dependabot alert against `engine/Cargo.lock` — the manifest whose contents are compiled into all 8 released binaries. Twelve are closed by version bumps that touch the lockfile only; the thirteenth is closed by **removing** the vulnerable crate from the graph entirely. Zero lines of XERJ logic change; the only source-adjacent edit is a Cargo feature flag.

The npm alerts (basic-ftp, ip-address, js-yaml, ws — all transitive from puppeteer, developer tooling that never reaches a released artifact) are PR #194's scope and are deliberately untouched.

## What each change closes

| crate | change | severity | advisories |
|---|---|---|---|
| openssl / openssl-sys | 0.10.77 → 0.10.81 / 0.9.113 → 0.9.117 | 5 high, 2 medium, 1 low | GHSA-8c75-8mhr-p7r9, GHSA-ghm9-cr32-g9qj, GHSA-hppc-g8h3-xhp3, GHSA-pqf5-4pqq-29f5, GHSA-xp3w-r5p5-63rr, GHSA-phqj-4mhp-q6mq, GHSA-xv59-967r-8726, GHSA-xmgf-hq76-4vx2 |
| rustls-webpki | 0.103.12 → 0.103.13 | high | GHSA-82j2-j2ch-gfr8 (DoS panic parsing a malformed CRL BIT STRING) |
| quinn-proto | 0.11.14 → 0.11.16 | high | GHSA-4w2j-m93h-cj5j (remote memory exhaustion) |
| rand | 0.8.5 → 0.8.7 | low | GHSA-cq8v-f236-94qc |
| webauthn-rs | 0.5.4 → 0.5.5 | low | GHSA-22w3-693w-x895 (origin-validation mismatch in webauthn-rs-core) |
| **protobuf** | **2.28.0 → REMOVED** | medium | GHSA-2gh3-rmm4-6rq5 (uncontrolled recursion when parsing) |

Notes on the non-obvious ones:

- **openssl**: the advisories require ≥ 0.10.80. Vendored `openssl-src` deliberately stays at 300.6.1+3.6.3, so the OpenSSL **C library** version does not move and the Windows Perl/NASM vendored-build path in release.yml is untouched — that is what keeps the 8-target cross-compile low-risk.
- **quinn-proto** is a lockfile ghost: it enters only through reqwest's optional `http3` feature, which we never enable, so it compiles to nothing. Bumped anyway so the alert closes rather than being argued with.
- **webauthn-rs**: the fix lives in webauthn-rs-core, but 0.5.4 pins `webauthn-rs-core = "=0.5.4"` exactly, so the parent must be the carrier. Still inside the existing `webauthn-rs = "0.5"` requirement — no manifest edit needed.

## protobuf: removed, not upgraded

protobuf 2.28.0 entered through exactly one edge: prometheus 0.13.4's `protobuf` feature, on by default. XERJ only ever **encodes** metrics, and only to the text exposition format — there is no protobuf ingest surface anywhere in the tree. `engine/Cargo.toml` now sets `prometheus = { version = "0.13", default-features = false }`; everything the two consumers (xerj-common, xerj-api) touch is unconditional (`Registry`, `Opts`, counter/gauge/histogram types, `Encoder`, `TextEncoder`, `proto::MetricFamily` — backed by prometheus's pure-Rust `plain_model` with the feature off). Only `ProtobufEncoder`/`PROTOBUF_FORMAT` are gated away, and nothing referenced them.

Removing the parser beats upgrading it: there is no protobuf parser left in the binary to be recursed into. It also avoids the prometheus 0.13 → 0.14 major bump (protobuf 3.x codegen, changed public type behind `MetricsRegistry::gather()`). `cargo tree -p xerj-server -i protobuf` now reports no such package.

Because this one **is** potentially behavioural — `/metrics` is a public scrape surface and the backing `proto` model changes underneath it — the commit adds two tests in `crates/xerj-common/src/metrics.rs` that pin the Prometheus text exposition format directly: the `# HELP` line, the `# TYPE ... counter` line, the unlabelled sample, and a labelled series (`xerj_docs_indexed_by_index_total{index="my-index"} 2`). The pre-existing test only asserted the metric name appeared somewhere in the output, which would not have caught a malformed scrape.

## Reachability: hygiene, not emergency

For the record, and so the release notes can be honest: **none of the 13 advisories was reachable in a default XERJ deployment.**

- quinn-proto is not even compiled (http3 off);
- the specific openssl functions named in all 8 advisories are called by nothing in the tree — XERJ makes zero `openssl::` calls; the dependency exists only to force `vendored` for cross-compilation;
- rustls-webpki's defect is in CRL parsing and XERJ configures no CRLs;
- protobuf was encode-only;
- rand's unsoundness needs a logger that calls rand, and XERJ logs through tracing-subscriber;
- webauthn's advisory needs `allow_subdomains(true)`, which our webauthn setup never sets.

This is a dependency refresh, not an emergency. It is worth taking anyway: the openssl crate sits directly behind unauthenticated attacker-controlled input via the pre-auth passkey login path (`/_xerj-console/api/v1/auth/login/*`), so the blast radius of a future advisory landing in a function that path **does** call is large enough that staying current is cheap insurance.

## Verification

```
cargo fmt --all --check                          clean
cargo build --release -j 32 -p xerj-server       ok
cargo build --release --locked -p xerj-server    ok (the mode release.yml uses)
cargo test --release -j 32 --workspace           84 suites: 1995 passed / 0 failed / 30 ignored (exit 0)
ES-YAML conformance (fresh data dir, :9400)      1365 passed · 0 failed · 3 skipped · 1368 total
```
