### PR TITLE
fix(security): API keys can now be revoked and listed

### DIFF
--- a/engine/crates/xerj-api/src/auth.rs
+++ b/engine/crates/xerj-api/src/auth.rs
@@ -456,7 +456,9 @@ mod tests {
         Router::new()
             .route(
                 "/_security/api_key",
-                post(crate::es_compat::security_create_api_key),
+                post(crate::es_compat::security_create_api_key)
+                    .get(crate::es_compat::security_get_api_keys)
+                    .delete(crate::es_compat::security_invalidate_api_key),
             )
             .route(
                 "/_security/_authenticate",
@@ -564,6 +566,255 @@ mod tests {
             status,
             StatusCode::UNAUTHORIZED,
             "invalidated key should 401"
+        );
+    }
+
+    /// Issue #208 — the full revocation lifecycle. Create a key, use it,
+    /// revoke it via `DELETE /_security/api_key`, and prove the same
+    /// credential is rejected afterwards. Also pins the ES wire shapes:
+    /// the GET listing never carries the secret, a second invalidate lands
+    /// in `previously_invalidated_api_keys`, a selector-less DELETE is a
+    /// 400 validation error, and both new endpoints leave audit entries.
+    #[tokio::test]
+    async fn api_key_revocation_lifecycle() {
+        let admin = "admin-secret-key";
+        let state = test_state(admin);
+        let app = app(state.clone());
+        let admin_hdr = format!("ApiKey {admin}");
+
+        // Mint a key.
+        let (status, body) = send(
+            &app,
+            "POST",
+            "/_security/api_key",
+            Some(&admin_hdr),
+            r#"{"name":"rotate-me"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "create returned {status}");
+        let id = body["id"].as_str().expect("id").to_string();
+        let key_hdr = format!("ApiKey {}", body["encoded"].as_str().expect("encoded"));
+
+        // The key works.
+        let (status, _) = send(&app, "GET", "/_security/_authenticate", Some(&key_hdr), "").await;
+        assert_eq!(status, StatusCode::OK, "fresh key must authenticate");
+
+        // It lists, live, and the listing exposes no secret material.
+        let (status, body) = send(&app, "GET", "/_security/api_key", Some(&admin_hdr), "").await;
+        assert_eq!(status, StatusCode::OK);
+        let keys = body["api_keys"].as_array().expect("api_keys array");
+        let item = keys
+            .iter()
+            .find(|k| k["id"] == id.as_str())
+            .expect("minted key listed");
+        assert_eq!(item["name"], "rotate-me");
+        assert_eq!(item["invalidated"], false);
+        assert_eq!(item["type"], "rest");
+        assert!(item.get("api_key").is_none(), "secret must never be listed");
+        assert!(item.get("encoded").is_none(), "secret must never be listed");
+        assert!(item.get("secret").is_none(), "secret must never be listed");
+        assert!(
+            item.get("invalidation").is_none(),
+            "no invalidation time while live"
+        );
+
+        // Revoke it.
+        let (status, body) = send(
+            &app,
+            "DELETE",
+            "/_security/api_key",
+            Some(&admin_hdr),
+            &format!(r#"{{"ids":["{id}"]}}"#),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "invalidate returned {status}");
+        assert_eq!(body["invalidated_api_keys"], serde_json::json!([id]));
+        assert_eq!(
+            body["previously_invalidated_api_keys"],
+            serde_json::json!([])
+        );
+        assert_eq!(body["error_count"], 0);
+
+        // THE issue-208 proof: the same credential is now rejected.
+        let (status, _) = send(&app, "GET", "/_security/_authenticate", Some(&key_hdr), "").await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "revoked key must be rejected"
+        );
+
+        // Revoking again reports it as previously invalidated.
+        let (status, body) = send(
+            &app,
+            "DELETE",
+            "/_security/api_key",
+            Some(&admin_hdr),
+            &format!(r#"{{"ids":["{id}"]}}"#),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["invalidated_api_keys"], serde_json::json!([]));
+        assert_eq!(
+            body["previously_invalidated_api_keys"],
+            serde_json::json!([id])
+        );
+
+        // The listing now shows it invalidated, with an invalidation time,
+        // and active_only=true hides it.
+        let (status, body) = send(&app, "GET", "/_security/api_key", Some(&admin_hdr), "").await;
+        assert_eq!(status, StatusCode::OK);
+        let item = body["api_keys"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|k| k["id"] == id.as_str())
+            .expect("still listed")
+            .clone();
+        assert_eq!(item["invalidated"], true);
+        assert!(item["invalidation"].is_u64(), "invalidation time recorded");
+        let (status, body) = send(
+            &app,
+            "GET",
+            "/_security/api_key?active_only=true",
+            Some(&admin_hdr),
+            "",
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["api_keys"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|k| k["id"] != id.as_str()),
+            "active_only must hide the revoked key"
+        );
+
+        // An unknown id on GET is a 404 (with the empty body still attached);
+        // on DELETE it matches nothing and errors nothing.
+        let (status, body) = send(
+            &app,
+            "GET",
+            "/_security/api_key?id=no-such-key",
+            Some(&admin_hdr),
+            "",
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["api_keys"], serde_json::json!([]));
+        let (status, body) = send(
+            &app,
+            "DELETE",
+            "/_security/api_key",
+            Some(&admin_hdr),
+            r#"{"ids":["no-such-key"]}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["invalidated_api_keys"], serde_json::json!([]));
+        assert_eq!(body["error_count"], 0);
+
+        // A selector-less DELETE is a 400 validation error (ES:
+        // InvalidateApiKeyRequest#validate).
+        let (status, body) =
+            send(&app, "DELETE", "/_security/api_key", Some(&admin_hdr), "{}").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["type"], "action_request_validation_exception");
+
+        // Both new endpoints audited what happened.
+        let ops: Vec<String> = state
+            .engine
+            .audit
+            .snapshot()
+            .iter()
+            .map(|e| e.op.clone())
+            .collect();
+        assert!(
+            ops.iter().any(|o| o == "security.api_key.invalidate"),
+            "invalidate must be audited, got {ops:?}"
+        );
+        assert!(
+            ops.iter().any(|o| o == "security.api_key.get"),
+            "get must be audited, got {ops:?}"
+        );
+        assert!(
+            ops.iter().any(|o| o == "security.api_key.create"),
+            "create must be audited, got {ops:?}"
+        );
+    }
+
+    /// Issue #208, authorization half: a *scoped* key may neither list nor
+    /// revoke keys — same 403 the create gate already gives it — while an
+    /// unscoped minted key (the historical operator credential) may.
+    #[tokio::test]
+    async fn scoped_key_cannot_list_or_revoke_keys() {
+        let admin = "admin-secret-key";
+        let state = test_state(admin);
+        let app = app(state.clone());
+        let admin_hdr = format!("ApiKey {admin}");
+
+        // Superuser mints a scoped key and an unscoped key.
+        let (status, body) = send(
+            &app,
+            "POST",
+            "/_security/api_key",
+            Some(&admin_hdr),
+            r#"{"name":"scoped","role_descriptors":{"r":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let scoped_hdr = format!("ApiKey {}", body["encoded"].as_str().unwrap());
+        let (status, body) = send(
+            &app,
+            "POST",
+            "/_security/api_key",
+            Some(&admin_hdr),
+            r#"{"name":"unscoped"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let unscoped_hdr = format!("ApiKey {}", body["encoded"].as_str().unwrap());
+        let unscoped_id = body["id"].as_str().unwrap().to_string();
+
+        // Scoped: 403 on both GET and DELETE.
+        let (status, _) = send(&app, "GET", "/_security/api_key", Some(&scoped_hdr), "").await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "scoped key must not list");
+        let (status, _) = send(
+            &app,
+            "DELETE",
+            "/_security/api_key",
+            Some(&scoped_hdr),
+            &format!(r#"{{"ids":["{unscoped_id}"]}}"#),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "scoped key must not revoke");
+
+        // Unscoped: allowed (revokes itself — rotation by an operator key).
+        let (status, body) = send(
+            &app,
+            "DELETE",
+            "/_security/api_key",
+            Some(&unscoped_hdr),
+            &format!(r#"{{"ids":["{unscoped_id}"]}}"#),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["invalidated_api_keys"],
+            serde_json::json!([unscoped_id])
+        );
+        let (status, _) = send(
+            &app,
+            "GET",
+            "/_security/_authenticate",
+            Some(&unscoped_hdr),
+            "",
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "self-revoked key must stop working"
         );
     }
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -25774,8 +25774,16 @@ pub async fn security_create_api_key(
             creation_ms: now_ms,
             expiration_ms,
             invalidated: false,
+            invalidation_ms: None,
             roles,
         },
+    );
+    state.engine.audit.append(
+        "security.api_key.create",
+        principal.label(),
+        "_security/api_key",
+        "ok",
+        &format!("id={key_id} name={name}"),
     );
 
     Json(json!({
@@ -25784,6 +25792,382 @@ pub async fn security_create_api_key(
         "expiration": expiration,
         "api_key": api_key,
         "encoded": encoded
+    }))
+    .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET    /_security/api_key — list keys (never returns secrets)
+// DELETE /_security/api_key — invalidate (revoke) keys
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #208: only create existed — GET and DELETE both 405'd. The enforcement
+// half was already built (`auth::check_minted_key` rejects a record with
+// `invalidated: true`), but nothing could ever set the flag, so a leaked key
+// was permanent and rotation impossible.
+//
+// Wire contract derived from ES source (APPROACH ONLY — AGPL/Elastic, read
+// for semantics, no code copied):
+//   * request selectors `ids`/`name`/`realm_name`/`username`/`owner` and
+//     their mutual-exclusion rules: InvalidateApiKeyRequest.java:163-195,
+//     RestInvalidateApiKeyAction.java:87-96
+//   * invalidate response `{invalidated_api_keys,
+//     previously_invalidated_api_keys, error_count[, error_details]}`, 200:
+//     InvalidateApiKeyResponse.java:92-108
+//   * unknown ids match nothing and land in neither list (empty response,
+//     not an error): ApiKeyService.java:1965-1973
+//   * GET query params + "404 with body when `id` names a missing key":
+//     RestGetApiKeyAction.java:47-54, 70-73
+//   * per-key GET item shape (no secret, `type: rest`, optional
+//     `expiration`/`invalidation`): ApiKey.java:289-310
+
+/// The single-node owner identity, matching `GET /_security/_authenticate`
+/// (`security_authenticate` above): xerj has no multi-user store, so every
+/// minted key belongs to this one principal. A `username`/`realm_name`
+/// selector therefore matches either every key or none, and `owner=true`
+/// (ES: "only keys owned by the caller") is satisfied by every key.
+const API_KEY_OWNER_USERNAME: &str = "xerj";
+const API_KEY_OWNER_REALM: &str = "native";
+
+/// 400 in ES's `action_request_validation_exception` shape — what ES's REST
+/// layer answers when `InvalidateApiKeyRequest#validate` rejects a request.
+/// `errors` are joined as `Validation Failed: 1: a;2: b;`, matching
+/// `ActionRequestValidationException`'s message format.
+fn api_key_validation_error(errors: &[String]) -> Response {
+    let numbered: String = errors
+        .iter()
+        .enumerate()
+        .map(|(i, e)| format!("{}: {};", i + 1, e))
+        .collect();
+    let reason = format!("Validation Failed: {numbered}");
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "root_cause": [{
+                    "type": "action_request_validation_exception",
+                    "reason": reason
+                }],
+                "type": "action_request_validation_exception",
+                "reason": reason
+            },
+            "status": 400
+        })),
+    )
+        .into_response()
+}
+
+/// Rebuild an ES-shaped `role_descriptors` object from a key's parsed grants.
+/// Honest-lossy: creation normalizes descriptors through
+/// `rbac::roles_from_role_descriptors` (index names + index privileges only),
+/// so what comes back is that normalized form, not the caller's original
+/// descriptor JSON. An unscoped key reports `{}` — the same "no usable grant"
+/// signal the parse produced.
+fn api_key_role_descriptors_json(roles: &[xerj_engine::rbac::Role]) -> Value {
+    use xerj_engine::rbac::Privilege;
+    let mut out = serde_json::Map::new();
+    for role in roles {
+        let mut privileges: Vec<&'static str> = role
+            .privileges
+            .iter()
+            .map(|p| match p {
+                Privilege::ReadIndex => "read",
+                Privilege::WriteIndex => "write",
+                Privilege::AdminIndex => "manage",
+                Privilege::SnapshotCreate => "create_snapshot",
+                Privilege::SnapshotRestore => "restore_snapshot",
+                Privilege::SecurityAdmin => "manage_security",
+                Privilege::AuditRead => "read_audit",
+            })
+            .collect();
+        // HashSet order is nondeterministic; sort so the wire shape is stable.
+        privileges.sort_unstable();
+        privileges.dedup();
+        out.insert(
+            role.name.clone(),
+            json!({
+                "indices": [{ "names": role.indices, "privileges": privileges }]
+            }),
+        );
+    }
+    Value::Object(out)
+}
+
+/// One `api_keys[]` item, per ES's `ApiKey#innerToXContent` (ApiKey.java:
+/// 289-310): `expiration`/`invalidation` appear only when set, and the secret
+/// is **never** part of this shape — only the create response carries it.
+fn api_key_item_json(id: &str, rec: &xerj_engine::engine::ApiKeyRecord) -> Value {
+    let mut item = json!({
+        "id": id,
+        "name": rec.name,
+        "type": "rest",
+        "creation": rec.creation_ms,
+        "invalidated": rec.invalidated,
+        "username": API_KEY_OWNER_USERNAME,
+        "realm": API_KEY_OWNER_REALM,
+        "realm_type": "native",
+        "metadata": {},
+        "role_descriptors": api_key_role_descriptors_json(&rec.roles),
+    });
+    if let Some(exp) = rec.expiration_ms {
+        item["expiration"] = json!(exp);
+    }
+    if let Some(inv) = rec.invalidation_ms {
+        item["invalidation"] = json!(inv);
+    }
+    item
+}
+
+/// Only the superuser and unscoped (historical operator) credentials may see
+/// or revoke keys; a scoped key gets the same 403 the create gate gives it,
+/// and the fail-closed default covers `Denied` too. Listing exposes no
+/// secrets, and revocation only ever *reduces* privilege, so the trust level
+/// that may mint keys (see `security_create_api_key`) is the right bar.
+fn api_key_admin_gate(principal: &crate::auth::Principal) -> Option<Response> {
+    if matches!(
+        principal,
+        crate::auth::Principal::Superuser | crate::auth::Principal::Unscoped { .. }
+    ) {
+        None
+    } else {
+        Some(crate::authz::forbidden(
+            principal,
+            "<api keys>",
+            xerj_engine::rbac::Privilege::SecurityAdmin,
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+pub struct GetApiKeyParams {
+    id: Option<String>,
+    name: Option<String>,
+    username: Option<String>,
+    realm_name: Option<String>,
+    /// Accepted for ES parity; a no-op filter here (see
+    /// [`API_KEY_OWNER_USERNAME`] — every key is owned by the caller).
+    #[serde(default)]
+    #[allow(dead_code)]
+    owner: bool,
+    #[serde(default)]
+    active_only: bool,
+}
+
+pub async fn security_get_api_keys(
+    State(state): State<AppState>,
+    principal: crate::auth::Principal,
+    Query(params): Query<GetApiKeyParams>,
+) -> impl IntoResponse {
+    if let Some(denied) = api_key_admin_gate(&principal) {
+        return denied;
+    }
+    let now_ms = Utc::now().timestamp_millis().max(0) as u64;
+    let mut items: Vec<(u64, String, Value)> = Vec::new();
+    // A username/realm selector that names anything but the single-node
+    // identity matches nothing (there is no such user/realm here).
+    let identity_mismatch = params
+        .username
+        .as_deref()
+        .is_some_and(|u| u != API_KEY_OWNER_USERNAME)
+        || params
+            .realm_name
+            .as_deref()
+            .is_some_and(|r| r != API_KEY_OWNER_REALM);
+    if !identity_mismatch {
+        for entry in state.engine.api_keys.iter() {
+            let (id, rec) = (entry.key(), entry.value());
+            if params.id.as_deref().is_some_and(|want| want != id) {
+                continue;
+            }
+            if params.name.as_deref().is_some_and(|want| want != rec.name) {
+                continue;
+            }
+            // `active_only` drops invalidated AND expired keys — ES filters
+            // both (ApiKeyService#findApiKeys: `api_key_invalidated: false`
+            // plus an expiration-window clause).
+            if params.active_only
+                && (rec.invalidated || rec.expiration_ms.is_some_and(|exp| now_ms >= exp))
+            {
+                continue;
+            }
+            items.push((rec.creation_ms, id.clone(), api_key_item_json(id, rec)));
+        }
+    }
+    // DashMap iteration order is arbitrary; sort by (creation, id) so
+    // repeated listings are stable. ES guarantees no order here.
+    items.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
+    let api_keys: Vec<Value> = items.into_iter().map(|(_, _, v)| v).collect();
+    state.engine.audit.append(
+        "security.api_key.get",
+        principal.label(),
+        "_security/api_key",
+        "ok",
+        &format!("returned={}", api_keys.len()),
+    );
+    // Looking up one specific id that doesn't exist is a resource lookup:
+    // 404, with the (empty) body still attached — RestGetApiKeyAction.java:
+    // 70-73 returns the rendered response at NOT_FOUND.
+    let status = if params.id.is_some() && api_keys.is_empty() {
+        StatusCode::NOT_FOUND
+    } else {
+        StatusCode::OK
+    };
+    (status, Json(json!({ "api_keys": api_keys }))).into_response()
+}
+
+pub async fn security_invalidate_api_key(
+    State(state): State<AppState>,
+    principal: crate::auth::Principal,
+    body: Option<Json<Value>>,
+) -> impl IntoResponse {
+    if let Some(denied) = api_key_admin_gate(&principal) {
+        return denied;
+    }
+    let payload = body.map(|Json(v)| v).unwrap_or(Value::Null);
+
+    // ── Parse the selector fields (RestInvalidateApiKeyAction.java:87-96) ──
+    // `ids` is the documented plural; a bare string `id` is also accepted
+    // (ES kept it as a deprecated REST-compat alias) — lenient parsing is
+    // this file's convention.
+    let mut blank_id_positions: Vec<usize> = Vec::new();
+    let ids: Option<Vec<String>> = match payload.get("ids") {
+        Some(Value::Array(arr)) => Some(
+            arr.iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let s = v.as_str().unwrap_or("").trim();
+                    if s.is_empty() {
+                        blank_id_positions.push(i);
+                    }
+                    s.to_string()
+                })
+                .collect(),
+        ),
+        Some(Value::String(s)) => Some(vec![s.clone()]),
+        _ => payload
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(|s| vec![s.to_string()]),
+    };
+    let name = payload
+        .get("name")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string);
+    let realm_name = payload
+        .get("realm_name")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string);
+    let username = payload
+        .get("username")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string);
+    let owner = payload
+        .get("owner")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    // ── Validate, mirroring InvalidateApiKeyRequest.java:163-195/228-252 ──
+    let mut errors: Vec<String> = Vec::new();
+    if let Some(ids) = &ids {
+        if ids.is_empty() {
+            errors.push("Field [ids] cannot be an empty array".to_string());
+        } else if !blank_id_positions.is_empty() {
+            let (noun, pos) = if blank_id_positions.len() == 1 {
+                ("id", "position")
+            } else {
+                ("ids", "positions")
+            };
+            errors.push(format!(
+                "Field [ids] must not contain blank id, but got blank {noun} at index {pos}: {blank_id_positions:?}"
+            ));
+        }
+    }
+    if ids.is_none() && name.is_none() && realm_name.is_none() && username.is_none() && !owner {
+        errors.push(
+            "One of [api key id(s), api key name, username, realm name] must be specified if \
+             [owner] flag is false"
+                .to_string(),
+        );
+    }
+    if (ids.is_some() || name.is_some()) && (realm_name.is_some() || username.is_some()) {
+        errors.push(
+            "username or realm name must not be specified when the api key id(s) or api key \
+             name are specified"
+                .to_string(),
+        );
+    }
+    if owner && (realm_name.is_some() || username.is_some()) {
+        errors.push(
+            "neither username nor realm-name may be specified when invalidating owned API keys"
+                .to_string(),
+        );
+    }
+    if ids.is_some() && name.is_some() {
+        errors.push("only one of [api key id(s), api key name] can be specified".to_string());
+    }
+    if !errors.is_empty() {
+        return api_key_validation_error(&errors);
+    }
+
+    // ── Resolve the selector to concrete key ids ──
+    let target_ids: Vec<String> = if let Some(ids) = ids {
+        // Dedupe, preserving order — ES's find phase returns each key once
+        // however many times its id was repeated.
+        let mut seen = std::collections::HashSet::new();
+        ids.into_iter()
+            .filter(|id| seen.insert(id.clone()))
+            .collect()
+    } else if let Some(name) = &name {
+        state
+            .engine
+            .api_keys
+            .iter()
+            .filter(|e| &e.value().name == name)
+            .map(|e| e.key().clone())
+            .collect()
+    } else if username
+        .as_deref()
+        .is_some_and(|u| u != API_KEY_OWNER_USERNAME)
+        || realm_name
+            .as_deref()
+            .is_some_and(|r| r != API_KEY_OWNER_REALM)
+    {
+        // A user/realm this node has never issued for: nothing to invalidate.
+        Vec::new()
+    } else {
+        // realm_name/username naming the single-node identity, or owner=true:
+        // both select every minted key (see API_KEY_OWNER_USERNAME).
+        state
+            .engine
+            .api_keys
+            .iter()
+            .map(|e| e.key().clone())
+            .collect()
+    };
+
+    let now_ms = Utc::now().timestamp_millis().max(0) as u64;
+    let (invalidated, previously) = state.engine.invalidate_api_keys(&target_ids, now_ms);
+    state.engine.audit.append(
+        "security.api_key.invalidate",
+        principal.label(),
+        "_security/api_key",
+        "ok",
+        &format!(
+            "invalidated=[{}] previously_invalidated=[{}]",
+            invalidated.join(","),
+            previously.join(",")
+        ),
+    );
+    // ES answers 200 whatever matched; ids that matched nothing appear in
+    // neither list. `error_details` exists only when per-key errors occurred,
+    // which this single-node store cannot produce — so `error_count` is 0 and
+    // the field is omitted (InvalidateApiKeyResponse.java:96-106).
+    Json(json!({
+        "invalidated_api_keys": invalidated,
+        "previously_invalidated_api_keys": previously,
+        "error_count": 0
     }))
     .into_response()
 }

--- a/engine/crates/xerj-api/src/router.rs
+++ b/engine/crates/xerj-api/src/router.rs
@@ -612,7 +612,9 @@ pub fn build_es_compat_router(state: AppState) -> Router {
         )
         .route(
             "/_security/api_key",
-            post(es_compat::security_create_api_key),
+            post(es_compat::security_create_api_key)
+                .get(es_compat::security_get_api_keys)
+                .delete(es_compat::security_invalidate_api_key),
         )
         .route(
             "/_security/privilege",

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -196,6 +196,13 @@ pub struct ApiKeyRecord {
     pub expiration_ms: Option<u64>,
     /// Set once the key has been invalidated (revoked).
     pub invalidated: bool,
+    /// When the key was invalidated, in epoch milliseconds — `None` while the
+    /// key is live. Reported as `invalidation` by `GET /_security/api_key`
+    /// (ES stamps the analogous `invalidation_time` on its key doc in the
+    /// same update that flips `api_key_invalidated`). `#[serde(default)]` so
+    /// an `api_keys.json` written before this field existed still loads.
+    #[serde(default)]
+    pub invalidation_ms: Option<u64>,
     /// Index-scoped grants parsed from the `role_descriptors` supplied at
     /// creation (`crate::rbac::roles_from_role_descriptors`).
     ///
@@ -968,6 +975,44 @@ impl Engine {
     pub fn persist_api_key(&self, id: String, record: ApiKeyRecord) {
         self.api_keys.insert(id, record);
         self.flush_api_keys();
+    }
+
+    /// Invalidate (revoke) minted API keys by id — issue #208's missing half.
+    /// `ApiKeyRecord.invalidated` has been honoured by the auth path since the
+    /// field existed, but nothing could ever set it, so a leaked key was
+    /// permanent and rotation impossible.
+    ///
+    /// Returns `(invalidated, previously_invalidated)` ids — the two non-error
+    /// buckets of ES's `DELETE /_security/api_key` response. An id that
+    /// matches no record lands in **neither** list: ES resolves selectors to
+    /// keys first and answers with an empty response when nothing matches
+    /// (`ApiKeyService#invalidateApiKeys`), it does not error per unknown id.
+    ///
+    /// The flag and `invalidation_ms` are flipped in-memory — the auth
+    /// middleware reads this same map, so revocation takes effect on the very
+    /// next request — and the store is flushed to `api_keys.json` once at the
+    /// end, same durability contract as [`Self::persist_api_key`].
+    pub fn invalidate_api_keys(&self, ids: &[String], now_ms: u64) -> (Vec<String>, Vec<String>) {
+        let mut invalidated = Vec::new();
+        let mut previously = Vec::new();
+        for id in ids {
+            let Some(mut rec) = self.api_keys.get_mut(id) else {
+                continue;
+            };
+            if rec.invalidated {
+                previously.push(id.clone());
+            } else {
+                rec.invalidated = true;
+                rec.invalidation_ms = Some(now_ms);
+                invalidated.push(id.clone());
+            }
+            // `rec` (a DashMap guard) drops here, before `flush_api_keys`
+            // re-iterates the map below.
+        }
+        if !invalidated.is_empty() {
+            self.flush_api_keys();
+        }
+        (invalidated, previously)
     }
 
     /// Serialize the current `api_keys` map to `<data_dir>/api_keys.json`

--- a/engine/crates/xerj-server/src/grpc.rs
+++ b/engine/crates/xerj-server/src/grpc.rs
@@ -691,6 +691,7 @@ mod tests {
                 creation_ms: 0,
                 expiration_ms: None,
                 invalidated: false,
+                invalidation_ms: None,
                 roles,
             },
         );

--- a/engine/tests/es-compat-yaml/src/main.rs
+++ b/engine/tests/es-compat-yaml/src/main.rs
@@ -1363,6 +1363,28 @@ fn resolve_action(action: &str, params: &serde_yaml::Mapping) -> (String, String
 
         // Security — API keys
         "security.create_api_key" => ("POST".into(), "/_security/api_key".into(), body),
+        "security.get_api_key" => {
+            let mut qs = Vec::new();
+            for k in [
+                "id",
+                "name",
+                "username",
+                "realm_name",
+                "owner",
+                "active_only",
+            ] {
+                if let Some(v) = get_param_str(params, k) {
+                    qs.push(format!("{}={}", k, v));
+                }
+            }
+            let path = if qs.is_empty() {
+                "/_security/api_key".to_string()
+            } else {
+                format!("/_security/api_key?{}", qs.join("&"))
+            };
+            ("GET".into(), path, None)
+        }
+        "security.invalidate_api_key" => ("DELETE".into(), "/_security/api_key".into(), body),
 
         // ML — anomaly detectors, datafeeds, results
         "ml.put_job" => {

--- a/engine/tests/es-compat-yaml/yaml/security/10_api_key.yml
+++ b/engine/tests/es-compat-yaml/yaml/security/10_api_key.yml
@@ -12,3 +12,53 @@
   - is_true: id
   - is_true: api_key
   - is_true: encoded
+
+---
+"api keys can be listed and invalidated (issue #208)":
+  - do:
+      security.create_api_key:
+        body:
+          name: revoke-me
+  - is_true: id
+  - set: { id: key_id }
+
+  # GET lists the key — WITHOUT the secret.
+  - do:
+      security.get_api_key:
+        id: $key_id
+  - match: { api_keys.0.id: $key_id }
+  - match: { api_keys.0.name: revoke-me }
+  - match: { api_keys.0.type: rest }
+  - match: { api_keys.0.invalidated: false }
+  - is_false: api_keys.0.api_key
+  - is_false: api_keys.0.encoded
+
+  # DELETE invalidates it.
+  - do:
+      security.invalidate_api_key:
+        body:
+          ids: [ "$key_id" ]
+  - match: { invalidated_api_keys.0: $key_id }
+  - length: { previously_invalidated_api_keys: 0 }
+  - match: { error_count: 0 }
+
+  # Invalidating again reports it as previously invalidated.
+  - do:
+      security.invalidate_api_key:
+        body:
+          ids: [ "$key_id" ]
+  - length: { invalidated_api_keys: 0 }
+  - match: { previously_invalidated_api_keys.0: $key_id }
+  - match: { error_count: 0 }
+
+  # The listing reflects the revocation; active_only hides it.
+  - do:
+      security.get_api_key:
+        id: $key_id
+  - match: { api_keys.0.invalidated: true }
+  - is_true: api_keys.0.invalidation
+  - do:
+      security.get_api_key:
+        name: revoke-me
+        active_only: true
+  - length: { api_keys: 0 }


### PR DESCRIPTION
Closes #208.

You could mint an API key but never revoke one: only `POST /_security/api_key` existed, and `GET`/`DELETE /_security/api_key` both 405'd. The enforcement half was already built (`auth::check_minted_key` rejects `invalidated: true` records) — nothing could set the flag, so a leaked key was permanent and rotation impossible.

## What this adds

- **`DELETE /_security/api_key`** — invalidates keys. ES selector set (`ids`, `name`, `realm_name`, `username`, `owner`) with ES's mutual-exclusion validation (aggregated 400 `action_request_validation_exception`). 200 response: `{invalidated_api_keys, previously_invalidated_api_keys, error_count}`; an unknown id matches nothing and errors nothing; an already-invalidated id reports as previously invalidated. Revocation is effective on the next request (the auth middleware reads the same map) and durable (`api_keys.json`, 0600, one atomic flush).
- **`GET /_security/api_key`** — lists keys **without secrets**: `id`, `name`, `type: "rest"`, `creation`, optional `expiration`/`invalidation`, `invalidated`, `username`/`realm` (the single-node identity `_authenticate` reports), and an honest-lossy `role_descriptors` rebuilt from the parsed grants. Filters: `id`/`name`/`username`/`realm_name`/`owner`/`active_only`; a specific `id` that matches nothing is a 404 carrying the empty body, per ES.
- **Audit** — `security.api_key.create` / `.get` / `.invalidate` entries in the tamper-evident ring, with key ids in the note.
- **Authorization** — same bar as minting: superuser + unscoped operator keys may list/revoke; scoped keys get 403; fail-closed for `Denied`. The admin key is config, not a record — it cannot be invalidated here.
- `ApiKeyRecord.invalidation_ms` (`#[serde(default)]` — pre-existing `api_keys.json` files still load).

## Wire contract (retrieval-first, ES corpus APPROACH ONLY — semantics read, no code copied)

- request fields: `RestInvalidateApiKeyAction.java:87-96`; validation rules: `InvalidateApiKeyRequest.java:163-195,228-252`
- invalidate response shape: `InvalidateApiKeyResponse.java:92-108`; unknown ids → empty response, not error: `ApiKeyService.java:1965-1973`; `invalidation_time` stamped with the flag: `ApiKeyService.java:2126`
- GET params + 404-with-body: `RestGetApiKeyAction.java:47-54,70-73`; item shape (secret never returned): `ApiKey.java:289-310`

## Evidence

- `cargo test -p xerj-api --lib auth::tests` — 7 passed / 0 failed, including the new `api_key_revocation_lifecycle` (create → use → revoke → **same credential 401s**) and `scoped_key_cannot_list_or_revoke_keys`
- `cargo test -p xerj-server` — all passed (touched test helper)
- **Full ES-YAML conformance suite: 1366 passed / 0 failed / 3 skipped** (+1 case: new list/invalidate block in `security/10_api_key.yml`; runner learned `security.get_api_key` / `security.invalidate_api_key`)
- Live probes that previously 405'd now behave per contract; the audit ring shows the full mint→list→revoke trail
- `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
