### PR TITLE
fix(cla): exempt dependabot[bot] from the CLA gate

### DIFF
--- a/.contributors
+++ b/.contributors
@@ -1,3 +1,4 @@
 [
-  "xerj-org"
+  "xerj-org",
+  "dependabot[bot]"
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cla-config:
+    name: CLA gate config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # cla-bot reads .contributors straight off this repo; malformed JSON or a
+      # missing bot exemption breaks the gate silently (it just flags everyone).
+      # Regression test for the dependabot[bot] exemption (PR #194 comment).
+      - name: Validate .contributors (valid JSON, bot exemptions present)
+        run: |
+          jq -e 'type == "array" and all(.[]; type == "string")' .contributors
+          jq -e 'index("dependabot[bot]") != null' .contributors
+
   lint:
     name: Format + Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Every Dependabot PR trips the cla-bot check. Seen live on **PR #194** (source of this feedback item): cla-bot posted its CLA demand at `@dependabot[bot]` twice — once per push — and the check needs a manual override on every dependency bump. Dependabot cannot open the "add yourself to .contributors" signature PR the message asks for, and a CLA from it is meaningless anyway: its commits are mechanical version bumps of manifests this repo already controls.

## Fix

Add `dependabot[bot]` to [`.contributors`](.contributors) — the exact username cla-bot reports on PR #194, and the file `.clabot`'s `contributors` URL points at (`https://api.github.com/repos/xerj-org/xerj/contents/.contributors`). cla-bot goes green on future Dependabot PRs with no manual override.

## Regression test

New `cla-config` CI job validates the CLA-gate config: `.contributors` must parse as a JSON array of strings and must contain the `dependabot[bot]` exemption. Verified locally:

- against `origin/main`'s `.contributors`: `jq -e 'index("dependabot[bot]") != null'` exits **1** (job would fail)
- against this branch: exits **0**

Malformed JSON in `.contributors` would otherwise break the gate silently (cla-bot just flags everyone), so the job also guards future edits to the file.

Source: PR #194 comment (feedback key `fix-clabot-dependabot`).