### PR TITLE
chore(git): identity-guard hooks — stop concurrent-session identity leaks at commit time

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,17 @@
+#!/bin/sh
+# XERJ identity guard — commit-msg hook.
+#
+# FOR xerj-org AGENT-FLEET MACHINES ONLY.
+#
+# Enforces the standing repository directive (2026-07-22): commit
+# messages must not carry Claude / AI co-author trailers. The history is
+# authored as xerj-org, full stop.
+#
+# $1 is the path to the commit message file.
+
+if grep -qiE '^[[:space:]]*Co-Authored-By:.*(claude|anthropic|noreply@anthropic\.com)' "$1"; then
+    echo "identity-guard: refusing commit — Co-Authored-By Claude/Anthropic trailer found." >&2
+    echo "identity-guard: this repository never carries AI co-author trailers (directive 2026-07-22)." >&2
+    exit 1
+fi
+exit 0

--- a/scripts/git-hooks/install.sh
+++ b/scripts/git-hooks/install.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Install the XERJ identity-guard hooks into this clone's shared .git/hooks.
+#
+# FOR xerj-org AGENT-FLEET MACHINES ONLY — enforces the xerj-org identity
+# on every worktree of the clone (hooks are shared across worktrees when
+# core.hooksPath is unset). Do not run on a personal contributor checkout.
+#
+# Usage: scripts/git-hooks/install.sh
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+git_common=$(git rev-parse --git-common-dir)
+
+if hooks_path=$(git config --get core.hooksPath); then
+    echo "install: core.hooksPath is set ($hooks_path); refusing to guess. Install manually." >&2
+    exit 1
+fi
+
+for hook in pre-commit commit-msg; do
+    dst="$git_common/hooks/$hook"
+    if [ -e "$dst" ] && ! cmp -s "$here/$hook" "$dst"; then
+        echo "install: $dst already exists and differs; not overwriting." >&2
+        exit 1
+    fi
+    cp "$here/$hook" "$dst"
+    chmod +x "$dst"
+    echo "installed $dst"
+done

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/sh
+# XERJ identity guard — pre-commit hook.
+#
+# FOR xerj-org AGENT-FLEET MACHINES ONLY. Do not install on a personal
+# contributor checkout; it enforces the xerj-org committer identity.
+#
+# Why this exists: many concurrent agent sessions share one repository
+# (one .git, many worktrees, one shared repo-local config). Twice on
+# 2026-08-08 a session's transient identity override (env var or a
+# momentary `git config user.email` edit of the shared config) leaked a
+# personal e-mail address into commits that reached the public repo
+# (PR #219 commit c16320bb, PR #231 commit 15082748), and on 2026-08-04
+# the same mechanism leaked a third-party address into main. Config
+# audits cannot stop a transient override; refusing the commit can.
+#
+# What it checks: the exact author and committer ident git is about to
+# use (`git var` resolves env vars AND config, in the same order commit
+# does). Anything but the sanctioned xerj-org identities is refused.
+#
+# Coverage note (honest): pre-commit runs on `git commit` (including
+# --amend) but NOT on rebase/cherry-pick continuation commits, and
+# `git commit --no-verify` bypasses it. It is a guard rail, not a
+# security boundary.
+
+allowed_1='xerj-org <git@xerj.org>'
+allowed_2='xerj-org <xerj-org@users.noreply.github.com>'
+
+# `git var GIT_AUTHOR_IDENT` -> "Name <email> epoch tz"; strip the date.
+author=$(git var GIT_AUTHOR_IDENT | sed 's/ [0-9][0-9]* [+-][0-9][0-9]*$//')
+committer=$(git var GIT_COMMITTER_IDENT | sed 's/ [0-9][0-9]* [+-][0-9][0-9]*$//')
+
+fail=0
+case "$author" in
+    "$allowed_1"|"$allowed_2") ;;
+    *) echo "identity-guard: refusing commit — author is '$author'" >&2; fail=1 ;;
+esac
+case "$committer" in
+    "$allowed_1"|"$allowed_2") ;;
+    *) echo "identity-guard: refusing commit — committer is '$committer'" >&2; fail=1 ;;
+esac
+
+if [ "$fail" -ne 0 ]; then
+    cat >&2 <<'EOF'
+identity-guard: commits in this repository must be authored as
+identity-guard:   xerj-org <git@xerj.org>
+identity-guard: fix with:
+identity-guard:   git config user.name xerj-org
+identity-guard:   git config user.email git@xerj.org
+identity-guard: and unset any GIT_AUTHOR_* / GIT_COMMITTER_* overrides.
+EOF
+    exit 1
+fi
+exit 0

--- a/scripts/git-hooks/test.sh
+++ b/scripts/git-hooks/test.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Self-test for the XERJ identity-guard hooks.
+#
+# Builds a scratch repository, proves the failure mode exists WITHOUT the
+# hooks (a leaked identity commits successfully), installs the hooks, and
+# proves each guard: wrong author/committer refused, correct identity
+# accepted, Claude co-author trailer refused.
+#
+# Exits 0 only if every assertion holds. No network, no shared state.
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fails=0
+check() { # check <desc> <expected 0|1> <actual-exit>
+    if [ "$2" -eq 0 ] && [ "$3" -eq 0 ]; then echo "PASS: $1";
+    elif [ "$2" -ne 0 ] && [ "$3" -ne 0 ]; then echo "PASS: $1";
+    else echo "FAIL: $1 (expected exit $2, got $3)"; fails=$((fails+1)); fi
+}
+
+git init -q "$tmp/repo"
+cd "$tmp/repo"
+git config user.name xerj-org
+git config user.email git@xerj.org
+
+# 1. Without the hooks the leak is silent — this is the bug being fixed.
+rc=0; git -c user.email=leaked@example.com -c user.name=xerj-org \
+    commit -q --allow-empty -m "leak without hooks" || rc=$?
+check "without hooks, a leaked identity commits (the pre-fix failure)" 0 "$rc"
+leaked_email=$(git log -1 --format=%ae)
+[ "$leaked_email" = "leaked@example.com" ] || { echo "FAIL: leak not recorded"; fails=$((fails+1)); }
+
+# Install the hooks.
+cp "$here/pre-commit" "$here/commit-msg" .git/hooks/
+chmod +x .git/hooks/pre-commit .git/hooks/commit-msg
+
+# 2. Wrong email via config — refused.
+rc=0; git -c user.email=leaked@example.com commit -q --allow-empty -m x 2>/dev/null || rc=$?
+check "wrong config email refused" 1 "$rc"
+
+# 3. Wrong email via environment — refused.
+rc=0; GIT_AUTHOR_EMAIL=leaked@example.com GIT_AUTHOR_NAME=xerj-org \
+    git commit -q --allow-empty -m x 2>/dev/null || rc=$?
+check "wrong env author refused" 1 "$rc"
+
+# 4. Wrong committer via environment — refused.
+rc=0; GIT_COMMITTER_EMAIL=leaked@example.com GIT_COMMITTER_NAME=xerj-org \
+    git commit -q --allow-empty -m x 2>/dev/null || rc=$?
+check "wrong env committer refused" 1 "$rc"
+
+# 5. Wrong name, sanctioned email — refused.
+rc=0; git -c user.name=somebody commit -q --allow-empty -m x 2>/dev/null || rc=$?
+check "wrong name refused" 1 "$rc"
+
+# 6. Claude co-author trailer — refused.
+rc=0; git commit -q --allow-empty \
+    -m "ok subject" -m "Co-Authored-By: Claude <noreply@anthropic.com>" 2>/dev/null || rc=$?
+check "Claude co-author trailer refused" 1 "$rc"
+
+# 7. Correct identity — accepted.
+rc=0; git commit -q --allow-empty -m "good identity" || rc=$?
+check "sanctioned identity accepted" 0 "$rc"
+
+# 8. Noreply variant — accepted.
+rc=0; git -c user.email=xerj-org@users.noreply.github.com \
+    commit -q --allow-empty -m "noreply variant" || rc=$?
+check "noreply variant accepted" 0 "$rc"
+
+echo "---"
+if [ "$fails" -eq 0 ]; then echo "identity-guard test: ALL PASS"; else
+    echo "identity-guard test: $fails FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Source: the author-identity reports on the PR #231 and PR #219 comment threads.

## What happened

PR #231's commit `15082748` and PR #219's `c16320bb` (already merged) were authored with a personal e-mail address instead of `xerj-org <git@xerj.org>`, tripping the CLA check on #231. A reflog audit shows the effective identity on the shared agent-fleet clone flipped four times in the past week, each time reverting within seconds to minutes — a transient override by one of the many concurrent sessions sharing the clone's single repo-local config, not a standing misconfiguration. Every identity input at rest (global config, shared repo config, per-worktree configs, shell profiles, hooksPath, other clones) audited clean.

## Already done (git-ops, not in this diff)

- `15082748` amended to `1b4ee45b` — identical tree/parent/message/dates, identity-only change (`git diff 15082748 1b4ee45b` is empty; raw objects differ only in the two ident lines) — and force-pushed to `fix/issue-210-require-if-match` with the lease pinned to the old sha. The stale local branch ref was CAS-updated so nothing can re-push the wrong author. `@cla-bot check` requested; the PR now attributes to login `xerj-org`.
- `c16320bb` is merged history — main is **not** rewritten; prevention is the remedy there.

## This diff: prevention

`scripts/git-hooks/` — identity-guard hooks for xerj-org **agent-fleet machines only** (not for personal contributor checkouts):

- `pre-commit` — resolves the ident git is about to use (`git var`, which sees env overrides and config alike) and refuses anything but `xerj-org <git@xerj.org>` / `xerj-org <xerj-org@users.noreply.github.com>`.
- `commit-msg` — refuses `Co-Authored-By` Claude/Anthropic trailers (standing directive).
- `install.sh` — one guarded copy into the clone's shared `.git/hooks` covers every worktree (~95 here).
- `test.sh` — scratch-repo self-test: first proves the pre-fix failure (without hooks, a leaked identity commits silently), then proves each guard. **8/8 PASS.**

Installed live on the fleet machine: a probe commit using the exact leaked identity is refused with exit 1; this PR's own commit passed the guard under the sanctioned identity.

Honest coverage note: `pre-commit` fires on `git commit` (incl. `--amend`) but not on rebase/cherry-pick continuations, and `--no-verify` bypasses it. Both observed leaks came through plain `git commit`.
