### PR TITLE
fix(autoindex): keep map metadata durable across an unchanged resume (supersedes #167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,9 +221,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than an invocation-local counter that read `0` after a no-op resume.
   Existing catalogs whose historical `started` field was dynamically mapped
   as text remain usable: the additive mapping upgrade no longer attempts an
-  incompatible text-to-date type change.
+  incompatible text-to-date type change. Concretely, this is catalogs written
+  by **v1.0.0-rc.4** — the one release that had `autoindex` but not yet
+  dynamic ISO-date inference (added in rc.5). Measured against a live engine,
+  adding `started` as `date` to such a catalog is refused 400
+  `mapper_parsing_exception` (*"field [started] already exists as [text],
+  cannot add [date]"*), which aborts the invocation before any document work.
+  Catalogs written by rc.5 or later already inferred `started` as `date` and
+  were never affected.
 
-  Two consequences worth knowing before you upgrade:
+  Three consequences worth knowing before you upgrade:
 
   - **`bytes` is redefined.** It used to be the bytes the latest invocation
     processed, credited to the first dataset a file was assigned to. It is now
@@ -241,6 +248,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     resume after upgrading, and only regains it once one of its files is
     reprocessed. Re-run with `--fresh` if the note matters more than the
     rescan.
+  - **`junk_records_total` is narrower than the number it replaces**, and one
+    class of failure has left it. It used to be an invocation counter that
+    also folded in records the *backend* refused per bulk item; it is now
+    parser junk only, so `xerj autoindex map`'s header counts exactly what the
+    per-dataset `junk_records` values count. No signal is lost in practice: a
+    single per-item rejection already aborts the run with
+    `autoindex stopped with bulk/backend failures`, before any run document or
+    map is written, so the folded-in number was never observable in a map.
+    That abort message now also states how many records were refused, which
+    the first-five error sample could not convey.
 
 - **The installer is now fail-closed on checksum *verification*, not just on
   checksum *download*.** `landing/get` printed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   document. This does **not** implement add/change/delete reconciliation for
   *indexed* files, which remains open.
 
+- **Repeated `autoindex` scans keep agent-facing map metadata durable.**
+  Dataset source bytes, parser-junk counts and coercion-drop notes now derive
+  from committed per-file journal records instead of invocation-local worker
+  counters, so an unchanged resume does not overwrite them with zero. Run
+  timestamps now distinguish invocation start (`started`) from summary
+  generation (`summary_generated_at`), and `junk_records_total` on the run
+  document is the same durable sum the per-dataset `junk_records` reports
+  rather than an invocation-local counter that read `0` after a no-op resume.
+  Existing catalogs whose historical `started` field was dynamically mapped
+  as text remain usable: the additive mapping upgrade no longer attempts an
+  incompatible text-to-date type change.
+
+  Two consequences worth knowing before you upgrade:
+
+  - **`bytes` is redefined.** It used to be the bytes the latest invocation
+    processed, credited to the first dataset a file was assigned to. It is now
+    the complete canonical source size, counted once in **every** distinct
+    dataset that source is assigned to. Per-dataset values therefore get
+    larger, and summing `bytes` across datasets can exceed the corpus size
+    when one source feeds several datasets — exactly as one source already
+    contributed to several dataset-local file counts. It is a dataset-local
+    source footprint, not a partition of physical storage.
+  - **Journals written before this release carry no per-dataset coercion
+    record**, because the new `dropped_by_dataset` field defaults to empty
+    when an older journal is replayed. Byte and junk counts reconstruct fine
+    (their journal fields already existed), but a dataset whose files are all
+    unchanged loses its `N field values dropped by coercion` note on the first
+    resume after upgrading, and only regains it once one of its files is
+    reprocessed. Re-run with `--fresh` if the note matters more than the
+    rescan.
+
 - **The installer is now fail-closed on checksum *verification*, not just on
   checksum *download*.** `landing/get` printed
   `warning: sha256sum/shasum not found — skipping checksum verification` and

--- a/engine/crates/xerj-autoindex/src/catalog.rs
+++ b/engine/crates/xerj-autoindex/src/catalog.rs
@@ -8,7 +8,28 @@ use serde_json::{json, Value};
 
 pub const CATALOG_INDEX: &str = "autoindex-catalog";
 
+/// Explicit mapping for a **freshly created** catalog index.
+///
+/// Tripwire — `started` is bimodal across installs, on purpose. This function
+/// declares it `date`, but the additive upgrade in `run_index_report`
+/// deliberately omits it: catalogs created before this mapping existed have a
+/// dynamically inferred `text` `started`, and asking the engine to change an
+/// existing `text` field to `date` is refused with a 400
+/// `illegal_argument_exception` (`xerj-api/src/es_compat.rs:1792`) and aborts
+/// the whole invocation. So a catalog created from here sorts `started`
+/// server-side, and an upgraded legacy catalog does not.
+///
+/// Nothing may rely on `started` being a `date`: `run_map` sorts runs
+/// client-side, which is what keeps the split benign. Any future server-side
+/// range query, `sort`, or date aggregation on `started` must first migrate
+/// legacy catalogs by reindexing them — not by adding `started` to the
+/// additive upgrade, which is exactly the abort described above.
 pub fn catalog_mapping() -> Value {
+    // The three run-metadata fields are inserted after the literal rather than
+    // written inside it: `serde_json::json!` recurses once per key, and at 40
+    // properties the macro exceeds the default `recursion_limit = 128` and
+    // fails to compile. Adding another field here must use this same tail, not
+    // the literal.
     let mut mapping = json!({
         "mappings": {"properties": {
             "doc_kind": {"type": "keyword"},
@@ -54,6 +75,7 @@ pub fn catalog_mapping() -> Value {
         .pointer_mut("/mappings/properties")
         .and_then(Value::as_object_mut)
         .expect("catalog mapping properties");
+    // See the tripwire on this function before touching `started`.
     properties.insert(
         "started".into(),
         json!({"type": "date", "format": "strict_date_optional_time||epoch_millis"}),

--- a/engine/crates/xerj-autoindex/src/catalog.rs
+++ b/engine/crates/xerj-autoindex/src/catalog.rs
@@ -56,11 +56,11 @@ pub fn catalog_mapping() -> Value {
         .expect("catalog mapping properties");
     properties.insert(
         "started".into(),
-        json!({"type": "date", "format": "strict_date_optional_time"}),
+        json!({"type": "date", "format": "strict_date_optional_time||epoch_millis"}),
     );
     properties.insert(
         "summary_generated_at".into(),
-        json!({"type": "date", "format": "strict_date_optional_time"}),
+        json!({"type": "date", "format": "strict_date_optional_time||epoch_millis"}),
     );
     properties.insert(
         "invocation_telemetry_scope".into(),

--- a/engine/crates/xerj-autoindex/src/catalog.rs
+++ b/engine/crates/xerj-autoindex/src/catalog.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 pub const CATALOG_INDEX: &str = "autoindex-catalog";
 
 pub fn catalog_mapping() -> Value {
-    json!({
+    let mut mapping = json!({
         "mappings": {"properties": {
             "doc_kind": {"type": "keyword"},
             "slug": {"type": "keyword"},
@@ -49,7 +49,24 @@ pub fn catalog_mapping() -> Value {
             "pearson_r": {"type": "double"},
             "activity_correlated": {"type": "boolean"},
         }}
-    })
+    });
+    let properties = mapping
+        .pointer_mut("/mappings/properties")
+        .and_then(Value::as_object_mut)
+        .expect("catalog mapping properties");
+    properties.insert(
+        "started".into(),
+        json!({"type": "date", "format": "strict_date_optional_time"}),
+    );
+    properties.insert(
+        "summary_generated_at".into(),
+        json!({"type": "date", "format": "strict_date_optional_time"}),
+    );
+    properties.insert(
+        "invocation_telemetry_scope".into(),
+        json!({"type": "keyword"}),
+    );
+    mapping
 }
 
 pub const GOTCHAS: &[&str] = &[
@@ -67,6 +84,11 @@ pub struct DatasetDocInput<'a> {
     pub pd: &'a PlanDataset,
     pub record_count: u64,
     pub junk_records: u64,
+    /// Canonical source bytes backing this dataset's durably live records.
+    ///
+    /// This is not a scan-time filesystem total: a removed path stays
+    /// represented until autoindex also removes its live records, and one
+    /// source feeding several datasets contributes its bytes to each.
     pub bytes: u64,
     pub file_count: usize,
     pub formats: Vec<String>,

--- a/engine/crates/xerj-autoindex/src/catalog.rs
+++ b/engine/crates/xerj-autoindex/src/catalog.rs
@@ -11,23 +11,42 @@ pub const CATALOG_INDEX: &str = "autoindex-catalog";
 /// Explicit mapping for a **freshly created** catalog index.
 ///
 /// Tripwire — `started` is bimodal across installs, on purpose. This function
-/// declares it `date`, but the additive upgrade in `run_index_report`
-/// deliberately omits it: catalogs created before this mapping existed have a
-/// dynamically inferred `text` `started`, and asking the engine to change an
-/// existing `text` field to `date` is refused with a 400
-/// `illegal_argument_exception` (`xerj-api/src/es_compat.rs:1792`) and aborts
-/// the whole invocation. So a catalog created from here sorts `started`
-/// server-side, and an upgraded legacy catalog does not.
+/// declares it `date`; the additive upgrade in `run_index_report` deliberately
+/// omits it. No release before this one declared `started` at all, so every
+/// existing catalog got it from dynamic inference, and which type that produced
+/// depends on which release wrote the catalog:
 ///
-/// Nothing may rely on `started` being a `date`: `run_map` sorts runs
-/// client-side, which is what keeps the split benign. Any future server-side
-/// range query, `sort`, or date aggregation on `started` must first migrate
-/// legacy catalogs by reindexing them — not by adding `started` to the
-/// additive upgrade, which is exactly the abort described above.
+/// - **v1.0.0-rc.4** — the only release with `autoindex` (0f3ef60d, 2026-07-09)
+///   but without dynamic ISO-date inference (a0f872ac, 2026-07-25, first in
+///   rc.5). Its catalogs inferred `started` as **`text`**. Adding `started` as
+///   `date` to those is refused **400 `mapper_parsing_exception`** — *"field
+///   [started] already exists as [text], cannot add [date]"* — from the
+///   `idx.schema()` guard in `xerj-api/src/es_compat.rs` (the
+///   `XerjError::invalid_mapping` arm; `InvalidMapping` maps to
+///   `mapper_parsing_exception` in `xerj-api/src/error.rs`). `es.update_mapping`
+///   surfaces that as an `Err`, which aborts the invocation before any document
+///   work.
+/// - **v1.0.0-rc.5 and later** — inference already produced `date`, so the same
+///   upgrade would simply be acknowledged 200.
+///
+/// It is specifically NOT the `illegal_argument_exception` *"mapper [started]
+/// cannot be changed from type [text] to [date]"* guard earlier in the same
+/// handler. That one reads `state.engine.index_mappings`, which holds only
+/// *declared* mappings, and `started` was never declared — so for a legacy
+/// catalog it cannot fire. (Measured against a live engine, v1.0.0-rc.13: text
+/// inferred → `mapper_parsing_exception`; text declared →
+/// `illegal_argument_exception`; date inferred → 200 acknowledged.)
+///
+/// So a catalog created from here sorts `started` server-side, an rc.4 catalog
+/// does not, and nothing may rely on `started` being a `date`: `run_map` sorts
+/// runs client-side, which is what keeps the split benign. Any future
+/// server-side range query, `sort`, or date aggregation on `started` must first
+/// migrate legacy catalogs by reindexing them — not by adding `started` to the
+/// additive upgrade, which is exactly the abort above.
 pub fn catalog_mapping() -> Value {
-    // The three run-metadata fields are inserted after the literal rather than
-    // written inside it: `serde_json::json!` recurses once per key, and at 40
-    // properties the macro exceeds the default `recursion_limit = 128` and
+    // The trailing run-metadata fields are inserted after the literal rather
+    // than written inside it: `serde_json::json!` recurses once per key, and at
+    // 40 properties the macro exceeds the default `recursion_limit = 128` and
     // fails to compile. Adding another field here must use this same tail, not
     // the literal.
     let mut mapping = json!({
@@ -88,6 +107,7 @@ pub fn catalog_mapping() -> Value {
         "invocation_telemetry_scope".into(),
         json!({"type": "keyword"}),
     );
+    properties.insert("junk_records_this_run".into(), json!({"type": "long"}));
     mapping
 }
 

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -27,6 +27,10 @@ struct MockState {
     fail_data_bulk: usize,
     failed_once: bool,
     delete_calls: usize,
+    response_delay_ms: u64,
+    catalog_preexists: bool,
+    catalog_mapping_upgraded: bool,
+    catalog_bulk_before_upgrade: bool,
     stop: bool,
     embedding_identity_sha256: String,
     /// Reject every data-bulk item with a 403 explicit write-block error
@@ -46,11 +50,16 @@ struct MockEndpoint {
 
 impl MockEndpoint {
     fn start(fail_data_bulk: usize) -> Self {
+        Self::start_with_delay(fail_data_bulk, 0)
+    }
+
+    fn start_with_delay(fail_data_bulk: usize, response_delay_ms: u64) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap());
         let state = Arc::new(Mutex::new(MockState {
             fail_data_bulk,
+            response_delay_ms,
             embedding_identity_sha256: "a".repeat(64),
             ..MockState::default()
         }));
@@ -72,6 +81,12 @@ impl MockEndpoint {
             state,
             join: Some(join),
         }
+    }
+
+    fn start_with_existing_catalog() -> Self {
+        let endpoint = Self::start(usize::MAX);
+        endpoint.state.lock().unwrap().catalog_preexists = true;
+        endpoint
     }
 }
 
@@ -111,19 +126,50 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("");
     let path = parts.next().unwrap_or("");
+    let response_delay_ms = state.lock().unwrap().response_delay_ms;
+    if response_delay_ms > 0 {
+        thread::sleep(std::time::Duration::from_millis(response_delay_ms));
+    }
 
-    let response = if method == "GET" && path == "/v1/embedding/identity" {
+    let (status, response) = if method == "GET" && path == "/v1/embedding/identity" {
         let identity = state.lock().unwrap().embedding_identity_sha256.clone();
-        json!({"data": {
-            "version": 1,
-            "backend": "lexical",
-            "identity_sha256": identity,
-            "dimensions": 384,
-            "semantic_contract": "semantic_text-derived-vector.v1",
-            "resumable": true
-        }, "took_ms": 0, "request_id": "test"})
+        (
+            200,
+            json!({"data": {
+                "version": 1,
+                "backend": "lexical",
+                "identity_sha256": identity,
+                "dimensions": 384,
+                "semantic_contract": "semantic_text-derived-vector.v1",
+                "resumable": true
+            }, "took_ms": 0, "request_id": "test"}),
+        )
+    } else if method == "PUT" && path == "/autoindex-catalog" {
+        if state.lock().unwrap().catalog_preexists {
+            (
+                400,
+                json!({"error": {"type": "resource_already_exists_exception"}}),
+            )
+        } else {
+            (200, json!({"acknowledged": true}))
+        }
+    } else if method == "PUT" && path == "/autoindex-catalog/_mapping" {
+        let mapping: Value = serde_json::from_slice(&body).unwrap();
+        let required = [
+            "started",
+            "summary_generated_at",
+            "invocation_telemetry_scope",
+        ];
+        let upgraded = required.iter().all(|field| {
+            mapping
+                .pointer(&format!("/properties/{field}/type"))
+                .and_then(Value::as_str)
+                .is_some()
+        });
+        state.lock().unwrap().catalog_mapping_upgraded = upgraded;
+        (200, json!({"acknowledged": true}))
     } else if method == "POST" && path == "/_bulk" {
-        bulk_response(&body, state)
+        (200, bulk_response(&body, state))
     } else if method == "POST" && path.contains("/_delete_by_query") {
         let query: Value = serde_json::from_slice(&body).unwrap();
         let ax_file = query
@@ -137,23 +183,27 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
                 .docs
                 .retain(|_, doc| doc.get("ax_file").and_then(Value::as_str) != Some(key.as_str()));
         }
-        json!({"deleted": 0, "failures": []})
+        (200, json!({"deleted": 0, "failures": []}))
     } else if method == "GET" && path.ends_with("/_count") {
-        json!({"count": state.lock().unwrap().docs.len()})
+        (200, json!({"count": state.lock().unwrap().docs.len()}))
     } else if method == "POST" && path.ends_with("/_search") {
         // Report the REAL number of stored docs: `run_index` now verifies
         // live counts against the journal (#195), so a mock that always
         // answered 0 hits would (rightly) fail every successful run.
         let total = state.lock().unwrap().docs.len();
-        json!({"hits":{"total":{"value":total},"hits":[]},"aggregations":{}})
+        (
+            200,
+            json!({"hits":{"total":{"value":total},"hits":[]},"aggregations":{}}),
+        )
     } else {
         // ping, index creation/mapping, refresh, and catalog operations
-        json!({"acknowledged": true})
+        (200, json!({"acknowledged": true}))
     };
     let bytes = response.to_string();
+    let reason = if status == 200 { "OK" } else { "Bad Request" };
     write!(
         stream,
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         bytes.len(),
         bytes
     )
@@ -176,6 +226,9 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
         // the junk sweep of #238), so walk the NDJSON rather than assuming
         // action/document pairs — a delete carries no document line.
         let mut locked = state.lock().unwrap();
+        if locked.catalog_preexists && !locked.catalog_mapping_upgraded {
+            locked.catalog_bulk_before_upgrade = true;
+        }
         let mut line = 0;
         while line < lines.len() {
             let Ok(action) = serde_json::from_slice::<Value>(lines[line]) else {
@@ -305,6 +358,25 @@ fn event_count(state_dir: &Path, kind: &str) -> usize {
         .count()
 }
 
+fn dataset_catalog_docs(endpoint: &MockEndpoint) -> Vec<Value> {
+    let mut docs: Vec<Value> = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .catalog_docs
+        .values()
+        .filter(|doc| doc.get("doc_kind").and_then(Value::as_str) == Some("dataset"))
+        .cloned()
+        .collect();
+    docs.sort_by_key(|doc| {
+        doc.get("slug")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string()
+    });
+    docs
+}
+
 #[test]
 fn semantic_resume_rejects_embedding_identity_drift_before_another_bulk() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
@@ -349,20 +421,240 @@ fn fresh_publication_skips_delete_and_noop_resume_does_not_append_plan() {
         "id,value\n0,fresh\n1,fresh\n",
     )
     .unwrap();
-    let endpoint = MockEndpoint::start(usize::MAX);
+    // A fixed endpoint delay makes the start/summary chronology
+    // deterministic instead of relying on scheduler timing.
+    let endpoint = MockEndpoint::start_with_delay(usize::MAX, 5);
     let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
 
-    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let (initial_code, initial_summary) = run_index_report(config.clone()).unwrap();
+    assert_eq!(initial_code, 0);
     assert_eq!(endpoint.state.lock().unwrap().delete_calls, 0);
     assert_eq!(event_count(state_dir.path(), "plan"), 1);
     assert_eq!(event_count(state_dir.path(), "file_replace_start"), 1);
+    let source_bytes = fs::metadata(corpus.path().join("records.csv"))
+        .unwrap()
+        .len();
+    let initial_dataset = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .catalog_docs
+        .values()
+        .find(|doc| doc.get("doc_kind").and_then(Value::as_str) == Some("dataset"))
+        .cloned()
+        .expect("dataset catalog document");
+    let initial_dataset_bytes = initial_dataset
+        .get("bytes")
+        .and_then(Value::as_u64)
+        .unwrap();
+    assert_eq!(initial_dataset_bytes, source_bytes);
+    let initial_summary = initial_summary.unwrap();
+    assert_eq!(
+        initial_summary["invocation_telemetry_scope"],
+        json!("latest_invocation_of_durable_run")
+    );
+    let initial_started =
+        chrono::DateTime::parse_from_rfc3339(initial_summary["started"].as_str().unwrap()).unwrap();
+    let initial_summary_generated_at = chrono::DateTime::parse_from_rfc3339(
+        initial_summary["summary_generated_at"].as_str().unwrap(),
+    )
+    .unwrap();
+    assert!(
+        initial_summary_generated_at - initial_started >= chrono::Duration::milliseconds(5),
+        "started must be captured before work, not synthesized with the summary"
+    );
 
-    assert_eq!(run_index(config).unwrap(), 0);
+    let (resume_code, resume_summary) = run_index_report(config).unwrap();
+    assert_eq!(resume_code, 0);
     assert_eq!(endpoint.state.lock().unwrap().delete_calls, 0);
     assert_eq!(
         event_count(state_dir.path(), "plan"),
         1,
         "an identical resume must reuse the durable plan"
+    );
+    let resumed_dataset = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .catalog_docs
+        .values()
+        .find(|doc| doc.get("doc_kind").and_then(Value::as_str) == Some("dataset"))
+        .cloned()
+        .expect("dataset catalog document after resume");
+    assert_eq!(
+        resumed_dataset["bytes"],
+        json!(source_bytes),
+        "an unchanged resume must not replace durable dataset bytes with zero"
+    );
+    assert_eq!(
+        resume_summary.unwrap()["invocation_telemetry_scope"],
+        json!("latest_invocation_of_durable_run")
+    );
+}
+
+#[test]
+fn changed_source_replaces_durable_dataset_bytes_across_reopen() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let path = corpus.path().join("records.csv");
+    fs::write(&path, "id,value\n0,old\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let initial_bytes = fs::metadata(&path).unwrap().len();
+    assert_eq!(dataset_catalog_docs(&endpoint)[0]["bytes"], initial_bytes);
+
+    fs::write(
+        &path,
+        "id,value,description\n0,new,a longer replacement source\n1,new,second row\n",
+    )
+    .unwrap();
+    let replacement_bytes = fs::metadata(&path).unwrap().len();
+    assert_ne!(replacement_bytes, initial_bytes);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    // Reopen the durable journal independently of the product invocation.
+    let root = config.root.canonicalize().unwrap();
+    let reopened = state::Journal::open(
+        state_dir.path(),
+        &root.to_string_lossy(),
+        &config.url,
+        &config.prefix,
+        config.bulk_timeout_secs,
+        false,
+    )
+    .unwrap();
+    assert_eq!(reopened.done.len(), 1);
+    assert_eq!(
+        reopened.done.values().next().unwrap().bytes,
+        replacement_bytes
+    );
+    drop(reopened);
+
+    // A following unchanged product rescan must publish the replacement
+    // generation's durable bytes, not zero and not the historical size.
+    assert_eq!(run_index(config).unwrap(), 0);
+    assert_eq!(
+        dataset_catalog_docs(&endpoint)[0]["bytes"],
+        replacement_bytes
+    );
+}
+
+#[test]
+fn deleted_path_bytes_remain_while_its_documents_remain_live() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let removed = corpus.path().join("removed.csv");
+    let retained = corpus.path().join("retained.csv");
+    fs::write(&removed, "id,value\n0,removed\n1,removed\n").unwrap();
+    fs::write(&retained, "id,value\n2,retained\n3,retained\n").unwrap();
+    let durable_live_bytes =
+        fs::metadata(&removed).unwrap().len() + fs::metadata(&retained).unwrap().len();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    assert_eq!(
+        dataset_catalog_docs(&endpoint)[0]["bytes"],
+        durable_live_bytes
+    );
+    assert_eq!(endpoint.state.lock().unwrap().docs.len(), 4);
+
+    fs::remove_file(&removed).unwrap();
+    // Current autoindex semantics do not reconcile a missing canonical path:
+    // its indexed documents and FileDone remain live. Dataset bytes must
+    // describe that durable live index rather than silently pretend deletion.
+    for _ in 0..2 {
+        assert_eq!(run_index(config.clone()).unwrap(), 0);
+        assert_eq!(endpoint.state.lock().unwrap().docs.len(), 4);
+        assert_eq!(
+            dataset_catalog_docs(&endpoint)[0]["bytes"],
+            durable_live_bytes
+        );
+    }
+}
+
+#[test]
+fn product_path_counts_shared_source_once_per_distinct_dataset() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let path = corpus.path().join("finance.sqlite");
+    {
+        let db = rusqlite::Connection::open(&path).unwrap();
+        db.execute_batch(
+            "CREATE TABLE quarterly (quarter TEXT, revenue INTEGER);
+             INSERT INTO quarterly VALUES ('2026-Q1', 100);
+             CREATE TABLE annual (year INTEGER, filing TEXT);
+             INSERT INTO annual VALUES (2026, '10-K');",
+        )
+        .unwrap();
+    }
+    let source_bytes = fs::metadata(&path).unwrap().len();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let root = config.root.canonicalize().unwrap();
+    let mut journal = state::Journal::open(
+        state_dir.path(),
+        &root.to_string_lossy(),
+        &config.url,
+        &config.prefix,
+        config.bulk_timeout_secs,
+        false,
+    )
+    .unwrap();
+    let mut plan = journal.plan.clone().unwrap();
+    assert_eq!(plan.datasets.len(), 2);
+    let assignment = plan.files.values_mut().next().unwrap();
+    assert_eq!(assignment.assignments.len(), 2);
+    // Model a compatible historical plan that repeated one group assignment.
+    // Catalog accounting must deduplicate it by dataset slug.
+    assignment
+        .assignments
+        .push(assignment.assignments[0].clone());
+    journal.write_plan(&plan).unwrap();
+    drop(journal);
+
+    assert_eq!(run_index(config).unwrap(), 0);
+    let datasets = dataset_catalog_docs(&endpoint);
+    assert_eq!(datasets.len(), 2);
+    assert!(datasets
+        .iter()
+        .all(|dataset| dataset["bytes"] == json!(source_bytes)));
+}
+
+#[test]
+fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("records.csv"), "id,value\n0,one\n").unwrap();
+    let endpoint = MockEndpoint::start_with_existing_catalog();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    let (code, summary) = run_index_report(config).unwrap();
+    assert_eq!(code, 0);
+    let summary = summary.unwrap();
+    assert!(summary["started"].is_string());
+    assert!(summary["summary_generated_at"].is_string());
+    assert_eq!(
+        summary["invocation_telemetry_scope"],
+        json!("latest_invocation_of_durable_run")
+    );
+    let state = endpoint.state.lock().unwrap();
+    assert!(state.catalog_mapping_upgraded);
+    assert!(
+        !state.catalog_bulk_before_upgrade,
+        "new run metadata must not reach a legacy catalog before its additive mapping upgrade"
     );
 }
 

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -31,6 +31,12 @@ struct MockState {
     catalog_preexists: bool,
     catalog_mapping_upgraded: bool,
     catalog_bulk_before_upgrade: bool,
+    /// Catalog bulk actions the fixture does not model. Recorded rather than
+    /// panicked on: this runs inside the server thread while the state guard
+    /// is held, so a panic here would poison the `Mutex` and turn
+    /// `MockEndpoint::drop`'s `join().unwrap()` into a second, misleading
+    /// panic. Tests assert on it from the test thread instead.
+    unexpected_catalog_actions: Vec<String>,
     stop: bool,
     embedding_identity_sha256: String,
     /// Reject every data-bulk item with a 403 explicit write-block error
@@ -165,12 +171,21 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
         });
         let mut locked = state.lock().unwrap();
         if locked.catalog_preexists && started_requested {
+            // The literal shape `PUT /_mapping` returns for an incompatible
+            // type change (`xerj-api/src/es_compat.rs`): 400
+            // `illegal_argument_exception`, not `mapper_parsing_exception`,
+            // which is reserved for a malformed mapping body.
+            let reason = "mapper [started] cannot be changed from type [text] to [date]";
             (
                 400,
-                json!({"error": {
-                    "type": "mapper_parsing_exception",
-                    "reason": "field [started] already exists as [text], cannot add [date]"
-                }}),
+                json!({
+                    "error": {
+                        "root_cause": [{"type": "illegal_argument_exception", "reason": reason}],
+                        "type": "illegal_argument_exception",
+                        "reason": reason,
+                    },
+                    "status": 400,
+                }),
             )
         } else {
             locked.catalog_mapping_upgraded = upgraded;
@@ -259,6 +274,14 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
                 locked.catalog_docs.insert(id.to_owned(), doc);
                 line += 2;
             } else {
+                // Fixture drift, not a product signal. Recorded rather than
+                // panicked on: this runs on the server thread with the state
+                // guard held, so a panic here poisons the `Mutex` and turns
+                // `MockEndpoint::drop`'s `join().unwrap()` into a second,
+                // misleading panic. Tests assert on it from the test thread.
+                locked
+                    .unexpected_catalog_actions
+                    .push(format!("unexpected catalog bulk action: {action}"));
                 line += 1;
             }
         }
@@ -663,6 +686,11 @@ fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
     assert!(
         !state.catalog_bulk_before_upgrade,
         "new run metadata must not reach a legacy catalog before its additive mapping upgrade"
+    );
+    assert!(
+        state.unexpected_catalog_actions.is_empty(),
+        "fixture does not model these catalog bulk actions: {:?}",
+        state.unexpected_catalog_actions
     );
 }
 

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -155,19 +155,27 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
         }
     } else if method == "PUT" && path == "/autoindex-catalog/_mapping" {
         let mapping: Value = serde_json::from_slice(&body).unwrap();
-        let required = [
-            "started",
-            "summary_generated_at",
-            "invocation_telemetry_scope",
-        ];
+        let started_requested = mapping.pointer("/properties/started").is_some();
+        let required = ["summary_generated_at", "invocation_telemetry_scope"];
         let upgraded = required.iter().all(|field| {
             mapping
                 .pointer(&format!("/properties/{field}/type"))
                 .and_then(Value::as_str)
                 .is_some()
         });
-        state.lock().unwrap().catalog_mapping_upgraded = upgraded;
-        (200, json!({"acknowledged": true}))
+        let mut locked = state.lock().unwrap();
+        if locked.catalog_preexists && started_requested {
+            (
+                400,
+                json!({"error": {
+                    "type": "mapper_parsing_exception",
+                    "reason": "field [started] already exists as [text], cannot add [date]"
+                }}),
+            )
+        } else {
+            locked.catalog_mapping_upgraded = upgraded;
+            (200, json!({"acknowledged": true}))
+        }
     } else if method == "POST" && path == "/_bulk" {
         (200, bulk_response(&body, state))
     } else if method == "POST" && path.contains("/_delete_by_query") {
@@ -656,6 +664,46 @@ fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
         !state.catalog_bulk_before_upgrade,
         "new run metadata must not reach a legacy catalog before its additive mapping upgrade"
     );
+}
+
+#[test]
+fn unchanged_resume_keeps_durable_dataset_junk_and_coercion_notes() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("records.csv"), "id,value\n0,one\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let root = config.root.canonicalize().unwrap();
+    let mut journal = state::Journal::open(
+        state_dir.path(),
+        &root.to_string_lossy(),
+        &config.url,
+        &config.prefix,
+        config.bulk_timeout_secs,
+        false,
+    )
+    .unwrap();
+    let plan = journal.plan.clone().unwrap();
+    let slug = plan.datasets[0].slug.clone();
+    let mut completion = journal.done.values().next().unwrap().clone();
+    completion.junk = 7;
+    completion.dropped_by_dataset.insert(slug.clone(), 3);
+    journal.file_done(&completion).unwrap();
+    drop(journal);
+
+    assert_eq!(run_index(config).unwrap(), 0);
+    let dataset = dataset_catalog_docs(&endpoint)
+        .into_iter()
+        .find(|doc| doc["slug"] == slug)
+        .unwrap();
+    assert_eq!(dataset["junk_records"], 7);
+    assert!(dataset["notes"].as_array().unwrap().iter().any(|note| note
+        .as_str()
+        .is_some_and(|text| { text.contains("3 field values could not be coerced") })));
 }
 
 #[test]

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -31,6 +31,12 @@ struct MockState {
     catalog_preexists: bool,
     catalog_mapping_upgraded: bool,
     catalog_bulk_before_upgrade: bool,
+    /// Set if the additive mapping upgrade ever asks for `started`. This is
+    /// the executable half of `catalog::catalog_mapping`'s tripwire: against a
+    /// legacy (v1.0.0-rc.4) catalog that request is refused 400 and aborts the
+    /// run, so the product must never send it. Asserted false rather than left
+    /// to the 400 branch below, which a correct product never reaches.
+    started_mapping_requested: bool,
     /// Catalog bulk actions the fixture does not model. Recorded rather than
     /// panicked on: this runs inside the server thread while the state guard
     /// is held, so a panic here would poison the `Mutex` and turn
@@ -46,6 +52,12 @@ struct MockState {
     /// Accept every data bulk (`errors: false`) but persist nothing — the
     /// shape of any rejection path the client-side classifier misses.
     swallow_data_bulks: bool,
+    /// Refuse the FIRST document of every data bulk with a per-item 400 and
+    /// apply the rest. This is the one bulk shape that produces an
+    /// `item_error` without a `server_error`: status is neither 429 nor 5xx
+    /// and the type is not a block, so the run continues and must still
+    /// report the rejection.
+    reject_first_data_item: bool,
 }
 
 struct MockEndpoint {
@@ -170,18 +182,31 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
                 .is_some()
         });
         let mut locked = state.lock().unwrap();
+        locked.started_mapping_requested |= started_requested;
         if locked.catalog_preexists && started_requested {
-            // The literal shape `PUT /_mapping` returns for an incompatible
-            // type change (`xerj-api/src/es_compat.rs`): 400
-            // `illegal_argument_exception`, not `mapper_parsing_exception`,
-            // which is reserved for a malformed mapping body.
-            let reason = "mapper [started] cannot be changed from type [text] to [date]";
+            // The shape a real engine returns when the additive upgrade asks
+            // for `started` on a legacy (v1.0.0-rc.4) catalog, where `started`
+            // was dynamically inferred as `text`. Measured against a live
+            // v1.0.0-rc.13 engine, not read off the handler: the request falls
+            // past the `illegal_argument_exception` guard — that one only sees
+            // *declared* mappings, and `started` was never declared — and is
+            // refused by the `idx.schema()` guard, which returns
+            // `XerjError::invalid_mapping` and therefore a 400
+            // `mapper_parsing_exception`.
+            //
+            // A correct product never reaches this branch (see
+            // `started_mapping_requested`, asserted false in
+            // `existing_catalog_is_upgraded_before_new_run_metadata_is_written`).
+            // It is kept, and kept accurate, so that adding `started` to the
+            // additive upgrade fails here with the message the operator would
+            // really see rather than passing silently.
+            let reason = "field [started] already exists as [text], cannot add [date]";
             (
                 400,
                 json!({
                     "error": {
-                        "root_cause": [{"type": "illegal_argument_exception", "reason": reason}],
-                        "type": "illegal_argument_exception",
+                        "root_cause": [{"type": "mapper_parsing_exception", "reason": reason}],
+                        "type": "mapper_parsing_exception",
                         "reason": reason,
                     },
                     "status": 400,
@@ -309,6 +334,27 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
     }
     if locked.swallow_data_bulks {
         return json!({"errors": false, "items": []});
+    }
+    if locked.reject_first_data_item {
+        let mut items = Vec::new();
+        for (nth, pair) in lines.chunks_exact(2).enumerate() {
+            if nth == 0 {
+                items.push(json!({"index": {
+                    "status": 400,
+                    "error": {
+                        "type": "document_parsing_exception",
+                        "reason": "refused: value could not be parsed"
+                    }
+                }}));
+                continue;
+            }
+            let action: Value = serde_json::from_slice(pair[0]).unwrap();
+            let doc: Value = serde_json::from_slice(pair[1]).unwrap();
+            let id = action.pointer("/index/_id").unwrap().as_str().unwrap();
+            locked.docs.insert(id.to_owned(), doc);
+            items.push(json!({"index": {"status": 201}}));
+        }
+        return json!({"errors": true, "items": items});
     }
     let fail = !locked.failed_once && locked.data_bulk_number == locked.fail_data_bulk;
     let pairs = lines.chunks_exact(2);
@@ -683,6 +729,13 @@ fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
     );
     let state = endpoint.state.lock().unwrap();
     assert!(state.catalog_mapping_upgraded);
+    assert!(
+        !state.started_mapping_requested,
+        "the additive upgrade asked a legacy catalog for `started`; a real v1.0.0-rc.4 catalog \
+         answers that with 400 mapper_parsing_exception (\"field [started] already exists as \
+         [text], cannot add [date]\") and the run aborts before any document work — see the \
+         tripwire on catalog::catalog_mapping"
+    );
     assert!(
         !state.catalog_bulk_before_upgrade,
         "new run metadata must not reach a legacy catalog before its additive mapping upgrade"
@@ -1443,6 +1496,66 @@ fn write_block_rejections_are_backend_fatal_and_the_file_stays_pending() {
     assert_eq!(run_index(config).unwrap(), 0);
     assert_eq!(file_done_count(state_dir.path()), 1);
     assert_eq!(endpoint.state.lock().unwrap().docs.len(), 2);
+}
+
+/// Pins WHY the run document carries no backend-rejection count, so nobody
+/// "restores" one that could only ever read 0.
+///
+/// Making `junk_records_total` durable narrowed it: it no longer folds in the
+/// per-item rejections that `record_bulk_outcome` counts. That looks like a
+/// lost signal, and it would be one — except that a single per-item rejection
+/// also lands in `bulk_errors`, which aborts the run before the run document,
+/// the map, the summary line and the exit code exist at all. So the narrowed
+/// number was unreachable in any published map either way.
+///
+/// The rejection count is therefore reported in the one place a rejected run
+/// ever reaches: the abort message, where it supplies the scale that
+/// `bulk_errors`' first-five sample cannot.
+#[test]
+fn backend_rejected_records_abort_the_run_before_any_map_is_written() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("records.csv"),
+        "id,value\n0,kept\n1,kept\n2,kept\n",
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    endpoint.state.lock().unwrap().reject_first_data_item = true;
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+
+    // A per-item 400 is NOT a server error (not 429, not 5xx, not a block), so
+    // it is the weakest rejection the classifier recognises — and even it is
+    // fatal.
+    let error = format!("{:#}", run_index_report(config).unwrap_err());
+    assert!(
+        error.contains("document_parsing_exception"),
+        "the refusal itself must be quoted: {error}"
+    );
+    assert!(
+        error.contains("The backend refused 1 record(s)."),
+        "the abort must state how many records were refused, not just sample the errors: {error}"
+    );
+
+    // Measured, and deliberately pinned even though it is NOT what the abort
+    // message implies: `record_bulk_outcome` treats a per-item rejection as
+    // non-fatal to the worker (only `server_errors` set `send_err`), so the
+    // file is journaled COMPLETE and the run aborts only at the end. A rerun
+    // therefore resumes past this file and never retries the refused record,
+    // while the message says failed sources "were not journaled complete".
+    //
+    // That divergence predates this branch — it is `main`'s behaviour for the
+    // item-error class — and fixing it means changing when a worker treats a
+    // rejection as fatal, which is a resume-semantics change with nothing to
+    // do with map metadata. Recorded here so the next reader finds the fact
+    // rather than the assumption; tracked in the PR body as a known gap.
+    assert_eq!(
+        file_done_count(state_dir.path()),
+        1,
+        "pre-existing: a per-item rejection still journals the source complete"
+    );
 }
 
 /// #195 last-resort gate: a backend that ACCEPTS every bulk but persists

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -1349,6 +1349,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             // `started` intentionally stays out of this additive upgrade.
             // Older catalogs dynamically mapped it as text, and asking the
             // engine to change that existing field to date aborts every run.
+            // `catalog::catalog_mapping` declares it `date` for a fresh
+            // catalog, so the field is permanently bimodal across installs;
+            // its doc comment carries the full tripwire.
             "summary_generated_at": {"type": "date", "format": "strict_date_optional_time||epoch_millis"},
             "invocation_telemetry_scope": {"type": "keyword"}
         }}),
@@ -2360,9 +2363,19 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     // dataset docs
     let mut junk_records_by_run: u64 = junk_records.load(Ordering::Relaxed);
-    let dataset_stats = {
+    let (dataset_stats, durable_junk_records) = {
         let journal = journal_mx.lock().unwrap();
-        durable_dataset_stats(&plan, &journal.done)
+        let stats = durable_dataset_stats(&plan, &journal.done);
+        // One definition of "junk records" per map. The dataset docs below
+        // report the durable per-file commits, so the run doc must too:
+        // reporting the invocation-local counter there made a no-op resume
+        // publish `junk_records_total: 0` next to dataset docs that showed
+        // the real number, in the same `xerj autoindex map` output. The
+        // per-dataset values are this same total attributed to each file's
+        // first assigned dataset, so they sum back to it for every file the
+        // frozen plan still describes.
+        let durable_junk: u64 = journal.done.values().map(|done| done.junk).sum();
+        (stats, durable_junk)
     };
     for d in &plan.datasets {
         let sample_queries = catalog::build_sample_queries(d, &key_corrs);
@@ -2558,7 +2571,11 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         "duplicate_files": plan.duplicate_files.len(),
         "files_junk": junk_file_count,
         "records_total": total_records,
-        "junk_records_total": junk_records_by_run,
+        // Durable corpus descriptor, same definition as every dataset doc's
+        // `junk_records`; `junk_records_this_run` below is the invocation
+        // counter, which also includes records the backend itself rejected.
+        "junk_records_total": durable_junk_records,
+        "junk_records_this_run": junk_records_by_run,
         // This-run submission accounting (#195): what THIS invocation sent
         // and had accepted, vs `records_total` above which is the live
         // server-side count. A healthy run keeps these consistent; a
@@ -3251,6 +3268,7 @@ mod map_metadata_tests {
                 .enumerate()
                 .map(|(group, slug)| (Some(format!("group-{group}")), (*slug).to_string()))
                 .collect(),
+            as_document: false,
         }
     }
 

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -920,6 +920,39 @@ pub fn derive_brain_name(root: &Path) -> String {
     }
 }
 
+/// Source bytes durably represented by each dataset.
+///
+/// `FileDone` is the commit record for a successfully published canonical
+/// source. A source can feed more than one inferred dataset (for example, a
+/// workbook or database with multiple tables), so each distinct assigned
+/// dataset reports the complete source bytes it depends on. Repeated groups
+/// within the same dataset count the source only once.
+fn durable_dataset_bytes(plan: &Plan, done: &HashMap<String, FileDone>) -> HashMap<String, u64> {
+    let mut bytes_by_dataset = HashMap::new();
+    for (file_key, completed) in done {
+        let Some(assignment) = plan.files.get(file_key) else {
+            continue;
+        };
+        let assigned_datasets: std::collections::HashSet<&str> = assignment
+            .assignments
+            .iter()
+            .map(|(_, slug)| slug.as_str())
+            .collect();
+        for slug in assigned_datasets {
+            let bytes = bytes_by_dataset.entry(slug.to_string()).or_insert(0u64);
+            *bytes = bytes.saturating_add(completed.bytes);
+        }
+    }
+    bytes_by_dataset
+}
+
+fn invocation_report_timestamps(
+    started: chrono::DateTime<chrono::Utc>,
+    summary_generated_at: chrono::DateTime<chrono::Utc>,
+) -> (String, String) {
+    (started.to_rfc3339(), summary_generated_at.to_rfc3339())
+}
+
 fn run_index(cfg: IndexCfg) -> Result<i32> {
     run_index_report(cfg).map(|(code, _)| code)
 }
@@ -932,6 +965,9 @@ fn run_index(cfg: IndexCfg) -> Result<i32> {
 /// `None` when the run ended before a plan produced one (empty folder,
 /// `--dry-run`).
 pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
+    // The very first statement of the function, deliberately: `started` must
+    // be when this invocation began, not when its summary was built.
+    let invocation_started = chrono::Utc::now();
     // Fix the phase-A pool width BEFORE anything parallel starts: hashing and
     // sniffing are the CPU-bound phase, and they used to take every core no
     // matter what the caller asked for (#240 §2).
@@ -1281,9 +1317,14 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     es.ensure_index(catalog::CATALOG_INDEX, &catalog::catalog_mapping())?;
     es.update_mapping(
         catalog::CATALOG_INDEX,
-        &json!({"properties": {"duplicate_of": {"type": "keyword"}}}),
+        &json!({"properties": {
+            "duplicate_of": {"type": "keyword"},
+            "started": {"type": "date", "format": "strict_date_optional_time"},
+            "summary_generated_at": {"type": "date", "format": "strict_date_optional_time"},
+            "invocation_telemetry_scope": {"type": "keyword"}
+        }}),
     )
-    .context("upgrade autoindex catalog mapping for duplicate aliases")?;
+    .context("upgrade autoindex catalog mapping")?;
     // A replacement transaction starts before the effective new plan is
     // persisted and before live visibility changes. If the process dies at
     // any later boundary, journal replay removes the older file_done and
@@ -1337,7 +1378,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         records: AtomicU64,
         junk: AtomicU64,
         dropped: AtomicU64,
-        bytes: AtomicU64,
     }
     let mut ds_rt: HashMap<String, DsRt> = HashMap::new();
     for d in &plan.datasets {
@@ -1349,7 +1389,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 records: AtomicU64::new(0),
                 junk: AtomicU64::new(0),
                 dropped: AtomicU64::new(0),
-                bytes: AtomicU64::new(0),
             },
         );
     }
@@ -1999,10 +2038,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     records_total.fetch_add(file_records, Ordering::Relaxed);
                     junk_records.fetch_add(file_junk, Ordering::Relaxed);
                     if let Some(rt) = fa.assignments.first().and_then(|(_, slug)| ds_rt.get(slug)) {
-                        rt.bytes.fetch_add(
-                            f.size / fa.assignments.len().max(1) as u64,
-                            Ordering::Relaxed,
-                        );
                         if file_junk > 0 {
                             rt.junk.fetch_add(file_junk, Ordering::Relaxed);
                         }
@@ -2301,6 +2336,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     // dataset docs
     let mut junk_records_by_run: u64 = junk_records.load(Ordering::Relaxed);
+    let dataset_bytes = {
+        let journal = journal_mx.lock().unwrap();
+        durable_dataset_bytes(&plan, &journal.done)
+    };
     for d in &plan.datasets {
         let rt = &ds_rt[&d.slug];
         let sample_queries = catalog::build_sample_queries(d, &key_corrs);
@@ -2339,7 +2378,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             pd: d,
             record_count: *ds_counts.get(&d.slug).unwrap_or(&0),
             junk_records: rt.junk.load(Ordering::Relaxed),
-            bytes: rt.bytes.load(Ordering::Relaxed),
+            bytes: dataset_bytes.get(&d.slug).copied().unwrap_or(0),
             file_count: d.file_count,
             formats,
             time_min: tmin,
@@ -2443,6 +2482,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     }
 
     let wall = t0.elapsed().as_secs_f64();
+    let (started, summary_generated_at) =
+        invocation_report_timestamps(invocation_started, chrono::Utc::now());
     let total_records: u64 = ds_counts.values().sum();
     // Run-summary honesty (§6.6.4): what the detectors wrote AND what they
     // could not resolve — a dangling [[link]] is a fact about the corpus, not
@@ -2475,13 +2516,18 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             "edges_invalidated": gr.invalidated,
         })
     });
+    // A resume intentionally reuses and upserts the durable run id. Timing
+    // and detector counters therefore describe this latest invocation,
+    // while corpus descriptors describe the durable live run state.
     let mut run_doc = json!({
         "doc_kind": "run",
         "run_id": run_id,
         "root": root_str,
         "url": cfg.url,
         "prefix": cfg.prefix,
-        "started": chrono::Utc::now().to_rfc3339(),
+        "started": started,
+        "summary_generated_at": summary_generated_at,
+        "invocation_telemetry_scope": "latest_invocation_of_durable_run",
         "files_total": paths_discovered,
         "unique_content_files": files.len(),
         "files_indexed": journal_mx.lock().unwrap().done.len(),
@@ -3161,6 +3207,130 @@ mod duplicate_integration_tests {
         })
         .unwrap();
         assert_eq!(live, HashSet::from(["r0".into(), "r1".into()]));
+    }
+}
+
+#[cfg(test)]
+mod map_metadata_tests {
+    use super::*;
+
+    fn assignment(slugs: &[&str]) -> FileAssignment {
+        FileAssignment {
+            rel: "report.dat".into(),
+            path_id: "path:report.dat".into(),
+            family: "json".into(),
+            gzip: false,
+            content_digest: Some("digest".into()),
+            assignments: slugs
+                .iter()
+                .enumerate()
+                .map(|(group, slug)| (Some(format!("group-{group}")), (*slug).to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn unchanged_resume_keeps_durable_assignment_aware_dataset_bytes() {
+        let _guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let state_dir = tempfile::tempdir().unwrap();
+        let plan = Plan {
+            files: HashMap::from([
+                (
+                    "shared".into(),
+                    assignment(&["quarterly", "quarterly", "annual"]),
+                ),
+                ("quarterly-only".into(), assignment(&["quarterly"])),
+            ]),
+            ..Plan::default()
+        };
+        let mut initial = state::Journal::open(
+            state_dir.path(),
+            "corpus",
+            "http://engine",
+            "ax",
+            300,
+            false,
+        )
+        .unwrap();
+        initial.write_plan(&plan).unwrap();
+        initial
+            .file_done(&FileDone {
+                file_key: "shared".into(),
+                path: "report.dat".into(),
+                records: 10,
+                junk: 0,
+                bytes: 100,
+                generation: Some("digest".into()),
+            })
+            .unwrap();
+        initial
+            .file_done(&FileDone {
+                file_key: "quarterly-only".into(),
+                path: "quarterly.json".into(),
+                records: 2,
+                junk: 0,
+                bytes: 23,
+                generation: Some("digest-2".into()),
+            })
+            .unwrap();
+        let before_resume = durable_dataset_bytes(&plan, &initial.done);
+        drop(initial);
+
+        // Opening the same durable run appends only an invocation-level
+        // resume record. No source is processed and no FileDone is appended.
+        let resumed = state::Journal::open(
+            state_dir.path(),
+            "corpus",
+            "http://engine",
+            "ax",
+            300,
+            false,
+        )
+        .unwrap();
+        let after_unchanged_resume =
+            durable_dataset_bytes(resumed.plan.as_ref().unwrap(), &resumed.done);
+
+        assert_eq!(before_resume, after_unchanged_resume);
+        assert_eq!(after_unchanged_resume["quarterly"], 123);
+        assert_eq!(after_unchanged_resume["annual"], 100);
+    }
+
+    #[test]
+    fn invocation_started_is_not_derived_from_summary_generation() {
+        let started = chrono::DateTime::parse_from_rfc3339("2026-08-04T00:29:05.673023686Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let summary_generated_at =
+            chrono::DateTime::parse_from_rfc3339("2026-08-04T00:31:37.937589283Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc);
+
+        let (reported_started, reported_summary_generated_at) =
+            invocation_report_timestamps(started, summary_generated_at);
+
+        assert_eq!(reported_started, "2026-08-04T00:29:05.673023686+00:00");
+        assert_eq!(
+            reported_summary_generated_at,
+            "2026-08-04T00:31:37.937589283+00:00"
+        );
+        assert_ne!(reported_started, reported_summary_generated_at);
+    }
+
+    #[test]
+    fn catalog_mapping_declares_latest_invocation_telemetry_fields() {
+        let mapping = catalog::catalog_mapping();
+        assert_eq!(
+            mapping.pointer("/mappings/properties/started/type"),
+            Some(&json!("date"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/summary_generated_at/type"),
+            Some(&json!("date"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/invocation_telemetry_scope/type"),
+            Some(&json!("keyword"))
+        );
     }
 }
 

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -93,10 +93,23 @@ fn replacement_failpoint(_boundary: u8) -> Result<()> {
     Ok(())
 }
 
+/// Send one bulk body and fold its per-item rejections into
+/// `rejected_records`.
+///
+/// This counter is deliberately NOT the parser-junk counter. A record the
+/// *backend* refused and a record the *parser* could not read are different
+/// failures with different lifetimes: parser junk is durable (journaled per
+/// file and replayed on every resume), a backend rejection is not (no
+/// `FileDone` records a document that was never accepted). Adding both to one
+/// number is what let `junk_records_total` mean two things at once.
+///
+/// Note where this number can and cannot surface. Any non-zero value here also
+/// puts an entry in `bulk_errors`, which aborts the run before the run
+/// document exists — so it is reported in the abort message and nowhere else.
 fn record_bulk_outcome(
     es: &Es,
     body: Vec<u8>,
-    junk_records: &AtomicU64,
+    rejected_records: &AtomicU64,
     bulk_errors: &Mutex<Vec<String>>,
     send_err: &mut Option<String>,
 ) -> bool {
@@ -115,7 +128,7 @@ fn record_bulk_outcome(
                 return true;
             }
             if outcome.item_errors > 0 {
-                junk_records.fetch_add(outcome.item_errors, Ordering::Relaxed);
+                rejected_records.fetch_add(outcome.item_errors, Ordering::Relaxed);
                 if let Some(error) = outcome.first_error {
                     let mut errors = bulk_errors.lock().unwrap();
                     if errors.len() < 5 {
@@ -1346,14 +1359,19 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         catalog::CATALOG_INDEX,
         &json!({"properties": {
             "duplicate_of": {"type": "keyword"},
-            // `started` intentionally stays out of this additive upgrade.
-            // Older catalogs dynamically mapped it as text, and asking the
-            // engine to change that existing field to date aborts every run.
-            // `catalog::catalog_mapping` declares it `date` for a fresh
-            // catalog, so the field is permanently bimodal across installs;
-            // its doc comment carries the full tripwire.
+            // `started` intentionally stays out of this additive upgrade. A
+            // catalog written by v1.0.0-rc.4 has a dynamically inferred TEXT
+            // `started`, and asking the engine to add it as `date` is refused
+            // 400 — which `es.update_mapping` turns into an `Err`, aborting
+            // the run before any document work. `catalog::catalog_mapping`
+            // declares it `date` for a fresh catalog, so the field is
+            // permanently bimodal across installs; its doc comment carries the
+            // full tripwire and the measured refusal.
             "summary_generated_at": {"type": "date", "format": "strict_date_optional_time||epoch_millis"},
-            "invocation_telemetry_scope": {"type": "keyword"}
+            "invocation_telemetry_scope": {"type": "keyword"},
+            // Safe to add here, unlike `started`: no release ever wrote this
+            // field, so no existing catalog has a conflicting inferred type.
+            "junk_records_this_run": {"type": "long"}
         }}),
     )
     .context("upgrade autoindex catalog mapping")?;
@@ -1479,7 +1497,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // replacement invalidation can only ever see prior-generation edges —
     // running it later would invalidate this run's own fresh edges.
     let bulk_cut = cfg.bulk_mb << 20;
+    // Parser junk this invocation read out of source files (durable: it is
+    // journaled per file and replayed on resume).
     let junk_records = AtomicU64::new(0);
+    // Records the backend refused in a bulk response (invocation-local: no
+    // journal record exists for a document that was never accepted).
+    let rejected_records = AtomicU64::new(0);
     let bulk_errors = Mutex::new(Vec::<String>::new());
     let graph: Option<GraphRt> = if cfg.no_graph {
         None
@@ -1582,7 +1605,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     && record_bulk_outcome(
                         &es,
                         std::mem::take(&mut buf),
-                        &junk_records,
+                        &rejected_records,
                         &bulk_errors,
                         &mut send_err,
                     )
@@ -1591,7 +1614,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 }
             }
             if send_err.is_none() && !buf.is_empty() {
-                record_bulk_outcome(&es, buf, &junk_records, &bulk_errors, &mut send_err);
+                record_bulk_outcome(&es, buf, &rejected_records, &bulk_errors, &mut send_err);
             }
             if let Some(e) = send_err {
                 anyhow::bail!("write structural graph edges to {edges_index}: {e}");
@@ -1985,7 +2008,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                                 && record_bulk_outcome(
                                     &es,
                                     std::mem::take(&mut buf),
-                                    &junk_records,
+                                    &rejected_records,
                                     &bulk_errors,
                                     &mut send_err,
                                 )
@@ -2001,7 +2024,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             record_bulk_outcome(
                                 &es,
                                 buf,
-                                &junk_records,
+                                &rejected_records,
                                 &bulk_errors,
                                 &mut send_err,
                             );
@@ -2026,7 +2049,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                                     && record_bulk_outcome(
                                         &es,
                                         std::mem::take(&mut ebuf),
-                                        &junk_records,
+                                        &rejected_records,
                                         &bulk_errors,
                                         &mut send_err,
                                     )
@@ -2038,7 +2061,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                                 record_bulk_outcome(
                                     &es,
                                     ebuf,
-                                    &junk_records,
+                                    &rejected_records,
                                     &bulk_errors,
                                     &mut send_err,
                                 );
@@ -2133,7 +2156,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                         && record_bulk_outcome(
                             &es,
                             std::mem::take(&mut buf),
-                            &junk_records,
+                            &rejected_records,
                             &bulk_errors,
                             &mut send_err,
                         )
@@ -2142,7 +2165,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     }
                 }
                 if send_err.is_none() && !buf.is_empty() {
-                    record_bulk_outcome(&es, buf, &junk_records, &bulk_errors, &mut send_err);
+                    record_bulk_outcome(&es, buf, &rejected_records, &bulk_errors, &mut send_err);
                 }
                 match send_err {
                     Some(e) => bulk_errors
@@ -2162,11 +2185,24 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     let bulk_errs = bulk_errors.into_inner().unwrap();
     if !bulk_errs.is_empty() {
+        // `bulk_errors` keeps only the first five distinct errors, so without
+        // the counter the operator cannot tell one refused document from ten
+        // thousand. That is the whole reason backend rejections are counted
+        // apart from parser junk: this is the only place the number is ever
+        // reported, because a run that gets here writes no run document and
+        // no map.
+        let rejected = rejected_records.load(Ordering::Relaxed);
+        let scale = if rejected > 0 {
+            format!(" The backend refused {rejected} record(s).")
+        } else {
+            String::new()
+        };
         anyhow::bail!(
-            "autoindex stopped with bulk/backend failures: {}. Failed source files were not \
+            "autoindex stopped with bulk/backend failures: {}.{} Failed source files were not \
              journaled complete; fix the reported server or embedding configuration and rerun \
              the same command to resume safely",
-            bulk_errs.join(" | ")
+            bulk_errs.join(" | "),
+            scale
         );
     }
 
@@ -2571,9 +2607,26 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         "duplicate_files": plan.duplicate_files.len(),
         "files_junk": junk_file_count,
         "records_total": total_records,
-        // Durable corpus descriptor, same definition as every dataset doc's
-        // `junk_records`; `junk_records_this_run` below is the invocation
-        // counter, which also includes records the backend itself rejected.
+        // Two numbers, one definition each, neither of them overlapping.
+        //
+        // `junk_records_total` is the durable corpus descriptor: the same
+        // definition as every dataset doc's `junk_records`, summed over every
+        // `FileDone` in the journal. It survives a no-op resume.
+        //
+        // `junk_records_this_run` is the same *kind* of failure narrowed to
+        // the files this invocation actually parsed. It is the NARROWER of the
+        // two, not the wider: every file counted here also committed a
+        // `FileDone` that the total sums. On an unchanged resume it reads 0
+        // while the total stays non-zero — which is the whole defect this
+        // change exists to fix, seen from the other side.
+        //
+        // Backend rejections are deliberately absent. They are a different
+        // failure, and they can never be reported here anyway: a per-item
+        // rejection populates `bulk_errors`, which aborts the run above,
+        // before this document exists. Publishing a
+        // `records_rejected_by_backend` field would ship a number that is
+        // provably always 0 — see `record_bulk_outcome` and
+        // `backend_rejected_records_abort_the_run_before_any_map_is_written`.
         "junk_records_total": durable_junk_records,
         "junk_records_this_run": junk_records_by_run,
         // This-run submission accounting (#195): what THIS invocation sent
@@ -2704,6 +2757,11 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             cfg.url, cfg.prefix
         );
     }
+    // Exit 3 means "completed, some input was unusable". Backend rejections
+    // are not consulted and must not be: a rejected item aborts the run with
+    // an error long before this line, so `rejected_records` is provably 0
+    // here. Splitting them out of `junk_total_records` therefore changes no
+    // exit code.
     let code = if junk_total_records > 0 || junk_file_count > 0 {
         3
     } else {

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -920,15 +920,28 @@ pub fn derive_brain_name(root: &Path) -> String {
     }
 }
 
-/// Source bytes durably represented by each dataset.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct DurableDatasetStats {
+    bytes: u64,
+    junk: u64,
+    dropped: u64,
+}
+
+/// Source metadata durably represented by each dataset.
 ///
 /// `FileDone` is the commit record for a successfully published canonical
 /// source. A source can feed more than one inferred dataset (for example, a
 /// workbook or database with multiple tables), so each distinct assigned
 /// dataset reports the complete source bytes it depends on. Repeated groups
-/// within the same dataset count the source only once.
-fn durable_dataset_bytes(plan: &Plan, done: &HashMap<String, FileDone>) -> HashMap<String, u64> {
-    let mut bytes_by_dataset = HashMap::new();
+/// within the same dataset count the source only once. Parser-level junk has
+/// no group after extraction rejects it, so it retains the historical
+/// attribution to the file's first assigned dataset. Coercion drops retain
+/// their exact dataset captured in the completion record.
+fn durable_dataset_stats(
+    plan: &Plan,
+    done: &HashMap<String, FileDone>,
+) -> HashMap<String, DurableDatasetStats> {
+    let mut stats_by_dataset: HashMap<String, DurableDatasetStats> = HashMap::new();
     for (file_key, completed) in done {
         let Some(assignment) = plan.files.get(file_key) else {
             continue;
@@ -939,11 +952,25 @@ fn durable_dataset_bytes(plan: &Plan, done: &HashMap<String, FileDone>) -> HashM
             .map(|(_, slug)| slug.as_str())
             .collect();
         for slug in assigned_datasets {
-            let bytes = bytes_by_dataset.entry(slug.to_string()).or_insert(0u64);
-            *bytes = bytes.saturating_add(completed.bytes);
+            let stats = stats_by_dataset.entry(slug.to_string()).or_default();
+            stats.bytes = stats.bytes.saturating_add(completed.bytes);
+        }
+        if let Some((_, slug)) = assignment.assignments.first() {
+            let stats = stats_by_dataset.entry(slug.clone()).or_default();
+            stats.junk = stats.junk.saturating_add(completed.junk);
+        }
+        for (slug, dropped) in &completed.dropped_by_dataset {
+            if assignment
+                .assignments
+                .iter()
+                .any(|(_, assigned)| assigned == slug)
+            {
+                let stats = stats_by_dataset.entry(slug.clone()).or_default();
+                stats.dropped = stats.dropped.saturating_add(*dropped);
+            }
         }
     }
-    bytes_by_dataset
+    stats_by_dataset
 }
 
 fn invocation_report_timestamps(
@@ -1319,8 +1346,10 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         catalog::CATALOG_INDEX,
         &json!({"properties": {
             "duplicate_of": {"type": "keyword"},
-            "started": {"type": "date", "format": "strict_date_optional_time"},
-            "summary_generated_at": {"type": "date", "format": "strict_date_optional_time"},
+            // `started` intentionally stays out of this additive upgrade.
+            // Older catalogs dynamically mapped it as text, and asking the
+            // engine to change that existing field to date aborts every run.
+            "summary_generated_at": {"type": "date", "format": "strict_date_optional_time||epoch_millis"},
             "invocation_telemetry_scope": {"type": "keyword"}
         }}),
     )
@@ -1376,8 +1405,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         index: String,
         plan: HashMap<String, coerce::Coerce>,
         records: AtomicU64,
-        junk: AtomicU64,
-        dropped: AtomicU64,
     }
     let mut ds_rt: HashMap<String, DsRt> = HashMap::new();
     for d in &plan.datasets {
@@ -1387,8 +1414,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 index: d.index.clone(),
                 plan: coerce::plan_from_specs(&d.specs),
                 records: AtomicU64::new(0),
-                junk: AtomicU64::new(0),
-                dropped: AtomicU64::new(0),
             },
         );
     }
@@ -1659,6 +1684,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     };
                     let mut file_records = 0u64;
                     let mut file_junk = 0u64;
+                    let mut file_dropped_by_dataset: HashMap<String, u64> = HashMap::new();
                     let mut send_err: Option<String> = None;
                     // Edges this file teaches — buffered apart from the node
                     // staging file (different target index) and sent only
@@ -1761,7 +1787,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             let mut fields = rec.fields;
                             let dropped = coerce::coerce_record(&mut fields, &rt.plan);
                             if dropped > 0 {
-                                rt.dropped.fetch_add(dropped as u64, Ordering::Relaxed);
+                                let durable =
+                                    file_dropped_by_dataset.entry(slug.clone()).or_default();
+                                *durable = durable.saturating_add(dropped as u64);
                             }
                             fields.insert("ax_path".into(), Value::String(f.rel.clone()));
                             fields.insert(
@@ -2037,11 +2065,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     }
                     records_total.fetch_add(file_records, Ordering::Relaxed);
                     junk_records.fetch_add(file_junk, Ordering::Relaxed);
-                    if let Some(rt) = fa.assignments.first().and_then(|(_, slug)| ds_rt.get(slug)) {
-                        if file_junk > 0 {
-                            rt.junk.fetch_add(file_junk, Ordering::Relaxed);
-                        }
-                    }
                     let (commit_result, journal_path) = {
                         let mut journal = journal_mx.lock().unwrap();
                         let path = journal.path().display().to_string();
@@ -2051,6 +2074,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                             records: file_records,
                             junk: file_junk,
                             bytes: f.size,
+                            dropped_by_dataset: file_dropped_by_dataset,
                             generation: Some(expected_digest.clone()),
                         });
                         (result, path)
@@ -2336,15 +2360,15 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
 
     // dataset docs
     let mut junk_records_by_run: u64 = junk_records.load(Ordering::Relaxed);
-    let dataset_bytes = {
+    let dataset_stats = {
         let journal = journal_mx.lock().unwrap();
-        durable_dataset_bytes(&plan, &journal.done)
+        durable_dataset_stats(&plan, &journal.done)
     };
     for d in &plan.datasets {
-        let rt = &ds_rt[&d.slug];
         let sample_queries = catalog::build_sample_queries(d, &key_corrs);
         let mut notes = Vec::new();
-        let dropped = rt.dropped.load(Ordering::Relaxed);
+        let durable = dataset_stats.get(&d.slug).copied().unwrap_or_default();
+        let dropped = durable.dropped;
         if dropped > 0 {
             notes.push(format!(
                 "{dropped} field values could not be coerced to the inferred types and were dropped (records still indexed)"
@@ -2377,8 +2401,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         let (id, doc) = catalog::dataset_doc(&catalog::DatasetDocInput {
             pd: d,
             record_count: *ds_counts.get(&d.slug).unwrap_or(&0),
-            junk_records: rt.junk.load(Ordering::Relaxed),
-            bytes: dataset_bytes.get(&d.slug).copied().unwrap_or(0),
+            junk_records: durable.junk,
+            bytes: durable.bytes,
             file_count: d.file_count,
             formats,
             time_min: tmin,
@@ -3129,6 +3153,7 @@ mod duplicate_integration_tests {
                 records,
                 junk: 0,
                 bytes: inventory.files[0].size,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some(inventory.digests[0].clone()),
             })
             .unwrap();
@@ -3258,8 +3283,9 @@ mod map_metadata_tests {
                 file_key: "shared".into(),
                 path: "report.dat".into(),
                 records: 10,
-                junk: 0,
+                junk: 5,
                 bytes: 100,
+                dropped_by_dataset: HashMap::from([("quarterly".into(), 7), ("annual".into(), 3)]),
                 generation: Some("digest".into()),
             })
             .unwrap();
@@ -3268,12 +3294,13 @@ mod map_metadata_tests {
                 file_key: "quarterly-only".into(),
                 path: "quarterly.json".into(),
                 records: 2,
-                junk: 0,
+                junk: 2,
                 bytes: 23,
+                dropped_by_dataset: HashMap::from([("quarterly".into(), 11)]),
                 generation: Some("digest-2".into()),
             })
             .unwrap();
-        let before_resume = durable_dataset_bytes(&plan, &initial.done);
+        let before_resume = durable_dataset_stats(&plan, &initial.done);
         drop(initial);
 
         // Opening the same durable run appends only an invocation-level
@@ -3288,11 +3315,15 @@ mod map_metadata_tests {
         )
         .unwrap();
         let after_unchanged_resume =
-            durable_dataset_bytes(resumed.plan.as_ref().unwrap(), &resumed.done);
+            durable_dataset_stats(resumed.plan.as_ref().unwrap(), &resumed.done);
 
         assert_eq!(before_resume, after_unchanged_resume);
-        assert_eq!(after_unchanged_resume["quarterly"], 123);
-        assert_eq!(after_unchanged_resume["annual"], 100);
+        assert_eq!(after_unchanged_resume["quarterly"].bytes, 123);
+        assert_eq!(after_unchanged_resume["annual"].bytes, 100);
+        assert_eq!(after_unchanged_resume["quarterly"].junk, 7);
+        assert_eq!(after_unchanged_resume["annual"].junk, 0);
+        assert_eq!(after_unchanged_resume["quarterly"].dropped, 18);
+        assert_eq!(after_unchanged_resume["annual"].dropped, 3);
     }
 
     #[test]
@@ -3330,6 +3361,14 @@ mod map_metadata_tests {
         assert_eq!(
             mapping.pointer("/mappings/properties/invocation_telemetry_scope/type"),
             Some(&json!("keyword"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/started/format"),
+            Some(&json!("strict_date_optional_time||epoch_millis"))
+        );
+        assert_eq!(
+            mapping.pointer("/mappings/properties/summary_generated_at/format"),
+            Some(&json!("strict_date_optional_time||epoch_millis"))
         );
     }
 }

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -246,6 +246,10 @@ pub struct FileDone {
     pub records: u64,
     pub junk: u64,
     pub bytes: u64,
+    /// Field values dropped by coercion, grouped by the dataset whose
+    /// inferred schema rejected them. Older journals predate this accounting.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub dropped_by_dataset: HashMap<String, u64>,
     /// Content generation committed by this record. Legacy completions have
     /// no generation and cannot commit a newer pending replacement.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -764,6 +768,7 @@ mod compatibility_tests {
             records: 6_001,
             junk: 0,
             bytes: 100,
+            dropped_by_dataset: HashMap::new(),
             generation: Some("old-generation".into()),
         };
         journal.file_done(&old).unwrap();
@@ -836,6 +841,7 @@ mod compatibility_tests {
                 records: 2,
                 junk: 0,
                 bytes: 20,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-2".into()),
             })
             .unwrap();
@@ -916,6 +922,7 @@ mod compatibility_tests {
                 records: 10,
                 junk: 0,
                 bytes: 10,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("old".into()),
             })
             .unwrap_err();
@@ -940,6 +947,7 @@ mod compatibility_tests {
                     records: 2,
                     junk: 0,
                     bytes: 20,
+                    dropped_by_dataset: HashMap::new(),
                     generation: Some("new".into()),
                 })
                 .unwrap_err();
@@ -977,6 +985,7 @@ mod compatibility_tests {
                 records: 2,
                 junk: 0,
                 bytes: 20,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-c".into()),
             })
             .unwrap_err();
@@ -991,6 +1000,7 @@ mod compatibility_tests {
                 records: 3,
                 junk: 0,
                 bytes: 30,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-d".into()),
             })
             .unwrap();
@@ -1008,6 +1018,7 @@ mod compatibility_tests {
                 records: 2,
                 junk: 0,
                 bytes: 20,
+                dropped_by_dataset: HashMap::new(),
                 generation: Some("generation-c".into()),
             })
             .unwrap();


### PR DESCRIPTION
Supersedes #167 by @buger.

#167's head lives on `probelabs/xerj` with `maintainerCanModify: false`, so
nobody on the xerj-org side can push the rebase it needs — every attempt 403s.
This is that work, rebased onto current `main`, with the outstanding review
items fixed. The first three commits carry `Co-authored-by: buger
<leonsbox@gmail.com>`; the fourth is this round's review follow-up. **Please close #167
in favour of this.** Do not close it before this merges.

## The bugs, still live on `main` before this branch

Both were re-verified against `origin/main`, not taken from the PR description:

1. **Dataset `bytes` collapses to zero on an unchanged resume.**
   `rt.bytes.fetch_add(...)` / `bytes: rt.bytes.load(...)` counted only the
   files *this* invocation processed, and finalization rewrote every dataset
   catalog document from that counter. A resume with nothing to do therefore
   replaced a durable non-zero byte count with `0` — in the catalog documents
   that *are* the agent-facing data map.
2. **`run.started` is fabricated at summary time.**
   `"started": chrono::Utc::now().to_rfc3339()` was built beside the summary,
   so a 152-second invocation reported starting when it was already ending.

## What the branch does

- **Bytes are derived from durable `FileDone` commits** joined through the
  frozen plan assignments (`durable_dataset_stats`). Each distinct dataset
  reports the complete canonical source bytes backing its live records;
  repeated assignments to one dataset count once.
- **`started` is captured as the first statement of `run_index_report`**, and
  the old summary-time value is renamed `summary_generated_at` — a name that
  deliberately does *not* imply the later catalog bulk, refresh, journal finish
  or process exit has completed. Timing and detector counters are tagged
  `invocation_telemetry_scope=latest_invocation_of_durable_run`.
- **Junk counts and coercion-drop notes get the same treatment**: junk from
  committed `FileDone` records, coercion drops from a new serde-default
  `FileDone.dropped_by_dataset`.
- **Legacy catalogs keep working.** The additive mapping upgrade deliberately
  omits `started`. See the measurement below for exactly which catalogs that
  protects and why.

## Measured: what the engine really does with `started`

The previous revision of this PR asserted the wrong exception type and the
wrong guard for the mapping refusal, in the PR body, the CHANGELOG, a shipped
doc comment and a test fixture. That was fixed by measuring rather than by
re-reading the text. Against a live `v1.0.0-rc.13` engine on a private port,
`PUT /autoindex-catalog/_mapping` with `started: date` splits three ways:

| `started` on the existing index | result |
|---|---|
| dynamically inferred `text` (non-ISO string) — **the real legacy shape** | 400 `mapper_parsing_exception` — *"field [started] already exists as [text], cannot add [date]"* |
| **declared** `text` | 400 `illegal_argument_exception` — *"mapper [started] cannot be changed from type [text] to [date]"* |
| dynamically inferred `date` (an RFC3339 string, which is what autoindex writes) | **200 `acknowledged`** |

Two corrections follow, and both are now in the code comments:

- **It is `mapper_parsing_exception`, not `illegal_argument_exception`.** The
  `illegal_argument_exception` guard reads `state.engine.index_mappings`, which
  holds only *declared* mappings. No release ever declared `started`, so for a
  catalog that guard can never fire. The refusal comes from the later
  `idx.schema()` guard, whose `XerjError::invalid_mapping` maps to
  `mapper_parsing_exception` (`xerj-api/src/error.rs`).
- **The affected population is one release, not "older catalogs".**
  `autoindex` landed in **v1.0.0-rc.4** (0f3ef60d, 2026-07-09) and dynamic
  ISO-date inference in **rc.5** (a0f872ac, 2026-07-25). rc.4 is the only
  release that wrote a `text` `started`. Catalogs from rc.5 onward already have
  `date` and would simply get a 200.

The branch's **conclusion** — omit `started` from the additive upgrade — is
unchanged and still correct: it is what keeps an rc.4 catalog from aborting
every later invocation. Only its stated reason was wrong.

### The fixture branch that encoded it was unreachable

The additive upgrade sends `duplicate_of`, `summary_generated_at`,
`invocation_telemetry_scope` and now `junk_records_this_run` — never `started`.
So the fixture's `started_requested` was always false and its synthetic 400 was
dead code, which is why nothing in CI caught the wrong exception type. Rather
than delete it, it now does the job the tripwire describes: `MockState` records
whether `started` was ever requested, and
`existing_catalog_is_upgraded_before_new_run_metadata_is_written` asserts it
was not. Adding `started` to the upgrade now fails loudly, with the message an
operator would really see.

## Measured: the junk-counter narrowing, and why it loses nothing

Making `junk_records_total` durable narrowed it — it no longer folds in the
per-item rejections `record_bulk_outcome` counts. That looks like a lost
signal. It is not, and the reason is measured, not assumed:

**a single per-item rejection also lands in `bulk_errors`, which aborts the run
before the run document, the map, the summary line and the exit code exist.**

New test `backend_rejected_records_abort_the_run_before_any_map_is_written`
pins this with the weakest rejection the classifier recognises (a per-item 400
that is neither 429, 5xx, nor a block). So the folded-in number was never
observable in any published map, on `main` either. Publishing a
`records_rejected_by_backend` field would have shipped a number provably always
0 — that was drafted and then removed for exactly that reason.

What the split does buy: backend rejections now have their own counter, and the
abort message states **how many** records were refused. It previously sampled
at most five errors and never gave the scale.

Also corrected: `junk_records_this_run` was described as "the wider of the two".
It is the **narrower** one — it reads 0 on precisely the unchanged resume this
branch exists to fix.

## Known gaps, stated plainly

- **A per-item rejection still journals the source file COMPLETE.** Only
  `server_errors` are fatal to a worker, so the run aborts at the end but a
  rerun resumes *past* that file and never retries the refused record — while
  the abort message says failed sources "were not journaled complete". This is
  `main`'s behaviour for the item-error class and predates this branch. It is
  measured and pinned by the new test rather than fixed here: changing when a
  worker treats a rejection as fatal is a resume-semantics change unrelated to
  map metadata. **Worth its own issue.**
- **Legacy journals still lose the coercion-drop note** on the first unchanged
  resume after upgrade, and only regain it when one of the dataset's files is
  reprocessed. `dropped_by_dataset` is `#[serde(default)]`, so a pre-upgrade
  journal replays empty and an unchanged file is never reprocessed. Documented
  in CHANGELOG with the `--fresh` escape, not fixed.
- **`bytes` deliberately survives a path's removal** while its documents and
  completion remain live, because autoindex does not do missing-path deletion.
  That reconciliation is a separate product change and is not in scope here.
- **`junk_records_total` sums every `FileDone` in the journal**, including
  files the frozen plan no longer describes, so it can exceed the sum of the
  per-dataset values. That is intended — it is the corpus-wide descriptor —
  and the join is commented at the site.
- **`started` is permanently bimodal across installs.** A catalog created fresh
  sorts `started` server-side; an rc.4 catalog does not. Benign only because
  `run_map` sorts runs client-side. Any future server-side sort, range query or
  date aggregation on `started` must migrate legacy catalogs by reindexing —
  not by adding `started` to the additive upgrade. Documented as a tripwire on
  `catalog_mapping()` and enforced by the test above.
- No FinanceBench-style or other performance claim is made; this changes
  metadata derivation, not throughput.

## Upgrade notes (CHANGELOG)

- **`bytes` is redefined**: was the latest invocation's processed bytes credited
  to a file's first dataset, now the full canonical source size counted once in
  **every** distinct dataset that source is assigned to. Per-dataset values get
  larger and cross-dataset sums can exceed corpus size.
- **`junk_records_total` is narrower**: parser junk only, matching the
  per-dataset `junk_records`. Backend rejections left it, for the reason
  measured above.

## Verification

Run on the rebased head (base `9b020903`, v1.0.0-rc.14):

```
cargo fmt --all -- --check                                   pass
cargo clippy -p xerj-autoindex --all-targets -- -D warnings  pass
cargo clippy -p xerj-server   --all-targets -- -D warnings   pass
cargo test -p xerj-autoindex                308 passed, 0 failed
cargo test -p xerj-server                    49 passed, 0 failed
```

`xerj-server` is included because it is the only other crate depending on
`xerj-autoindex` (`brain.rs` calls `run_index_report`).

New regression coverage exercises the real HTTP product path: initial run and
no-op resume, changed-size replacement across a journal reopen, removed-path
live-state semantics, a real two-table SQLite source with repeated assignment,
an existing legacy catalog upgraded before new run metadata is written (now
also asserting `started` is never requested), an unchanged resume preserving
non-zero junk and coercion metadata, and backend rejection aborting before any
map is written.

## Rebase notes

Rebased from `1ee31ecd` onto `9b020903` (v1.0.0-rc.14, 19 commits including
#257's resource policy and #264's progress surface in this same crate). One
conflict, in `run_index_report`'s opening lines: `main` now configures the
phase-A rayon pool there and this branch captures `invocation_started` there.
Both are wanted, and the order matters — `invocation_started` goes first, so
`started` remains what it claims to be. `xerj-autoindex` now reports 308 tests,
the intervening merges plus this branch's new one.
