### PR TITLE
chore(release): verify the published rc.13 artifacts, and make the check repeatable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ cannot push at all: [.github/AI_CONTRIBUTIONS.md](./.github/AI_CONTRIBUTIONS.md)
 | Architecture map | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) |
 | Pre-submission and review protocol | [docs/CONTRIBUTION_REVIEW.md](./docs/CONTRIBUTION_REVIEW.md) |
 | How to send a bug or a fix back upstream (written for agents) | [.github/AI_CONTRIBUTIONS.md](./.github/AI_CONTRIBUTIONS.md) |
+| Checking a published release is actually good | `scripts/verify-release.sh [tag]` — downloads every asset, verifies checksums, asserts each binary reports its tag's version, boots the host-native one and runs a search |
 
 ## How to evaluate this project fairly
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ cannot push at all: [.github/AI_CONTRIBUTIONS.md](./.github/AI_CONTRIBUTIONS.md)
 | Architecture map | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) |
 | Pre-submission and review protocol | [docs/CONTRIBUTION_REVIEW.md](./docs/CONTRIBUTION_REVIEW.md) |
 | How to send a bug or a fix back upstream (written for agents) | [.github/AI_CONTRIBUTIONS.md](./.github/AI_CONTRIBUTIONS.md) |
-| Checking a published release is actually good | `scripts/verify-release.sh [tag]` — downloads every asset, verifies checksums, asserts each binary reports its tag's version, boots the host-native one and runs a search |
+| Checking a published release is actually good | `scripts/verify-release.sh [tag]` — downloads every asset, asserts every target we ship is present, verifies checksums, asserts each binary reports its tag's version, boots the host-native one and runs a search |
 
 ## How to evaluate this project fairly
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ cannot push at all: [.github/AI_CONTRIBUTIONS.md](./.github/AI_CONTRIBUTIONS.md)
 | Architecture map | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) |
 | Pre-submission and review protocol | [docs/CONTRIBUTION_REVIEW.md](./docs/CONTRIBUTION_REVIEW.md) |
 | How to send a bug or a fix back upstream (written for agents) | [.github/AI_CONTRIBUTIONS.md](./.github/AI_CONTRIBUTIONS.md) |
-| Checking a published release is actually good | `scripts/verify-release.sh [tag]` — downloads every asset, asserts every target we ship is present, verifies checksums, asserts each binary reports its tag's version, boots the host-native one and runs a search |
+| Checking a published release is actually good | `scripts/verify-release.sh [tag]` — downloads every asset, asserts every target we ship is present, verifies checksums, asserts each binary reports its tag's version, then boots the host-native binary and runs a real search (Linux and macOS hosts; on a host where it cannot run one it says so and exits non-zero rather than passing) |
 
 ## How to evaluate this project fairly
 

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -21,7 +21,9 @@
 #      the release page, so a release that lost a matrix leg fails instead of
 #      quietly verifying the targets that did make it
 #   2. every archive has a .sha256 companion, and matches it
-#   3. every archive contains the binary + LICENSE + README
+#   3. every archive contains the binary + LICENSE + README. An archive that
+#      matched its published checksum and still will not extract is a defect in
+#      the release, so it FAILS rather than being skipped
 #   4. every binary — including the ones this host cannot execute — carries the
 #      tag's version in its startup banner, and carries no other version
 #   5. the host-native binary: --version, boot on a clean data dir, health
@@ -96,6 +98,10 @@ SKIPPED_TARGETS=0
 # Set when step 6 did not execute anything for a reason the operator did NOT
 # ask for (no runnable artifact for this host). --no-smoke does not set it.
 SKIPPED_SMOKE=0
+# Archives that were present and checksum-clean but would not extract. Already
+# counted in FAILURES at step 4; tracked so step 5 does not ALSO count them as
+# skipped targets and hand the operator the wrong remedy.
+UNPACKABLE=""
 pass() { printf '  %sPASS%s  %s\n' "$GRN" "$RST" "$1"; }
 fail() { printf '  %sFAIL%s  %s\n' "$RED" "$RST" "$1"; FAILURES=$((FAILURES + 1)); }
 warn() { printf '  %sSKIP%s  %s\n' "$YEL" "$RST" "$1"; }
@@ -186,11 +192,27 @@ step "4. archive contents"
 for a in $ARCHIVES; do
   d="unpack/${a%.tar.gz}"; d="${d%.zip}"
   mkdir -p "$d"
+  # An archive that matched its published checksum and still will not extract is
+  # a defect in the RELEASE, not a gap in this host's tooling — so it is a FAIL,
+  # not a SKIP. Guarding the extractor also keeps `set -e` from ending the run
+  # right here with the extractor's own error and no verdict at all, which is
+  # the one way this script could stop short of the promise in its header that
+  # everything it could not check is counted and reported.
   case "$a" in
-    *.tar.gz) tar -xzf "$a" -C "$d" ;;
+    *.tar.gz)
+      if ! tar -xzf "$a" -C "$d"; then
+        fail "$a — matched its published checksum but did not extract"
+        UNPACKABLE="$UNPACKABLE $a"
+        continue
+      fi ;;
     *.zip)
-      if command -v unzip >/dev/null 2>&1; then unzip -q -o "$a" -d "$d"
-      else warn "$a — unzip not on PATH, contents NOT checked"; continue; fi ;;
+      if ! command -v unzip >/dev/null 2>&1; then
+        warn "$a — unzip not on PATH, contents NOT checked"; continue
+      elif ! unzip -q -o "$a" -d "$d"; then
+        fail "$a — matched its published checksum but did not extract"
+        UNPACKABLE="$UNPACKABLE $a"
+        continue
+      fi ;;
   esac
   # `|| true`: under `set -o pipefail`, find killed by SIGPIPE once head exits
   # returns 141 for the whole pipeline and `set -e` would abort the verifier
@@ -211,11 +233,20 @@ for a in $ARCHIVES; do
   target=$(printf '%s' "$a" | sed "s/^xerj-$EXPECTED-//; s/\.tar\.gz$//; s/\.zip$//")
   bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) 2>/dev/null | head -1 || true)
   if [ -z "$bin" ]; then
-    # Step 4 could not unpack this archive (typically: no unzip for a Windows
-    # .zip). Dropping it here would leave this section headed "on every target"
-    # quietly checking fewer targets than it names.
-    warn "$target — no binary unpacked, version NOT checked"
-    SKIPPED_TARGETS=$((SKIPPED_TARGETS + 1))
+    case " $UNPACKABLE " in
+      *" $a "*)
+        # Step 4 already counted this one as a FAIL: the archive is broken, and
+        # the run is already failing closed for the right reason. Counting it a
+        # second time as a skipped target would add the "install unzip" remedy
+        # to the verdict, which is the wrong advice for a defective release.
+        warn "$target — version NOT checked (archive did not extract, see step 4)" ;;
+      *)
+        # Step 4 could not unpack this archive (typically: no unzip for a
+        # Windows .zip). Dropping it here would leave this section headed "on
+        # every target" quietly checking fewer targets than it names.
+        warn "$target — no binary unpacked, version NOT checked"
+        SKIPPED_TARGETS=$((SKIPPED_TARGETS + 1)) ;;
+    esac
     continue
   fi
   found=$(banner_versions "$bin" | tr '\n' ' ' | sed 's/ $//')

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -25,11 +25,17 @@
 #   4. every binary — including the ones this host cannot execute — carries the
 #      tag's version in its startup banner, and carries no other version
 #   5. the host-native binary: --version, boot on a clean data dir, health
-#      green, index a doc, search it back, run a terms aggregation
+#      green, index a doc, search it back, run a terms aggregation. Runs on
+#      Linux and macOS hosts (both architectures). It is NOT run on a Windows
+#      host — those archives are checksum- and version-checked like every
+#      other target, but this script never boots the .exe.
 #
-# A target this host cannot unpack (no unzip for the Windows .zip) is counted
-# and reported, never silently dropped: the run then exits non-zero, because a
-# partially-checked release is not a verified release.
+# Anything this run could not check is counted and reported, never silently
+# dropped, and the run then exits non-zero — a partially-checked release is not
+# a verified release. That covers a target this host cannot unpack (no unzip
+# for the Windows .zip) and a check-5 smoke (printed as "step 6" at run time)
+# that never executed because this host has no runnable artifact. The one
+# narrowing that still exits 0 is --no-smoke, because the operator asked for it.
 #
 # Usage:
 #   scripts/verify-release.sh                  # latest release
@@ -87,6 +93,9 @@ FAILURES=0
 # this host). Counted separately from failures: not a defect in the release, but
 # not a verification either, and the verdict must never round it up to PASS.
 SKIPPED_TARGETS=0
+# Set when step 6 did not execute anything for a reason the operator did NOT
+# ask for (no runnable artifact for this host). --no-smoke does not set it.
+SKIPPED_SMOKE=0
 pass() { printf '  %sPASS%s  %s\n' "$GRN" "$RST" "$1"; }
 fail() { printf '  %sFAIL%s  %s\n' "$RED" "$RST" "$1"; FAILURES=$((FAILURES + 1)); }
 warn() { printf '  %sSKIP%s  %s\n' "$YEL" "$RST" "$1"; }
@@ -183,11 +192,14 @@ for a in $ARCHIVES; do
       if command -v unzip >/dev/null 2>&1; then unzip -q -o "$a" -d "$d"
       else warn "$a — unzip not on PATH, contents NOT checked"; continue; fi ;;
   esac
-  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) | head -1)
+  # `|| true`: under `set -o pipefail`, find killed by SIGPIPE once head exits
+  # returns 141 for the whole pipeline and `set -e` would abort the verifier
+  # mid-run rather than report anything.
+  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) | head -1 || true)
   missing=""
   [ -n "$bin" ] || missing="$missing binary"
-  [ -n "$(find "$d" -type f -name LICENSE  | head -1)" ] || missing="$missing LICENSE"
-  [ -n "$(find "$d" -type f -name 'README*' | head -1)" ] || missing="$missing README"
+  [ -n "$(find "$d" -type f -name LICENSE  | head -1 || true)" ] || missing="$missing LICENSE"
+  [ -n "$(find "$d" -type f -name 'README*' | head -1 || true)" ] || missing="$missing README"
   if [ -n "$missing" ]; then fail "$a — missing:$missing"; else pass "$a  binary + LICENSE + README"; fi
 done
 
@@ -197,7 +209,7 @@ step "5. version string matches the tag, on every target"
 for a in $ARCHIVES; do
   d="unpack/${a%.tar.gz}"; d="${d%.zip}"
   target=$(printf '%s' "$a" | sed "s/^xerj-$EXPECTED-//; s/\.tar\.gz$//; s/\.zip$//")
-  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) 2>/dev/null | head -1)
+  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) 2>/dev/null | head -1 || true)
   if [ -z "$bin" ]; then
     # Step 4 could not unpack this archive (typically: no unzip for a Windows
     # .zip). Dropping it here would leave this section headed "on every target"
@@ -217,28 +229,52 @@ for a in $ARCHIVES; do
 done
 
 # ── 6. run the one we can actually run ───────────────────────────────────────
-HOST_OS=$(uname -s); HOST_ARCH=$(uname -m)
+HOST_OS=$(uname -s); HOST_ARCH=$(uname -m); HOST_ARCH_RAW="$HOST_ARCH"
+# `uname -m` and the Rust target triple disagree about the same CPU: an Apple
+# Silicon Mac says `arm64` where the artifact is named `aarch64-apple-darwin`.
+# Without this normalization the glob matched zero files on exactly the host a
+# maintainer is most likely to verify a release from, step 6 was skipped, and
+# the run still printed PASS — "everything green, nobody ran the artifact",
+# which is the rc.10 shape this script exists to catch.
+case "$HOST_ARCH" in
+  arm64|armv8b|armv8l) HOST_ARCH=aarch64 ;;
+  amd64)               HOST_ARCH=x86_64 ;;
+esac
 case "$HOST_OS" in
   Linux)  host_glob="*${HOST_ARCH}-unknown-linux-*" ;;
   Darwin) host_glob="*${HOST_ARCH}-apple-darwin*" ;;
+  # Windows (MSYS/MinGW/Cygwin) and everything else: the .zip is checksum- and
+  # version-checked like every other target, but this script does not boot the
+  # .exe, so there is no host binary to run here.
   *)      host_glob="" ;;
 esac
 
 HOST_BIN=""
 if [ -n "$host_glob" ]; then
   # shellcheck disable=SC2086
-  HOST_BIN=$(find unpack -type f -name xerj -path "$host_glob" 2>/dev/null | head -1)
+  HOST_BIN=$(find unpack -type f -name xerj -path "$host_glob" 2>/dev/null | head -1 || true)
 fi
 
 # Whether a live search was actually executed. The verdict line must not claim
-# it when it did not happen — a cross-arch runner or --no-smoke leaves this 0.
+# it when it did not happen: --no-smoke leaves this 0 and still passes, any
+# other reason leaves it 0 and sets SKIPPED_SMOKE, which fails the run.
 SMOKED=0
 
 step "6. run the host-native artifact"
-if [ -z "$HOST_BIN" ]; then
-  warn "no artifact for $HOST_OS/$HOST_ARCH — nothing to execute here"
-elif [ "$DO_SMOKE" = 0 ]; then
-  warn "--no-smoke"
+if [ "$DO_SMOKE" = 0 ]; then
+  # The operator asked for this narrowing, so it does not fail the run — but
+  # the verdict below still refuses to claim a live search it never ran.
+  warn "--no-smoke — no binary was executed"
+elif [ -z "$HOST_BIN" ]; then
+  # Not "no artifact for this platform": on a Windows host the archive for it
+  # was published, downloaded and version-checked by this very run. Say which
+  # of the two actually happened, and count it — nobody asked for it.
+  if [ -z "$host_glob" ]; then
+    warn "this script does not boot a release binary on $HOST_OS/$HOST_ARCH_RAW (Linux and macOS hosts only) — the artifacts for it, if any, were still checksum- and version-checked above"
+  else
+    warn "no unpacked binary matched $host_glob — the archive for this host was not unpacked (see step 4), so nothing was executed"
+  fi
+  SKIPPED_SMOKE=1
 else
   SMOKED=1
   chmod +x "$HOST_BIN"
@@ -310,19 +346,24 @@ fi
 
 step "verdict"
 # PASS is only ever printed for a release where every declared target was
-# actually checked. --no-smoke narrows the verdict text because the operator
-# asked for it; a skipped target is not something anyone asked for, so it fails
-# closed rather than being rounded up into a PASS this run did not earn.
-if [ "$FAILURES" -eq 0 ] && [ "$SKIPPED_TARGETS" -eq 0 ]; then
+# actually checked AND the host-native binary actually ran. --no-smoke narrows
+# the verdict text because the operator asked for it; a skipped target, or a
+# step 6 that silently never executed, is not something anyone asked for, so it
+# fails closed rather than being rounded up into a PASS this run did not earn.
+if [ "$FAILURES" -eq 0 ] && [ "$SKIPPED_TARGETS" -eq 0 ] && [ "$SKIPPED_SMOKE" -eq 0 ]; then
   if [ "$SMOKED" = 1 ]; then
     scope="checksums and versions verified on $TOTAL_TARGETS/$TOTAL_TARGETS targets, plus a live search"
   else
-    scope="checksums and versions verified on $TOTAL_TARGETS/$TOTAL_TARGETS targets — NO binary was executed, so nothing here says it runs"
+    scope="checksums and versions verified on $TOTAL_TARGETS/$TOTAL_TARGETS targets — NO binary was executed (--no-smoke), so nothing here says it runs"
   fi
   printf '  %sPASS%s  %s: %s\n' "$GRN" "$RST" "$TAG" "$scope"
   exit 0
 fi
 
+if [ "$SKIPPED_SMOKE" -gt 0 ]; then
+  printf '  %sFAIL%s  %s: nothing was executed — no binary ran on this host and nobody asked for that (see SKIP at step 6); re-run on a host this release ships a runnable binary for, or pass --no-smoke to accept a checksums-and-versions-only check\n' \
+    "$RED" "$RST" "$TAG"
+fi
 if [ "$SKIPPED_TARGETS" -gt 0 ]; then
   printf '  %sFAIL%s  %s: %s of %s target(s) NOT verified (see SKIP above) — install the missing tool (unzip, for the Windows .zip archives) and re-run; do not announce a partially checked release\n' \
     "$RED" "$RST" "$TAG" "$SKIPPED_TARGETS" "$TOTAL_TARGETS"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -17,12 +17,19 @@
 #   scripts/verify-release.sh v1.0.0-rc.13   ->  PASS
 #
 # Checks, in order:
-#   1. every archive has a .sha256 companion, and matches it
-#   2. every archive contains the binary + LICENSE + README
-#   3. every binary — including the ones this host cannot execute — carries the
+#   1. every target we ship is present — the set is DECLARED below, not read off
+#      the release page, so a release that lost a matrix leg fails instead of
+#      quietly verifying the targets that did make it
+#   2. every archive has a .sha256 companion, and matches it
+#   3. every archive contains the binary + LICENSE + README
+#   4. every binary — including the ones this host cannot execute — carries the
 #      tag's version in its startup banner, and carries no other version
-#   4. the host-native binary: --version, boot on a clean data dir, health
+#   5. the host-native binary: --version, boot on a clean data dir, health
 #      green, index a doc, search it back, run a terms aggregation
+#
+# A target this host cannot unpack (no unzip for the Windows .zip) is counted
+# and reported, never silently dropped: the run then exits non-zero, because a
+# partially-checked release is not a verified release.
 #
 # Usage:
 #   scripts/verify-release.sh                  # latest release
@@ -30,8 +37,8 @@
 #   scripts/verify-release.sh --keep           # keep the download dir
 #   scripts/verify-release.sh --no-smoke       # checksums + versions only
 #
-# Requires: gh (authenticated), curl, tar, sha256sum|shasum. unzip for the
-# Windows archives (skipped with a warning if absent).
+# Requires: gh (authenticated), curl, tar, sha256sum|shasum, and unzip for the
+# Windows archives.
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -46,7 +53,7 @@ while [ $# -gt 0 ]; do
     --keep)     KEEP=1 ;;
     --no-smoke) DO_SMOKE=0 ;;
     --repo)     REPO="$2"; shift ;;
-    -h|--help)  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help)  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
     -*)         echo "unknown flag: $1" >&2; exit 2 ;;
     *)          TAG="$1" ;;
   esac
@@ -59,7 +66,27 @@ if [ -t 1 ]; then
   GRN=$(printf '\033[32m'); YEL=$(printf '\033[33m'); RST=$(printf '\033[0m')
 fi
 
+# Every target .github/workflows/release.yml publishes (its `matrix.include`).
+# Declared, not discovered. A gate that verifies whatever the release page
+# happens to hold reports a clean PASS for a release that is missing platforms:
+# delete the two windows-msvc archives from a release and the rest of this
+# script goes 6-for-6 green. Keep this list in step with release.yml — if the
+# matrix gains or loses a target, this is the other half of that change.
+EXPECTED_TARGETS="aarch64-apple-darwin
+aarch64-pc-windows-msvc
+aarch64-unknown-linux-gnu
+aarch64-unknown-linux-musl
+x86_64-apple-darwin
+x86_64-pc-windows-msvc
+x86_64-unknown-linux-gnu
+x86_64-unknown-linux-musl"
+TOTAL_TARGETS=$(printf '%s\n' "$EXPECTED_TARGETS" | wc -l | tr -d ' ')
+
 FAILURES=0
+# Targets that were present but could not be checked (archive not unpackable on
+# this host). Counted separately from failures: not a defect in the release, but
+# not a verification either, and the verdict must never round it up to PASS.
+SKIPPED_TARGETS=0
 pass() { printf '  %sPASS%s  %s\n' "$GRN" "$RST" "$1"; }
 fail() { printf '  %sFAIL%s  %s\n' "$RED" "$RST" "$1"; FAILURES=$((FAILURES + 1)); }
 warn() { printf '  %sSKIP%s  %s\n' "$YEL" "$RST" "$1"; }
@@ -120,7 +147,18 @@ ARCHIVES=$(find . -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | 
 [ -n "$ARCHIVES" ] || { fail "no .tar.gz or .zip assets on $TAG"; exit 1; }
 printf '  %s%s archives%s\n' "$DIM" "$(printf '%s\n' "$ARCHIVES" | wc -l | tr -d ' ')" "$RST"
 
-step "2. checksums"
+step "2. every target we ship is present"
+# Asserted against EXPECTED_TARGETS, never inferred from what was downloaded:
+# one failed leg of the release matrix must fail this gate, not shrink it.
+for t in $EXPECTED_TARGETS; do
+  if printf '%s\n' "$ARCHIVES" | grep -qE -- "-${t}\.(tar\.gz|zip)\$"; then
+    pass "$t"
+  else
+    fail "$t — NO archive published for this target"
+  fi
+done
+
+step "3. checksums"
 for a in $ARCHIVES; do
   if [ ! -f "$a.sha256" ]; then
     fail "$a — no .sha256 companion published"
@@ -135,7 +173,7 @@ for a in $ARCHIVES; do
   fi
 done
 
-step "3. archive contents"
+step "4. archive contents"
 for a in $ARCHIVES; do
   d="unpack/${a%.tar.gz}"; d="${d%.zip}"
   mkdir -p "$d"
@@ -143,7 +181,7 @@ for a in $ARCHIVES; do
     *.tar.gz) tar -xzf "$a" -C "$d" ;;
     *.zip)
       if command -v unzip >/dev/null 2>&1; then unzip -q -o "$a" -d "$d"
-      else warn "$a — unzip not on PATH"; continue; fi ;;
+      else warn "$a — unzip not on PATH, contents NOT checked"; continue; fi ;;
   esac
   bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) | head -1)
   missing=""
@@ -153,14 +191,21 @@ for a in $ARCHIVES; do
   if [ -n "$missing" ]; then fail "$a — missing:$missing"; else pass "$a  binary + LICENSE + README"; fi
 done
 
-step "4. version string matches the tag, on every target"
+step "5. version string matches the tag, on every target"
 # The rc.10 check. A binary whose banner disagrees with its own filename is the
 # defect; a binary carrying two different versions is a stale-artifact defect.
 for a in $ARCHIVES; do
   d="unpack/${a%.tar.gz}"; d="${d%.zip}"
-  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) 2>/dev/null | head -1)
-  [ -n "$bin" ] || continue
   target=$(printf '%s' "$a" | sed "s/^xerj-$EXPECTED-//; s/\.tar\.gz$//; s/\.zip$//")
+  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) 2>/dev/null | head -1)
+  if [ -z "$bin" ]; then
+    # Step 4 could not unpack this archive (typically: no unzip for a Windows
+    # .zip). Dropping it here would leave this section headed "on every target"
+    # quietly checking fewer targets than it names.
+    warn "$target — no binary unpacked, version NOT checked"
+    SKIPPED_TARGETS=$((SKIPPED_TARGETS + 1))
+    continue
+  fi
   found=$(banner_versions "$bin" | tr '\n' ' ' | sed 's/ $//')
   if [ -z "$found" ]; then
     fail "$target — no version banner found in the binary"
@@ -171,7 +216,7 @@ for a in $ARCHIVES; do
   fi
 done
 
-# ── 5. run the one we can actually run ───────────────────────────────────────
+# ── 6. run the one we can actually run ───────────────────────────────────────
 HOST_OS=$(uname -s); HOST_ARCH=$(uname -m)
 case "$HOST_OS" in
   Linux)  host_glob="*${HOST_ARCH}-unknown-linux-*" ;;
@@ -189,7 +234,7 @@ fi
 # it when it did not happen — a cross-arch runner or --no-smoke leaves this 0.
 SMOKED=0
 
-step "5. run the host-native artifact"
+step "6. run the host-native artifact"
 if [ -z "$HOST_BIN" ]; then
   warn "no artifact for $HOST_OS/$HOST_ARCH — nothing to execute here"
 elif [ "$DO_SMOKE" = 0 ]; then
@@ -264,14 +309,25 @@ EOF
 fi
 
 step "verdict"
-if [ "$FAILURES" -eq 0 ]; then
+# PASS is only ever printed for a release where every declared target was
+# actually checked. --no-smoke narrows the verdict text because the operator
+# asked for it; a skipped target is not something anyone asked for, so it fails
+# closed rather than being rounded up into a PASS this run did not earn.
+if [ "$FAILURES" -eq 0 ] && [ "$SKIPPED_TARGETS" -eq 0 ]; then
   if [ "$SMOKED" = 1 ]; then
-    scope="checksums, versions and a live search all verified"
+    scope="checksums and versions verified on $TOTAL_TARGETS/$TOTAL_TARGETS targets, plus a live search"
   else
-    scope="checksums and versions verified — NO binary was executed, so nothing here says it runs"
+    scope="checksums and versions verified on $TOTAL_TARGETS/$TOTAL_TARGETS targets — NO binary was executed, so nothing here says it runs"
   fi
   printf '  %sPASS%s  %s: %s\n' "$GRN" "$RST" "$TAG" "$scope"
   exit 0
 fi
-printf '  %sFAIL%s  %s: %s check(s) failed — do not announce this release\n' "$RED" "$RST" "$TAG" "$FAILURES"
+
+if [ "$SKIPPED_TARGETS" -gt 0 ]; then
+  printf '  %sFAIL%s  %s: %s of %s target(s) NOT verified (see SKIP above) — install the missing tool (unzip, for the Windows .zip archives) and re-run; do not announce a partially checked release\n' \
+    "$RED" "$RST" "$TAG" "$SKIPPED_TARGETS" "$TOTAL_TARGETS"
+fi
+if [ "$FAILURES" -gt 0 ]; then
+  printf '  %sFAIL%s  %s: %s check(s) failed — do not announce this release\n' "$RED" "$RST" "$TAG" "$FAILURES"
+fi
 exit 1

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# verify-release.sh — post-release check on the PUBLISHED artifacts.
+#
+# Not a build check. This downloads what a user actually downloads and asserts
+# the things a green CI run cannot: that every archive has a checksum and
+# matches it, that every binary reports the version its tag promises, and that
+# the binary for this host boots on a clean data dir and answers a real search.
+#
+# It exists because v1.0.0-rc.10 shipped binaries that print "xerj v1.0.0-rc.9".
+# The tag was cut at a commit where engine/Cargo.toml still held the old
+# version: asset FILENAMES come from the git tag, the banner comes from
+# CARGO_PKG_VERSION, and nothing made the two agree. Every test passed. The
+# only way to see it is to run the artifact. Still reproducible today:
+#
+#   scripts/verify-release.sh v1.0.0-rc.10   ->  FAIL (version drift)
+#   scripts/verify-release.sh v1.0.0-rc.13   ->  PASS
+#
+# Checks, in order:
+#   1. every archive has a .sha256 companion, and matches it
+#   2. every archive contains the binary + LICENSE + README
+#   3. every binary — including the ones this host cannot execute — carries the
+#      tag's version in its startup banner, and carries no other version
+#   4. the host-native binary: --version, boot on a clean data dir, health
+#      green, index a doc, search it back, run a terms aggregation
+#
+# Usage:
+#   scripts/verify-release.sh                  # latest release
+#   scripts/verify-release.sh v1.0.0-rc.13     # a specific tag
+#   scripts/verify-release.sh --keep           # keep the download dir
+#   scripts/verify-release.sh --no-smoke       # checksums + versions only
+#
+# Requires: gh (authenticated), curl, tar, sha256sum|shasum. unzip for the
+# Windows archives (skipped with a warning if absent).
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPO="${XERJ_REPO:-xerj-org/xerj}"
+TAG=""
+KEEP=0
+DO_SMOKE=1
+WORKDIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep)     KEEP=1 ;;
+    --no-smoke) DO_SMOKE=0 ;;
+    --repo)     REPO="$2"; shift ;;
+    -h|--help)  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)         echo "unknown flag: $1" >&2; exit 2 ;;
+    *)          TAG="$1" ;;
+  esac
+  shift
+done
+
+BOLD=''; DIM=''; RED=''; GRN=''; YEL=''; RST=''
+if [ -t 1 ]; then
+  BOLD=$(printf '\033[1m'); DIM=$(printf '\033[2m'); RED=$(printf '\033[31m')
+  GRN=$(printf '\033[32m'); YEL=$(printf '\033[33m'); RST=$(printf '\033[0m')
+fi
+
+FAILURES=0
+pass() { printf '  %sPASS%s  %s\n' "$GRN" "$RST" "$1"; }
+fail() { printf '  %sFAIL%s  %s\n' "$RED" "$RST" "$1"; FAILURES=$((FAILURES + 1)); }
+warn() { printf '  %sSKIP%s  %s\n' "$YEL" "$RST" "$1"; }
+step() { printf '\n%s%s%s\n' "$BOLD" "$1" "$RST"; }
+
+cleanup() {
+  [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null || true
+  if [ "$KEEP" = 0 ] && [ -n "$WORKDIR" ] && [ -d "$WORKDIR" ]; then
+    rm -rf "$WORKDIR"
+  elif [ -n "$WORKDIR" ]; then
+    printf '\n%skept: %s%s\n' "$DIM" "$WORKDIR" "$RST"
+  fi
+}
+trap cleanup EXIT
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum   >/dev/null 2>&1; then shasum -a 256 "$1" | cut -d' ' -f1
+  else echo "no sha256sum or shasum on PATH" >&2; exit 2
+  fi
+}
+
+# The version a binary claims, read from its startup banner. Works on binaries
+# this host cannot execute, which is the whole point — the drift we are hunting
+# can just as easily land in the macOS or Windows artifact, and executing them
+# is not an option on a Linux runner.
+banner_versions() {
+  LC_ALL=C grep -a -o -E 'xerj v[0-9][0-9A-Za-z.+-]* starting' "$1" 2>/dev/null \
+    | sed 's/^xerj v//; s/ starting$//' | sort -u
+}
+
+free_port() {
+  python3 - <<'PY' 2>/dev/null || echo "$((20000 + RANDOM % 20000))"
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 2; }
+
+# ── resolve the tag ──────────────────────────────────────────────────────────
+if [ -z "$TAG" ]; then
+  TAG=$(gh release view --repo "$REPO" --json tagName --jq .tagName)
+fi
+EXPECTED="${TAG#v}"
+
+printf '%srelease verification%s  %s  tag %s%s%s\n' "$BOLD" "$RST" "$REPO" "$BOLD" "$TAG" "$RST"
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/xerj-verify-XXXXXX")
+cd "$WORKDIR"
+
+step "1. download every published asset"
+gh release download "$TAG" --repo "$REPO" --dir "$WORKDIR" --clobber >/dev/null
+ARCHIVES=$(find . -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | sed 's|^\./||' | sort)
+[ -n "$ARCHIVES" ] || { fail "no .tar.gz or .zip assets on $TAG"; exit 1; }
+printf '  %s%s archives%s\n' "$DIM" "$(printf '%s\n' "$ARCHIVES" | wc -l | tr -d ' ')" "$RST"
+
+step "2. checksums"
+for a in $ARCHIVES; do
+  if [ ! -f "$a.sha256" ]; then
+    fail "$a — no .sha256 companion published"
+    continue
+  fi
+  want=$(cut -d' ' -f1 < "$a.sha256")
+  got=$(sha256_of "$a")
+  if [ "$want" = "$got" ]; then
+    pass "$a  ${got:0:16}…"
+  else
+    fail "$a — published $want, downloaded $got"
+  fi
+done
+
+step "3. archive contents"
+for a in $ARCHIVES; do
+  d="unpack/${a%.tar.gz}"; d="${d%.zip}"
+  mkdir -p "$d"
+  case "$a" in
+    *.tar.gz) tar -xzf "$a" -C "$d" ;;
+    *.zip)
+      if command -v unzip >/dev/null 2>&1; then unzip -q -o "$a" -d "$d"
+      else warn "$a — unzip not on PATH"; continue; fi ;;
+  esac
+  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) | head -1)
+  missing=""
+  [ -n "$bin" ] || missing="$missing binary"
+  [ -n "$(find "$d" -type f -name LICENSE  | head -1)" ] || missing="$missing LICENSE"
+  [ -n "$(find "$d" -type f -name 'README*' | head -1)" ] || missing="$missing README"
+  if [ -n "$missing" ]; then fail "$a — missing:$missing"; else pass "$a  binary + LICENSE + README"; fi
+done
+
+step "4. version string matches the tag, on every target"
+# The rc.10 check. A binary whose banner disagrees with its own filename is the
+# defect; a binary carrying two different versions is a stale-artifact defect.
+for a in $ARCHIVES; do
+  d="unpack/${a%.tar.gz}"; d="${d%.zip}"
+  bin=$(find "$d" -type f \( -name xerj -o -name xerj.exe \) 2>/dev/null | head -1)
+  [ -n "$bin" ] || continue
+  target=$(printf '%s' "$a" | sed "s/^xerj-$EXPECTED-//; s/\.tar\.gz$//; s/\.zip$//")
+  found=$(banner_versions "$bin" | tr '\n' ' ' | sed 's/ $//')
+  if [ -z "$found" ]; then
+    fail "$target — no version banner found in the binary"
+  elif [ "$found" = "$EXPECTED" ]; then
+    pass "$target  reports $EXPECTED"
+  else
+    fail "$target — tag says $EXPECTED, binary says: $found"
+  fi
+done
+
+# ── 5. run the one we can actually run ───────────────────────────────────────
+HOST_OS=$(uname -s); HOST_ARCH=$(uname -m)
+case "$HOST_OS" in
+  Linux)  host_glob="*${HOST_ARCH}-unknown-linux-*" ;;
+  Darwin) host_glob="*${HOST_ARCH}-apple-darwin*" ;;
+  *)      host_glob="" ;;
+esac
+
+HOST_BIN=""
+if [ -n "$host_glob" ]; then
+  # shellcheck disable=SC2086
+  HOST_BIN=$(find unpack -type f -name xerj -path "$host_glob" 2>/dev/null | head -1)
+fi
+
+# Whether a live search was actually executed. The verdict line must not claim
+# it when it did not happen — a cross-arch runner or --no-smoke leaves this 0.
+SMOKED=0
+
+step "5. run the host-native artifact"
+if [ -z "$HOST_BIN" ]; then
+  warn "no artifact for $HOST_OS/$HOST_ARCH — nothing to execute here"
+elif [ "$DO_SMOKE" = 0 ]; then
+  warn "--no-smoke"
+else
+  SMOKED=1
+  chmod +x "$HOST_BIN"
+  reported=$("$HOST_BIN" --version 2>&1 || true)
+  if [ "$reported" = "xerj v$EXPECTED" ]; then
+    pass "--version  ->  $reported"
+  else
+    fail "--version  ->  '$reported', expected 'xerj v$EXPECTED'"
+  fi
+
+  ES_PORT=$(free_port); REST_PORT=$(free_port); GRPC_PORT=$(free_port)
+  mkdir -p smoke/data
+  cat > smoke/xerj.toml <<EOF
+[server]
+rest_port = $REST_PORT
+grpc_port = $GRPC_PORT
+es_compat_port = $ES_PORT
+bind_address = "127.0.0.1"
+EOF
+  "$HOST_BIN" --config "$WORKDIR/smoke/xerj.toml" --data-dir "$WORKDIR/smoke/data" \
+      --insecure > "$WORKDIR/smoke/server.log" 2>&1 &
+  SERVER_PID=$!
+
+  B="http://127.0.0.1:$ES_PORT"
+  health=""
+  for _ in $(seq 1 60); do
+    health=$(curl -s -m 2 "$B/_cluster/health" 2>/dev/null || true)
+    [ -n "$health" ] && break
+    kill -0 "$SERVER_PID" 2>/dev/null || break
+    sleep 1
+  done
+
+  if [ -z "$health" ]; then
+    fail "server never answered on :$ES_PORT — see $WORKDIR/smoke/server.log"
+  else
+    case "$health" in
+      *'"status":"green"'*) pass "boots on a clean data dir, cluster green" ;;
+      *) fail "cluster not green: $health" ;;
+    esac
+
+    curl -s -X POST "$B/xerj-verify/_doc/1?refresh=true" \
+      -H 'Content-Type: application/json' \
+      -d '{"title":"release verification","body":"published artifact booted and searched"}' \
+      > smoke/index.json 2>&1 || true
+    case "$(cat smoke/index.json)" in
+      *'"result":"created"'*) pass "indexes a document" ;;
+      *) fail "index failed: $(cat smoke/index.json)" ;;
+    esac
+
+    curl -s -X POST "$B/xerj-verify/_search" -H 'Content-Type: application/json' \
+      -d '{"query":{"match":{"body":"published artifact"}}}' > smoke/search.json 2>&1 || true
+    case "$(cat smoke/search.json)" in
+      *'"total":{"value":1'*) pass "searches it back  ($(sed 's/.*"max_score":\([0-9.]*\).*/max_score \1/' smoke/search.json))" ;;
+      *) fail "search returned no hit: $(head -c 300 smoke/search.json)" ;;
+    esac
+
+    curl -s -X POST "$B/xerj-verify/_search" -H 'Content-Type: application/json' \
+      -d '{"size":0,"aggs":{"t":{"terms":{"field":"title.keyword"}}}}' > smoke/agg.json 2>&1 || true
+    case "$(cat smoke/agg.json)" in
+      *'"key":"release verification","doc_count":1'*) pass "terms aggregation buckets it" ;;
+      *) fail "aggregation wrong: $(head -c 300 smoke/agg.json)" ;;
+    esac
+  fi
+
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+  SERVER_PID=""
+fi
+
+step "verdict"
+if [ "$FAILURES" -eq 0 ]; then
+  if [ "$SMOKED" = 1 ]; then
+    scope="checksums, versions and a live search all verified"
+  else
+    scope="checksums and versions verified — NO binary was executed, so nothing here says it runs"
+  fi
+  printf '  %sPASS%s  %s: %s\n' "$GRN" "$RST" "$TAG" "$scope"
+  exit 0
+fi
+printf '  %sFAIL%s  %s: %s check(s) failed — do not announce this release\n' "$RED" "$RST" "$TAG" "$FAILURES"
+exit 1


### PR DESCRIPTION
Fixes #197

## What #197 asked for

Issue #197 recorded a manual post-release check of the **rc.12** tarball — checksum, version string, one indexed doc searched back — and closed with *"filing it so the check is on the record and someone can repeat it for the next cut."*

rc.13 has since shipped. This PR does two things: **re-runs that check against the current latest release**, and **turns the ritual into one command** so the next cut does not depend on someone remembering.

## Evidence: v1.0.0-rc.13 verified against the published artifacts

Not a local build — downloaded from the release page.

```
xerj-1.0.0-rc.13-x86_64-unknown-linux-gnu.tar.gz
size      19,396,449 bytes
sha256    b2ad2276b3386aeb9d509fa3e1131d9b57d57a59e5137adf33754658632f1b4c
          matches the published .sha256
--version xerj v1.0.0-rc.13
```

Booted on a clean data dir, indexed one document, searched it back:

```
cluster status  green
hits.total      1
max_score       0.57536423
took            0 ms
```

Widened past rc.12's single tarball — **all 8 published targets**:

| check | result |
|---|---|
| every target release.yml publishes is present on the release | 8/8 |
| `.sha256` companion published for every archive | 8/8 |
| checksum matches the download | 8/8 |
| archive carries binary + LICENSE + README | 8/8 |
| binary reports `1.0.0-rc.13` (incl. macOS + Windows) | 8/8 |
| `curl -fsSL https://xerj.org/get \| sh` resolves the current *latest* release, verifies sha256, installs, `--version` agrees | pass — resolved rc.13 when first measured; re-run 2026-08-10 it resolves **rc.14** and still agrees |

The version string is the part worth calling out, exactly as #197 said. Re-confirmed at the tag: `engine/Cargo.toml` at `v1.0.0-rc.13` (`de13be53`) holds `1.0.0-rc.13`, and that value survived to the binary a user downloads on every one of the eight targets.

**No defect found in the rc.13 release artifacts.**

## Why a script, and not just a comment on the issue

The bug class #197 exists to watch for is still live and still reproducible **today**, from the published release page:

```
$ ./scripts/verify-release.sh v1.0.0-rc.10
  FAIL  aarch64-apple-darwin — tag says 1.0.0-rc.10, binary says: 1.0.0-rc.9
  ... all 8 targets ...
  FAIL  --version  ->  'xerj v1.0.0-rc.9', expected 'xerj v1.0.0-rc.10'
  FAIL  v1.0.0-rc.10: 9 check(s) failed — do not announce this release       exit 1

$ ./scripts/verify-release.sh v1.0.0-rc.13
  PASS  v1.0.0-rc.13: checksums and versions verified on 8/8 targets,
        plus a live search                                                   exit 0
```

That is the regression test: **fails on the known-bad release, passes on the current one**, against real published bytes rather than a fixture. rc.10's CI was green and every test passed — asset filenames come from the git tag, the banner comes from `CARGO_PKG_VERSION`, and nothing made the two agree. Only running the artifact shows it.

## What the script checks

1. **every target we ship is present.** The eight targets are declared in the script and asserted, not read off the release page — see below
2. every archive has a `.sha256` companion, and matches it
3. every archive contains binary + LICENSE + README. An archive that matched its published checksum and still will not extract is a defect in the *release*, so it **fails** — it is not rounded down to "this host could not read it"
4. every binary reports the tag's version — **including the macOS and Windows binaries a Linux runner cannot execute**, by reading the startup-banner bytes out of the binary instead of running it. Drift is just as likely to land in a target the checker cannot boot, so checking only the native one would have been the weaker check
5. the host-native binary: `--version`, boot on a clean data dir, cluster green, index a doc, search it back, terms aggregation. **Linux and macOS hosts, both architectures.** On a host where it cannot run one — a Windows host, or any platform we do not ship a binary for — it says so and the run **fails**; it does not report a PASS for a release nobody executed

```
scripts/verify-release.sh                  # latest release
scripts/verify-release.sh v1.0.0-rc.13     # a specific tag
scripts/verify-release.sh --no-smoke       # checksums + versions only
```

**Honesty behaviours, deliberately.** A gate whose failure text is *"do not announce this release"* must never print an unqualified PASS for a run that checked less than it claims:

- with `--no-smoke` the verdict says *"NO binary was executed (`--no-smoke`), so nothing here says it runs"* instead of claiming a live search it never ran. That exits 0 — it is a narrowing of scope the operator asked for, and it is the only one that does.
- a host where **no** binary could be executed and nobody asked for that — a Windows host, an unsupported platform — is counted like a skipped target and **fails closed with exit 1**, naming the host and the remedy. An earlier revision of this PR exited 0 there; see the second repair table below.
- a target that **could not** be checked (e.g. a Windows `.zip` on a host with no `unzip`) is counted, printed as `SKIP`, and **fails closed with exit 1**: nobody asked for that reduction in scope, so it is not rounded up into a PASS. The verdict names the count and the remedy.
- a broken archive **fails and still reaches a verdict**: the extractors are guarded, so `set -e` cannot end the run mid-step with no verdict at all. See the third repair round below.
- PASS is only ever printed as `verified on 8/8 targets`.
- ports are allocated free rather than hardcoded, so it will not collide with a xerj already listening on 9200.

## Review repairs (commit `dbfcabaf`)

Adversarial review of the first revision found the gate could still greenlight a release that was **missing platforms**. Three connected holes, all fixed, each with the fault re-injected and re-run:

| fault injected | before | after |
|---|---|---|
| two `windows-msvc` archives absent from the release | `6 archives`, 6/6 PASS every step, verdict "checksums and versions verified", **exit 0** | 2× `FAIL … NO archive published for this target`, **exit 1** |
| host without `unzip` (all 8 archives present) | step 4 prints 6 lines, both Windows binaries never version-checked, nothing marks it, **exit 0** | 2× `SKIP … version NOT checked`, verdict `2 of 8 target(s) NOT verified`, **exit 1** |

Root cause of the first: the target set was whatever `gh release download` happened to fetch, so one failed leg of the `release.yml` matrix shrank the gate instead of failing it. The eight targets are now a declared constant checked before anything else. Root cause of the second: a bare `continue` dropped an unreadable archive out of the section headed *"on every target"* with no output at all.

Re-verified after the repair, against the real published bytes: **rc.13 PASS 8/8 + live search, exit 0 (13s)**; **rc.10 FAIL 9 checks, exit 1** — the new step adds no spurious failure, rc.10 did publish all eight targets, they just all carried the rc.9 banner.

## Second repair round (commit `218f3fda`) — the verifier no-op'd on Apple Silicon

The merge gate re-ran every measurement above against the real published bytes and found one hole the first repair left open, on the host a maintainer is *most* likely to verify a release from.

`verify-release.sh` built its host glob out of a raw `uname -m`. An Apple Silicon Mac reports `arm64`; the artifact is named `aarch64-apple-darwin`. They never matched. So the Mac ARM archive was downloaded, unpacked and version-checked as PASS at step 5 — and then step 6 printed `SKIP no artifact for Darwin/arm64 — nothing to execute here` and the run exited **0 PASS**.

That is three defects in one line:

- **the check this script exists for never ran, and the verdict still said PASS.** Everything green, nobody executed the binary — the rc.10 shape, reappearing inside the tool written to catch it, and the repo's accepted-and-silently-ignored class (#204).
- **the message was false on its face.** The Mac ARM artifact *was* published, and this very run had already unpacked it. An operator reading that line would conclude we ship no Mac ARM build.
- it was **the only `warn` in the script incrementing neither `FAILURES` nor `SKIPPED_TARGETS`**, contradicting the rule the first repair wrote 74 lines below it: *"a skipped target is not something anyone asked for, so it fails closed."*

| fault | before (`dbfcabaf`) | after (`218f3fda`) |
|---|---|---|
| Apple Silicon host (`uname` shim `Darwin`/`arm64`, real rc.13 assets) | 8/8 PASS on steps 2–5 including `aarch64-apple-darwin reports 1.0.0-rc.13`, then `SKIP no artifact for Darwin/arm64`, verdict **PASS, exit 0** | glob normalises to `aarch64`, `unpack/…-aarch64-apple-darwin/xerj` is selected and executed; step 6 no longer skips, **exit 1** on this Linux host (see the honest caveat below) |
| host that genuinely cannot run any artifact (`uname` shim `FreeBSD/amd64`) | verdict PASS, exit 0 | `SKIP this script does not boot a release binary on FreeBSD/amd64 (Linux and macOS hosts only) …`, verdict `nothing was executed — no binary ran on this host and nobody asked for that`, **exit 1**, remedy named |

Also fixed while in here: `x=$(find … | head -1)` appears five times under `set -o pipefail`. When `head` exits first, `find` takes SIGPIPE, the pipeline reports 141, and `set -e` aborts the whole verifier mid-run with no verdict at all. `|| true` on those five assignments. Latent, never observed to fire — fixed because a release gate that can vanish silently is the same bug class as the one above.

Everything re-measured after the fix, against the real published bytes:

| run | result |
|---|---|
| real Linux x86_64, rc.13 | 8/8 + live search, `max_score 0.57536423`, **PASS exit 0** (unchanged) |
| `--no-smoke` | `NO binary was executed (--no-smoke)`, **PASS exit 0** |
| no `unzip` on PATH | `2 of 8 target(s) NOT verified`, **exit 1** (unchanged) |
| two `windows-msvc` archives absent | 2× `NO archive published for this target`, **exit 1** (unchanged) |
| `v1.0.0-rc.10` | 9 check(s) failed, **exit 1** (unchanged) |

## Third repair round (commit `f8472018`) — independent re-measurement, and one more hole closed

Every row above was re-run from scratch against the **real published bytes**, not inferred from the diff, and the fault injections were repeated rather than trusted. The Apple Silicon hole is confirmed closed.

Re-measuring turned up one last way the verifier could stop short of its own header promise (*"anything this run could not check is counted and reported… the run then exits non-zero"*): **an archive that matched its published checksum and still would not extract killed the script mid-run.** `tar -xzf` / `unzip` ran unguarded, so `set -e` ended the run with the extractor's own error and **no verdict line at all** — fault-injected with a garbage `…-aarch64-unknown-linux-musl.tar.gz` plus a matching `.sha256`, observed `exit 2`, output stopping after three PASS lines in step 4.

It could never become a false PASS, but it was the one partial check that was neither counted nor reported. Now: a checksum-clean archive that will not extract is treated as a defect in the **release**, so it `FAIL`s (not `SKIP`s), the run reaches a verdict, and step 5 deliberately does not *also* count it as a skipped target — that would attach the "install unzip" remedy to what is actually a broken artifact.

| fault | before | after |
|---|---|---|
| `.tar.gz` matches its `.sha256` but is not a gzip stream | script aborts inside step 4, **no verdict**, `exit 2` | `FAIL … matched its published checksum but did not extract`, `SKIP … version NOT checked (archive did not extract, see step 4)`, `FAIL v1.0.0-rc.13: 1 check(s) failed — do not announce this release`, **exit 1** |
| `.zip` matches its `.sha256` but has no central directory | same abort, **no verdict** | same `FAIL` pair and verdict, **exit 1** |

Full matrix at the head of this branch — every row an actual run, exit codes as printed:

| run | observed | exit |
|---|---|---|
| Linux x86_64, `v1.0.0-rc.13` | steps 2–5 8/8, step 6 boots green, indexes, `max_score 0.57536423`, terms agg; `PASS … 8/8 targets, plus a live search` | 0 |
| `uname` shim `Darwin`/`arm64`, rc.13 | step 6 **no longer skips** — it selects and exec's `unpack/…-aarch64-apple-darwin/…/xerj`, which on a Linux host cannot run (`Exec format error`) → `FAIL --version`, `FAIL server never answered`, `2 check(s) failed` | 1 |
| `--no-smoke`, rc.13 | `SKIP --no-smoke — no binary was executed`; `PASS … NO binary was executed (--no-smoke), so nothing here says it runs` | 0 |
| `uname` shim `FreeBSD`/`amd64`, rc.13 | `SKIP this script does not boot a release binary on FreeBSD/amd64 …`; `FAIL … nothing was executed — no binary ran on this host and nobody asked for that` | 1 |
| PATH mirrored without `unzip`, rc.13 | 2× `SKIP … contents NOT checked`, 2× `SKIP … version NOT checked`, `FAIL … 2 of 8 target(s) NOT verified` | 1 |
| both `windows-msvc` archives removed from the asset set | 2× `FAIL … NO archive published for this target`, `FAIL … 2 check(s) failed` | 1 |
| `v1.0.0-rc.10` (the known-bad release) | 8× `tag says 1.0.0-rc.10, binary says: 1.0.0-rc.9` + `FAIL --version -> 'xerj v1.0.0-rc.9'`, `9 check(s) failed` | 1 |
| checksum-clean `.tar.gz` that will not extract | `FAIL … did not extract`, verdict `1 check(s) failed` | 1 |
| checksum-clean `.zip` that will not extract | `FAIL … did not extract`, verdict `1 check(s) failed` | 1 |
| **`v1.0.0-rc.14` — the release that is *currently* latest** | 8/8 on every step + live search, `PASS v1.0.0-rc.14: checksums and versions verified on 8/8 targets, plus a live search` | 0 |

The last row is the check #197 asked to be repeatable, run against the release that shipped while this PR was open: **no defect found in the rc.14 release artifacts either.**

Also re-confirmed at head: `EXPECTED_TARGETS` still matches `release.yml`'s matrix 8-for-8; `bash -n` clean; `cargo fmt --all -- --check` clean.

### Known gaps, stated plainly

- **The Apple Silicon path is proven only up to selecting and exec'ing the right binary.** No macOS hardware was available; the measurement used a `uname` shim on a Linux host, where the Mach-O then fails with `Exec format error`. That is the shim's limit, not the script's — what it proves is that step 6 now resolves `…-aarch64-apple-darwin/xerj` and runs it instead of skipping. The boot/index/search half of step 6 on a real Mac is unverified by this PR.
- **The Windows `.exe` is never booted.** Windows archives are checksum- and version-checked like every other target; on a Windows host the script says so and exits 1 unless `--no-smoke` is passed. Booting the `.exe` from MSYS/Git-Bash is not attempted (path translation into the config file is its own problem), so a Windows-host smoke remains a gap.
- **`EXPECTED_TARGETS` is a hand-maintained constant.** It is asserted, not discovered — that is the point — but nothing mechanically ties it to `release.yml`'s matrix. It matched 8-for-8 when written; a future matrix change has to update both.
- **Not wired into CI.** This is a command a human or agent runs after a release, not a gate that runs itself. See Scope.
- **`--no-smoke` is still a real reduction in scope, and it exits 0.** It is the only narrowing that does, it is opt-in, and the verdict text says in full that no binary ran — but an operator who habitually passes it gets exactly the rc.10 blind spot back. There is no guard against that beyond the wording.
- **The first commit's message quotes an older verdict string.** `e1011255`'s body says `PASS v1.0.0-rc.13: checksums, versions and a live search all verified`; the wording the code actually prints at head is `checksums and versions verified on 8/8 targets, plus a live search`. Superseded by the two repair commits — recorded here so the history log is not read as a claim about current behaviour.

## Scope

No engine code touched. `cargo fmt --all -- --check` clean; no Rust crate changed, so there is no clippy/test surface in this diff. `.github/workflows/` deliberately untouched — wiring this into the release workflow as a post-publish gate is a judgement call for the owner, and it is the obvious follow-up.

## Separate finding, NOT fixed here

While checking version drift across shipped surfaces I found the same class of drift in the Helm chart, verified live:

- `deploy/helm/xerj/Chart.yaml` still pins `version: 1.0.0-rc.1` and `appVersion: "1.0.0-rc.1"`, 13 releases stale as of rc.14 — and `values.yaml` defaults the image tag to `.Chart.AppVersion`, so a default `helm install` asks for tag `1.0.0-rc.1`.
- `image.repository: xerj/xerj` returns **404 on Docker Hub** (`hub.docker.com/v2/repositories/xerj/xerj/` → 404). A `Dockerfile` does exist — `engine/Dockerfile`, tracked on `main` since `cbd19714` alongside `engine/docker-compose.yml`, and its header documents building `xerj/xerj`, the very repository `values.yaml:5` points at. What is missing is the **publishing** half: no workflow in `.github/workflows/` references `docker/build-push-action`, `docker buildx`, `ghcr.io` or `docker push`, so no tag of that image is ever pushed and the chart cannot pull one.
- `home:` and `sources:` point at `github.com/xerj-ai/xerj`, which **404s** (the repo is `xerj-org/xerj`).

rc.13's release notes advertise a Helm fix (`3e2a0a14`, "helm secure default"), so this is a surface we ship and claim. A default install fails with `ImagePullBackOff` — accepted-and-ignored input, the #204 class. Left out of this PR on purpose: it needs a product decision (publish the image the Dockerfile already describes, or mark the chart unsupported), not a silent edit.


