### PR TITLE
fix(autoindex): refuse reruns that would strand documents (supersedes #156)

### DIFF
--- a/.github/scripts/usecase-smoke.sh
+++ b/.github/scripts/usecase-smoke.sh
@@ -170,6 +170,74 @@ else
   bad "expected >=3 hits for 'zanzibarite' across the discovered datasets, got ${HITS:-0}"
 fi
 
+# ── 4. autoindex: a removed file is refused, and the refusal is reversible ─
+phase "4. autoindex rerun over a mutated folder"
+# Nothing above reruns autoindex over a folder that CHANGED, which is where the
+# silent-skip bug lived: a rerun used to exit 0 while the removed file's
+# documents stayed live with no source behind them. The refusal has unit and
+# in-process HTTP tests; this is the end-to-end gate — and it also proves the
+# cheapest recovery the message names (put the file back) actually works.
+AX_STATE="$AX_WORK/state"
+ax_run() { "$XERJ_BIN" autoindex "$CORPUS" --url "$AX_URL" --state-dir "$AX_STATE" \
+             --prefix ax-eval --brain eval "$@" 2>&1; }
+
+mv "$CORPUS/logs/app.log" "$AX_WORK/app.log.away"
+REMOVED="$(ax_run)"; REMOVED_RC=$?
+if [ "$REMOVED_RC" != 0 ] \
+   && grep -q "no longer exist in the folder" <<<"$REMOVED" \
+   && grep -q "app.log" <<<"$REMOVED"; then
+  ok "a rerun after a removal refuses (exit $REMOVED_RC) and names the removed file"
+else
+  bad "expected a nonzero refusal naming logs/app.log, got exit $REMOVED_RC"
+  echo "$REMOVED" | tail -20
+fi
+
+mv "$AX_WORK/app.log.away" "$CORPUS/logs/app.log"
+RESTORED="$(ax_run)"; RESTORED_RC=$?
+if [ "$RESTORED_RC" = 0 ] || [ "$RESTORED_RC" = 3 ]; then
+  ok "restoring the file — recovery (1) in the refusal — lets the rerun through again"
+else
+  bad "expected the restored folder to rerun cleanly, got exit $RESTORED_RC"
+  echo "$RESTORED" | tail -20
+fi
+
+# ── 5. brain: a wiped data dir refuses, and the --fresh it names recovers ──
+phase "5. brain resume safety (journal survives a wiped data dir)"
+# The resume journal lives outside the server's data directory (default
+# ~/.xerj/autoindex/<hash>), so wiping the data dir leaves a journal claiming
+# the vault is fully indexed while the server holds none of it. `xerj brain`
+# used to resolve that ambiguity by resetting on the operator's behalf; it must
+# now refuse, and the in-place rebuild it names has to actually work.
+BRAIN_DATA="$BRAIN_ROOT/data"
+BRAIN_URL="http://localhost:$BRAIN_PORT"
+brain_run() { "$XERJ_BIN" brain "$BRAIN_ROOT/vault" --brain vault --url "$BRAIN_URL" \
+                --data-dir "$BRAIN_DATA" --no-open "$@" 2>&1; }
+
+[ -s "$BRAIN_DATA/server.pid" ] && kill "$(cat "$BRAIN_DATA/server.pid")" 2>/dev/null
+for _ in $(seq 1 60); do
+  curl -s -o /dev/null -m 5 "$BRAIN_URL/health/ready" || break
+  sleep 1
+done
+rm -rf "$BRAIN_DATA"
+
+REFUSAL="$(brain_run)"; REFUSAL_RC=$?
+if [ "$REFUSAL_RC" != 0 ] \
+   && grep -q "resume journal and server disagree" <<<"$REFUSAL" \
+   && grep -q -- "--fresh" <<<"$REFUSAL"; then
+  ok "a journal/server disagreement refuses (exit $REFUSAL_RC) and names a recovery"
+else
+  bad "expected a nonzero refusal naming the disagreement, got exit $REFUSAL_RC"
+  echo "$REFUSAL" | tail -20
+fi
+
+RECOVERY="$(brain_run --fresh)"; RECOVERY_RC=$?
+if [ "$RECOVERY_RC" = 0 ] || [ "$RECOVERY_RC" = 3 ]; then
+  ok "the --fresh rebuild the refusal names recovers the brain (exit $RECOVERY_RC)"
+else
+  bad "the --fresh recovery named by the refusal failed with exit $RECOVERY_RC"
+  echo "$RECOVERY" | tail -20
+fi
+
 # ── summary ───────────────────────────────────────────────────────────────
 echo
 if [ "$FAILED" = 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,7 +555,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   URL, prefix, and brain identity plus recovery instructions, including the
   explicit `--fresh` rerun for a genuinely wiped data directory. Probe
   transport and malformed-response failures remain errors instead of being
-  reported as an empty destination.
+  reported as an empty destination. A nodes index that was deleted out from
+  under a surviving brain meta doc reads as absence and reaches that recovery
+  text, rather than surfacing as a raw HTTP 404.
+- **`--fresh` still recovers a state directory whose journal cannot be
+  parsed.** The rerun gate reads the durable plan before the run starts, and a
+  plan that is malformed, or recorded for a different root/URL/prefix, is fatal
+  to a resume — but not to `--fresh`, which deletes that journal unread. The
+  preflight is now no more fatal than the open it precedes: under `--fresh` the
+  unreadable plan is reported on stderr and rebuilt from the current folder.
+  Without `--fresh` the refusal is unchanged. Because the removal gate has no
+  comparison basis in that case, the warning says so: documents already
+  published for files that are now gone cannot be identified from an unreadable
+  plan and are not deleted.
+- **Refusal and skip listings are capped at ten entries plus an "and N more"
+  tail.** Unmounting a bind mount under an indexed root vanishes every content
+  group at once, so the uncapped listing was one rendered entry per journalled
+  file. `--json` still carries every entry.
 
 ## [1.0.0-rc.10] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pdf_extraction_reuse` block so the behaviour is observable rather than
   inferred from timing. Original work by Leonid Bugaev (@buger).
 
+### Changed — autoindex refuses reruns that would strand documents
+
+- **Deleting an indexed file and rerunning `xerj autoindex` now fails instead
+  of exiting 0.** Nothing in the pipeline removes the documents, aliases,
+  graph edges or catalog entries that the deleted file published, so a rerun
+  that ignored the deletion left them live and searchable with no source file
+  behind them. The rerun is now refused before any remote call other than the
+  endpoint-readiness ping: no mapping, delete-by-query, bulk, refresh, graph
+  or catalog write is attempted, and the journal is not appended to. The error
+  names the removed files and their content keys — the first ten, then an
+  `… and N more` tail, since a whole unmounted subtree can vanish at once —
+  and gives three recovery routes: restore the files and rerun, rebuild in
+  place by deleting the named indices and the state directory, or rebuild
+  under a new state directory, prefix and brain. `--fresh` is refused for the
+  same case, because it does not delete those documents either. `--json` emits
+  the same facts — every removed entry, uncapped — as
+  `xerj.autoindex.unsupported_sync_delta.v1` on stdout with exit 1. Deleting a
+  file that was only ever *skipped* is not refused: a junk file publishes no
+  documents, and the stale junk-catalog sweep removes its one catalog row, so
+  nothing is stranded.
+- **Files added after a plan was frozen are now called out on stderr.** They
+  are still not indexed by a rerun that resumes an existing plan — the plan is
+  a crash-resume boundary, not a folder-sync generation — but the run now
+  lists them, records them as skipped (exit 3, completed-with-junk) and points
+  at `--fresh`, which rebuilds the plan in place and picks them up. Adding or
+  changing files and rerunning keeps working; only removals are refused.
+- **`xerj brain` no longer turns an absent or zero node-count probe into an
+  automatic reset.** Journal/server disagreement now fails with the journal,
+  URL, prefix, and brain identity plus recovery instructions, including the
+  explicit `--fresh` rerun for a genuinely wiped data directory. Probe
+  transport and malformed-response failures remain errors instead of being
+  reported as an empty destination. A nodes index that was deleted out from
+  under a surviving brain meta doc reads as absence and reaches that recovery
+  text, rather than surfacing as a raw HTTP 404.
+- **`--fresh` still recovers a state directory whose journal cannot be
+  parsed.** The rerun gate reads the durable plan before the run starts, and a
+  plan that is malformed, or recorded for a different root/URL/prefix, is fatal
+  to a resume — but not to `--fresh`, which deletes that journal unread. The
+  preflight is now no more fatal than the open it precedes: under `--fresh` the
+  unreadable plan is reported on stderr and rebuilt from the current folder.
+  Without `--fresh` the refusal is unchanged. Because the removal gate has no
+  comparison basis in that case, the warning says so: documents already
+  published for files that are now gone cannot be identified from an unreadable
+  plan and are not deleted.
+- **Refusal and skip listings are capped at ten entries plus an "and N more"
+  tail.** Unmounting a bind mount under an indexed root vanishes every content
+  group at once, so the uncapped listing was one rendered entry per journalled
+  file. `--json` still carries every entry.
+
+
 ## [1.0.0-rc.14] - 2026-08-10
 
 ### Changed
@@ -529,53 +579,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/v1/embedding/identity` reports `lexical` — the backend the server will
   really use — rather than `proxy`.
 
-### Changed — autoindex refuses reruns that would strand documents
-
-- **Deleting an indexed file and rerunning `xerj autoindex` now fails instead
-  of exiting 0.** Nothing in the pipeline removes the documents, aliases,
-  graph edges or catalog entries that the deleted file published, so a rerun
-  that ignored the deletion left them live and searchable with no source file
-  behind them. The rerun is now refused before any remote call other than the
-  endpoint-readiness ping: no mapping, delete-by-query, bulk, refresh, graph
-  or catalog write is attempted, and the journal is not appended to. The error
-  names every removed file and its content key and gives three recovery
-  routes — restore the files and rerun, rebuild in place by deleting the named
-  indices and the state directory, or rebuild under a new state directory,
-  prefix and brain. `--fresh` is refused for the same case, because it does
-  not delete those documents either. `--json` emits the same facts as
-  `xerj.autoindex.unsupported_sync_delta.v1` on stdout with exit 1. Deleting a
-  file that was only ever *skipped* is not refused: a junk file publishes no
-  documents, and the stale junk-catalog sweep removes its one catalog row, so
-  nothing is stranded.
-- **Files added after a plan was frozen are now called out on stderr.** They
-  are still not indexed by a rerun that resumes an existing plan — the plan is
-  a crash-resume boundary, not a folder-sync generation — but the run now
-  lists them, records them as skipped (exit 3, completed-with-junk) and points
-  at `--fresh`, which rebuilds the plan in place and picks them up. Adding or
-  changing files and rerunning keeps working; only removals are refused.
-- **`xerj brain` no longer turns an absent or zero node-count probe into an
-  automatic reset.** Journal/server disagreement now fails with the journal,
-  URL, prefix, and brain identity plus recovery instructions, including the
-  explicit `--fresh` rerun for a genuinely wiped data directory. Probe
-  transport and malformed-response failures remain errors instead of being
-  reported as an empty destination. A nodes index that was deleted out from
-  under a surviving brain meta doc reads as absence and reaches that recovery
-  text, rather than surfacing as a raw HTTP 404.
-- **`--fresh` still recovers a state directory whose journal cannot be
-  parsed.** The rerun gate reads the durable plan before the run starts, and a
-  plan that is malformed, or recorded for a different root/URL/prefix, is fatal
-  to a resume — but not to `--fresh`, which deletes that journal unread. The
-  preflight is now no more fatal than the open it precedes: under `--fresh` the
-  unreadable plan is reported on stderr and rebuilt from the current folder.
-  Without `--fresh` the refusal is unchanged. Because the removal gate has no
-  comparison basis in that case, the warning says so: documents already
-  published for files that are now gone cannot be identified from an unreadable
-  plan and are not deleted.
-- **Refusal and skip listings are capped at ten entries plus an "and N more"
-  tail.** Unmounting a bind mount under an indexed root vanishes every content
-  group at once, so the uncapped listing was one rendered entry per journalled
-  file. `--json` still carries every entry.
-
 ## [1.0.0-rc.10] - 2026-08-03
 
 ### Security
@@ -651,6 +654,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reaching the HNSW graph. Each arrived with a standalone harness and honest
   caveats. They are tracked for the following release rather than rushed into
   this one.
+
 
 ### Changed — runtime-field types (can break existing mappings)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,6 +529,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/v1/embedding/identity` reports `lexical` — the backend the server will
   really use — rather than `proxy`.
 
+### Changed — fail-closed autoindex restart semantics
+
+- **`autoindex --fresh` no longer discards a durable resume plan.** A durable
+  plan contains the alias, path, graph, and stale-record knowledge needed for
+  safe reconciliation. `--fresh` is accepted only when the selected state
+  directory has no durable plan and never cleans the destination. An
+  independent rebuild must use a new state directory, new prefix, and new brain
+  namespace when graph detection is enabled (or disable graph writes), be
+  validated, and only then replace the old reader target. The shared catalog
+  and old target require explicit, validated cleanup. Membership additions and
+  removals are refused; same-path replacement remains supported.
+- **`xerj brain` no longer turns an absent or zero node-count probe into an
+  automatic reset.** Journal/server disagreement now fails with the journal,
+  URL, prefix, and brain identity plus recovery instructions. Probe transport
+  and malformed-response failures remain errors instead of being reported as
+  an empty destination.
+
 ## [1.0.0-rc.10] - 2026-08-03
 
 ### Security
@@ -604,7 +621,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reaching the HNSW graph. Each arrived with a standalone harness and honest
   caveats. They are tracked for the following release rather than rushed into
   this one.
-
 
 ### Changed — runtime-field types (can break existing mappings)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,22 +529,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/v1/embedding/identity` reports `lexical` — the backend the server will
   really use — rather than `proxy`.
 
-### Changed — fail-closed autoindex restart semantics
+### Changed — autoindex refuses reruns that would strand documents
 
-- **`autoindex --fresh` no longer discards a durable resume plan.** A durable
-  plan contains the alias, path, graph, and stale-record knowledge needed for
-  safe reconciliation. `--fresh` is accepted only when the selected state
-  directory has no durable plan and never cleans the destination. An
-  independent rebuild must use a new state directory, new prefix, and new brain
-  namespace when graph detection is enabled (or disable graph writes), be
-  validated, and only then replace the old reader target. The shared catalog
-  and old target require explicit, validated cleanup. Membership additions and
-  removals are refused; same-path replacement remains supported.
+- **Deleting an indexed file and rerunning `xerj autoindex` now fails instead
+  of exiting 0.** Nothing in the pipeline removes the documents, aliases,
+  graph edges or catalog entries that the deleted file published, so a rerun
+  that ignored the deletion left them live and searchable with no source file
+  behind them. The rerun is now refused before any remote call other than the
+  endpoint-readiness ping: no mapping, delete-by-query, bulk, refresh, graph
+  or catalog write is attempted, and the journal is not appended to. The error
+  names every removed file and its content key and gives three recovery
+  routes — restore the files and rerun, rebuild in place by deleting the named
+  indices and the state directory, or rebuild under a new state directory,
+  prefix and brain. `--fresh` is refused for the same case, because it does
+  not delete those documents either. `--json` emits the same facts as
+  `xerj.autoindex.unsupported_sync_delta.v1` on stdout with exit 1.
+- **Files added after a plan was frozen are now called out on stderr.** They
+  are still not indexed by a rerun that resumes an existing plan — the plan is
+  a crash-resume boundary, not a folder-sync generation — but the run now
+  lists them, records them as skipped (exit 3, completed-with-junk) and points
+  at `--fresh`, which rebuilds the plan in place and picks them up. Adding or
+  changing files and rerunning keeps working; only removals are refused.
 - **`xerj brain` no longer turns an absent or zero node-count probe into an
   automatic reset.** Journal/server disagreement now fails with the journal,
-  URL, prefix, and brain identity plus recovery instructions. Probe transport
-  and malformed-response failures remain errors instead of being reported as
-  an empty destination.
+  URL, prefix, and brain identity plus recovery instructions, including the
+  explicit `--fresh` rerun for a genuinely wiped data directory. Probe
+  transport and malformed-response failures remain errors instead of being
+  reported as an empty destination.
 
 ## [1.0.0-rc.10] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,7 +543,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indices and the state directory, or rebuild under a new state directory,
   prefix and brain. `--fresh` is refused for the same case, because it does
   not delete those documents either. `--json` emits the same facts as
-  `xerj.autoindex.unsupported_sync_delta.v1` on stdout with exit 1.
+  `xerj.autoindex.unsupported_sync_delta.v1` on stdout with exit 1. Deleting a
+  file that was only ever *skipped* is not refused: a junk file publishes no
+  documents, and the stale junk-catalog sweep removes its one catalog row, so
+  nothing is stranded.
 - **Files added after a plan was frozen are now called out on stderr.** They
   are still not indexed by a rerun that resumes an existing plan — the plan is
   a crash-resume boundary, not a folder-sync generation — but the run now

--- a/demo/usecases/autoindex/RECIPE_DRAFT.md
+++ b/demo/usecases/autoindex/RECIPE_DRAFT.md
@@ -203,13 +203,11 @@ done in 0.1s — 3 datasets, 5801 records live, 0 junk records, 1 junk/skipped f
 just polite re-runs: in the robustness evaluation, a `kill -9` at 18 s into a
 200 MB file followed by a re-run converged to **byte-identical counts across
 all 9 datasets** — no duplicates. `xerj autoindex status` shows the journal
-and live index counts. `--fresh` starts without resume state only when the
-selected state directory has no durable plan; it never removes stale
-destination records. For an independent rebuild, use a new `--state-dir`, new
-`--prefix`, and new `--brain` when graph detection is enabled (or add
-`--no-graph`). Validate before switching readers. The shared
-`autoindex-catalog` and old target require explicit, validated cleanup. Added
-or removed content groups are refused; same-path replacement remains supported.
+and live index counts; `--fresh` ignores the journal and rebuilds the plan in
+place (ids stay idempotent), which is how a rerun picks up files added since
+the last one. Deleting an indexed file is refused before any destination
+change — nothing here removes the documents it already published — and the
+error names what is gone plus the recovery routes.
 
 ## Reproduce it yourself
 

--- a/demo/usecases/autoindex/RECIPE_DRAFT.md
+++ b/demo/usecases/autoindex/RECIPE_DRAFT.md
@@ -203,8 +203,13 @@ done in 0.1s — 3 datasets, 5801 records live, 0 junk records, 1 junk/skipped f
 just polite re-runs: in the robustness evaluation, a `kill -9` at 18 s into a
 200 MB file followed by a re-run converged to **byte-identical counts across
 all 9 datasets** — no duplicates. `xerj autoindex status` shows the journal
-and live index counts; `--fresh` ignores the journal and restarts (ids stay
-idempotent).
+and live index counts. `--fresh` starts without resume state only when the
+selected state directory has no durable plan; it never removes stale
+destination records. For an independent rebuild, use a new `--state-dir`, new
+`--prefix`, and new `--brain` when graph detection is enabled (or add
+`--no-graph`). Validate before switching readers. The shared
+`autoindex-catalog` and old target require explicit, validated cleanup. Added
+or removed content groups are refused; same-path replacement remains supported.
 
 ## Reproduce it yourself
 

--- a/demo/usecases/autoindex/run-eval.sh
+++ b/demo/usecases/autoindex/run-eval.sh
@@ -2,9 +2,11 @@
 # End-to-end eval of `xerj autoindex` against a corpus folder.
 #
 # Boots a dedicated server on es_compat $PORT (rest PORT+100, grpc PORT+101),
-# runs autoindex over $CORPUS, proves same-state resume, then performs an
-# isolated data/graph rebuild under a new state directory, prefix, and brain.
-# The global autoindex-catalog remains shared and is excluded from comparison.
+# runs autoindex over $CORPUS, then re-runs twice to prove idempotency — the
+# resume path (all files done) and a full --fresh re-extract — and requires the
+# per-index doc counts to be byte-identical to run 1. Ends with the data map.
+# The shared autoindex-catalog is excluded from the comparison: every run
+# appends its own run record, so a growing catalog is the design, not drift.
 #
 # Nothing here is bound to one machine: every path is an env override with a
 # default under the repo or $TMPDIR, so the same script gates CI and drives a
@@ -33,20 +35,11 @@ CFG="$WORK/server-$PORT.toml"
 LOG="$WORK/server-$PORT.log"
 URL="http://localhost:$PORT"
 STATE="$WORK/state"
-REBUILD_STATE="$WORK/rebuild-state"
-PREFIX="ax-eval-a"
-REBUILD_PREFIX="ax-eval-b"
-BRAIN="eval-a"
-REBUILD_BRAIN="eval-b"
+PREFIX="ax-eval"
+BRAIN="eval"
 
 [ -x "$BIN" ] || { echo "xerj binary not found at $BIN"; exit 1; }
 [ -d "$CORPUS" ] || { echo "corpus folder not found at $CORPUS"; exit 1; }
-[ ! -e "$DATA" ] && [ ! -e "$STATE" ] && [ ! -e "$REBUILD_STATE" ] || {
-  echo "work directory already contains eval state: $WORK"
-  echo "choose a new XERJ_AUTOINDEX_WORK or explicitly remove the old isolated eval directory"
-  exit 1
-}
-
 mkdir -p "$WORK"
 cat >"$CFG" <<EOF
 [server]
@@ -85,10 +78,10 @@ if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
   FAIL=1
 fi
 
-# Name + doc count only. The _cat row also carries on-disk size, which an
-# isolated data/graph rebuild legitimately changes (segments are rewritten).
-# The shared global catalog is excluded because every run appends its own run
-# record — a growing catalog is the design, not drift. Columns of the _cat row:
+# Name + doc count only. The _cat row also carries on-disk size, which a
+# --fresh re-extract legitimately changes (segments are rewritten), and the
+# catalog is excluded outright because every run appends its own run record —
+# a growing catalog is the design, not drift. Columns of the _cat row:
 # green(1) open(2) name(3) uuid(4) pri(5) rep(6) docs(7).
 counts() { curl -s "$URL/_cat/indices" | awk -v prefix="$1-" '$3 ~ ("^" prefix) {sub("^" prefix, "", $3); print $3, $7}' | sort; }
 
@@ -104,16 +97,16 @@ if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
   FAIL=1
 fi
 
-echo "=== isolated data/graph rebuild reproducibility (new state, prefix, and brain; shared catalog excluded) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$REBUILD_STATE" --prefix "$REBUILD_PREFIX" --brain "$REBUILD_BRAIN"
+echo "=== idempotency: re-run with --fresh (full re-extract, idempotent ids) ==="
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --prefix "$PREFIX" --brain "$BRAIN" --fresh
 RC=$?
 if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
-  echo "isolated data/graph rebuild exited $RC (expected 0 or 3)"
+  echo "--fresh re-extract exited $RC (expected 0 or 3)"
   FAIL=1
 fi
 
-counts "$REBUILD_PREFIX" > "$WORK/counts-run3.txt"
-echo "=== normalized data-index count diff original vs isolated data/graph rebuild (shared catalog excluded; must be empty) ==="
+counts "$PREFIX" > "$WORK/counts-run3.txt"
+echo "=== doc-count diff run1 vs run3 (must be empty) ==="
 cat "$WORK/counts-run3.txt"
 if diff "$WORK/counts-run1.txt" "$WORK/counts-run3.txt"; then
   echo "IDENTICAL COUNTS ✓"

--- a/demo/usecases/autoindex/run-eval.sh
+++ b/demo/usecases/autoindex/run-eval.sh
@@ -2,9 +2,9 @@
 # End-to-end eval of `xerj autoindex` against a corpus folder.
 #
 # Boots a dedicated server on es_compat $PORT (rest PORT+100, grpc PORT+101),
-# runs autoindex over $CORPUS, then re-runs twice to prove idempotency — the
-# resume path (all files done) and a full --fresh re-extract — and requires the
-# per-index doc counts to be byte-identical to run 1. Ends with the data map.
+# runs autoindex over $CORPUS, proves same-state resume, then performs an
+# isolated data/graph rebuild under a new state directory, prefix, and brain.
+# The global autoindex-catalog remains shared and is excluded from comparison.
 #
 # Nothing here is bound to one machine: every path is an env override with a
 # default under the repo or $TMPDIR, so the same script gates CI and drives a
@@ -33,9 +33,19 @@ CFG="$WORK/server-$PORT.toml"
 LOG="$WORK/server-$PORT.log"
 URL="http://localhost:$PORT"
 STATE="$WORK/state"
+REBUILD_STATE="$WORK/rebuild-state"
+PREFIX="ax-eval-a"
+REBUILD_PREFIX="ax-eval-b"
+BRAIN="eval-a"
+REBUILD_BRAIN="eval-b"
 
 [ -x "$BIN" ] || { echo "xerj binary not found at $BIN"; exit 1; }
 [ -d "$CORPUS" ] || { echo "corpus folder not found at $CORPUS"; exit 1; }
+[ ! -e "$DATA" ] && [ ! -e "$STATE" ] && [ ! -e "$REBUILD_STATE" ] || {
+  echo "work directory already contains eval state: $WORK"
+  echo "choose a new XERJ_AUTOINDEX_WORK or explicitly remove the old isolated eval directory"
+  exit 1
+}
 
 mkdir -p "$WORK"
 cat >"$CFG" <<EOF
@@ -66,7 +76,7 @@ curl -sf "$URL/" >/dev/null || { echo "server failed to boot"; tail -20 "$LOG"; 
 FAIL=0
 
 echo "=== autoindex run ($CORPUS) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --fresh
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --prefix "$PREFIX" --brain "$BRAIN"
 RC=$?
 echo "exit code: $RC"
 # 0 complete, 3 completed-with-junk (unreadable files recorded, never fatal).
@@ -75,25 +85,35 @@ if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
   FAIL=1
 fi
 
-# Name + doc count only. The _cat row also carries on-disk size, which a
-# --fresh re-extract legitimately changes (segments are rewritten), and the
-# catalog is excluded outright because every run appends its own run record —
-# a growing catalog is the design, not drift. Columns of the _cat row:
+# Name + doc count only. The _cat row also carries on-disk size, which an
+# isolated data/graph rebuild legitimately changes (segments are rewritten).
+# The shared global catalog is excluded because every run appends its own run
+# record — a growing catalog is the design, not drift. Columns of the _cat row:
 # green(1) open(2) name(3) uuid(4) pri(5) rep(6) docs(7).
-counts() { curl -s "$URL/_cat/indices" | awk '$3 ~ /^ax-/ {print $3, $7}' | sort; }
+counts() { curl -s "$URL/_cat/indices" | awk -v prefix="$1-" '$3 ~ ("^" prefix) {sub("^" prefix, "", $3); print $3, $7}' | sort; }
 
 echo "=== per-index counts (run 1) ==="
 curl -s "$URL/_cat/indices" | grep -E 'ax-|autoindex-catalog' | sort
-counts > "$WORK/counts-run1.txt"
+counts "$PREFIX" > "$WORK/counts-run1.txt"
 
 echo "=== idempotency: re-run (resume path — all files done) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE"
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --prefix "$PREFIX" --brain "$BRAIN"
+RC=$?
+if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
+  echo "resume run exited $RC (expected 0 or 3)"
+  FAIL=1
+fi
 
-echo "=== idempotency: re-run with --fresh (full re-extract, idempotent ids) ==="
-time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$STATE" --fresh
+echo "=== isolated data/graph rebuild reproducibility (new state, prefix, and brain; shared catalog excluded) ==="
+time "$BIN" autoindex "$CORPUS" --url "$URL" --state-dir "$REBUILD_STATE" --prefix "$REBUILD_PREFIX" --brain "$REBUILD_BRAIN"
+RC=$?
+if [ "$RC" != "0" ] && [ "$RC" != "3" ]; then
+  echo "isolated data/graph rebuild exited $RC (expected 0 or 3)"
+  FAIL=1
+fi
 
-counts > "$WORK/counts-run3.txt"
-echo "=== doc-count diff run1 vs run3 (must be empty) ==="
+counts "$REBUILD_PREFIX" > "$WORK/counts-run3.txt"
+echo "=== normalized data-index count diff original vs isolated data/graph rebuild (shared catalog excluded; must be empty) ==="
 cat "$WORK/counts-run3.txt"
 if diff "$WORK/counts-run1.txt" "$WORK/counts-run3.txt"; then
   echo "IDENTICAL COUNTS ✓"

--- a/docs/EXPERIMENTAL_ONNX.md
+++ b/docs/EXPERIMENTAL_ONNX.md
@@ -88,7 +88,7 @@ In another terminal, index a corpus:
 target/release/xerj autoindex /path/to/corpus \
   --url http://localhost:9200 \
   --prefix finance-onnx \
-  --fresh
+  --state-dir /path/to/new-finance-onnx-state
 
 target/release/xerj autoindex map \
   --url http://localhost:9200 \
@@ -152,9 +152,11 @@ with the same assets. XERJ refuses:
 - enabling ONNX in place on a populated marker-less semantic index;
 - caller-supplied derived vectors whose identity cannot be verified.
 
-The error tells the operator to restore the original assets or re-run
-autoindex with `--fresh` and a new prefix. XERJ never silently mixes vector
-spaces.
+The error tells the operator to restore the original assets or perform an
+isolated autoindex rebuild with a new state directory, new prefix, and new
+brain when graph detection is enabled (or `--no-graph`). Validate the new
+target before switching readers; the shared catalog and old target require
+explicit, validated cleanup. XERJ never silently mixes vector spaces.
 
 The transformer-fused graph produced by the offline recipe is a different
 model identity from its source graph because its model hash differs. Do not

--- a/docs/design/second_brain_graph_wf.js
+++ b/docs/design/second_brain_graph_wf.js
@@ -99,9 +99,8 @@ heterogeneous content (code + PDFs + docs), and captured as a screencast.
   automaticPresenceSimulation:true})\`, then claim via the setup magic-link the server prints
   at first boot. A working reference script is ${REPO}/sb_capture.mjs.
 - \`xerj brain\` gotcha: a stale resume journal in \`~/.xerj/autoindex\` makes re-runs skip
-  detection. For an independent clean run, choose a new \`--state-dir\`, new
-  \`--prefix\`, and new \`--brain\` (or \`--no-graph\`); \`--fresh\` cannot
-  discard a durable plan or clean the shared catalog or old target.
+  detection. Use \`--fresh\` (or clear it) for clean runs; note that \`--fresh\` rebuilds
+  the plan in place and never removes documents for notes you deleted.
 - Commits authored \`xerj-org <git@xerj.org>\`, NO Claude co-author trailer, never mention
   ctrl-frk. Do NOT push. Commit on \`feat/second-brain\`.
 

--- a/docs/design/second_brain_graph_wf.js
+++ b/docs/design/second_brain_graph_wf.js
@@ -99,7 +99,9 @@ heterogeneous content (code + PDFs + docs), and captured as a screencast.
   automaticPresenceSimulation:true})\`, then claim via the setup magic-link the server prints
   at first boot. A working reference script is ${REPO}/sb_capture.mjs.
 - \`xerj brain\` gotcha: a stale resume journal in \`~/.xerj/autoindex\` makes re-runs skip
-  detection. Use \`--fresh\` (or clear it) for clean runs.
+  detection. For an independent clean run, choose a new \`--state-dir\`, new
+  \`--prefix\`, and new \`--brain\` (or \`--no-graph\`); \`--fresh\` cannot
+  discard a durable plan or clean the shared catalog or old target.
 - Commits authored \`xerj-org <git@xerj.org>\`, NO Claude co-author trailer, never mention
   ctrl-frk. Do NOT push. Commit on \`feat/second-brain\`.
 

--- a/docs/recipes/zero-config-indexing.md
+++ b/docs/recipes/zero-config-indexing.md
@@ -228,13 +228,17 @@ live indices at http://localhost:9280:
   autoindex-catalog                                 9 docs
 ```
 
-`--fresh` starts without resume state only when the selected state directory
-has no durable plan; it never removes stale destination records. For an
-independent rebuild, use a new `--state-dir`, new `--prefix`, and new
-`--brain` when graph detection is enabled (or add `--no-graph`). Validate
-before switching readers. The shared `autoindex-catalog` and old target require
-explicit, validated cleanup. Added or removed content groups are refused;
-same-path replacement remains supported.
+`--fresh` ignores the journal and rebuilds the plan in place (ids stay
+idempotent), which is how you pick up files added since the last run.
+
+A rerun that resumes an existing plan indexes changed files and reports added
+ones as skipped. Deleting a file is refused: nothing here removes the
+documents it already published, so the rerun stops before touching the
+destination and names what is gone. Restore the file and rerun, or rebuild —
+in place by deleting the named indices and the state directory, or isolated
+under a new `--state-dir`, `--prefix` and `--brain` (or `--no-graph`),
+validated before you switch readers. The shared `autoindex-catalog` and the
+old target require explicit cleanup.
 
 ## Reproduce it yourself
 

--- a/docs/recipes/zero-config-indexing.md
+++ b/docs/recipes/zero-config-indexing.md
@@ -228,7 +228,13 @@ live indices at http://localhost:9280:
   autoindex-catalog                                 9 docs
 ```
 
-`--fresh` ignores the journal and restarts (ids stay idempotent).
+`--fresh` starts without resume state only when the selected state directory
+has no durable plan; it never removes stale destination records. For an
+independent rebuild, use a new `--state-dir`, new `--prefix`, and new
+`--brain` when graph detection is enabled (or add `--no-graph`). Validate
+before switching readers. The shared `autoindex-catalog` and old target require
+explicit, validated cleanup. Added or removed content groups are refused;
+same-path replacement remains supported.
 
 ## Reproduce it yourself
 

--- a/docs/usecases/second-brain/README.md
+++ b/docs/usecases/second-brain/README.md
@@ -205,12 +205,13 @@ other note tools. No such numbers are claimed.
   root-caused.
 - **YAML-frontmatter markdown can sniff as YAML:** one `SKILL.md` with
   frontmatter landed in junk/skipped instead of being indexed.
-- **Stale resume journals can pollute links** after a wiped data dir;
-  `--fresh` cannot discard a durable plan and is not stale-journal recovery.
-  Restore the server data directory used by the journal. For an explicitly
-  isolated rebuild, use a new state directory, prefix, and brain namespace,
-  validate it, then switch readers. The shared `autoindex-catalog` and old
-  target require explicit, validated cleanup.
+- **Stale resume journals can pollute links** after a wiped data dir. `xerj
+  brain` no longer guesses: it reports the disagreement between the journal
+  and the server instead of resetting on its own. If the data directory really
+  was wiped, rerun with `--fresh` to rebuild the plan and republish every note
+  in place; if it was not, point at the data directory the journal was written
+  against, or rebuild under a new state directory, prefix and brain and
+  validate before switching readers.
 - **Wikilink detection was not exercised on this corpus** (real docs use
   markdown links); it is covered by the demo-corpus run (30 wikilinks) and
   the autoindex test suite.

--- a/docs/usecases/second-brain/README.md
+++ b/docs/usecases/second-brain/README.md
@@ -206,7 +206,11 @@ other note tools. No such numbers are claimed.
 - **YAML-frontmatter markdown can sniff as YAML:** one `SKILL.md` with
   frontmatter landed in junk/skipped instead of being indexed.
 - **Stale resume journals can pollute links** after a wiped data dir;
-  `--fresh` re-walks everything and is the mitigation.
+  `--fresh` cannot discard a durable plan and is not stale-journal recovery.
+  Restore the server data directory used by the journal. For an explicitly
+  isolated rebuild, use a new state directory, prefix, and brain namespace,
+  validate it, then switch readers. The shared `autoindex-catalog` and old
+  target require explicit, validated cleanup.
 - **Wikilink detection was not exercised on this corpus** (real docs use
   markdown links); it is covered by the demo-corpus run (30 wikilinks) and
   the autoindex test suite.

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -72,6 +72,10 @@ pub enum Cmd {
     Help,
 }
 
+const FRESH_HELP: &str =
+    "start without resume state only when the selected state directory has no \
+durable plan; an existing plan is refused and destination records are never reset";
+
 pub fn print_help() {
     println!(
         "xerj autoindex — point it at any folder and make the contents AI-searchable, zero config\n\
@@ -99,7 +103,7 @@ pub fn print_help() {
                                   valid range 1..=3600)\n\
              --prefix <P>         index prefix (default ax)\n\
              --state-dir <PATH>   resume journal location (default ~/.xerj/autoindex/<hash>/)\n\
-             --fresh              ignore existing journal, restart (ids stay idempotent)\n\
+             --fresh              {fresh_help}\n\
              --follow-symlinks    follow symlinks (loop-safe); off by default\n\
              --max-file-gb <N>    skip+record oversized non-streamable files (default 2)\n\
              --sample <N>         records sampled per file for inference (default 500)\n\
@@ -165,8 +169,17 @@ pub fn print_help() {
              `pct`/`eta_s` are the literal word `unknown` (JSON null) whenever they\n\
              cannot be computed honestly, never a filler number.\n\
          \n\
+         RESUME POLICY:\n\
+             A durable plan supports no-op resume and same-path content replacement.\n\
+             Added or removed content groups are refused before remote mutation.\n\
+             An independent rebuild needs a new --state-dir, new --prefix, and, when\n\
+             graph detection is enabled, new --brain (or --no-graph). Validate before\n\
+             switching readers; the shared autoindex-catalog and old target require\n\
+             explicit, validated cleanup.\n\
+         \n\
          EXIT CODES: 0 complete; 3 completed-with-junk (junk recorded, never fatal);\n\
-                     2 usage; 1 endpoint unreachable / journal-config mismatch\n"
+                     2 usage; 1 endpoint/journal failure or unsupported corpus delta\n",
+        fresh_help = FRESH_HELP
     );
 }
 
@@ -460,6 +473,13 @@ mod tests {
     #[test]
     fn bulk_timeout_defaults_to_300_seconds() {
         assert_eq!(index(&["data"]).bulk_timeout_secs, 300);
+    }
+
+    #[test]
+    fn fresh_help_warns_that_it_is_not_destination_reconciliation() {
+        assert!(super::FRESH_HELP.contains("no durable plan"));
+        assert!(super::FRESH_HELP.contains("existing plan is refused"));
+        assert!(super::FRESH_HELP.contains("destination records are never reset"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -72,9 +72,8 @@ pub enum Cmd {
     Help,
 }
 
-const FRESH_HELP: &str =
-    "start without resume state only when the selected state directory has no \
-durable plan; an existing plan is refused and destination records are never reset";
+const FRESH_HELP: &str = "ignore the existing journal and rebuild the plan in place\n\
+                                  (ids stay idempotent) — see RESUME POLICY";
 
 pub fn print_help() {
     println!(
@@ -171,14 +170,16 @@ pub fn print_help() {
          \n\
          RESUME POLICY:\n\
              A durable plan supports no-op resume and same-path content replacement.\n\
-             Added or removed content groups are refused before remote mutation.\n\
-             An independent rebuild needs a new --state-dir, new --prefix, and, when\n\
-             graph detection is enabled, new --brain (or --no-graph). Validate before\n\
-             switching readers; the shared autoindex-catalog and old target require\n\
-             explicit, validated cleanup.\n\
+             Files added after the plan was frozen are reported as skipped and are not\n\
+             indexed; --fresh rebuilds the plan in place and picks them up.\n\
+             Removing an indexed file is refused before any remote mutation: its\n\
+             documents are already live and nothing here deletes them. Restore the file\n\
+             and rerun, or rebuild — in place by deleting the published indices and the\n\
+             state directory, or isolated under a new --state-dir, --prefix and --brain\n\
+             (or --no-graph), validated before you switch readers.\n\
          \n\
          EXIT CODES: 0 complete; 3 completed-with-junk (junk recorded, never fatal);\n\
-                     2 usage; 1 endpoint/journal failure or unsupported corpus delta\n",
+                     2 usage; 1 endpoint/journal failure or a refused corpus removal\n",
         fresh_help = FRESH_HELP
     );
 }
@@ -476,10 +477,10 @@ mod tests {
     }
 
     #[test]
-    fn fresh_help_warns_that_it_is_not_destination_reconciliation() {
-        assert!(super::FRESH_HELP.contains("no durable plan"));
-        assert!(super::FRESH_HELP.contains("existing plan is refused"));
-        assert!(super::FRESH_HELP.contains("destination records are never reset"));
+    fn fresh_help_points_at_the_resume_policy_that_bounds_it() {
+        assert!(super::FRESH_HELP.contains("rebuild the plan in place"));
+        assert!(super::FRESH_HELP.contains("ids stay idempotent"));
+        assert!(super::FRESH_HELP.contains("RESUME POLICY"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/esclient.rs
+++ b/engine/crates/xerj-autoindex/src/esclient.rs
@@ -665,7 +665,7 @@ impl Es {
         )
     }
 
-    pub fn search(&self, index: &str, body: &Value) -> Result<Value> {
+    fn search_raw(&self, index: &str, body: &Value) -> Result<(reqwest::StatusCode, Value)> {
         self.with_retry(
             "search",
             || {
@@ -677,12 +677,36 @@ impl Es {
             |resp| {
                 let status = resp.status();
                 let v: Value = resp.json().unwrap_or(Value::Null);
-                if !status.is_success() {
-                    return Err(anyhow!("search /{index} HTTP {status}: {v}"));
-                }
-                Ok(v)
+                Ok((status, v))
             },
         )
+    }
+
+    pub fn search(&self, index: &str, body: &Value) -> Result<Value> {
+        let (status, v) = self.search_raw(index, body)?;
+        if !status.is_success() {
+            return Err(anyhow!("search /{index} HTTP {status}: {v}"));
+        }
+        Ok(v)
+    }
+
+    /// `search`, but a missing index is an answer rather than a failure.
+    ///
+    /// A probe whose whole job is to decide "does the server still hold what
+    /// the journal says it holds?" must be able to tell *the index is gone*
+    /// apart from *the server refused* — only the first has a recovery worth
+    /// printing, and propagating its 404 replaces that recovery text with a raw
+    /// HTTP error. Every other status keeps `search`'s behaviour, so this never
+    /// launders a real failure into an absence.
+    pub fn search_present(&self, index: &str, body: &Value) -> Result<Option<Value>> {
+        let (status, v) = self.search_raw(index, body)?;
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(anyhow!("search /{index} HTTP {status}: {v}"));
+        }
+        Ok(Some(v))
     }
 
     pub fn count(&self, index: &str) -> Result<u64> {
@@ -822,13 +846,70 @@ mod tests {
     }
 
     fn respond_json(stream: &mut std::net::TcpStream, body: &[u8]) {
+        respond_status(stream, "200 OK", body);
+    }
+
+    fn respond_status(stream: &mut std::net::TcpStream, status: &str, body: &[u8]) {
         write!(
             stream,
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
             body.len()
         )
         .unwrap();
         stream.write_all(body).unwrap();
+    }
+
+    /// A deleted index is an answer for the probes that ask whether the server
+    /// still holds what a journal claims it holds — `search` propagating that
+    /// 404 replaces `xerj brain`'s recovery text with a raw HTTP error. Every
+    /// other refusal must still propagate, so absence is never laundered out of
+    /// a real failure.
+    #[test]
+    fn search_present_reports_a_missing_index_as_absence_and_nothing_else() {
+        for (status, body, expect_absent) in [
+            (
+                "404 Not Found",
+                &br#"{"error":{"type":"index_not_found_exception"},"status":404}"#[..],
+                true,
+            ),
+            (
+                "403 Forbidden",
+                &br#"{"error":{"type":"security_exception"},"status":403}"#[..],
+                false,
+            ),
+            (
+                "200 OK",
+                &br#"{"hits":{"total":{"value":7,"relation":"eq"}}}"#[..],
+                false,
+            ),
+        ] {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let address = listener.local_addr().unwrap();
+            let owned = body.to_vec();
+            let status_line = status.to_owned();
+            let server = std::thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request = read_request(&mut stream);
+                assert!(
+                    String::from_utf8_lossy(&request).starts_with("POST /nodes/_search HTTP/1.1"),
+                    "{}",
+                    String::from_utf8_lossy(&request)
+                );
+                respond_status(&mut stream, &status_line, &owned);
+            });
+            let es = Es::new(&format!("http://{address}"), None).unwrap();
+            let result = es.search_present("nodes", &serde_json::json!({"size": 0}));
+            if expect_absent {
+                assert!(result.unwrap().is_none(), "{status}");
+            } else if status.starts_with("200") {
+                let value = result.unwrap().expect("a served index is present");
+                assert_eq!(value.pointer("/hits/total/value").unwrap(), 7);
+            } else {
+                let error = result.unwrap_err();
+                assert!(format!("{error:#}").contains("403"), "{error:#}");
+            }
+            server.join().unwrap();
+        }
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -69,6 +69,9 @@ struct MockState {
     /// what `_count`/`_search` answer with, and the run verifies live data
     /// counts against the journal (#195). Catalog rows are not data rows.
     catalog_docs: HashMap<String, Value>,
+    /// Every (method, path) the run issued. The refusal tests assert on the
+    /// ABSENCE of remote mutations, which no document count can express.
+    requests: Vec<(String, String)>,
     data_bulk_number: usize,
     fail_data_bulk: usize,
     failed_once: bool,
@@ -190,6 +193,11 @@ fn handle(mut stream: TcpStream, state: &Arc<Mutex<MockState>>) {
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("");
     let path = parts.next().unwrap_or("");
+    state
+        .lock()
+        .unwrap()
+        .requests
+        .push((method.to_owned(), path.to_owned()));
     let response_delay_ms = state.lock().unwrap().response_delay_ms;
     if response_delay_ms > 0 {
         thread::sleep(std::time::Duration::from_millis(response_delay_ms));
@@ -498,6 +506,230 @@ fn dataset_catalog_docs(endpoint: &MockEndpoint) -> Vec<Value> {
             .to_string()
     });
     docs
+}
+
+fn assert_unsupported_delta_without_remote_mutation(
+    endpoint: &MockEndpoint,
+    config: IndexCfg,
+    expected_added: &[&str],
+    expected_vanished: &[&str],
+) {
+    let request_start = endpoint.state.lock().unwrap().requests.len();
+    let journal_path = config.state_dir.as_ref().unwrap().join("journal.ndjson");
+    let journal_before = fs::read(&journal_path).unwrap();
+    let error = run_index(config).unwrap_err();
+    let attempted_requests = endpoint.state.lock().unwrap().requests[request_start..].to_vec();
+    assert_eq!(
+        attempted_requests,
+        [("GET".to_owned(), "/".to_owned())],
+        "a refused attempt may perform only the endpoint-readiness GET"
+    );
+    assert_eq!(
+        fs::read(journal_path).unwrap(),
+        journal_before,
+        "preflight refusal must not append a resume event or rewrite the journal"
+    );
+    let message = format!("{error:#}");
+    assert!(message.contains("made no remote mutations"), "{message}");
+    assert!(
+        message.contains("existing destination may already be partial or stale"),
+        "{message}"
+    );
+    assert!(
+        message.contains("`--fresh` is not recovery or destination reconciliation"),
+        "{message}"
+    );
+    assert!(
+        message.contains("new --state-dir, a new --prefix"),
+        "{message}"
+    );
+    assert!(message.contains("new --brain"), "{message}");
+    for path in expected_added {
+        assert!(
+            message.contains(path),
+            "missing added path {path}: {message}"
+        );
+    }
+    for path in expected_vanished {
+        assert!(
+            message.contains(path),
+            "missing vanished path {path}: {message}"
+        );
+    }
+}
+
+#[test]
+fn completed_plan_rejects_added_content_group_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["second.csv"], &[]);
+}
+
+#[test]
+fn completed_plan_rejects_vanished_content_group_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
+    fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("second.csv")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["second.csv"]);
+}
+
+#[test]
+fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("b-old.csv"), "id,value\n1,b\n").unwrap();
+    fs::write(corpus.path().join("a-old.csv"), "id,value\n2,a\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("b-old.csv")).unwrap();
+    fs::remove_file(corpus.path().join("a-old.csv")).unwrap();
+    fs::write(corpus.path().join("z-new.csv"), "id,value\n3,z\n").unwrap();
+    fs::write(corpus.path().join("m-new.csv"), "id,value\n4,m\n").unwrap();
+    config.json = true;
+    let request_start = endpoint.state.lock().unwrap().requests.len();
+    let error = run_index(config).unwrap_err();
+    assert_eq!(
+        endpoint.state.lock().unwrap().requests[request_start..],
+        [("GET".to_owned(), "/".to_owned())]
+    );
+
+    let typed = error
+        .downcast_ref::<UnsupportedInventoryDeltaError>()
+        .unwrap();
+    let value = typed.to_json();
+    assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
+    assert_eq!(value["status"], "error");
+    let added: Vec<&str> = value["added_content_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap())
+        .collect();
+    let vanished: Vec<&str> = value["vanished_content_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap())
+        .collect();
+    assert_eq!(added, ["m-new.csv", "z-new.csv"]);
+    assert_eq!(vanished, ["a-old.csv", "b-old.csv"]);
+}
+
+#[test]
+fn nonempty_fresh_cannot_erase_plan_and_bypass_membership_gate() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("old.csv"), "id,value\n1,old\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("old.csv")).unwrap();
+    fs::write(corpus.path().join("new.csv"), "id,value\n2,new\n").unwrap();
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["new.csv"], &["old.csv"]);
+}
+
+#[test]
+fn fresh_rejects_same_content_canonical_promotion_even_when_group_key_matches() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let bytes = "id,value\n1,same\n";
+    fs::write(corpus.path().join("a.csv"), bytes).unwrap();
+    fs::write(corpus.path().join("b.csv"), bytes).unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    // b.csv becomes canonical with the same content key. A key-only delta is
+    // empty, but fresh would discard the alias/path cleanup knowledge.
+    fs::remove_file(corpus.path().join("a.csv")).unwrap();
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &[]);
+}
+
+#[test]
+fn unchanged_planned_junk_is_not_reported_as_added_content() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
+    fs::write(
+        corpus.path().join("opaque.bin"),
+        [0_u8, 159, 146, 150, 0, 255],
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
+    let result = run_index(config);
+    assert!(
+        result.is_ok(),
+        "unchanged durable junk must not trip the membership gate: {result:?}"
+    );
+}
+
+#[test]
+fn deleted_planned_junk_fails_closed_before_catalog_can_stay_stale() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
+    fs::write(
+        corpus.path().join("opaque.bin"),
+        [0_u8, 159, 146, 150, 0, 255],
+    )
+    .unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
+
+    fs::remove_file(corpus.path().join("opaque.bin")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["opaque.bin"]);
+}
+
+#[test]
+fn completed_plan_rejects_empty_current_folder_before_remote_mutation() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("only.csv"), "id,value\n1,only\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::remove_file(corpus.path().join("only.csv")).unwrap();
+    // Even `--fresh` must not erase the only durable inventory evidence and
+    // then report success while the destination still contains the document.
+    config.fresh = true;
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["only.csv"]);
 }
 
 #[test]
@@ -1286,12 +1518,12 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     )
     .unwrap();
     fs::write(corpus.path().join("b.csv"), original).unwrap();
-    assert_eq!(run_index(config.clone()).unwrap(), 3);
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &["b.csv"], &[]);
     {
         let locked = endpoint.state.lock().unwrap();
         assert_eq!(locked.docs.len(), 2);
         assert!(locked.docs.values().all(|doc| {
-            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("rewritten")
+            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("original")
         }));
     }
     let replay = state::Journal::open(
@@ -1306,24 +1538,20 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     assert!(replay.pending_replacements.is_empty());
     assert_eq!(replay.done.len(), 1);
     let plan = replay.plan.clone().unwrap();
-    assert_eq!(plan.junk_files.len(), 1);
-    assert_eq!(plan.junk_files[0].rel, "b.csv");
-    assert!(plan.junk_files[0]
-        .reason
-        .contains("key ownership exclusive"));
+    assert!(plan.junk_files.is_empty());
     drop(replay);
 
-    // The divergence is durable and deterministic: an identical rerun keeps
-    // the same owner, appends no new plan, and changes no documents.
+    // The refusal is deterministic: an identical rerun keeps the old owner,
+    // appends no new plan, and changes no documents.
     let plans_before = event_count(state_dir.path(), "plan");
-    assert_eq!(run_index(config).unwrap(), 3);
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["b.csv"], &[]);
     assert_eq!(event_count(state_dir.path(), "plan"), plans_before);
     let locked = endpoint.state.lock().unwrap();
     assert_eq!(locked.docs.len(), 2);
     assert!(locked
         .docs
         .values()
-        .all(|doc| doc["value"].as_str() == Some("rewritten")));
+        .all(|doc| doc["value"].as_str() == Some("original")));
 }
 
 /// #238: a file added after the plan was frozen is skipped and reported in the
@@ -1442,7 +1670,12 @@ fn deleting_an_entire_duplicate_group_strands_no_pending_replacement() {
     fs::remove_file(corpus.path().join("dup-a.csv")).unwrap();
     fs::remove_file(corpus.path().join("dup-b.csv")).unwrap();
     for _ in 0..2 {
-        assert_eq!(run_index(config.clone()).unwrap(), 0);
+        assert_unsupported_delta_without_remote_mutation(
+            &endpoint,
+            config.clone(),
+            &[],
+            &["dup-a.csv"],
+        );
         assert_eq!(
             event_count(state_dir.path(), "file_replace_start"),
             starts,

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -532,11 +532,15 @@ fn assert_unsupported_delta_without_remote_mutation(
     let message = format!("{error:#}");
     assert!(message.contains("made no remote mutations"), "{message}");
     assert!(
-        message.contains("existing destination may already be partial or stale"),
+        message.contains("no longer exist in the folder"),
         "{message}"
     );
     assert!(
-        message.contains("`--fresh` is not recovery or destination reconciliation"),
+        message.contains("restore the removed file(s) and rerun"),
+        "{message}"
+    );
+    assert!(
+        message.contains("rebuild in place by deleting the indices"),
         "{message}"
     );
     assert!(
@@ -558,19 +562,52 @@ fn assert_unsupported_delta_without_remote_mutation(
     }
 }
 
+/// The documented headline workflow: point autoindex at a folder, add a file,
+/// rerun. The rerun must not fail, must say plainly that the added file was
+/// not indexed, and `--fresh` must then absorb it in place.
 #[test]
-fn completed_plan_rejects_added_content_group_before_remote_mutation() {
+fn a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
     let endpoint = MockEndpoint::start(usize::MAX);
-    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
     assert_eq!(run_index(config.clone()).unwrap(), 0);
 
     fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["second.csv"], &[]);
+    // 3 = completed-with-junk: the added file is reported as skipped, not
+    // indexed, because the frozen plan cannot absorb it.
+    let (code, report) = run_index_report(config.clone()).unwrap();
+    assert_eq!(code, 3);
+    let report = report.unwrap();
+    assert_eq!(report["files_junk"], 1, "{report}");
+    assert_eq!(report["records_total"], 0, "{report}");
+    {
+        let locked = endpoint.state.lock().unwrap();
+        let live: Vec<&str> = locked
+            .docs
+            .values()
+            .filter_map(|doc| doc["ax_path"].as_str())
+            .collect();
+        assert!(
+            live.iter().all(|path| *path == "first.csv"),
+            "the added file must not be published by a plan that predates it: {live:?}"
+        );
+    }
+
+    // --fresh rebuilds the plan in place and picks the new file up.
+    config.fresh = true;
+    assert_eq!(run_index(config).unwrap(), 0);
+    let locked = endpoint.state.lock().unwrap();
+    let indexed: std::collections::HashSet<&str> = locked
+        .docs
+        .values()
+        .filter_map(|doc| doc["ax_path"].as_str())
+        .collect();
+    assert!(indexed.contains("first.csv"), "{indexed:?}");
+    assert!(indexed.contains("second.csv"), "{indexed:?}");
 }
 
 #[test]
@@ -636,7 +673,7 @@ fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
 }
 
 #[test]
-fn nonempty_fresh_cannot_erase_plan_and_bypass_membership_gate() {
+fn fresh_cannot_erase_the_plan_and_bypass_the_removal_gate() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
@@ -653,7 +690,7 @@ fn nonempty_fresh_cannot_erase_plan_and_bypass_membership_gate() {
 }
 
 #[test]
-fn fresh_rejects_same_content_canonical_promotion_even_when_group_key_matches() {
+fn deleting_one_path_of_a_duplicate_pair_is_not_a_removed_content_group() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
@@ -662,14 +699,24 @@ fn fresh_rejects_same_content_canonical_promotion_even_when_group_key_matches() 
     fs::write(corpus.path().join("a.csv"), bytes).unwrap();
     fs::write(corpus.path().join("b.csv"), bytes).unwrap();
     let endpoint = MockEndpoint::start(usize::MAX);
-    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
     assert_eq!(run_index(config.clone()).unwrap(), 0);
 
-    // b.csv becomes canonical with the same content key. A key-only delta is
-    // empty, but fresh would discard the alias/path cleanup knowledge.
+    // b.csv becomes canonical under the same content key: the group survives
+    // the deletion, so no document is stranded and the rerun is allowed.
     fs::remove_file(corpus.path().join("a.csv")).unwrap();
-    config.fresh = true;
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &[]);
+    let result = run_index(config);
+    assert!(
+        result.is_ok(),
+        "a surviving content group must not trip the removal gate: {result:?}"
+    );
+    let locked = endpoint.state.lock().unwrap();
+    let live: Vec<&str> = locked
+        .docs
+        .values()
+        .filter_map(|doc| doc["ax_path"].as_str())
+        .collect();
+    assert_eq!(live, ["b.csv"], "canonical path follows the surviving file");
 }
 
 #[test]
@@ -726,6 +773,7 @@ fn completed_plan_rejects_empty_current_folder_before_remote_mutation() {
     assert_eq!(run_index(config.clone()).unwrap(), 0);
 
     fs::remove_file(corpus.path().join("only.csv")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &[], &["only.csv"]);
     // Even `--fresh` must not erase the only durable inventory evidence and
     // then report success while the destination still contains the document.
     config.fresh = true;
@@ -1518,12 +1566,12 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     )
     .unwrap();
     fs::write(corpus.path().join("b.csv"), original).unwrap();
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config.clone(), &["b.csv"], &[]);
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
     {
         let locked = endpoint.state.lock().unwrap();
         assert_eq!(locked.docs.len(), 2);
         assert!(locked.docs.values().all(|doc| {
-            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("original")
+            doc["ax_path"].as_str() == Some("a.csv") && doc["value"].as_str() == Some("rewritten")
         }));
     }
     let replay = state::Journal::open(
@@ -1538,20 +1586,24 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
     assert!(replay.pending_replacements.is_empty());
     assert_eq!(replay.done.len(), 1);
     let plan = replay.plan.clone().unwrap();
-    assert!(plan.junk_files.is_empty());
+    assert_eq!(plan.junk_files.len(), 1);
+    assert_eq!(plan.junk_files[0].rel, "b.csv");
+    assert!(plan.junk_files[0]
+        .reason
+        .contains("key ownership exclusive"));
     drop(replay);
 
-    // The refusal is deterministic: an identical rerun keeps the old owner,
-    // appends no new plan, and changes no documents.
+    // The divergence is durable and deterministic: an identical rerun keeps
+    // the same owner, appends no new plan, and changes no documents.
     let plans_before = event_count(state_dir.path(), "plan");
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &["b.csv"], &[]);
+    assert_eq!(run_index(config).unwrap(), 3);
     assert_eq!(event_count(state_dir.path(), "plan"), plans_before);
     let locked = endpoint.state.lock().unwrap();
     assert_eq!(locked.docs.len(), 2);
     assert!(locked
         .docs
         .values()
-        .all(|doc| doc["value"].as_str() == Some("original")));
+        .all(|doc| doc["value"].as_str() == Some("rewritten")));
 }
 
 /// #238: a file added after the plan was frozen is skipped and reported in the
@@ -1664,9 +1716,11 @@ fn deleting_an_entire_duplicate_group_strands_no_pending_replacement() {
     assert_eq!(run_index(config.clone()).unwrap(), 0);
     let starts = event_count(state_dir.path(), "file_replace_start");
 
-    // The whole duplicate group disappears. There is no current file left to
-    // republish its key, so no replacement intent may be journaled — a
-    // stranded intent would be re-appended forever without ever committing.
+    // The whole duplicate group disappears: its documents stay live with no
+    // source file, so the rerun is refused. The original invariant still
+    // holds and is still checked — a key with no current file must never get
+    // a replacement intent journaled, which would be re-appended forever
+    // without ever committing.
     fs::remove_file(corpus.path().join("dup-a.csv")).unwrap();
     fs::remove_file(corpus.path().join("dup-b.csv")).unwrap();
     for _ in 0..2 {

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -748,7 +748,7 @@ fn unchanged_planned_junk_is_not_reported_as_added_content() {
 }
 
 #[test]
-fn deleted_planned_junk_fails_closed_before_catalog_can_stay_stale() {
+fn deleted_planned_junk_is_swept_rather_than_refused() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
     let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
     let corpus = tempfile::tempdir().unwrap();
@@ -763,8 +763,33 @@ fn deleted_planned_junk_fails_closed_before_catalog_can_stay_stale() {
     let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
     assert_eq!(run_index(config.clone()).unwrap(), 3);
 
+    // A junk file publishes exactly one catalog row and nothing else, and the
+    // #238 sweep deletes that row. Nothing is stranded, so the removal gate
+    // must not fire — refusing here would block a case the pipeline handles
+    // completely. Only a file that published DOCUMENTS refuses a rerun.
     fs::remove_file(corpus.path().join("opaque.bin")).unwrap();
-    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["opaque.bin"]);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    {
+        let locked = endpoint.state.lock().unwrap();
+        assert!(
+            locked
+                .catalog_docs
+                .values()
+                .all(|doc| doc["path"].as_str() != Some("opaque.bin")),
+            "the deleted junk file's catalog row must be swept, not left immortal"
+        );
+        assert!(
+            locked
+                .catalog_docs
+                .values()
+                .any(|doc| doc["path"].as_str() == Some("rows.csv")),
+            "the surviving indexed file keeps its entry"
+        );
+    }
+
+    // Deleting the INDEXED file is still refused: its documents are live.
+    fs::remove_file(corpus.path().join("rows.csv")).unwrap();
+    assert_unsupported_delta_without_remote_mutation(&endpoint, config, &[], &["rows.csv"]);
 }
 
 #[test]

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -583,7 +583,13 @@ fn a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it() {
     assert_eq!(code, 3);
     let report = report.unwrap();
     assert_eq!(report["files_junk"], 1, "{report}");
-    assert_eq!(report["records_total"], 0, "{report}");
+    // `records_total` is the live server-side count (#195), so it still reports
+    // the record the first run published. What must be zero is the run-local
+    // counter: this rerun indexed nothing, because the frozen plan cannot
+    // absorb a file that appeared after it was written.
+    assert_eq!(report["records_submitted_this_run"], 0, "{report}");
+    assert_eq!(report["files_submitted_this_run"], 0, "{report}");
+    assert_eq!(report["records_total"], 1, "{report}");
     {
         let locked = endpoint.state.lock().unwrap();
         let live: Vec<&str> = locked

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -1119,11 +1119,20 @@ fn deleted_path_bytes_remain_while_its_documents_remain_live() {
     assert_eq!(endpoint.state.lock().unwrap().docs.len(), 4);
 
     fs::remove_file(&removed).unwrap();
-    // Current autoindex semantics do not reconcile a missing canonical path:
-    // its indexed documents and FileDone remain live. Dataset bytes must
-    // describe that durable live index rather than silently pretend deletion.
+    // Autoindex still does not reconcile a missing canonical path: its indexed
+    // documents and FileDone stay live, so dataset bytes must keep describing
+    // that durable live index rather than silently pretend deletion (#249).
+    // What changed is the exit: the rerun that used to return 0 while leaving
+    // those documents stranded now refuses before any remote mutation. Run
+    // twice — a refusal is a stop, not a state change, so the second attempt
+    // must see exactly what the first one saw.
     for _ in 0..2 {
-        assert_eq!(run_index(config.clone()).unwrap(), 0);
+        assert_unsupported_delta_without_remote_mutation(
+            &endpoint,
+            config.clone(),
+            &[],
+            &["removed.csv"],
+        );
         assert_eq!(endpoint.state.lock().unwrap().docs.len(), 4);
         assert_eq!(
             dataset_catalog_docs(&endpoint)[0]["bytes"],

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -678,6 +678,125 @@ fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
     assert_eq!(vanished, ["a-old.csv", "b-old.csv"]);
 }
 
+/// An in-place EDIT is a replacement, not a removal. `--fresh` is the route
+/// the refusal itself recommends for picking up added and changed files, so
+/// the gate must not classify the edited file's superseded content key as a
+/// vanished group — the path is still there, and the pipeline republishes it.
+#[test]
+fn fresh_absorbs_an_edited_file_instead_of_calling_it_a_removal() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("notes.csv"), "id,value\n1,before\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(corpus.path().join("notes.csv"), "id,value\n1,after\n").unwrap();
+    config.fresh = true;
+    assert_eq!(
+        run_index(config).unwrap(),
+        0,
+        "an edited file is a same-path replacement, not a vanished content group"
+    );
+    let locked = endpoint.state.lock().unwrap();
+    assert!(
+        locked
+            .docs
+            .values()
+            .any(|doc| doc["value"].as_str() == Some("after")),
+        "the new content is live: {:?}",
+        locked.docs
+    );
+    // Documented, and NOT what this gate is for: `--fresh` rebuilds the plan,
+    // it does not reconcile the destination. Document ids derive from the
+    // content key (`ids::doc_id`), so the pre-edit record stays live beside
+    // the new one — the same outcome `--fresh` has always had. An ordinary
+    // rerun is the clean route for an edit: it keeps the planned key and runs
+    // a delete-before-replace transaction on it. What must never happen is
+    // this run being REFUSED by a message claiming a file that is sitting in
+    // the folder has vanished.
+    assert!(
+        locked
+            .docs
+            .values()
+            .any(|doc| doc["value"].as_str() == Some("before")),
+        "known --fresh gap: superseded records are not deleted: {:?}",
+        locked.docs
+    );
+}
+
+/// The clean route for the same edit: an ordinary rerun keeps the planned key
+/// and replaces its records, so nothing is stranded. This is the contrast that
+/// makes the `--fresh` gap above a documented trade-off rather than a silent
+/// one.
+#[test]
+fn an_ordinary_rerun_replaces_an_edited_file_without_stranding_records() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("notes.csv"), "id,value\n1,before\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(corpus.path().join("notes.csv"), "id,value\n1,after\n").unwrap();
+    assert_eq!(run_index(config).unwrap(), 0);
+    let locked = endpoint.state.lock().unwrap();
+    let values: Vec<&str> = locked
+        .docs
+        .values()
+        .filter_map(|doc| doc["value"].as_str())
+        .collect();
+    assert_eq!(values, ["after"], "the superseded record is replaced");
+}
+
+/// The composite workflow the run's own stderr recommends: index, then add one
+/// file and edit another, rerun (added file reported and skipped by the frozen
+/// plan), then `--fresh` to absorb both.
+#[test]
+fn fresh_absorbs_an_addition_and_an_edit_after_a_reported_rerun() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,before\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+
+    fs::write(corpus.path().join("first.csv"), "id,value\n1,after\n").unwrap();
+    fs::write(corpus.path().join("second.csv"), "id,value\n2,second\n").unwrap();
+    // 3 = completed-with-junk: the frozen plan cannot absorb the added file,
+    // so the rerun reports it as skipped rather than refusing.
+    assert_eq!(run_index(config.clone()).unwrap(), 3);
+
+    config.fresh = true;
+    assert_eq!(
+        run_index(config).unwrap(),
+        0,
+        "--fresh is the documented way out of exactly this state"
+    );
+    let locked = endpoint.state.lock().unwrap();
+    let live: std::collections::HashSet<&str> = locked
+        .docs
+        .values()
+        .filter_map(|doc| doc["ax_path"].as_str())
+        .collect();
+    assert!(live.contains("first.csv"), "{live:?}");
+    assert!(live.contains("second.csv"), "{live:?}");
+    assert!(
+        locked
+            .docs
+            .values()
+            .any(|doc| doc["value"].as_str() == Some("after")),
+        "the edited file's new content is live: {:?}",
+        locked.docs
+    );
+}
+
 #[test]
 fn fresh_cannot_erase_the_plan_and_bypass_the_removal_gate() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -1301,15 +1301,14 @@ impl UnsupportedInventoryDelta {
                 path: assignment.rel.clone(),
             })
             .collect();
-        vanished_content_groups.extend(
-            plan.junk_files
-                .iter()
-                .filter(|junk| !current_keys.contains(junk.file_key.as_str()))
-                .map(|junk| InventoryDeltaEntry {
-                    file_key: junk.file_key.clone(),
-                    path: junk.rel.clone(),
-                }),
-        );
+        // Deliberately NOT extended with `plan.junk_files`. A junk/skipped file
+        // published no documents, no aliases and no graph edges — its entire
+        // live footprint is one `file:{key}` catalog row, and the stale
+        // junk-catalog sweep below (#238) deletes that row before dropping the
+        // plan entry. Removing it therefore strands nothing, so refusing the
+        // rerun would block a case the pipeline now handles completely. Junk
+        // keys stay in `durable_keys` above: an unchanged skipped file is still
+        // not an addition.
 
         let stable_order = |left: &InventoryDeltaEntry, right: &InventoryDeltaEntry| {
             left.path

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -102,6 +102,12 @@ pub fn run_cli() -> i32 {
 }
 
 const GB: u64 = 1 << 30;
+/// How many entries a human-facing listing prints before it summarises the
+/// rest. These lists are bounded by the corpus, not by the fault: unmounting a
+/// bind mount under an indexed root makes every content group vanish at once,
+/// so an uncapped listing is one rendered entry per journalled file — megabytes
+/// of stderr, in the code paths whose entire job is to be read by a person.
+const REFUSAL_LIST_CAP: usize = 10;
 const SAMPLE_LIMIT_BYTES: u64 = 4 << 20;
 const SQLDUMP_SAMPLE_LIMIT: u64 = 64 << 20;
 
@@ -1211,12 +1217,21 @@ impl UnsupportedInventoryDeltaError {
 
 impl std::fmt::Display for UnsupportedInventoryDeltaError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Capped like the duplicate and unplanned-file listings above; see
+        // REFUSAL_LIST_CAP. The machine-readable `--json` rendering keeps the
+        // full lists, so nothing is lost — only the prose is bounded.
         let render = |entries: &[InventoryDeltaEntry]| {
-            entries
+            let mut rendered = entries
                 .iter()
+                .take(REFUSAL_LIST_CAP)
                 .map(|entry| format!("{} ({})", entry.path, entry.file_key))
                 .collect::<Vec<_>>()
-                .join(", ")
+                .join(", ");
+            let remaining = entries.len().saturating_sub(REFUSAL_LIST_CAP);
+            if remaining > 0 {
+                rendered.push_str(&format!(", … and {remaining} more"));
+            }
+            rendered
         };
         write!(
             formatter,
@@ -1515,7 +1530,20 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // Acquire state authority before discovery as well as hashing. A waiter
     // must never classify a path snapshot taken while another owner was
     // publishing or replacing the durable plan.
-    let preflight = state::Journal::preflight(&state_dir, &root_str, &cfg.url, &cfg.prefix)?;
+    let preflight =
+        state::Journal::preflight(&state_dir, &root_str, &cfg.url, &cfg.prefix, cfg.fresh)?;
+    if let Some(reason) = preflight.unreadable_plan.as_deref() {
+        // Only reachable under --fresh; without it the preflight would have
+        // returned this as an error. It goes through the progress surface, not
+        // a raw eprintln!, so `--progress none` (which `--quiet` selects) stays
+        // silent and `--progress json` stays one parseable stream (#241).
+        pr.note(&format!(
+            "autoindex: --fresh: the durable resume plan in {} could not be read ({reason}); \
+             rebuilding it from the current folder. Documents published for files that are no \
+             longer present cannot be identified from an unreadable plan and are not deleted.",
+            state_dir.join("journal.ndjson").display()
+        ));
+    }
     // Totals are unknown until the walk returns, so this phase honestly
     // reports `pct=unknown` and proves liveness with the clock alone.
     pr.phase("walk", 0, 0);
@@ -1722,14 +1750,15 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             "autoindex: {} byte-identical duplicate path(s) will reuse canonical content",
             duplicate_files.len()
         ));
-        for duplicate in duplicate_files.iter().take(10) {
+        for duplicate in duplicate_files.iter().take(REFUSAL_LIST_CAP) {
             pr.note(&format!(
                 "  duplicate: {} → {}",
                 duplicate.rel, duplicate.duplicate_of
             ));
         }
-        if duplicate_files.len() > 10 {
-            pr.note(&format!("  … and {} more", duplicate_files.len() - 10));
+        let remaining = duplicate_files.len().saturating_sub(REFUSAL_LIST_CAP);
+        if remaining > 0 {
+            pr.note(&format!("  … and {remaining} more"));
         }
     }
 
@@ -1995,11 +2024,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
              indexed:",
             new_unplanned.len()
         );
-        for jf in new_unplanned.iter().take(10) {
+        for jf in new_unplanned.iter().take(REFUSAL_LIST_CAP) {
             eprintln!("  not in plan, skipped: {}", jf.rel);
         }
-        if new_unplanned.len() > 10 {
-            eprintln!("  … and {} more", new_unplanned.len() - 10);
+        let remaining = new_unplanned.len().saturating_sub(REFUSAL_LIST_CAP);
+        if remaining > 0 {
+            eprintln!("  … and {remaining} more");
         }
         eprintln!(
             "autoindex: re-run with --fresh to rebuild the plan in place and index them (ids \
@@ -3800,6 +3830,55 @@ mod inventory_delta_tests {
         assert!(message.contains(".xerj-memory-corpus-edges"), "{message}");
         assert!(message.contains("new --state-dir"), "{message}");
         assert!(message.contains("`--fresh`"), "{message}");
+    }
+
+    /// The prose refusal is bounded by REFUSAL_LIST_CAP, not by the corpus: an
+    /// unmounted bind mount under an indexed root vanishes every group at once,
+    /// and rendering 82k entries into one String is megabytes of stderr in the
+    /// one path whose job is to be read. `--json` still carries all of them.
+    #[test]
+    fn refusal_prose_caps_its_listings_while_json_keeps_every_entry() {
+        let mut plan = Plan::default();
+        let total = REFUSAL_LIST_CAP * 3;
+        for i in 0..total {
+            plan.files.insert(
+                format!("gone{i:03}"),
+                assignment(&format!("gone{i:03}.csv")),
+            );
+        }
+        let error = UnsupportedInventoryDelta::between(&[], &[], &plan).into_error(targets());
+        let message = format!("{error:#}");
+        assert!(message.contains("gone000.csv"), "{message}");
+        assert!(
+            message.contains(&format!(", … and {} more", total - REFUSAL_LIST_CAP)),
+            "{message}"
+        );
+        // The tail past the cap must not be rendered at all, not merely elided.
+        let last = format!("gone{:03}.csv", total - 1);
+        assert!(!message.contains(&last), "{message}");
+        assert_eq!(
+            message.matches(".csv (").count(),
+            REFUSAL_LIST_CAP,
+            "{message}"
+        );
+
+        let stdout = route_cli_error(&error, true)
+            .stdout
+            .expect("the typed refusal renders as JSON under --json");
+        let value: Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(
+            value["vanished_content_groups"].as_array().unwrap().len(),
+            total
+        );
+    }
+
+    #[test]
+    fn refusal_prose_below_the_cap_has_no_more_tail() {
+        let mut plan = Plan::default();
+        plan.files.insert("gone".into(), assignment("gone.csv"));
+        let error = UnsupportedInventoryDelta::between(&[], &[], &plan).into_error(targets());
+        let message = format!("{error:#}");
+        assert!(!message.contains("… and "), "{message}");
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -1034,10 +1034,8 @@ fn select_resume_plan_keys(
     for (key, assignment) in &plan.files {
         if let Some(previous) = planned_by_rel.insert(&assignment.rel, key) {
             anyhow::bail!(
-                "resume plan assigns path {} to both {} and {}; refusing to discard history under \
-                 the same destination. For an isolated rebuild use a new --state-dir, new \
-                 --prefix, and new --brain when graph detection is enabled (or --no-graph); \
-                 explicitly validate and clean the shared catalog and old target",
+                "resume plan assigns path {} to both {} and {}; use --fresh after verifying the \
+                 existing index",
                 assignment.rel,
                 previous,
                 key
@@ -1046,11 +1044,8 @@ fn select_resume_plan_keys(
         if !assignment.path_id.is_empty() {
             if let Some(previous) = planned_by_path_id.insert(&assignment.path_id, key) {
                 anyhow::bail!(
-                    "resume plan assigns one native path identity to both {} and {}; refusing to \
-                     discard history under the same destination. For an isolated rebuild use a \
-                     new --state-dir, new --prefix, and new --brain when graph detection is \
-                     enabled (or --no-graph); explicitly validate and clean the shared catalog \
-                     and old target",
+                    "resume plan assigns one native path identity to both {} and {}; use --fresh \
+                     after verifying the existing index",
                     previous,
                     key
                 );
@@ -1088,11 +1083,9 @@ fn select_resume_plan_keys(
                     anyhow::bail!(
                         "{} collides with legacy resume key {} already owned by {}. No documents \
                          were changed; remove or move one of these two files out of the corpus \
-                         and rerun — every other file keeps its resume state. Refusing to discard \
-                         history under the same destination. For an isolated rebuild use a new \
-                         --state-dir, new --prefix, and new --brain when graph detection is \
-                         enabled (or --no-graph); explicitly validate and clean the shared \
-                         catalog and old target. Journal: {}",
+                         and rerun — every other file keeps its resume state. Deleting the \
+                         journal at {} (or rerunning with --fresh) also clears the collision, \
+                         but re-extracts and re-embeds the entire corpus",
                         file.rel,
                         legacy_key,
                         assignment.rel,
@@ -1136,10 +1129,58 @@ struct UnsupportedInventoryDelta {
     vanished_content_groups: Vec<InventoryDeltaEntry>,
 }
 
+/// Everything the refusal needs to name the destination it is protecting.
+/// Collected at the gate so the message can list the exact indices and state
+/// directory an operator has to act on, instead of describing them abstractly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RefusalTargets {
+    state_dir: String,
+    data_indices: Vec<String>,
+    edges_index: Option<String>,
+}
+
+impl RefusalTargets {
+    fn describe(cfg: &IndexCfg, state_dir: &Path, plan: &Plan) -> Self {
+        let mut data_indices: Vec<String> = plan.datasets.iter().map(|d| d.index.clone()).collect();
+        data_indices.sort();
+        data_indices.dedup();
+        let edges_index = (!cfg.no_graph).then(|| {
+            let brain = cfg
+                .brain
+                .clone()
+                .unwrap_or_else(|| derive_brain_name(&cfg.root));
+            detect::edges_index_name(&brain)
+        });
+        Self {
+            state_dir: state_dir.display().to_string(),
+            data_indices,
+            edges_index,
+        }
+    }
+
+    fn indices_phrase(&self) -> String {
+        if self.data_indices.is_empty() {
+            "the indices this plan publishes".to_string()
+        } else {
+            self.data_indices.join(", ")
+        }
+    }
+
+    fn edges_note(&self) -> String {
+        match &self.edges_index {
+            Some(edges) => format!(
+                " Graph edges taught by the removed file(s) stay live in {edges} until that \
+                 index is deleted too."
+            ),
+            None => String::new(),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct UnsupportedInventoryDeltaError {
     delta: UnsupportedInventoryDelta,
-    fresh_existing_plan: bool,
+    targets: RefusalTargets,
 }
 
 impl UnsupportedInventoryDeltaError {
@@ -1147,21 +1188,22 @@ impl UnsupportedInventoryDeltaError {
         json!({
             "schema": "xerj.autoindex.unsupported_sync_delta.v1",
             "status": "error",
-            "error": if self.fresh_existing_plan {
-                "unsafe_fresh_existing_plan"
-            } else {
-                "unsupported_inventory_delta"
-            },
-            "message": if self.fresh_existing_plan {
-                "this attempt made no remote mutations; --fresh cannot discard an existing plan under the same destination because alias, path, graph, and stale-record cleanup knowledge would be lost; the existing destination may already be partial or stale"
-            } else {
-                "this attempt made no remote mutations because this autoindex plan cannot safely reconcile corpus membership changes; the existing destination may already be partial or stale"
-            },
-            "added_content_groups": self.delta.added_content_groups,
+            "error": "unsupported_content_group_removal",
+            "message": "this attempt made no remote mutations. Files that were indexed under this resume plan no longer exist in the folder, and their documents are still live in the destination; removing files from an indexed folder is not reconciled yet",
             "vanished_content_groups": self.delta.vanished_content_groups,
+            // Context, not the reason for the refusal: a rerun over a frozen
+            // plan does not index files added after the plan was frozen.
+            "added_content_groups": self.delta.added_content_groups,
             "recovery": {
-                "exact_rebuild": "index with a new --state-dir, new --prefix, and (when graph detection is enabled) new --brain; alternatively add --no-graph. Validate the isolated target before switching readers",
-                "warning": "--fresh is not recovery or destination reconciliation. The global autoindex-catalog and old target are not cleaned automatically; validate and clean them explicitly"
+                "restore_removed_files": "put the listed file(s) back and rerun; every other file keeps its resume state",
+                "rebuild_in_place": format!(
+                    "delete the indices this plan publishes ({}) and the state directory {}, then rerun. This re-extracts and re-embeds the whole corpus.{}",
+                    self.targets.indices_phrase(),
+                    self.targets.state_dir,
+                    self.targets.edges_note().trim_start_matches(' ')
+                ),
+                "rebuild_isolated": "index with a new --state-dir, new --prefix, and (when graph detection is enabled) new --brain; alternatively add --no-graph. Validate the isolated target before switching readers, then clean the old one",
+                "fresh_warning": "--fresh re-extracts the current folder in place and does pick up added and changed files, but it never deletes documents already published for removed files, so it is refused here"
             }
         })
     }
@@ -1176,23 +1218,36 @@ impl std::fmt::Display for UnsupportedInventoryDeltaError {
                 .collect::<Vec<_>>()
                 .join(", ")
         };
-        let reason = if self.fresh_existing_plan {
-            "`--fresh` cannot discard an existing plan under the same destination because alias, \
-             path, graph, and stale-record cleanup knowledge would be lost"
-        } else {
-            "corpus membership synchronization is not yet supported"
-        };
         write!(
             formatter,
-            "this attempt made no remote mutations; the existing destination may already be \
-             partial or stale. {reason}. Added \
-             content groups [{}]; vanished content groups [{}]. For an exact rebuild, index the \
-             current folder with a new --state-dir, a new --prefix, and, when graph detection is \
-             enabled, a new --brain (or use --no-graph). Validate the isolated target before \
-             switching readers. `--fresh` is not recovery or destination reconciliation; the \
-             global autoindex-catalog and old target require explicit validated cleanup",
-            render(&self.delta.added_content_groups),
+            "{} file(s) indexed under this resume plan no longer exist in the folder, and their \
+             documents are still live in the destination. Removing files from an indexed folder \
+             is not reconciled yet, so this attempt made no remote mutations — no documents, \
+             aliases, graph edges or catalog entries were written. Removed content groups [{}].",
+            self.delta.vanished_content_groups.len(),
             render(&self.delta.vanished_content_groups)
+        )?;
+        if !self.delta.added_content_groups.is_empty() {
+            write!(
+                formatter,
+                " Also present but not in the frozen resume plan, so not indexed by this run \
+                 either [{}].",
+                render(&self.delta.added_content_groups)
+            )?;
+        }
+        write!(
+            formatter,
+            " Recovery, cheapest first: (1) restore the removed file(s) and rerun — every other \
+             file keeps its resume state; (2) rebuild in place by deleting the indices this plan \
+             publishes ({}) and the state directory {}, then rerunning — this re-extracts and \
+             re-embeds the whole corpus.{} (3) rebuild isolated with a new --state-dir, a new \
+             --prefix and, when graph detection is enabled, a new --brain (or --no-graph), \
+             validate it, switch readers, then clean the old target. `--fresh` picks up added \
+             and changed files in place but never deletes documents for removed files, so it is \
+             refused here too",
+            self.targets.indices_phrase(),
+            self.targets.state_dir,
+            self.targets.edges_note()
         )
     }
 }
@@ -1254,22 +1309,19 @@ impl UnsupportedInventoryDelta {
         }
     }
 
-    fn is_empty(&self) -> bool {
-        self.added_content_groups.is_empty() && self.vanished_content_groups.is_empty()
+    /// A rerun is refused only when a content group the plan published has
+    /// vanished from the folder: those documents stay live and searchable with
+    /// no source file behind them, and nothing in this pipeline removes them.
+    /// Additions are not refused — they are skipped by the frozen plan exactly
+    /// as before and `--fresh` rebuilds the plan in place to include them.
+    fn refuses(&self) -> bool {
+        !self.vanished_content_groups.is_empty()
     }
 
-    fn into_error(self) -> anyhow::Error {
+    fn into_error(self, targets: RefusalTargets) -> anyhow::Error {
         UnsupportedInventoryDeltaError {
             delta: self,
-            fresh_existing_plan: false,
-        }
-        .into()
-    }
-
-    fn into_fresh_error(self) -> anyhow::Error {
-        UnsupportedInventoryDeltaError {
-            delta: self,
-            fresh_existing_plan: true,
+            targets,
         }
         .into()
     }
@@ -1505,16 +1557,13 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             .map(|(planned, current)| planned.unwrap_or_else(|| current.clone()))
             .collect()
         };
+        // `--fresh` is checked here too: discarding the plan does not delete
+        // the documents already published for a file that is now gone, so a
+        // removal is unsafe in place whether or not the plan is kept.
         let delta =
             UnsupportedInventoryDelta::between(&inventory.files, &comparison_keys, prior_plan);
-        if cfg.fresh {
-            // Even an apparently unchanged content-key set can have alias,
-            // path, graph, catalog, or partial-publication history that only
-            // the old plan can reconcile. Route 1 cannot safely discard it.
-            return Err(delta.into_fresh_error());
-        }
-        if !delta.is_empty() {
-            return Err(delta.into_error());
+        if delta.refuses() {
+            return Err(delta.into_error(RefusalTargets::describe(&cfg, &state_dir, prior_plan)));
         }
     }
     let mut journal = state::Journal::open_after_preflight(
@@ -1741,20 +1790,19 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         plan
     };
 
-    // A durable plan is a crash-resume boundary, not a folder-sync
-    // generation. Fail before index creation/mapping, replacement intent,
-    // graph invalidation, delete-by-query, bulk publication, refresh, or
-    // catalog writes when the current inventory adds or removes an entire
-    // canonical content group. Continuing would either silently skip new
-    // data or leave vanished source records searchable. Existing planned-key
-    // content replacement and crash repair remain supported.
+    // Second gate, after key selection has settled: fail before index
+    // creation/mapping, replacement intent, graph invalidation,
+    // delete-by-query, bulk publication, refresh, or catalog writes when a
+    // canonical content group the plan published is gone from the folder.
+    // Continuing would leave those documents searchable with no source file.
+    // Additions, same-path replacement and crash repair remain supported.
     //
-    // This runs before the junk sweep below on purpose: a refused rerun must
-    // compute nothing and mutate nothing.
+    // It runs before the #238 junk sweep below on purpose: a refused rerun
+    // must compute nothing and mutate nothing.
     if resumed_with_plan {
         let delta = UnsupportedInventoryDelta::between(&files, &keys, &plan);
-        if !delta.is_empty() {
-            return Err(delta.into_error());
+        if delta.refuses() {
+            return Err(delta.into_error(RefusalTargets::describe(&cfg, &state_dir, &plan)));
         }
     }
 
@@ -1930,13 +1978,33 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 rel: files[i].rel.clone(),
                 format: "unknown".into(),
                 status: "skipped".into(),
-                reason: "not in the frozen resume plan; no destination change was made. For an \
-                         exact rebuild use a new --state-dir, a new --prefix, and, when graph \
-                         detection is enabled, a new --brain (or use --no-graph)"
+                reason: "not in the frozen resume plan, so nothing was published for it. Re-run \
+                         with --fresh to rebuild the plan in place and include it (ids stay \
+                         idempotent), or index it under a new --state-dir and --prefix"
                     .into(),
                 bytes: files[i].size,
             });
         }
+    }
+    if !new_unplanned.is_empty() && !cfg.quiet {
+        // The frozen plan cannot absorb files discovered after it was written.
+        // Say so on stderr rather than leaving it to the catalog: a rerun that
+        // quietly ignores new files is the bug this gate exists to surface.
+        eprintln!(
+            "autoindex: {} file(s) appeared after the resume plan was frozen and were NOT \
+             indexed:",
+            new_unplanned.len()
+        );
+        for jf in new_unplanned.iter().take(10) {
+            eprintln!("  not in plan, skipped: {}", jf.rel);
+        }
+        if new_unplanned.len() > 10 {
+            eprintln!("  … and {} more", new_unplanned.len() - 10);
+        }
+        eprintln!(
+            "autoindex: re-run with --fresh to rebuild the plan in place and index them (ids \
+             stay idempotent)"
+        );
     }
     if resumed_with_plan {
         // Legacy journals predate intent-before-publication and may have live
@@ -3633,14 +3701,39 @@ mod inventory_delta_tests {
         }
     }
 
+    fn targets() -> RefusalTargets {
+        RefusalTargets {
+            state_dir: "/state".into(),
+            data_indices: vec!["ax-rows".into()],
+            edges_index: Some(".xerj-memory-corpus-edges".into()),
+        }
+    }
+
     #[test]
-    fn classifier_is_empty_for_noop_and_sorts_added_and_vanished_groups() {
+    fn only_a_removed_content_group_refuses_a_rerun() {
         let mut plan = Plan::default();
         plan.files.insert("keep".into(), assignment("keep.csv"));
         assert!(
-            UnsupportedInventoryDelta::between(&[file("keep.csv")], &["keep".into()], &plan)
-                .is_empty()
+            !UnsupportedInventoryDelta::between(&[file("keep.csv")], &["keep".into()], &plan)
+                .refuses()
         );
+        // An added file is skipped by the frozen plan, not a refusal: the
+        // documented rerun-then---fresh workflow has to keep working.
+        let added = UnsupportedInventoryDelta::between(
+            &[file("keep.csv"), file("new.csv")],
+            &["keep".into(), "new".into()],
+            &plan,
+        );
+        assert_eq!(added.added_content_groups.len(), 1);
+        assert!(!added.refuses(), "an addition alone must not fail the run");
+        // A removal leaves live documents with no source file behind them.
+        assert!(UnsupportedInventoryDelta::between(&[], &[], &plan).refuses());
+    }
+
+    #[test]
+    fn classifier_sorts_added_and_vanished_groups() {
+        let mut plan = Plan::default();
+        plan.files.insert("keep".into(), assignment("keep.csv"));
         plan.junk_files.push(JunkFile {
             file_key: "junk".into(),
             rel: "broken.pdf".into(),
@@ -3650,13 +3743,13 @@ mod inventory_delta_tests {
             bytes: 1,
         });
         assert!(
-            UnsupportedInventoryDelta::between(
+            !UnsupportedInventoryDelta::between(
                 &[file("keep.csv"), file("broken.pdf")],
                 &["keep".into(), "junk".into()],
                 &plan,
             )
-            .is_empty(),
-            "unchanged durable junk is not newly added content"
+            .refuses(),
+            "unchanged durable junk is neither added nor vanished"
         );
 
         plan.files.insert("old-z".into(), assignment("z-old.csv"));
@@ -3690,22 +3783,47 @@ mod inventory_delta_tests {
     }
 
     #[test]
+    fn refusal_names_the_removed_files_and_every_recovery_route() {
+        let mut plan = Plan::default();
+        plan.files.insert("gone".into(), assignment("gone.csv"));
+        let error = UnsupportedInventoryDelta::between(&[], &[], &plan).into_error(targets());
+        let message = format!("{error:#}");
+        assert!(message.contains("gone.csv"), "{message}");
+        assert!(
+            message.contains("no longer exist in the folder"),
+            "{message}"
+        );
+        assert!(message.contains("made no remote mutations"), "{message}");
+        assert!(message.contains("restore the removed file(s)"), "{message}");
+        assert!(message.contains("ax-rows"), "{message}");
+        assert!(message.contains("/state"), "{message}");
+        assert!(message.contains(".xerj-memory-corpus-edges"), "{message}");
+        assert!(message.contains("new --state-dir"), "{message}");
+        assert!(message.contains("`--fresh`"), "{message}");
+    }
+
+    #[test]
     fn cli_error_routing_separates_typed_json_from_unrelated_human_errors() {
         let typed = UnsupportedInventoryDelta {
-            added_content_groups: vec![InventoryDeltaEntry {
+            added_content_groups: Vec::new(),
+            vanished_content_groups: vec![InventoryDeltaEntry {
                 file_key: "key".into(),
-                path: "new.csv".into(),
+                path: "gone.csv".into(),
             }],
-            vanished_content_groups: Vec::new(),
         }
-        .into_error();
+        .into_error(targets());
         let route = route_cli_error(&typed, true);
         assert_eq!(route.exit_code, 1);
         assert!(route.stderr.is_none());
         let stdout = route.stdout.unwrap();
         let value: Value = serde_json::from_str(&stdout).unwrap();
         assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
-        assert_eq!(value["error"], "unsupported_inventory_delta");
+        assert_eq!(value["error"], "unsupported_content_group_removal");
+        assert_eq!(value["vanished_content_groups"][0]["path"], "gone.csv");
+        assert!(value["recovery"]["rebuild_in_place"]
+            .as_str()
+            .unwrap()
+            .contains("ax-rows"));
 
         let unrelated = anyhow::anyhow!("endpoint unavailable");
         let route = route_cli_error(&unrelated, true);
@@ -3765,11 +3883,11 @@ mod duplicate_integration_tests {
         .unwrap_err();
         let message = format!("{error:#}");
         assert!(message.contains("collides with legacy resume key"));
-        // Recovery advice must stay scoped to the two colliding files and
-        // keep an exact rebuild isolated from the old destination.
+        // Recovery advice must stay scoped to the two colliding files and be
+        // honest that discarding the journal re-embeds the whole corpus.
         assert!(message.contains("remove or move one of these two files"));
         assert!(message.contains("/state/journal.ndjson"));
-        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
+        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -1183,6 +1183,43 @@ impl RefusalTargets {
     }
 }
 
+/// The #195 zero-live verification failure, as a type rather than a string.
+///
+/// The journal claims records were made visible; the destination answers with
+/// none. That is always a failure, but not always the *same* failure: for a
+/// composing caller like `xerj brain` a resume journal that outlived a wiped
+/// data directory has a specific, executable recovery (`--fresh` in place),
+/// while a write-blocked or unreachable server does not. Only a typed error
+/// lets the caller tell them apart — `anyhow::bail!` forces it to either
+/// string-match the prose or reprint it verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZeroLiveVerificationError {
+    /// Records the resume journal says were published.
+    pub journal_records: u64,
+    /// Completed files those records came from.
+    pub files_done_journaled: usize,
+    /// Dataset indices that answered with zero live documents.
+    pub dataset_indices: usize,
+}
+
+impl std::fmt::Display for ZeroLiveVerificationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "autoindex verification failed: the resume journal records {} \
+             record(s) from {} completed file(s), but 0 documents are \
+             live across the {} dataset index(es). The indices exist and look healthy but \
+             hold nothing — a server-side write rejection (e.g. a disk flood-stage or \
+             index write block), deleted indices, or an unreadable server can all cause \
+             this. Fix the server-side condition, then rerun with --fresh to re-index \
+             from scratch",
+            self.journal_records, self.files_done_journaled, self.dataset_indices
+        )
+    }
+}
+
+impl std::error::Error for ZeroLiveVerificationError {}
+
 #[derive(Debug)]
 struct UnsupportedInventoryDeltaError {
     delta: UnsupportedInventoryDelta,
@@ -2940,16 +2977,21 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     };
     let live_records: u64 = ds_counts.values().sum();
     if journal_records > 0 && live_records == 0 {
-        anyhow::bail!(
-            "autoindex verification failed: the resume journal records {journal_records} \
-             record(s) from {files_done_journaled} completed file(s), but 0 documents are \
-             live across the {} dataset index(es). The indices exist and look healthy but \
-             hold nothing — a server-side write rejection (e.g. a disk flood-stage or \
-             index write block), deleted indices, or an unreadable server can all cause \
-             this. Fix the server-side condition, then rerun with --fresh to re-index \
-             from scratch",
-            plan.datasets.len()
-        );
+        // Typed, not `bail!`: a caller that composes this pipeline can only
+        // tell "the journal outlived its destination" from "the server
+        // rejected our writes" if the condition carries a type. `xerj brain`
+        // downcasts it (brain.rs) to offer the in-place rebuild instead of
+        // printing this text raw. Peer precedent for classifying a
+        // recoverable condition rather than folding it into a generic error:
+        // redb's `Database::do_repair` returns `DatabaseError::RepairAborted`
+        // as its own variant (redb/src/db.rs:994, Apache-2.0/MIT) so the
+        // caller can distinguish it from ordinary corruption.
+        return Err(ZeroLiveVerificationError {
+            journal_records,
+            files_done_journaled,
+            dataset_indices: plan.datasets.len(),
+        }
+        .into());
     }
 
     // correlations

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -2074,25 +2074,28 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             });
         }
     }
-    if !new_unplanned.is_empty() && !cfg.quiet {
+    if !new_unplanned.is_empty() {
         // The frozen plan cannot absorb files discovered after it was written.
         // Say so on stderr rather than leaving it to the catalog: a rerun that
         // quietly ignores new files is the bug this gate exists to surface.
-        eprintln!(
+        // Routed through the progress surface, which owns stderr (#241): a raw
+        // eprintln! here would break `--progress json`'s single parseable
+        // stream, and `--quiet` already selects `--progress none`.
+        pr.note(&format!(
             "autoindex: {} file(s) appeared after the resume plan was frozen and were NOT \
              indexed:",
             new_unplanned.len()
-        );
+        ));
         for jf in new_unplanned.iter().take(REFUSAL_LIST_CAP) {
-            eprintln!("  not in plan, skipped: {}", jf.rel);
+            pr.note(&format!("  not in plan, skipped: {}", jf.rel));
         }
         let remaining = new_unplanned.len().saturating_sub(REFUSAL_LIST_CAP);
         if remaining > 0 {
-            eprintln!("  … and {remaining} more");
+            pr.note(&format!("  … and {remaining} more"));
         }
-        eprintln!(
+        pr.note(
             "autoindex: re-run with --fresh to rebuild the plan in place and index them (ids \
-             stay idempotent)"
+             stay idempotent)",
         );
     }
     if resumed_with_plan {

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -22,6 +22,7 @@ pub mod state;
 pub mod walk;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Seek, Write};
@@ -39,6 +40,30 @@ use progress::Progress;
 use sniff::{Family, Sniffed};
 use state::{DuplicateFile, FileAssignment, FileDone, JunkFile, Plan, PlanDataset};
 
+#[derive(Debug, PartialEq, Eq)]
+struct CliErrorRoute {
+    exit_code: i32,
+    stdout: Option<String>,
+    stderr: Option<String>,
+}
+
+fn route_cli_error(error: &anyhow::Error, json_output: bool) -> CliErrorRoute {
+    if json_output {
+        if let Some(delta) = error.downcast_ref::<UnsupportedInventoryDeltaError>() {
+            return CliErrorRoute {
+                exit_code: 1,
+                stdout: Some(delta.to_json().to_string()),
+                stderr: None,
+            };
+        }
+    }
+    CliErrorRoute {
+        exit_code: 1,
+        stdout: None,
+        stderr: Some(format!("error: {error:#}")),
+    }
+}
+
 /// Entry point for the `xerj autoindex` subcommand (blocking; the server
 /// binary calls this via spawn_blocking). Returns the process exit code.
 pub fn run_cli() -> i32 {
@@ -51,6 +76,7 @@ pub fn run_cli() -> i32 {
             return 2;
         }
     };
+    let json_output = matches!(&cmd, Cmd::Index(cfg) if cfg.json);
     let res = match cmd {
         Cmd::Help => {
             cli::print_help();
@@ -63,8 +89,14 @@ pub fn run_cli() -> i32 {
     match res {
         Ok(code) => code,
         Err(e) => {
-            eprintln!("error: {e:#}");
-            1
+            let route = route_cli_error(&e, json_output);
+            if let Some(stdout) = route.stdout {
+                println!("{stdout}");
+            }
+            if let Some(stderr) = route.stderr {
+                eprintln!("{stderr}");
+            }
+            route.exit_code
         }
     }
 }
@@ -1002,8 +1034,10 @@ fn select_resume_plan_keys(
     for (key, assignment) in &plan.files {
         if let Some(previous) = planned_by_rel.insert(&assignment.rel, key) {
             anyhow::bail!(
-                "resume plan assigns path {} to both {} and {}; use --fresh after verifying the \
-                 existing index",
+                "resume plan assigns path {} to both {} and {}; refusing to discard history under \
+                 the same destination. For an isolated rebuild use a new --state-dir, new \
+                 --prefix, and new --brain when graph detection is enabled (or --no-graph); \
+                 explicitly validate and clean the shared catalog and old target",
                 assignment.rel,
                 previous,
                 key
@@ -1012,8 +1046,11 @@ fn select_resume_plan_keys(
         if !assignment.path_id.is_empty() {
             if let Some(previous) = planned_by_path_id.insert(&assignment.path_id, key) {
                 anyhow::bail!(
-                    "resume plan assigns one native path identity to both {} and {}; use --fresh \
-                     after verifying the existing index",
+                    "resume plan assigns one native path identity to both {} and {}; refusing to \
+                     discard history under the same destination. For an isolated rebuild use a \
+                     new --state-dir, new --prefix, and new --brain when graph detection is \
+                     enabled (or --no-graph); explicitly validate and clean the shared catalog \
+                     and old target",
                     previous,
                     key
                 );
@@ -1051,9 +1088,11 @@ fn select_resume_plan_keys(
                     anyhow::bail!(
                         "{} collides with legacy resume key {} already owned by {}. No documents \
                          were changed; remove or move one of these two files out of the corpus \
-                         and rerun — every other file keeps its resume state. Deleting the \
-                         journal at {} (or rerunning with --fresh) also clears the collision, \
-                         but re-extracts and re-embeds the entire corpus",
+                         and rerun — every other file keeps its resume state. Refusing to discard \
+                         history under the same destination. For an isolated rebuild use a new \
+                         --state-dir, new --prefix, and new --brain when graph detection is \
+                         enabled (or --no-graph); explicitly validate and clean the shared \
+                         catalog and old target. Journal: {}",
                         file.rel,
                         legacy_key,
                         assignment.rel,
@@ -1083,6 +1122,157 @@ fn select_resume_plan_keys(
         selected.push(key);
     }
     Ok(selected)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct InventoryDeltaEntry {
+    file_key: String,
+    path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct UnsupportedInventoryDelta {
+    added_content_groups: Vec<InventoryDeltaEntry>,
+    vanished_content_groups: Vec<InventoryDeltaEntry>,
+}
+
+#[derive(Debug)]
+struct UnsupportedInventoryDeltaError {
+    delta: UnsupportedInventoryDelta,
+    fresh_existing_plan: bool,
+}
+
+impl UnsupportedInventoryDeltaError {
+    fn to_json(&self) -> Value {
+        json!({
+            "schema": "xerj.autoindex.unsupported_sync_delta.v1",
+            "status": "error",
+            "error": if self.fresh_existing_plan {
+                "unsafe_fresh_existing_plan"
+            } else {
+                "unsupported_inventory_delta"
+            },
+            "message": if self.fresh_existing_plan {
+                "this attempt made no remote mutations; --fresh cannot discard an existing plan under the same destination because alias, path, graph, and stale-record cleanup knowledge would be lost; the existing destination may already be partial or stale"
+            } else {
+                "this attempt made no remote mutations because this autoindex plan cannot safely reconcile corpus membership changes; the existing destination may already be partial or stale"
+            },
+            "added_content_groups": self.delta.added_content_groups,
+            "vanished_content_groups": self.delta.vanished_content_groups,
+            "recovery": {
+                "exact_rebuild": "index with a new --state-dir, new --prefix, and (when graph detection is enabled) new --brain; alternatively add --no-graph. Validate the isolated target before switching readers",
+                "warning": "--fresh is not recovery or destination reconciliation. The global autoindex-catalog and old target are not cleaned automatically; validate and clean them explicitly"
+            }
+        })
+    }
+}
+
+impl std::fmt::Display for UnsupportedInventoryDeltaError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let render = |entries: &[InventoryDeltaEntry]| {
+            entries
+                .iter()
+                .map(|entry| format!("{} ({})", entry.path, entry.file_key))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let reason = if self.fresh_existing_plan {
+            "`--fresh` cannot discard an existing plan under the same destination because alias, \
+             path, graph, and stale-record cleanup knowledge would be lost"
+        } else {
+            "corpus membership synchronization is not yet supported"
+        };
+        write!(
+            formatter,
+            "this attempt made no remote mutations; the existing destination may already be \
+             partial or stale. {reason}. Added \
+             content groups [{}]; vanished content groups [{}]. For an exact rebuild, index the \
+             current folder with a new --state-dir, a new --prefix, and, when graph detection is \
+             enabled, a new --brain (or use --no-graph). Validate the isolated target before \
+             switching readers. `--fresh` is not recovery or destination reconciliation; the \
+             global autoindex-catalog and old target require explicit validated cleanup",
+            render(&self.delta.added_content_groups),
+            render(&self.delta.vanished_content_groups)
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedInventoryDeltaError {}
+
+impl UnsupportedInventoryDelta {
+    fn between(files: &[walk::FileEntry], keys: &[String], plan: &Plan) -> Self {
+        let current_keys: std::collections::HashSet<&str> = keys
+            .iter()
+            .filter(|key| !key.is_empty())
+            .map(String::as_str)
+            .collect();
+        let durable_keys: std::collections::HashSet<&str> = plan
+            .files
+            .keys()
+            .map(String::as_str)
+            .chain(plan.junk_files.iter().map(|junk| junk.file_key.as_str()))
+            .collect();
+
+        let mut added_content_groups: Vec<InventoryDeltaEntry> = files
+            .iter()
+            .zip(keys)
+            .filter(|(_, key)| !key.is_empty() && !durable_keys.contains(key.as_str()))
+            .map(|(file, key)| InventoryDeltaEntry {
+                file_key: key.clone(),
+                path: file.rel.clone(),
+            })
+            .collect();
+        let mut vanished_content_groups: Vec<InventoryDeltaEntry> = plan
+            .files
+            .iter()
+            .filter(|(key, _)| !current_keys.contains(key.as_str()))
+            .map(|(key, assignment)| InventoryDeltaEntry {
+                file_key: key.clone(),
+                path: assignment.rel.clone(),
+            })
+            .collect();
+        vanished_content_groups.extend(
+            plan.junk_files
+                .iter()
+                .filter(|junk| !current_keys.contains(junk.file_key.as_str()))
+                .map(|junk| InventoryDeltaEntry {
+                    file_key: junk.file_key.clone(),
+                    path: junk.rel.clone(),
+                }),
+        );
+
+        let stable_order = |left: &InventoryDeltaEntry, right: &InventoryDeltaEntry| {
+            left.path
+                .cmp(&right.path)
+                .then_with(|| left.file_key.cmp(&right.file_key))
+        };
+        added_content_groups.sort_by(stable_order);
+        vanished_content_groups.sort_by(stable_order);
+        Self {
+            added_content_groups,
+            vanished_content_groups,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.added_content_groups.is_empty() && self.vanished_content_groups.is_empty()
+    }
+
+    fn into_error(self) -> anyhow::Error {
+        UnsupportedInventoryDeltaError {
+            delta: self,
+            fresh_existing_plan: false,
+        }
+        .into()
+    }
+
+    fn into_fresh_error(self) -> anyhow::Error {
+        UnsupportedInventoryDeltaError {
+            delta: self,
+            fresh_existing_plan: true,
+        }
+        .into()
+    }
 }
 
 fn alias_keys_to_reindex(
@@ -1260,49 +1450,35 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         .with_bulk_concurrency(cfg.workers, pr.enabled());
     es.ping()?;
 
-    // Totals are unknown until the walk returns, so this phase honestly
-    // reports `pct=unknown` and proves liveness with the clock alone.
-    pr.phase("walk", 0, 0);
-    let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
-    if discovered_files.is_empty() {
-        println!("no files found under {}", cfg.root.display());
-        pr.finish(true, 0, "no-files", &[]);
-        return Ok((0, None));
-    }
-    let discovered_bytes: u64 = discovered_files.iter().map(|f| f.size).sum();
     let root_str = cfg
         .root
         .canonicalize()
         .unwrap_or_else(|_| cfg.root.clone())
         .to_string_lossy()
         .to_string();
+    let state_dir = cfg
+        .state_dir
+        .clone()
+        .unwrap_or_else(|| state::default_state_dir(&root_str, &cfg.url, &cfg.prefix));
+    // Acquire state authority before discovery as well as hashing. A waiter
+    // must never classify a path snapshot taken while another owner was
+    // publishing or replacing the durable plan.
+    let preflight = state::Journal::preflight(&state_dir, &root_str, &cfg.url, &cfg.prefix)?;
+    // Totals are unknown until the walk returns, so this phase honestly
+    // reports `pct=unknown` and proves liveness with the clock alone.
+    pr.phase("walk", 0, 0);
+    let discovered_files = walk::walk(&cfg.root, cfg.follow_symlinks)?;
+    let discovered_bytes: u64 = discovered_files.iter().map(|f| f.size).sum();
     pr.note(&format!(
         "autoindex: {} files ({} MB) under {}",
         discovered_files.len(),
         discovered_bytes / (1 << 20),
         root_str
     ));
-
-    let state_dir = cfg
-        .state_dir
-        .clone()
-        .unwrap_or_else(|| state::default_state_dir(&root_str, &cfg.url, &cfg.prefix));
-    let mut journal = state::Journal::open(
-        &state_dir,
-        &root_str,
-        &cfg.url,
-        &cfg.prefix,
-        cfg.bulk_timeout_secs,
-        cfg.fresh,
-    )?;
-    let resumed_with_plan = journal.plan.is_some();
-    let run_id = journal.run_id.clone();
-    if journal.resumed {
-        pr.note(&format!(
-            "resuming from journal {} ({} files already done)",
-            journal.path().display(),
-            journal.done.len()
-        ));
+    if discovered_files.is_empty() && !preflight.journal_exists {
+        println!("no files found under {}", cfg.root.display());
+        pr.finish(true, 0, "no-files", &[]);
+        return Ok((0, None));
     }
     // Full hashing on every run is deliberate: size/mtime/inode fingerprints
     // cannot prove byte identity across all supported local and network
@@ -1312,6 +1488,57 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // real work, and before #241 it was minutes with no output at all.
     pr.phase("hash", discovered_files.len() as u64, discovered_bytes);
     let mut inventory = content::resolve_reporting(discovered_files, &|bytes| pr.item_done(bytes))?;
+    if let Some(prior_plan) = preflight.plan.as_ref() {
+        let comparison_keys = if cfg.fresh {
+            inventory.keys.clone()
+        } else {
+            // Ordinary resume preserves planned-key identity for supported
+            // same-path replacement and legacy plans.
+            select_resume_plan_keys(
+                &inventory.files,
+                &inventory.keys,
+                prior_plan,
+                &state_dir.join("journal.ndjson"),
+            )?
+            .into_iter()
+            .zip(inventory.keys.iter())
+            .map(|(planned, current)| planned.unwrap_or_else(|| current.clone()))
+            .collect()
+        };
+        let delta =
+            UnsupportedInventoryDelta::between(&inventory.files, &comparison_keys, prior_plan);
+        if cfg.fresh {
+            // Even an apparently unchanged content-key set can have alias,
+            // path, graph, catalog, or partial-publication history that only
+            // the old plan can reconcile. Route 1 cannot safely discard it.
+            return Err(delta.into_fresh_error());
+        }
+        if !delta.is_empty() {
+            return Err(delta.into_error());
+        }
+    }
+    let mut journal = state::Journal::open_after_preflight(
+        preflight,
+        &root_str,
+        &cfg.url,
+        &cfg.prefix,
+        cfg.bulk_timeout_secs,
+        cfg.fresh,
+    )?;
+    let resumed_with_plan = journal.plan.is_some();
+    if inventory.files.is_empty() && !resumed_with_plan {
+        println!("no files found under {}", cfg.root.display());
+        pr.finish(true, 0, "no-files", &[]);
+        return Ok((0, None));
+    }
+    let run_id = journal.run_id.clone();
+    if journal.resumed {
+        pr.note(&format!(
+            "resuming from journal {} ({} files already done)",
+            journal.path().display(),
+            journal.done.len()
+        ));
+    }
     let journal_path = journal.path().to_path_buf();
     let mut content_changed = std::collections::HashSet::new();
     let mut stale_alias_ids = Vec::new();
@@ -1514,6 +1741,23 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         plan
     };
 
+    // A durable plan is a crash-resume boundary, not a folder-sync
+    // generation. Fail before index creation/mapping, replacement intent,
+    // graph invalidation, delete-by-query, bulk publication, refresh, or
+    // catalog writes when the current inventory adds or removes an entire
+    // canonical content group. Continuing would either silently skip new
+    // data or leave vanished source records searchable. Existing planned-key
+    // content replacement and crash repair remain supported.
+    //
+    // This runs before the junk sweep below on purpose: a refused rerun must
+    // compute nothing and mutate nothing.
+    if resumed_with_plan {
+        let delta = UnsupportedInventoryDelta::between(&files, &keys, &plan);
+        if !delta.is_empty() {
+            return Err(delta.into_error());
+        }
+    }
+
     // ── stale junk-catalog sweep (#238) ──────────────────────────────────
     //
     // A junk/skipped file is never indexed and never enters the graph corpus
@@ -1686,7 +1930,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 rel: files[i].rel.clone(),
                 format: "unknown".into(),
                 status: "skipped".into(),
-                reason: "not in the frozen resume plan (re-run with --fresh to include new files)"
+                reason: "not in the frozen resume plan; no destination change was made. For an \
+                         exact rebuild use a new --state-dir, a new --prefix, and, when graph \
+                         detection is enabled, a new --brain (or use --no-graph)"
                     .into(),
                 bytes: files[i].size,
             });
@@ -3361,6 +3607,115 @@ mod section_label_tests {
 }
 
 #[cfg(test)]
+mod inventory_delta_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn file(path: &str) -> walk::FileEntry {
+        walk::FileEntry {
+            path: PathBuf::from(path),
+            rel: path.to_owned(),
+            rel_id: format!("id:{path}"),
+            is_symlink: false,
+            size: 1,
+        }
+    }
+
+    fn assignment(path: &str) -> FileAssignment {
+        FileAssignment {
+            rel: path.to_owned(),
+            path_id: format!("id:{path}"),
+            family: "csv".into(),
+            gzip: false,
+            content_digest: Some(format!("digest:{path}")),
+            assignments: vec![(None, "rows".into())],
+            as_document: false,
+        }
+    }
+
+    #[test]
+    fn classifier_is_empty_for_noop_and_sorts_added_and_vanished_groups() {
+        let mut plan = Plan::default();
+        plan.files.insert("keep".into(), assignment("keep.csv"));
+        assert!(
+            UnsupportedInventoryDelta::between(&[file("keep.csv")], &["keep".into()], &plan)
+                .is_empty()
+        );
+        plan.junk_files.push(JunkFile {
+            file_key: "junk".into(),
+            rel: "broken.pdf".into(),
+            format: "pdf".into(),
+            status: "junk".into(),
+            reason: "fixture".into(),
+            bytes: 1,
+        });
+        assert!(
+            UnsupportedInventoryDelta::between(
+                &[file("keep.csv"), file("broken.pdf")],
+                &["keep".into(), "junk".into()],
+                &plan,
+            )
+            .is_empty(),
+            "unchanged durable junk is not newly added content"
+        );
+
+        plan.files.insert("old-z".into(), assignment("z-old.csv"));
+        plan.files.insert("old-a".into(), assignment("a-old.csv"));
+        let delta = UnsupportedInventoryDelta::between(
+            &[
+                file("keep.csv"),
+                file("broken.pdf"),
+                file("z-new.csv"),
+                file("m-new.csv"),
+            ],
+            &["keep".into(), "junk".into(), "new-z".into(), "new-m".into()],
+            &plan,
+        );
+        assert_eq!(
+            delta
+                .added_content_groups
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["m-new.csv", "z-new.csv"]
+        );
+        assert_eq!(
+            delta
+                .vanished_content_groups
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["a-old.csv", "z-old.csv"]
+        );
+    }
+
+    #[test]
+    fn cli_error_routing_separates_typed_json_from_unrelated_human_errors() {
+        let typed = UnsupportedInventoryDelta {
+            added_content_groups: vec![InventoryDeltaEntry {
+                file_key: "key".into(),
+                path: "new.csv".into(),
+            }],
+            vanished_content_groups: Vec::new(),
+        }
+        .into_error();
+        let route = route_cli_error(&typed, true);
+        assert_eq!(route.exit_code, 1);
+        assert!(route.stderr.is_none());
+        let stdout = route.stdout.unwrap();
+        let value: Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(value["schema"], "xerj.autoindex.unsupported_sync_delta.v1");
+        assert_eq!(value["error"], "unsupported_inventory_delta");
+
+        let unrelated = anyhow::anyhow!("endpoint unavailable");
+        let route = route_cli_error(&unrelated, true);
+        assert_eq!(route.exit_code, 1);
+        assert!(route.stdout.is_none());
+        assert_eq!(route.stderr.as_deref(), Some("error: endpoint unavailable"));
+    }
+}
+
+#[cfg(test)]
 mod duplicate_integration_tests {
     use super::*;
     use std::collections::HashSet;
@@ -3410,11 +3765,11 @@ mod duplicate_integration_tests {
         .unwrap_err();
         let message = format!("{error:#}");
         assert!(message.contains("collides with legacy resume key"));
-        // Recovery advice must stay scoped to the two colliding files and be
-        // honest that discarding the journal re-embeds the whole corpus.
+        // Recovery advice must stay scoped to the two colliding files and
+        // keep an exact rebuild isolated from the old destination.
         assert!(message.contains("remove or move one of these two files"));
         assert!(message.contains("/state/journal.ndjson"));
-        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
+        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -1282,6 +1282,27 @@ impl UnsupportedInventoryDelta {
             .map(String::as_str)
             .chain(plan.junk_files.iter().map(|junk| junk.file_key.as_str()))
             .collect();
+        // Path identity, not just content identity. An in-place EDIT gives the
+        // same file a new content key, so a key-only comparison reads the
+        // superseded key as vanished and the new one as added — the SAME path
+        // listed as both removed and added. That is a replacement, and the file
+        // is still there to be republished, so it must never be refused.
+        // Ordinary resume already reaches this conclusion by mapping each file
+        // onto its planned key (`select_resume_plan_keys`); doing it here makes
+        // `--fresh`, which has no plan to map through, agree — without making
+        // the gate more fatal than the open it precedes.
+        let current_rels: std::collections::HashSet<&str> =
+            files.iter().map(|file| file.rel.as_str()).collect();
+        let current_path_ids: std::collections::HashSet<&str> = files
+            .iter()
+            .map(|file| file.rel_id.as_str())
+            .filter(|id| !id.is_empty())
+            .collect();
+        let path_survives = |assignment: &FileAssignment| {
+            current_rels.contains(assignment.rel.as_str())
+                || (!assignment.path_id.is_empty()
+                    && current_path_ids.contains(assignment.path_id.as_str()))
+        };
 
         let mut added_content_groups: Vec<InventoryDeltaEntry> = files
             .iter()
@@ -1295,7 +1316,9 @@ impl UnsupportedInventoryDelta {
         let mut vanished_content_groups: Vec<InventoryDeltaEntry> = plan
             .files
             .iter()
-            .filter(|(key, _)| !current_keys.contains(key.as_str()))
+            .filter(|(key, assignment)| {
+                !current_keys.contains(key.as_str()) && !path_survives(assignment)
+            })
             .map(|(key, assignment)| InventoryDeltaEntry {
                 file_key: key.clone(),
                 path: assignment.rel.clone(),

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -179,10 +179,76 @@ mod tests {
         }
     }
 
+    /// The preflight must never be more fatal than the open it precedes.
+    /// `open_after_preflight` deletes the journal unread when `--fresh` is set,
+    /// so a preflight that hard-errors while parsing that journal would make
+    /// `--fresh` unreachable in exactly the states whose error text recommends
+    /// it — a state directory no supported flag can recover.
+    #[test]
+    fn fresh_recovers_journals_that_the_preflight_refuses_to_resume() {
+        for (label, journal, refusal_marker) in [
+            (
+                "malformed record",
+                concat!(
+                    "{\"v\":1,\"kind\":\"run\",\"root\":\"root\",\"url\":\"url\",",
+                    "\"prefix\":\"prefix\",\"run_id\":\"legacy\"}\n",
+                    "{not json at all\n"
+                ),
+                "--fresh",
+            ),
+            (
+                "root/url/prefix mismatch",
+                concat!(
+                    "{\"v\":1,\"kind\":\"run\",\"root\":\"elsewhere\",\"url\":\"url\",",
+                    "\"prefix\":\"prefix\",\"run_id\":\"legacy\"}\n"
+                ),
+                "was created for root=",
+            ),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("journal.ndjson");
+            std::fs::write(&path, journal).unwrap();
+
+            let refused = Journal::preflight(dir.path(), "root", "url", "prefix", false)
+                .err()
+                .unwrap_or_else(|| panic!("{label}: a resume must still refuse this journal"));
+            let refused = format!("{refused:#}");
+            assert!(refused.contains(refusal_marker), "{label}: {refused}");
+
+            let preflight = Journal::preflight(dir.path(), "root", "url", "prefix", true)
+                .unwrap_or_else(|e| panic!("{label}: --fresh must pass the preflight: {e:#}"));
+            assert!(preflight.plan.is_none(), "{label}");
+            let reason = preflight
+                .unreadable_plan
+                .clone()
+                .unwrap_or_else(|| panic!("{label}: the discarded plan must be reported"));
+            assert!(!reason.is_empty(), "{label}");
+
+            let journal =
+                Journal::open_after_preflight(preflight, "root", "url", "prefix", 300, true)
+                    .unwrap_or_else(|e| panic!("{label}: --fresh must open: {e:#}"));
+            drop(journal);
+            // And the rebuilt state directory is resumable again without --fresh.
+            Journal::open(dir.path(), "root", "url", "prefix", 300, false)
+                .unwrap_or_else(|e| panic!("{label}: the rebuilt journal must resume: {e:#}"));
+        }
+    }
+
+    /// A readable journal must not be reported as unreadable just because the
+    /// run asked for `--fresh`; the note is a discarded-state warning, not a
+    /// `--fresh` banner.
+    #[test]
+    fn fresh_over_a_readable_journal_reports_nothing_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        drop(Journal::open(dir.path(), "root", "url", "prefix", 300, true).unwrap());
+        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix", true).unwrap();
+        assert!(preflight.unreadable_plan.is_none());
+    }
+
     #[test]
     fn preflight_holds_the_same_exclusive_lock_through_authoritative_open() {
         let dir = tempfile::tempdir().unwrap();
-        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix").unwrap();
+        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix", false).unwrap();
         let error = Journal::open(dir.path(), "root", "url", "prefix", 300, false)
             .err()
             .expect("a second opener must not pass the held preflight lock");
@@ -376,14 +442,25 @@ pub struct JournalPreflight {
     state_lock: std::fs::File,
     pub plan: Option<Plan>,
     pub journal_exists: bool,
+    /// Set only under `--fresh`, when the durable plan could not be read and
+    /// the run is about to discard the journal anyway. The caller owns the
+    /// decision to print it (autoindex honours `--quiet`).
+    pub unreadable_plan: Option<String>,
 }
 
 impl Journal {
+    /// `fresh` is not a formality here. `open_after_preflight` removes the
+    /// journal before replaying it when `--fresh` is set, so nothing inside a
+    /// journal can be fatal to that path — and a preflight that hard-errors on
+    /// a corrupt record or a root/url/prefix mismatch would make `--fresh`
+    /// unreachable in exactly the cases whose error text recommends it. The
+    /// preflight must therefore never be more fatal than the open it precedes.
     pub fn preflight(
         state_dir: &Path,
         root: &str,
         url: &str,
         prefix: &str,
+        fresh: bool,
     ) -> Result<JournalPreflight> {
         std::fs::create_dir_all(state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
@@ -403,12 +480,22 @@ impl Journal {
         })?;
         let journal_path = state_dir.join("journal.ndjson");
         let journal_exists = journal_path.exists();
-        let plan = read_plan_for_preflight(&journal_path, root, url, prefix)?;
+        let (plan, unreadable_plan) =
+            match read_plan_for_preflight(&journal_path, root, url, prefix) {
+                Ok(plan) => (plan, None),
+                // The journal is about to be deleted unread. Losing the plan here
+                // costs the removed-file gate its comparison basis, which is
+                // exactly what a full in-place rebuild accepts; the alternative is
+                // a state directory that no supported flag can recover.
+                Err(error) if fresh => (None, Some(format!("{error:#}"))),
+                Err(error) => return Err(error),
+            };
         Ok(JournalPreflight {
             state_dir: state_dir.to_owned(),
             state_lock,
             plan,
             journal_exists,
+            unreadable_plan,
         })
     }
 
@@ -420,7 +507,7 @@ impl Journal {
         bulk_timeout_secs: u64,
         fresh: bool,
     ) -> Result<Journal> {
-        let preflight = Self::preflight(state_dir, root, url, prefix)?;
+        let preflight = Self::preflight(state_dir, root, url, prefix, fresh)?;
         Self::open_after_preflight(preflight, root, url, prefix, bulk_timeout_secs, fresh)
     }
 

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -178,6 +178,21 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn preflight_holds_the_same_exclusive_lock_through_authoritative_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let preflight = Journal::preflight(dir.path(), "root", "url", "prefix").unwrap();
+        let error = Journal::open(dir.path(), "root", "url", "prefix", 300, false)
+            .err()
+            .expect("a second opener must not pass the held preflight lock");
+        assert!(format!("{error:#}").contains("already in use"));
+
+        let journal =
+            Journal::open_after_preflight(preflight, "root", "url", "prefix", 300, false).unwrap();
+        drop(journal);
+        assert!(Journal::open(dir.path(), "root", "url", "prefix", 300, false).is_ok());
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -280,15 +295,97 @@ pub fn default_state_dir(root: &str, url: &str, prefix: &str) -> PathBuf {
         .join(crate::ids::state_key(root, url, prefix))
 }
 
+/// Read the last durable plan without locking, repairing, truncating or
+/// appending to the journal. This is a preflight hint only: `Journal::open`
+/// remains the authority after the caller passes its fail-closed inventory
+/// gate and acquires the state lock.
+fn read_plan_for_preflight(
+    path: &Path,
+    root: &str,
+    url: &str,
+    prefix: &str,
+) -> Result<Option<Plan>> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut plan = None;
+    let mut offset = 0u64;
+    loop {
+        let record_start = offset;
+        let mut bytes = Vec::new();
+        let read = reader.read_until(b'\n', &mut bytes)?;
+        if read == 0 {
+            break;
+        }
+        offset += read as u64;
+        if bytes.last() != Some(&b'\n') {
+            // `Journal::open` will repair this torn final record after the
+            // preflight accepts. It cannot be treated as durable here.
+            break;
+        }
+        let value: Value =
+            serde_json::from_slice(bytes.strip_suffix(b"\n").unwrap_or(bytes.as_slice()))
+                .with_context(|| {
+                    format!(
+                        "journal corruption at byte {record_start} in {}: malformed \
+                         newline-terminated record. Refusing to discard later records. Restore \
+                         the journal from a backup, or truncate it to exactly {record_start} \
+                         bytes to keep every completion recorded before the corruption. For an \
+                         isolated rebuild use a new --state-dir, new --prefix, and new --brain \
+                         when graph detection is enabled (or --no-graph); explicitly validate \
+                         and clean the shared catalog and old target",
+                        path.display()
+                    )
+                })?;
+        match value.get("kind").and_then(Value::as_str) {
+            Some("run") => {
+                let recorded_root = value.get("root").and_then(Value::as_str).unwrap_or("");
+                let recorded_url = value.get("url").and_then(Value::as_str).unwrap_or("");
+                let recorded_prefix = value.get("prefix").and_then(Value::as_str).unwrap_or("");
+                anyhow::ensure!(
+                    recorded_root == root && recorded_url == url && recorded_prefix == prefix,
+                    "journal at {} was created for root={} url={} prefix={}; current run has \
+                     root={} url={} prefix={}",
+                    path.display(),
+                    recorded_root,
+                    recorded_url,
+                    recorded_prefix,
+                    root,
+                    url,
+                    prefix
+                );
+            }
+            Some("plan") => {
+                if let Some(encoded) = value.get("plan") {
+                    plan =
+                        Some(serde_json::from_value(encoded.clone()).with_context(|| {
+                            format!("decode durable plan in {}", path.display())
+                        })?);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(plan)
+}
+
+pub struct JournalPreflight {
+    state_dir: PathBuf,
+    state_lock: std::fs::File,
+    pub plan: Option<Plan>,
+    pub journal_exists: bool,
+}
+
 impl Journal {
-    pub fn open(
+    pub fn preflight(
         state_dir: &Path,
         root: &str,
         url: &str,
         prefix: &str,
-        bulk_timeout_secs: u64,
-        fresh: bool,
-    ) -> Result<Journal> {
+    ) -> Result<JournalPreflight> {
         std::fs::create_dir_all(state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
         let lock_path = state_dir.join(".autoindex.lock");
@@ -305,10 +402,46 @@ impl Journal {
                 state_dir.display()
             )
         })?;
+        let journal_path = state_dir.join("journal.ndjson");
+        let journal_exists = journal_path.exists();
+        let plan = read_plan_for_preflight(&journal_path, root, url, prefix)?;
+        Ok(JournalPreflight {
+            state_dir: state_dir.to_owned(),
+            state_lock,
+            plan,
+            journal_exists,
+        })
+    }
+
+    pub fn open(
+        state_dir: &Path,
+        root: &str,
+        url: &str,
+        prefix: &str,
+        bulk_timeout_secs: u64,
+        fresh: bool,
+    ) -> Result<Journal> {
+        let preflight = Self::preflight(state_dir, root, url, prefix)?;
+        Self::open_after_preflight(preflight, root, url, prefix, bulk_timeout_secs, fresh)
+    }
+
+    pub fn open_after_preflight(
+        preflight: JournalPreflight,
+        root: &str,
+        url: &str,
+        prefix: &str,
+        bulk_timeout_secs: u64,
+        fresh: bool,
+    ) -> Result<Journal> {
+        let JournalPreflight {
+            state_dir,
+            state_lock,
+            ..
+        } = preflight;
         // Hard kills cannot run NamedTempFile::drop. Stages are owned by this
         // journal directory and use a reserved prefix, so removing only
         // regular files with that prefix is deterministic and scope-safe.
-        for entry in std::fs::read_dir(state_dir)? {
+        for entry in std::fs::read_dir(&state_dir)? {
             let entry = entry?;
             if entry
                 .file_name()
@@ -361,7 +494,10 @@ impl Journal {
                                     anyhow::bail!(
                                 "journal at {} was created for root={jr} url={ju} prefix={jp}; \
                                  current run has root={root} url={url} prefix={prefix}. \
-                                 Use --fresh to discard it or --state-dir for a separate state.",
+                                 Refusing to discard history under the same destination. For an \
+                                 isolated rebuild use a new --state-dir, new --prefix, and new \
+                                 --brain when graph detection is enabled (or --no-graph); \
+                                 explicitly validate and clean the shared catalog and old target.",
                                 jpath.display()
                             );
                                 }
@@ -470,9 +606,10 @@ impl Journal {
                              after corruption. Restore the journal from a backup, or truncate it \
                              to exactly {record_start} bytes to keep every completion recorded \
                              before the corruption (files journaled after that point are \
-                             re-verified, re-indexed and re-embedded on the next run). Deleting \
-                             the whole journal (or rerunning with --fresh) also recovers, but \
-                             re-extracts and re-embeds the entire corpus",
+                             re-verified, re-indexed and re-embedded on the next run). For an \
+                             isolated rebuild use a new --state-dir, new --prefix, and new --brain \
+                             when graph detection is enabled (or --no-graph); explicitly validate \
+                             and clean the shared catalog and old target",
                             jpath.display()
                         );
                     }
@@ -902,9 +1039,10 @@ mod compatibility_tests {
         let message = format!("{error:#}");
         assert!(message.contains("journal corruption"));
         // Recovery guidance must stay scoped and honest: byte-exact truncation
-        // keeps prior completions; discarding the journal re-embeds everything.
+        // keeps prior completions; an exact rebuild needs isolated state and
+        // destination identities.
         assert!(message.contains("truncate it to exactly"));
-        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
+        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -333,10 +333,9 @@ fn read_plan_for_preflight(
                         "journal corruption at byte {record_start} in {}: malformed \
                          newline-terminated record. Refusing to discard later records. Restore \
                          the journal from a backup, or truncate it to exactly {record_start} \
-                         bytes to keep every completion recorded before the corruption. For an \
-                         isolated rebuild use a new --state-dir, new --prefix, and new --brain \
-                         when graph detection is enabled (or --no-graph); explicitly validate \
-                         and clean the shared catalog and old target",
+                         bytes to keep every completion recorded before the corruption. Deleting \
+                         the whole journal (or rerunning with --fresh) also recovers, but \
+                         re-extracts and re-embeds the entire corpus",
                         path.display()
                     )
                 })?;
@@ -494,10 +493,9 @@ impl Journal {
                                     anyhow::bail!(
                                 "journal at {} was created for root={jr} url={ju} prefix={jp}; \
                                  current run has root={root} url={url} prefix={prefix}. \
-                                 Refusing to discard history under the same destination. For an \
-                                 isolated rebuild use a new --state-dir, new --prefix, and new \
-                                 --brain when graph detection is enabled (or --no-graph); \
-                                 explicitly validate and clean the shared catalog and old target.",
+                                 Use --state-dir for separate state, or --fresh to rebuild the \
+                                 plan in place — note that --fresh never deletes documents \
+                                 already published under the other root, url or prefix.",
                                 jpath.display()
                             );
                                 }
@@ -606,10 +604,9 @@ impl Journal {
                              after corruption. Restore the journal from a backup, or truncate it \
                              to exactly {record_start} bytes to keep every completion recorded \
                              before the corruption (files journaled after that point are \
-                             re-verified, re-indexed and re-embedded on the next run). For an \
-                             isolated rebuild use a new --state-dir, new --prefix, and new --brain \
-                             when graph detection is enabled (or --no-graph); explicitly validate \
-                             and clean the shared catalog and old target",
+                             re-verified, re-indexed and re-embedded on the next run). Deleting \
+                             the whole journal (or rerunning with --fresh) also recovers, but \
+                             re-extracts and re-embeds the entire corpus",
                             jpath.display()
                         );
                     }
@@ -1039,10 +1036,9 @@ mod compatibility_tests {
         let message = format!("{error:#}");
         assert!(message.contains("journal corruption"));
         // Recovery guidance must stay scoped and honest: byte-exact truncation
-        // keeps prior completions; an exact rebuild needs isolated state and
-        // destination identities.
+        // keeps prior completions; discarding the journal re-embeds everything.
         assert!(message.contains("truncate it to exactly"));
-        assert!(message.contains("new --state-dir, new --prefix, and new --brain"));
+        assert!(message.contains("re-extracts and re-embeds the entire corpus"));
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -24573,7 +24573,9 @@ fn validate_embedding_identity(
                     "embedding identity mismatch for index {}: persisted backend={} \
                      model={} tokenizer={}, configured backend={} model={} tokenizer={}. \
                      Refusing to mix incompatible vector spaces. Restore the original assets \
-                     or re-run autoindex with --fresh and a new index prefix.",
+                     or rebuild with a new autoindex state directory, new index prefix, and new \
+                     brain when graph detection is enabled (or --no-graph); validate before \
+                     switching readers and explicitly clean the shared catalog and old target.",
                     index_dir.display(),
                     persisted.backend,
                     persisted.model_sha256,
@@ -24587,7 +24589,9 @@ fn validate_embedding_identity(
                 format!(
                     "index {} contains ONNX vectors but the server is configured for \
                      embedding.mode={:?}. Restart with onnx-experimental and the original \
-                     assets, or reindex under a new prefix.",
+                     assets, or rebuild with a new autoindex state directory, new prefix, and new \
+                     brain when graph detection is enabled (or --no-graph); validate before \
+                     switching readers and explicitly clean the shared catalog and old target.",
                     index_dir.display(),
                     cfg.mode
                 ),
@@ -24602,8 +24606,9 @@ fn validate_embedding_identity(
             format!(
                 "existing semantic index {} has no embedding identity marker. It may contain \
                  vectors from another backend, so ONNX cannot be enabled safely in place. \
-                 Re-run autoindex with --fresh and a new --prefix, or rebuild the index from \
-                 source.",
+                 Rebuild from source with a new autoindex state directory, new --prefix, and new \
+                 --brain when graph detection is enabled (or --no-graph); validate before \
+                 switching readers and explicitly clean the shared catalog and old target.",
                 index_dir.display()
             ),
         )));
@@ -24999,6 +25004,9 @@ mod embedding_identity_tests {
                 .to_string();
         assert!(error.contains("identity mismatch"), "{error}");
         assert!(error.contains("new index prefix"), "{error}");
+        assert!(error.contains("new brain"), "{error}");
+        assert!(error.contains("--no-graph"), "{error}");
+        assert!(error.contains("shared catalog"), "{error}");
     }
 
     #[test]
@@ -25017,6 +25025,9 @@ mod embedding_identity_tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("no embedding identity marker"), "{error}");
+        assert!(error.contains("new --brain"), "{error}");
+        assert!(error.contains("--no-graph"), "{error}");
+        assert!(error.contains("shared catalog"), "{error}");
     }
 
     #[cfg(feature = "onnx-experimental")]

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -279,7 +279,7 @@ fn run(cfg: BrainCfg) -> Result<i32> {
     };
     // `records_total` is run-scoped: a resumed re-run over an already-indexed
     // folder legitimately reports 0. Server truth decides what that means.
-    if run_u64(&run_doc, "records_total") == 0 {
+    if needs_live_node_probe(run_u64(&run_doc, "records_total")) {
         let live_nodes = live_node_docs(&es, &brain)?;
         if journal_server_disagrees(run_u64(&run_doc, "files_indexed"), live_nodes, cfg.fresh) {
             bail!("{}", journal_server_disagreement(&cfg, &brain));
@@ -439,6 +439,10 @@ fn journal_server_disagreement(cfg: &BrainCfg, brain: &str) -> String {
 
 fn journal_server_disagrees(files_indexed: u64, live_nodes: Option<u64>, fresh: bool) -> bool {
     files_indexed > 0 && matches!(live_nodes, None | Some(0)) && !fresh
+}
+
+fn needs_live_node_probe(records_total: u64) -> bool {
+    records_total == 0
 }
 
 fn index_cfg(cfg: &BrainCfg, brain: &str, api_key: Option<String>) -> IndexCfg {
@@ -720,6 +724,11 @@ mod tests {
 
     #[test]
     fn disagreement_decision_refuses_absent_and_zero_but_not_positive_server_truth() {
+        assert!(
+            !needs_live_node_probe(1),
+            "a run that indexed a new note must not enter resume probing"
+        );
+        assert!(needs_live_node_probe(0));
         assert!(journal_server_disagrees(1, None, false));
         assert!(journal_server_disagrees(1, Some(0), false));
         assert!(!journal_server_disagrees(1, Some(7), false));

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -79,8 +79,8 @@ pub fn print_help() {
              --api-key <K>      API key for an already-running secured server\n\
                                 (or env XERJ_API_KEY; a server booted by this command\n\
                                 needs neither — its key is read from <data-dir>/admin.key)\n\
-             --fresh            ignore the resume journal, re-walk everything\n\
-                                (ids stay idempotent; converges to the same brain)\n\
+             --fresh            start without resume state only when the selected\n\
+                                journal has no durable plan; never resets server data\n\
              --no-open          print the links but do not open a browser\n\
              --help, -h         this help\n\
          \n\
@@ -267,7 +267,7 @@ fn run(cfg: BrainCfg) -> Result<i32> {
     }
 
     // ── index: the autoindex pipeline, graph detection on ────────────────
-    let (mut code, mut run_doc) =
+    let (code, run_doc) =
         xerj_autoindex::run_index_report(index_cfg(&cfg, &brain, api_key.clone()))?;
 
     let run_u64 = |doc: &Option<Value>, key: &str| {
@@ -279,30 +279,16 @@ fn run(cfg: BrainCfg) -> Result<i32> {
     // `records_total` is run-scoped: a resumed re-run over an already-indexed
     // folder legitimately reports 0. Server truth decides what that means.
     if run_u64(&run_doc, "records_total") == 0 {
-        let live_nodes = live_node_docs(&es, &brain);
-        if live_nodes == 0 && run_u64(&run_doc, "files_indexed") > 0 && !cfg.fresh {
-            // The resume journal says this folder is done, but the server has
-            // none of it (wiped data dir, or a different --url than the run
-            // that wrote the journal). Trusting the journal here would leave a
-            // silent, permanently-empty brain — with only structural edges,
-            // since text detectors ride the per-file indexing pass. Re-index
-            // from scratch once; ids are idempotent, so this converges.
-            eprintln!(
-                "\nresume journal says {} is already indexed, but the server at {} has none \
-                 of it — re-indexing from scratch",
-                cfg.root.display(),
-                cfg.url
-            );
-            let mut fresh_cfg = index_cfg(&cfg, &brain, api_key);
-            fresh_cfg.fresh = true;
-            (code, run_doc) = xerj_autoindex::run_index_report(fresh_cfg)?;
+        let live_nodes = live_node_docs(&es, &brain)?;
+        if journal_server_disagrees(run_u64(&run_doc, "files_indexed"), live_nodes, cfg.fresh) {
+            bail!("{}", journal_server_disagreement(&cfg, &brain));
         }
     }
 
     // Server truth for every surface below: run-scoped counters read 0 on a
     // converged re-run, but the brain is live on the server all the same.
     let records_live = match run_u64(&run_doc, "records_total") {
-        0 => live_node_docs(&es, &brain),
+        0 => live_node_docs(&es, &brain)?.unwrap_or(0),
         n => n,
     };
     if records_live == 0 {
@@ -391,12 +377,13 @@ fn run(cfg: BrainCfg) -> Result<i32> {
 
 /// Count the node documents live on the server behind `brain`, via the brain
 /// meta doc's `nodes_index` (SECOND_BRAIN_SPEC §2.5 — autoindex writes the
-/// comma-list of its dataset indices there). 0 on any miss: an unreadable
-/// meta doc and an empty brain call for the same honest answer.
-fn live_node_docs(es: &Es, brain: &str) -> u64 {
+/// comma-list of its dataset indices there). Absence is distinct from an
+/// authoritative zero, and probe failures are never converted into reset
+/// authorization.
+fn live_node_docs(es: &Es, brain: &str) -> Result<Option<u64>> {
     let edges_index = detect::edges_index_name(brain);
-    let Ok(Some(meta)) = es.get_doc(&edges_index, detect::BRAIN_META_ID) else {
-        return 0;
+    let Some(meta) = es.get_doc(&edges_index, detect::BRAIN_META_ID)? else {
+        return Ok(None);
     };
     // `Es::get_doc` returns the document `_source` itself.
     let Some(nodes_index) = meta
@@ -404,15 +391,46 @@ fn live_node_docs(es: &Es, brain: &str) -> u64 {
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
     else {
-        return 0;
+        bail!(
+            "brain metadata {edges_index}/{} has no usable nodes_index",
+            detect::BRAIN_META_ID
+        );
     };
-    es.search(
+    let response = es.search(
         nodes_index,
         &json!({"size": 0, "track_total_hits": true, "query": {"match_all": {}}}),
+    )?;
+    response
+        .pointer("/hits/total/value")
+        .and_then(Value::as_u64)
+        .map(Some)
+        .context("node-count response has no numeric hits.total.value")
+}
+
+fn journal_server_disagreement(cfg: &BrainCfg, brain: &str) -> String {
+    let root = std::fs::canonicalize(&cfg.root).unwrap_or_else(|_| cfg.root.clone());
+    let state_dir =
+        xerj_autoindex::state::default_state_dir(&root.to_string_lossy(), &cfg.url, "ax");
+    format!(
+        "the resume journal and server disagree: journal {} says {} is already indexed, \
+         but {} has no confirmed live node documents for prefix ax and brain {brain}. No reset \
+         was attempted: an absent or zero node probe does not prove that data, catalog, and \
+         graph namespaces are empty. Restore the server data directory used by this journal. \
+         Otherwise, after validating or cleaning the old destination, run an isolated rebuild:\n\
+         xerj autoindex {} --url {} --state-dir <new-state-dir> --prefix <new-prefix> \
+         --brain <new-brain>\n\
+         For a secured endpoint, set XERJ_API_KEY or add --api-key without placing its value in \
+         logs. Validate the new target before switching readers",
+        state_dir.display(),
+        root.display(),
+        cfg.url,
+        root.display(),
+        cfg.url,
     )
-    .ok()
-    .and_then(|v| v.pointer("/hits/total/value").and_then(Value::as_u64))
-    .unwrap_or(0)
+}
+
+fn journal_server_disagrees(files_indexed: u64, live_nodes: Option<u64>, fresh: bool) -> bool {
+    files_indexed > 0 && matches!(live_nodes, None | Some(0)) && !fresh
 }
 
 fn index_cfg(cfg: &BrainCfg, brain: &str, api_key: Option<String>) -> IndexCfg {
@@ -663,6 +681,40 @@ mod tests {
         assert!(cfg.no_open);
         assert_eq!(cfg.brain.as_deref(), Some("kb"));
         assert_eq!(cfg.url, "http://localhost:9200");
+    }
+
+    #[test]
+    fn journal_server_disagreement_refuses_reset_with_executable_recovery() {
+        let cfg = BrainCfg {
+            root: PathBuf::from("/corpus/notes"),
+            brain: Some("team-notes".into()),
+            url: "http://localhost:9200".into(),
+            data_dir: None,
+            api_key: None,
+            fresh: false,
+            no_open: true,
+        };
+        let message = journal_server_disagreement(&cfg, "team-notes");
+        assert!(message.contains("resume journal and server disagree"));
+        assert!(message.contains("No reset was attempted"));
+        assert!(message.contains("http://localhost:9200"));
+        assert!(message.contains("prefix ax"));
+        assert!(message.contains("brain team-notes"));
+        assert!(message.contains("xerj autoindex /corpus/notes"));
+        assert!(message.contains("--url http://localhost:9200"));
+        assert!(message.contains("--state-dir <new-state-dir>"));
+        assert!(message.contains("--prefix <new-prefix>"));
+        assert!(message.contains("--brain <new-brain>"));
+        assert!(message.contains("XERJ_API_KEY"));
+    }
+
+    #[test]
+    fn disagreement_decision_refuses_absent_and_zero_but_not_positive_server_truth() {
+        assert!(journal_server_disagrees(1, None, false));
+        assert!(journal_server_disagrees(1, Some(0), false));
+        assert!(!journal_server_disagrees(1, Some(7), false));
+        assert!(!journal_server_disagrees(0, Some(0), false));
+        assert!(!journal_server_disagrees(1, Some(0), true));
     }
 
     #[test]

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -79,8 +79,9 @@ pub fn print_help() {
              --api-key <K>      API key for an already-running secured server\n\
                                 (or env XERJ_API_KEY; a server booted by this command\n\
                                 needs neither — its key is read from <data-dir>/admin.key)\n\
-             --fresh            start without resume state only when the selected\n\
-                                journal has no durable plan; never resets server data\n\
+             --fresh            ignore the resume journal and rebuild the plan in place,\n\
+                                re-walking everything (ids stay idempotent). It never\n\
+                                deletes documents for notes you removed\n\
              --no-open          print the links but do not open a browser\n\
              --help, -h         this help\n\
          \n\
@@ -386,15 +387,16 @@ fn live_node_docs(es: &Es, brain: &str) -> Result<Option<u64>> {
         return Ok(None);
     };
     // `Es::get_doc` returns the document `_source` itself.
+    // A meta doc without `nodes_index` predates the field (or was written by
+    // something other than autoindex). That is absence of evidence, not a
+    // failure: report it as unknown instead of hard-failing every brain that
+    // an older autoindex wrote.
     let Some(nodes_index) = meta
         .get("nodes_index")
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
     else {
-        bail!(
-            "brain metadata {edges_index}/{} has no usable nodes_index",
-            detect::BRAIN_META_ID
-        );
+        return Ok(None);
     };
     let response = es.search(
         nodes_index,
@@ -415,13 +417,19 @@ fn journal_server_disagreement(cfg: &BrainCfg, brain: &str) -> String {
         "the resume journal and server disagree: journal {} says {} is already indexed, \
          but {} has no confirmed live node documents for prefix ax and brain {brain}. No reset \
          was attempted: an absent or zero node probe does not prove that data, catalog, and \
-         graph namespaces are empty. Restore the server data directory used by this journal. \
+         graph namespaces are empty. If this is the wrong server, restore or point at the data \
+         directory this journal was written against. If the data directory really was wiped, \
+         rerun with --fresh to rebuild the plan and republish every file in place (ids are \
+         idempotent):\n\
+         xerj brain {} --url {} --fresh\n\
          Otherwise, after validating or cleaning the old destination, run an isolated rebuild:\n\
          xerj autoindex {} --url {} --state-dir <new-state-dir> --prefix <new-prefix> \
          --brain <new-brain>\n\
          For a secured endpoint, set XERJ_API_KEY or add --api-key without placing its value in \
          logs. Validate the new target before switching readers",
         state_dir.display(),
+        root.display(),
+        cfg.url,
         root.display(),
         cfg.url,
         root.display(),
@@ -700,6 +708,8 @@ mod tests {
         assert!(message.contains("http://localhost:9200"));
         assert!(message.contains("prefix ax"));
         assert!(message.contains("brain team-notes"));
+        assert!(message.contains("xerj brain /corpus/notes"));
+        assert!(message.contains("--fresh"));
         assert!(message.contains("xerj autoindex /corpus/notes"));
         assert!(message.contains("--url http://localhost:9200"));
         assert!(message.contains("--state-dir <new-state-dir>"));

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -269,7 +269,29 @@ fn run(cfg: BrainCfg) -> Result<i32> {
 
     // ── index: the autoindex pipeline, graph detection on ────────────────
     let (code, run_doc) =
-        xerj_autoindex::run_index_report(index_cfg(&cfg, &brain, api_key.clone()))?;
+        match xerj_autoindex::run_index_report(index_cfg(&cfg, &brain, api_key.clone())) {
+            Ok(report) => report,
+            // #195's zero-live verification fires INSIDE `run_index_report`,
+            // before the probe below ever runs. A resume journal that outlived
+            // a wiped data directory reaches it first — the run resumes, skips
+            // every already-done file, and finds nothing live — so propagating
+            // it unchanged hands the operator raw verification prose for
+            // exactly the case `journal_server_disagreement()` was written to
+            // explain, with no `xerj brain --fresh` recovery in it. Classify it
+            // here instead. Every other failure keeps its own message, and so
+            // does this one when the probe fails or contradicts it: a probe
+            // that cannot answer is not evidence of a wiped destination.
+            Err(error) => {
+                if error.is::<xerj_autoindex::ZeroLiveVerificationError>() {
+                    if let Ok(live_nodes) = live_node_docs(&es, &brain) {
+                        if zero_live_is_journal_server_disagreement(&error, live_nodes, cfg.fresh) {
+                            bail!("{}", journal_server_disagreement(&cfg, &brain));
+                        }
+                    }
+                }
+                return Err(error);
+            }
+        };
 
     let run_u64 = |doc: &Option<Value>, key: &str| {
         doc.as_ref()
@@ -448,6 +470,24 @@ fn journal_server_disagreement(cfg: &BrainCfg, brain: &str) -> String {
 
 fn journal_server_disagrees(files_indexed: u64, live_nodes: Option<u64>, fresh: bool) -> bool {
     files_indexed > 0 && matches!(live_nodes, None | Some(0)) && !fresh
+}
+
+/// A failed indexing run is the wiped-destination case only when the failure
+/// is autoindex's own zero-live verification (#195) *and* the live-node probe
+/// agrees that nothing is there. The journal's completed-file count is the
+/// claim being contradicted, so it is what the disagreement test reads —
+/// the run summary that would normally carry `files_indexed` is never
+/// produced when the pipeline fails.
+fn zero_live_is_journal_server_disagreement(
+    error: &anyhow::Error,
+    live_nodes: Option<u64>,
+    fresh: bool,
+) -> bool {
+    error
+        .downcast_ref::<xerj_autoindex::ZeroLiveVerificationError>()
+        .is_some_and(|zero_live| {
+            journal_server_disagrees(zero_live.files_done_journaled as u64, live_nodes, fresh)
+        })
 }
 
 fn needs_live_node_probe(records_total: u64) -> bool {
@@ -743,6 +783,65 @@ mod tests {
         assert!(!journal_server_disagrees(1, Some(7), false));
         assert!(!journal_server_disagrees(0, Some(0), false));
         assert!(!journal_server_disagrees(1, Some(0), true));
+    }
+
+    /// The wiped-data-dir case never reaches the probe above on its own: the
+    /// pipeline's own zero-live verification fails first. Unless that failure
+    /// is classified, the operator reads verification prose instead of the
+    /// recovery, which is what CI's use-case smoke phase 5 caught.
+    #[test]
+    fn a_zero_live_verification_failure_is_read_as_the_wiped_destination() {
+        let zero_live: anyhow::Error = xerj_autoindex::ZeroLiveVerificationError {
+            journal_records: 42,
+            files_done_journaled: 7,
+            dataset_indices: 2,
+        }
+        .into();
+        assert!(zero_live_is_journal_server_disagreement(
+            &zero_live, None, false
+        ));
+        assert!(zero_live_is_journal_server_disagreement(
+            &zero_live,
+            Some(0),
+            false
+        ));
+        // Server truth contradicts the verification: keep the original error.
+        assert!(!zero_live_is_journal_server_disagreement(
+            &zero_live,
+            Some(9),
+            false
+        ));
+        // `--fresh` republishes in place, so a zero-live failure under it is
+        // a real write problem, not a stale journal.
+        assert!(!zero_live_is_journal_server_disagreement(
+            &zero_live, None, true
+        ));
+        // Every other failure keeps its own message.
+        assert!(!zero_live_is_journal_server_disagreement(
+            &anyhow::anyhow!("server at http://localhost:9200 stopped answering"),
+            None,
+            false
+        ));
+    }
+
+    /// The classified message must still be the recovery text, not the
+    /// verification text — the two are distinguishable by their first clause.
+    #[test]
+    fn zero_live_verification_prose_is_not_the_recovery_prose() {
+        let verification = xerj_autoindex::ZeroLiveVerificationError {
+            journal_records: 3,
+            files_done_journaled: 1,
+            dataset_indices: 1,
+        }
+        .to_string();
+        assert!(
+            verification.contains("0 documents are live"),
+            "{verification}"
+        );
+        assert!(
+            !verification.contains("resume journal and server disagree"),
+            "{verification}"
+        );
     }
 
     #[test]

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -398,10 +398,19 @@ fn live_node_docs(es: &Es, brain: &str) -> Result<Option<u64>> {
     else {
         return Ok(None);
     };
-    let response = es.search(
+    // A meta doc that outlived its nodes index is precisely the wiped-data-dir
+    // case this probe exists to catch, so the index being gone must reach
+    // `journal_server_disagreement()` as absence. Propagating the 404 would
+    // short-circuit the caller and print a raw HTTP error instead of the
+    // recovery text. Any other failure still propagates: a probe failure is
+    // never converted into reset authorization.
+    let Some(response) = es.search_present(
         nodes_index,
         &json!({"size": 0, "track_total_hits": true, "query": {"match_all": {}}}),
-    )?;
+    )?
+    else {
+        return Ok(None);
+    };
     response
         .pointer("/hits/total/value")
         .and_then(Value::as_u64)

--- a/landing/docs/recipes/zero-config-autoindex.html
+++ b/landing/docs/recipes/zero-config-autoindex.html
@@ -239,7 +239,8 @@ live indices at http://localhost:9280:
   ax-docs                                           1 docs
   ax-exports                                      800 docs
   autoindex-catalog                                 9 docs</pre>
-  <p><code class="inline">--fresh</code> starts without resume state only when the selected state directory has no durable plan; it never removes stale destination records. For an independent rebuild, use a new <code class="inline">--state-dir</code>, new <code class="inline">--prefix</code>, and new <code class="inline">--brain</code> when graph detection is enabled (or add <code class="inline">--no-graph</code>). Validate before switching readers. The shared <code class="inline">autoindex-catalog</code> and old target require explicit, validated cleanup. Added or removed content groups are refused; same-path replacement remains supported.</p>
+  <p><code class="inline">--fresh</code> ignores the journal and rebuilds the plan in place (ids stay idempotent), which is how you pick up files added since the last run.</p>
+  <p>A rerun that resumes an existing plan indexes changed files and reports added ones as skipped. Deleting a file is refused: nothing here removes the documents it already published, so the rerun stops before touching the destination and names what is gone. Restore the file and rerun, or rebuild — in place by deleting the named indices and the state directory, or isolated under a new <code class="inline">--state-dir</code>, <code class="inline">--prefix</code> and <code class="inline">--brain</code> (or <code class="inline">--no-graph</code>), validated before you switch readers. The shared <code class="inline">autoindex-catalog</code> and the old target require explicit cleanup.</p>
 
   <hr>
 

--- a/landing/docs/recipes/zero-config-autoindex.html
+++ b/landing/docs/recipes/zero-config-autoindex.html
@@ -239,7 +239,7 @@ live indices at http://localhost:9280:
   ax-docs                                           1 docs
   ax-exports                                      800 docs
   autoindex-catalog                                 9 docs</pre>
-  <p><code class="inline">--fresh</code> ignores the journal and restarts (ids stay idempotent).</p>
+  <p><code class="inline">--fresh</code> starts without resume state only when the selected state directory has no durable plan; it never removes stale destination records. For an independent rebuild, use a new <code class="inline">--state-dir</code>, new <code class="inline">--prefix</code>, and new <code class="inline">--brain</code> when graph detection is enabled (or add <code class="inline">--no-graph</code>). Validate before switching readers. The shared <code class="inline">autoindex-catalog</code> and old target require explicit, validated cleanup. Added or removed content groups are refused; same-path replacement remains supported.</p>
 
   <hr>
 

--- a/landing/llms-full.txt
+++ b/landing/llms-full.txt
@@ -140,16 +140,18 @@ destabilize the server.
   xerj autoindex map      [--url U] [--json] [--dataset SLUG]
   xerj autoindex status   [--url U] [--state-dir P]
 
---fresh starts without resume state only when the selected state directory has
-no durable plan. It never removes stale destination records. An independent
-rebuild requires a new --state-dir, new --prefix, and new --brain when graph
-detection is enabled (or --no-graph), followed by validation before switching
-readers. The shared autoindex-catalog and old target require explicit,
-validated cleanup. Added or removed content groups are refused; same-path
-replacement remains supported.
+--fresh ignores the journal and rebuilds the plan in place (ids stay
+idempotent); it is how you pick up files added since the last run. A rerun
+that resumes an existing plan indexes changed files and reports added ones as
+skipped. Deleting an indexed file is refused before any destination change,
+because nothing here removes the documents it already published: restore the
+file and rerun, or rebuild — in place by deleting the named indices and the
+state directory, or isolated under a new --state-dir, --prefix and --brain (or
+--no-graph), validated before switching readers. The shared autoindex-catalog
+and the old target require explicit cleanup.
 
 Exit codes: 0 complete · 3 completed-with-junk (junk recorded, never fatal) ·
-2 usage · 1 endpoint/journal error or refused unsafe corpus-state transition.
+2 usage · 1 endpoint/journal error or a refused corpus removal.
 
 Pipeline: walk → sniff → sample → infer → map → extract → bulk → correlate →
 catalog → verify.

--- a/landing/llms-full.txt
+++ b/landing/llms-full.txt
@@ -140,8 +140,16 @@ destabilize the server.
   xerj autoindex map      [--url U] [--json] [--dataset SLUG]
   xerj autoindex status   [--url U] [--state-dir P]
 
+--fresh starts without resume state only when the selected state directory has
+no durable plan. It never removes stale destination records. An independent
+rebuild requires a new --state-dir, new --prefix, and new --brain when graph
+detection is enabled (or --no-graph), followed by validation before switching
+readers. The shared autoindex-catalog and old target require explicit,
+validated cleanup. Added or removed content groups are refused; same-path
+replacement remains supported.
+
 Exit codes: 0 complete · 3 completed-with-junk (junk recorded, never fatal) ·
-2 usage · 1 endpoint unreachable / journal-config mismatch.
+2 usage · 1 endpoint/journal error or refused unsafe corpus-state transition.
 
 Pipeline: walk → sniff → sample → infer → map → extract → bulk → correlate →
 catalog → verify.


### PR DESCRIPTION
Supersedes #156 by @buger.

His work, our rebase. #156's head is on a fork with `maintainerCanModify=false`, so nobody in xerj-org can push to it — every attempt 403s. This branch carries his commits across with authorship preserved (`buger <leonsbox@gmail.com>` on two of them), rebased onto current `main`, with the outstanding review blockers fixed. Please close #156 when this merges.

## What it does

A durable resume plan is a crash-resume boundary, not a folder-sync generation. Deleting an indexed file and rerunning `xerj autoindex` used to exit 0 while the deleted file's documents, aliases, graph edges and catalog entries stayed live and searchable with no source behind them. That rerun is now refused before any remote call other than the endpoint-readiness ping, with a message that names every removed file and three recovery routes. `xerj brain` stops turning an absent or zero node-count probe into an automatic reset.

## Review blockers fixed on top of #156

**1. `--fresh` had stopped being an escape hatch.** `Journal::preflight` read the durable plan unconditionally and propagated every failure, so a malformed journal record or a root/url/prefix mismatch aborted the run before the `fresh` flag was consulted in `open_after_preflight` — which deletes that journal unread. The refusal text recommends `--fresh` as the recovery from exactly the error that had begun to block it, leaving a state directory no supported flag could repair.

`fresh` is now threaded into `preflight`; under `--fresh` an unreadable plan becomes `JournalPreflight::unreadable_plan` instead of an error. The preflight is never more fatal than the open it precedes. Without `--fresh` the refusal is byte-for-byte unchanged. Because the removal gate compares against `preflight.plan`, discarding an unreadable plan also discards its comparison basis — the run says so on stderr rather than proceeding quietly.

Peer precedent for separating verification from opening once the caller has opted into a rebuild: redb `Database::do_repair` (`redb/src/db.rs:994`, Apache-2.0/MIT) enters a repair session on a failed checksum instead of failing the open, and still refuses when repair is genuinely impossible — which is why only the `--fresh` path is softened here.

**2. Unbounded error rendering.** `UnsupportedInventoryDeltaError::fmt` rendered every entry into one `String` with no cap, while the duplicate and unplanned-file listings 400 lines away already capped at ten. Unmounting a bind mount under an indexed root makes every content group vanish at once, so on an 82k-file journal the refusal was megabytes of stderr — in the one code path whose entire job is to be read by a person. All three listings now share `REFUSAL_LIST_CAP` and the same "… and N more" tail. `--json` still carries every entry.

**3. `xerj brain` took the wrong branch for the case its new message exists for.** `live_node_docs` correctly reported absence for a missing meta doc or a missing `nodes_index` field, then called `es.search(...)?`, which propagates on non-2xx. A meta doc that outlives its nodes index — a wiped data dir, the exact condition the probe was added to catch — 404s, and `?` short-circuited before `journal_server_disagreement()` could print the recovery text. The operator got a raw HTTP 404 instead. New `Es::search_present` returns `Ok(None)` for 404 and behaves like `search` for every other status, so absence is never laundered out of a real failure.

**4. PR body accuracy.** #156's description still claimed "adding or removing a canonical content group is detected and rejected". After the rescope in `b0ed1c81`, `InventoryDelta::refuses()` is `!vanished_content_groups.is_empty()` — additions are reported and skipped, not fatal. This body describes what the code does.

## Rebase: four semantic conflicts, not just textual ones

`main` moved 110 commits since #156's merge base. Four conflicts needed decisions, not just hunk picking. The first two were found before the first push; the last two were found by review + CI on the pushed head and fixed in `420c5834` and `8c1667d3`:

**#238's junk sweep vs. the removal gate.** The gate built its vanished set from `plan.files` **and** `plan.junk_files`, on the reasoning that a deleted junk file left an immortal `file:{key}` catalog row nobody would clean up. True when the gate was written; no longer true — main's stale junk-catalog sweep deletes that row, then drops the plan entry only after the delete lands. A junk file publishes no documents, aliases or graph edges, so its removal now strands nothing. Merging the two unchanged made the gate refuse the very rerun the sweep exists to perform: main's own #238 regression test `an_added_then_deleted_file_leaves_no_immortal_catalog_entry` failed with the removal refusal naming `added.csv`.

The vanished set is now `plan.files` only — the files that actually published documents. Junk keys stay in `durable_keys`, so an unchanged skipped file is still not classified as an addition. `deleted_planned_junk_fails_closed_before_catalog_can_stay_stale` encoded the superseded rule and is replaced by `deleted_planned_junk_is_swept_rather_than_refused`, which pins both halves of the new boundary. The removal gate is also placed *before* the sweep computation, so a refused rerun computes nothing and mutates nothing.

**#195's counter redefinition.** `main` redefined `records_total` to the live server-side count and added `records_submitted_this_run` for the run-local one. `a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it` asserted the old run-local semantics on the new name. It now pins both: the rerun submits zero files and zero records, and the record the first run published is still live.

`MockState` keeps both main's `catalog_docs` (data counts are verified against the journal since #195, and catalog rows are not data rows) and this branch's `requests` recorder, which is what the refusal tests assert absence with.

**#195's zero-live gate vs. the `--fresh` escape hatch** (`420c5834`). Under `--fresh` the removal gate compared against `inventory.keys` — the CURRENT content keys — because there is no plan to map through. An in-place EDIT changes a file's content key, so the plan's key read as vanished and the new key read as added: the same path listed as both removed and added, and the run refused. `--fresh` is the route the refusal itself recommends for changed files, so the gate was blocking its own documented recovery, and it named a file that was sitting in the folder. Differential, both run here: `origin/main` returns `Ok(0)` for run → edit → `--fresh` (it carries no membership gate at all — `UnsupportedInventoryDelta` does not exist there), the pushed head returned the refusal above with `first.csv` named as both removed and added.

`UnsupportedInventoryDelta::between` now treats a plan entry whose `rel` or `path_id` is still present in the folder as a same-path replacement, never as a vanished group. That is fixed in the classifier rather than by calling `select_resume_plan_keys` under `--fresh`, because that helper bails on plan collisions and `--fresh` exists to get past exactly those — the gate must not be more fatal than the open it precedes. Genuine removals are unaffected: a removed file's `rel` and `path_id` are both gone, and all three removal tests still refuse.

**#195's zero-live gate vs. `xerj brain`'s refusal** (`8c1667d3`). Blocker 3 above was unreachable on the path it was written for, and this branch's own new CI phase caught it: run 31325755326 / job 93275739339 at head `5b0a6c7d` — *"expected a nonzero refusal naming the disagreement, got exit 1"*. Main's #195 verification lives INSIDE `run_index_report`, and on a wiped data dir it fires first: the run resumes, skips every already-done file, finds zero live documents and bails there, so `brain.rs`'s `?` propagated it and `needs_live_node_probe` / `journal_server_disagrees` / `journal_server_disagreement` never ran.

Reproduced by hand on this tree, then fixed and re-reproduced:

```
$ xerj autoindex <vault> --url http://localhost:9561 --brain zlvault   # wiped destination
error: autoindex verification failed: the resume journal records 2 record(s) from 2
completed file(s), but 0 documents are live across the 1 dataset index(es) …   (exit 1)
```

That is verbatim what `xerj brain` was printing. The condition is now the typed `ZeroLiveVerificationError { journal_records, files_done_journaled, dataset_indices }` — Display text unchanged, so `xerj autoindex` prints exactly what it printed before — and `brain.rs` downcasts it, converting it to `journal_server_disagreement()` only when the live-node probe agrees nothing is there. A write-blocked server, an unreachable server, the removal refusal, `--fresh`, and a probe that cannot answer all keep their own error. Peer precedent for typing a recoverable condition instead of folding it into a generic error: redb's `Database::do_repair` returns `DatabaseError::RepairAborted` as its own variant (`redb/src/db.rs:994`, Apache-2.0/MIT).

```
$ xerj brain <vault> --url http://localhost:9561 --data-dir <wiped> --no-open
error: the resume journal and server disagree: journal ~/.xerj/autoindex/765f64a0…
says <vault> is already indexed, but http://localhost:9561 has no confirmed live
node documents …                                                              (exit 1)
$ xerj brain <vault> … --fresh
✓ your second brain is ready — 2 files, 4 links                               (exit 0)
```

## Verification

Re-run on the current head after a second rebase onto `main` (`1ee31ecd`) — not carried over from an earlier measurement, which is the mistake that let the CI failure through the first time:

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p xerj-autoindex -p xerj-server -p xerj-engine --all-targets -- -D warnings` — clean
- `cargo test -p xerj-autoindex` — **282 passed, 0 failed**, at default thread count *and* `--test-threads=1`
- `cargo test -p xerj-server` — **44 passed, 0 failed** across 7 targets
- `cargo test -p xerj-engine --lib embedding_identity` — 4 passed, 0 failed

New coverage: `fresh_recovers_journals_that_the_preflight_refuses_to_resume` (both fatal shapes; refused without `--fresh`, rebuilt and re-resumable with it), `fresh_over_a_readable_journal_reports_nothing_unreadable`, `refusal_prose_caps_its_listings_while_json_keeps_every_entry`, `refusal_prose_below_the_cap_has_no_more_tail`, `search_present_reports_a_missing_index_as_absence_and_nothing_else` (404 → absent, 403 → error, 200 → parsed), `deleted_planned_junk_is_swept_rather_than_refused`.

Repair coverage added on top: `fresh_absorbs_an_edited_file_instead_of_calling_it_a_removal`, `fresh_absorbs_an_addition_and_an_edit_after_a_reported_rerun` (the composite workflow the run's own stderr recommends), `an_ordinary_rerun_replaces_an_edited_file_without_stranding_records`, `a_zero_live_verification_failure_is_read_as_the_wiped_destination`, `zero_live_verification_prose_is_not_the_recovery_prose`.

Plus the end-to-end CI gate from #156: `usecase-smoke.sh` reruns autoindex over a folder a file was removed from and requires the refusal *by text*, then restores the file and requires the rerun through again — proving the gate is a stop, not a brick. The brain half wipes a data directory out from under a surviving resume journal and requires both the refusal and the `--fresh` recovery it names.

**`usecase-smoke.sh` was re-run locally on this head**, with release binaries built from it — all five phases, which is the thing the previous head's body implied but had not done:

```
════ 4. autoindex rerun over a mutated folder ════
  PASS: a rerun after a removal refuses (exit 1) and names the removed file
  PASS: restoring the file — recovery (1) in the refusal — lets the rerun through again

════ 5. brain resume safety (journal survives a wiped data dir) ════
  PASS: a journal/server disagreement refuses (exit 1) and names a recovery
  PASS: the --fresh rebuild the refusal names recovers the brain (exit 0)

USE-CASE SMOKE PASSED (second brain · MCP · autoindex)
```

## Not verified locally

- The two modified assertions in `xerj-engine` (`changed_onnx_assets_are_rejected`, `markerless_existing_index_fails_closed_for_onnx`) sit behind `#[cfg(feature = "onnx-experimental")]`, which this sandbox cannot build. Both were checked by inspection against the new message text; CI covers them if the feature is enabled there.
- The ES-YAML conformance suite was not run locally (it needs a booted server). The engine changes on this branch are error-string edits in `validate_embedding_identity`, which the suite does not exercise, but the required CI check is the authority.

## Known gaps, deliberately not fixed here

- **Added-but-skipped files still leave a live catalog entry until they are deleted** (#238's sweep handles the deletion, not the addition). This PR reports additions on stderr and records them as skipped; it does not index them. `--fresh` remains the way to absorb them.
- **`run_id` uniqueness** (`state.rs`) is closed only in-process and wraps at 65536 — carried over from #156, unchanged.
- **`--fresh` does not delete the records a same-path EDIT supersedes.** Document ids derive from the content key (`ids::doc_id`), so a `--fresh` rerun over an edited file publishes the new records and leaves the pre-edit ones live. That is `--fresh`'s behaviour on `main` too — it rebuilds the plan, it does not reconcile the destination — and an ordinary (non-fresh) rerun is the clean route for an edit: it keeps the planned key and runs a delete-before-replace transaction on it. Both halves are now asserted (`fresh_absorbs_an_edited_file_instead_of_calling_it_a_removal` vs `an_ordinary_rerun_replaces_an_edited_file_without_stranding_records`) rather than assumed. Closing it properly needs a durable "supersede these keys" intent in the journal, which is a design change, not a repair.
- **Nothing here reconciles removals.** The refusal is a fail-closed stop with documented recovery, not a sync implementation. Removing a file from an indexed folder still requires one of the three named routes.


## Before merge: the CLA check is a real blocker, not a flake

`verification/cla-signed` is `error` on this head because cla-bot resolves the commit authors and two commits are authored `buger <leonsbox@gmail.com>` — authorship preserved on purpose, since this is his work. `.contributors` currently holds only `xerj-org` and `dependabot[bot]`, so the bot's verdict is correct, not broken:

> Before we can, we need a signed Contributor License Agreement from: @buger

Per `CLA.md` the signature *is* a pull request from his own account adding his username, so nobody else can supply it: adding `buger` to `.contributors` from this branch would fake a signature and has deliberately not been done. Resolution is a maintainer decision — ask @buger to sign and comment `@cla-bot check`, or decide how his authorship is carried. Please do not merge past the check.
