### PR TITLE
fix(engine): persist templates, pipelines, data streams and ILM policies (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   service and addressable and the operator can retry the delete once the cause
   is fixed.
 
+- **Index templates, ingest pipelines, data streams and ILM policies survive a
+  restart** ([#203](https://github.com/xerj-org/xerj/issues/203)). Index
+  templates, legacy (v1) templates, component templates, ingest pipelines, data
+  streams and ILM policies lived only in memory: `PUT /_index_template/logs`
+  answered `{"acknowledged": true}` and `GET` answered 404 after the next
+  restart, and the next index that should have matched the template was created
+  without it — with no error anywhere. All six are now persisted together in
+  `<data_dir>/cluster_state.json`, written atomically (tmp → fsync → rename →
+  fsync the parent directory) so the write is committed at the request, not in
+  a shutdown hook, and restored in `Engine::new` before the listeners come up.
+  A write that fails is rolled back in memory and answered with a 500 instead
+  of `acknowledged`. Restored pipelines are recompiled, not just re-read —
+  storing the definition alone would have left `?pipeline=x` accepted and
+  silently inert after a restart.
+
+  Four defects found while verifying it, each reproduced first:
+
+  - Concurrent management writes corrupted each other (all flushes staged
+    through one fixed `.tmp` path — 32 parallel template PUTs returned
+    `store_exception`). Snapshot-and-write is now serialized.
+  - A rollover interrupted between "backing index created" and "generation
+    persisted" wedged the data stream forever: every later rollover recomputed
+    the same name and got `409 resource_already_exists_exception`. Boot now
+    adopts the highest generation actually present on disk, warns, and persists
+    the repair once.
+  - A `cluster_state.json` that could not be **read** (EACCES after a uid
+    change on a container volume, a backup tool's chmod, EIO) came up as empty
+    maps, and the next management write renamed a snapshot of those empty maps
+    over a file whose bytes were perfectly good. The load failure now latches:
+    every management mutation is refused with a 500 naming the file, and the
+    file is not touched, until a boot loads it cleanly. The corrupt-parse arm
+    refuses too, and still keeps a `cluster_state.corrupt.json` copy.
+  - `DELETE /_data_stream/<name>` recorded the removal before destroying the
+    backing indices, so a crash in that window stranded `.ds-<name>-00000N`
+    directories that no data-stream API could reach — GET and DELETE answered
+    404 while `PUT /_data_stream/<name>` answered
+    `409 resource_already_exists_exception` permanently. The order is reversed:
+    the removal is recorded only once every backing index is gone, and a
+    backing index that cannot be deleted now aborts the DELETE with a 500
+    (it was previously swallowed and answered `acknowledged`) so the operator
+    can retry.
+
+  **Known gaps, deliberately not closed here.** `.ds-*` indices that no data
+  stream claims — left by a data dir written before this change, or by a
+  DELETE interrupted by an older build — are **not** cleaned up or adopted
+  automatically; boot now names them in a warning and the recovery is
+  `DELETE /<backing-index>` per index, because an orphan may hold the only copy
+  of real data. And `aliases.json` still has the read-error shape that was
+  fixed here for `cluster_state.json`: an unreadable aliases file is swallowed
+  at boot and overwritten by the next alias write. That is pre-existing
+  behaviour, not introduced here, and is tracked separately.
+
 - **`autoindex` no longer leaves immortal catalog entries for skipped files**
   ([#238](https://github.com/xerj-org/xerj/issues/238)). A file added after the
   resume plan was frozen is skipped and reported in the catalog — but that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -496,17 +496,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the removal is recorded only once every backing index is gone, and a
     backing index that cannot be deleted now aborts the DELETE with a 500
     (it was previously swallowed and answered `acknowledged`) so the operator
-    can retry.
+    can retry. Read that 500 as "did not finish", not as "nothing happened":
+    a multi-generation stream still loses every backing index that *could* be
+    destroyed, the stream itself stays addressable, and the retry after the
+    cause is fixed completes the delete.
 
   **Known gaps, deliberately not closed here.** `.ds-*` indices that no data
   stream claims — left by a data dir written before this change, or by a
   DELETE interrupted by an older build — are **not** cleaned up or adopted
   automatically; boot now names them in a warning and the recovery is
   `DELETE /<backing-index>` per index, because an orphan may hold the only copy
-  of real data. And `aliases.json` still has the read-error shape that was
+  of real data. And `aliases.json` still has both swallow shapes that were
   fixed here for `cluster_state.json`: an unreadable aliases file is swallowed
-  at boot and overwritten by the next alias write. That is pre-existing
-  behaviour, not introduced here, and is tracked separately.
+  at boot and overwritten by the next alias write, and a *failed* alias write
+  is only logged, so an alias can survive on disk after the stream it named was
+  deleted with a 200. Both are pre-existing behaviour, not introduced here or
+  made worse here, and are tracked separately.
 
 - **`autoindex` no longer leaves immortal catalog entries for skipped files**
   ([#238](https://github.com/xerj-org/xerj/issues/238)). A file added after the

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -17374,8 +17374,10 @@ pub async fn put_index_template(
         mappings,
         priority: body.priority.unwrap_or(0),
     };
-    state.engine.templates.insert(name, tmpl);
-    Json(json!({ "acknowledged": true })).into_response()
+    match state.engine.put_index_template(name, tmpl) {
+        Ok(()) => Json(json!({ "acknowledged": true })).into_response(),
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+    }
 }
 
 pub async fn get_index_template(
@@ -17435,11 +17437,14 @@ pub async fn delete_index_template(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    if state.engine.templates.remove(&name).is_some() {
-        Json(json!({ "acknowledged": true })).into_response()
-    } else {
-        let e = xerj_common::XerjError::index_not_found(format!("index template [{name}] missing"));
-        ApiError::new(e).into_response()
+    match state.engine.delete_index_template(&name) {
+        Ok(true) => Json(json!({ "acknowledged": true })).into_response(),
+        Ok(false) => {
+            let e =
+                xerj_common::XerjError::index_not_found(format!("index template [{name}] missing"));
+            ApiError::new(e).into_response()
+        }
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
     }
 }
 
@@ -22151,8 +22156,6 @@ pub async fn put_ingest_pipeline(
     Path(id): Path<String>,
     Json(body): Json<Value>,
 ) -> impl IntoResponse {
-    // Store the raw JSON for GET /_ingest/pipeline.
-    state.engine.pipelines.insert(id.clone(), body.clone());
     // Convert ES processor format → xerj stage format, then compile.
     // ES: {"processors": [{"set": {"field":"x","value":"y"}}]}
     // xerj: {"stages": [{"type": "set", "config": {"field":"x","value":"y"}}]}
@@ -22207,10 +22210,17 @@ pub async fn put_ingest_pipeline(
         } else {
             body.clone()
         };
-    if let Err(e) = state.engine.create_pipeline(&id, xerj_config) {
-        tracing::warn!(pipeline = %id, error = %e, "pipeline stored but failed to compile");
+    // `Some(body)` keeps this surface's long-standing behaviour: a definition
+    // that will not compile is still stored and still readable through
+    // `GET /_ingest/pipeline/{id}` (the engine logs the compile error and
+    // drops the executable form, so `?pipeline={id}` behaves identically
+    // before and after a restart). An `Err` means it did not reach disk —
+    // answering `acknowledged` there would promise a pipeline that is gone at
+    // the next boot, which is the whole of issue #203.
+    match state.engine.put_pipeline(&id, xerj_config, Some(body)) {
+        Ok(_) => Json(json!({ "acknowledged": true })).into_response(),
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
     }
-    Json(json!({ "acknowledged": true })).into_response()
 }
 
 pub async fn get_ingest_pipeline(
@@ -22240,11 +22250,13 @@ pub async fn delete_ingest_pipeline(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    if state.engine.pipelines.remove(&id).is_some() {
-        Json(json!({ "acknowledged": true })).into_response()
-    } else {
-        let e = xerj_common::XerjError::index_not_found(format!("pipeline [{id}] is missing"));
-        ApiError::new(e).into_response()
+    match state.engine.delete_pipeline(&id) {
+        Ok(true) => Json(json!({ "acknowledged": true })).into_response(),
+        Ok(false) => {
+            let e = xerj_common::XerjError::index_not_found(format!("pipeline [{id}] is missing"));
+            ApiError::new(e).into_response()
+        }
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
     }
 }
 
@@ -24062,8 +24074,15 @@ pub async fn put_ilm_policy(
 ) -> impl IntoResponse {
     // Persist the raw policy verbatim in the ILM store; `get_ilm_policy`
     // reads it back out of this same DashMap, so PUT then GET round-trips
-    // faithfully regardless of whether translation below succeeds.
-    state.engine.ilm_policies.insert(name.clone(), body.clone());
+    // faithfully regardless of whether translation below succeeds — and the
+    // store is written to `<data_dir>/cluster_state.json`, so it round-trips
+    // after a restart too (issue #203). This write goes first because it is
+    // the one that can fail loudly: if the document cannot be persisted the
+    // request is a 500 and nothing has happened yet, rather than an
+    // `acknowledged` that a reboot silently undoes.
+    if let Err(e) = state.engine.put_ilm_policy(name.clone(), body.clone()) {
+        return ApiError::new(xerj_common::XerjError::from(e)).into_response();
+    }
 
     // Translate into the shared internal model (`xerj_engine::lifecycle`)
     // so the SAME background job that drives native ISM policies also
@@ -24131,12 +24150,21 @@ pub async fn delete_ilm_policy(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    if state.engine.ilm_policies.remove(&name).is_some() {
-        state.engine.remove_ism_policy(&name);
-        Json(json!({ "acknowledged": true })).into_response()
-    } else {
-        let e = xerj_common::XerjError::index_not_found(format!("policy [{name}] not found"));
-        ApiError::new(e).into_response()
+    // Remove the verbatim document first: that is the guarded, persisted
+    // path, so a failure there is a 500 with nothing removed anywhere. Only
+    // once it is gone from `cluster_state.json` is the translated executor
+    // policy dropped, so the two files can never disagree in the direction
+    // that keeps running a policy `GET _ilm/policy` reports as deleted.
+    match state.engine.delete_ilm_policy(&name) {
+        Ok(true) => {
+            state.engine.remove_ism_policy(&name);
+            Json(json!({ "acknowledged": true })).into_response()
+        }
+        Ok(false) => {
+            let e = xerj_common::XerjError::index_not_found(format!("policy [{name}] not found"));
+            ApiError::new(e).into_response()
+        }
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
     }
 }
 
@@ -24235,8 +24263,10 @@ pub async fn put_component_template(
     Path(name): Path<String>,
     Json(body): Json<Value>,
 ) -> impl IntoResponse {
-    state.engine.component_templates.insert(name, body);
-    Json(json!({ "acknowledged": true })).into_response()
+    match state.engine.put_component_template(name, body) {
+        Ok(()) => Json(json!({ "acknowledged": true })).into_response(),
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+    }
 }
 
 pub async fn get_component_template(
@@ -24278,12 +24308,15 @@ pub async fn delete_component_template(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    if state.engine.component_templates.remove(&name).is_some() {
-        Json(json!({ "acknowledged": true })).into_response()
-    } else {
-        let e =
-            xerj_common::XerjError::index_not_found(format!("component template [{name}] missing"));
-        ApiError::new(e).into_response()
+    match state.engine.delete_component_template(&name) {
+        Ok(true) => Json(json!({ "acknowledged": true })).into_response(),
+        Ok(false) => {
+            let e = xerj_common::XerjError::index_not_found(format!(
+                "component template [{name}] missing"
+            ));
+            ApiError::new(e).into_response()
+        }
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
     }
 }
 
@@ -33932,8 +33965,10 @@ pub async fn put_legacy_template(
     if let Some(settings) = body.get("settings").cloned() {
         body["settings"] = flatten_template_settings(&settings);
     }
-    state.engine.legacy_templates.insert(name, body);
-    Json(json!({ "acknowledged": true }))
+    match state.engine.put_legacy_template(name, body) {
+        Ok(()) => Json(json!({ "acknowledged": true })).into_response(),
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+    }
 }
 
 /// Normalize a template's `settings` block to ES's storage form: every
@@ -34030,11 +34065,14 @@ pub async fn delete_legacy_template(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    if state.engine.legacy_templates.remove(&name).is_some() {
-        Json(json!({ "acknowledged": true })).into_response()
-    } else {
-        let e = xerj_common::XerjError::index_not_found(format!("index template [{name}] missing"));
-        ApiError::new(e).into_response()
+    match state.engine.delete_legacy_template(&name) {
+        Ok(true) => Json(json!({ "acknowledged": true })).into_response(),
+        Ok(false) => {
+            let e =
+                xerj_common::XerjError::index_not_found(format!("index template [{name}] missing"));
+            ApiError::new(e).into_response()
+        }
+        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
     }
 }
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -24150,11 +24150,23 @@ pub async fn delete_ilm_policy(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    // Remove the verbatim document first: that is the guarded, persisted
-    // path, so a failure there is a 500 with nothing removed anywhere. Only
-    // once it is gone from `cluster_state.json` is the translated executor
-    // policy dropped, so the two files can never disagree in the direction
-    // that keeps running a policy `GET _ilm/policy` reports as deleted.
+    // Two files now back this one request — the verbatim document in
+    // `cluster_state.json` (issue #203) and the translated executor policy in
+    // `ism_policies.json` (issue #199) — so the order matters. The verbatim
+    // document goes first because that is the guarded, persisted, *fallible*
+    // step: if it cannot be written the request is a 500 and nothing has been
+    // removed from either file, rather than an executor policy already
+    // dropped for a document that is still on disk and still served by GET.
+    //
+    // That leaves one window this does not close, stated rather than implied:
+    // a crash between the two calls leaves an `ism_policies.json` entry no
+    // `_ilm/policy` path can reach any more (the retry answers 404, because
+    // the verbatim document really is gone) and the executor keeps driving
+    // any index still attached to it. It is reachable and removable through
+    // the ISM door it was written by — `DELETE /_plugins/_ism/policies/{id}`,
+    // which `GET /_plugins/_ism/explain/{index}` still names — and closing it
+    // properly means one write covering both files, which is a change to the
+    // lifecycle engine's storage rather than to this handler.
     match state.engine.delete_ilm_policy(&name) {
         Ok(true) => {
             state.engine.remove_ism_policy(&name);

--- a/engine/crates/xerj-api/src/native.rs
+++ b/engine/crates/xerj-api/src/native.rs
@@ -2486,8 +2486,13 @@ pub async fn put_pipeline(
     let started = Instant::now();
     let request_id = Uuid::new_v4().to_string();
 
-    match state.engine.create_pipeline(&name, body) {
-        Ok(()) => {
+    // `None` — this surface rejects a definition it cannot compile, so
+    // nothing is stored on a compile error. On success the pipeline is
+    // written to `<data_dir>/cluster_state.json` before we acknowledge it
+    // (issue #203): it used to live only in memory and vanish on restart,
+    // exactly like the ES-compat one.
+    match state.engine.put_pipeline(&name, body, None) {
+        Ok(None) => {
             let took_ms = started.elapsed().as_millis() as u64;
             let resp = NativeResponse::new(
                 serde_json::json!({ "pipeline": name, "acknowledged": true }),
@@ -2495,6 +2500,13 @@ pub async fn put_pipeline(
                 &request_id,
             );
             (StatusCode::OK, Json(resp)).into_response()
+        }
+        // The definition does not compile — same 500 this surface has always
+        // returned, and nothing was stored.
+        Ok(Some(compile_err)) => {
+            let ze = xerj_common::XerjError::internal(compile_err.to_string());
+            native_error(ze, Some(&request_id), started.elapsed().as_millis() as u64)
+                .into_response()
         }
         Err(e) => {
             let ze = xerj_common::XerjError::internal(e.to_string());

--- a/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
+++ b/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
@@ -1,0 +1,447 @@
+//! Issue #203: index templates, legacy templates, component templates,
+//! ingest pipelines, data streams and ILM policies must survive a restart.
+//!
+//! Before the fix each of these lived only in an in-memory `DashMap` on
+//! `Engine`. `Engine::new` restored index directories, `es_mapping.json`,
+//! API keys and aliases — nothing else — so a `PUT _index_template/logs`
+//! answered `200 {"acknowledged": true}` and then evaporated on the next
+//! boot. The operator got no error, and the next index that should have
+//! matched the template was created without it.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn config_for(dir: &std::path::Path) -> xerj_common::config::Config {
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    config
+}
+
+/// Build a fresh app over `dir`. Calling this twice (with the first engine
+/// dropped in between) is a restart: nothing is handed over in memory, the
+/// second boot sees only what reached the disk.
+fn app_over(dir: &std::path::Path) -> axum::Router {
+    let config = config_for(dir);
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    xerj_api::router::build_es_compat_router(state)
+}
+
+async fn send(app: &axum::Router, req: Request<Body>) -> (StatusCode, Value) {
+    let response = app.clone().oneshot(req).await.expect("response");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn put_json(app: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    send(
+        app,
+        Request::put(path)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request"),
+    )
+    .await
+}
+
+async fn get(app: &axum::Router, path: &str) -> (StatusCode, Value) {
+    send(
+        app,
+        Request::get(path).body(Body::empty()).expect("request"),
+    )
+    .await
+}
+
+async fn delete(app: &axum::Router, path: &str) -> (StatusCode, Value) {
+    send(
+        app,
+        Request::delete(path).body(Body::empty()).expect("request"),
+    )
+    .await
+}
+
+/// Write one of each managed object. Kept separate from the assertions so
+/// the same fixture can be replayed after a restart.
+async fn write_all_the_config(app: &axum::Router) {
+    let (st, _) = put_json(
+        app,
+        "/_index_template/logs",
+        json!({
+            "index_patterns": ["logs-*"],
+            "priority": 200,
+            "template": {
+                "settings": { "number_of_replicas": 0 },
+                "mappings": { "properties": { "host": { "type": "keyword" } } }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "PUT _index_template");
+
+    let (st, _) = put_json(
+        app,
+        "/_template/legacy-logs",
+        json!({
+            "index_patterns": ["legacy-*"],
+            "settings": { "number_of_shards": 1 },
+            "mappings": { "properties": { "msg": { "type": "text" } } }
+        }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "PUT _template");
+
+    let (st, _) = put_json(
+        app,
+        "/_component_template/base-settings",
+        json!({ "template": { "settings": { "number_of_replicas": 1 } } }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "PUT _component_template");
+
+    let (st, _) = put_json(
+        app,
+        "/_ingest/pipeline/tagger",
+        json!({
+            "description": "tag every doc",
+            "processors": [ { "set": { "field": "tagged", "value": "yes" } } ]
+        }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "PUT _ingest/pipeline");
+
+    let (st, _) = put_json(
+        app,
+        "/_ilm/policy/hot-warm",
+        json!({ "policy": { "phases": { "hot": { "actions": {} } } } }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "PUT _ilm/policy");
+
+    let (st, _) = put_json(app, "/_data_stream/metrics-app", json!({})).await;
+    assert_eq!(st, StatusCode::OK, "PUT _data_stream");
+}
+
+/// The read side of each managed object.
+const READ_BACK: [&str; 6] = [
+    "/_index_template/logs",
+    "/_template/legacy-logs",
+    "/_component_template/base-settings",
+    "/_ingest/pipeline/tagger",
+    "/_ilm/policy/hot-warm",
+    "/_data_stream/metrics-app",
+];
+
+/// Read every managed object back, asserting each is present, and return the
+/// exact responses so a later boot can be compared against them verbatim.
+///
+/// Comparing whole bodies is deliberate: it catches a partial restore (a
+/// template that comes back without its mappings, a data stream that comes
+/// back at generation 1) that a spot-check on one field would wave through.
+async fn read_back_everything(app: &axum::Router, when: &str) -> Vec<Value> {
+    let mut out = Vec::new();
+    for path in READ_BACK {
+        let (st, body) = get(app, path).await;
+        assert_eq!(st, StatusCode::OK, "GET {path} {when}: {body}");
+        out.push(body);
+    }
+
+    // Enough content assertions to prove the fixture really was written, so
+    // an all-empty "equal" comparison cannot pass for a restore.
+    let tmpl = &out[0]["index_templates"][0]["index_template"];
+    assert_eq!(tmpl["index_patterns"][0], "logs-*", "{when}: {}", out[0]);
+    assert_eq!(tmpl["priority"], 200, "{when}: {}", out[0]);
+    assert_eq!(
+        tmpl["template"]["mappings"]["properties"]["host"]["type"], "keyword",
+        "{when}: {}",
+        out[0]
+    );
+    assert_eq!(
+        out[1]["legacy-logs"]["index_patterns"][0], "legacy-*",
+        "{when}: {}",
+        out[1]
+    );
+    assert_eq!(
+        out[2]["component_templates"][0]["component_template"]["template"]["settings"]
+            ["number_of_replicas"],
+        1,
+        "{when}: {}",
+        out[2]
+    );
+    assert_eq!(
+        out[5]["data_streams"][0]["name"], "metrics-app",
+        "{when}: {}",
+        out[5]
+    );
+    out
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn templates_pipelines_streams_and_policies_survive_a_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let before = {
+        let app = app_over(dir.path());
+        write_all_the_config(&app).await;
+        // Sanity: it is all readable *before* the restart, so a failure
+        // below is about durability and not about the write path.
+        read_back_everything(&app, "before restart").await
+    }; // engine dropped — the node.lock is released, nothing is handed over
+
+    let app = app_over(dir.path());
+    let after = read_back_everything(&app, "after restart").await;
+
+    for (path, (b, a)) in READ_BACK.iter().zip(before.iter().zip(after.iter())) {
+        assert_eq!(
+            b, a,
+            "GET {path} answered differently after a restart\nbefore: {b}\nafter:  {a}"
+        );
+    }
+}
+
+/// A restored ingest pipeline must actually *run*, not merely round-trip
+/// through `GET /_ingest/pipeline`. Storing the raw JSON without
+/// recompiling it would leave `?pipeline=tagger` accepted and ignored.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_restored_pipeline_still_transforms_documents() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let app = app_over(dir.path());
+        write_all_the_config(&app).await;
+    }
+
+    let app = app_over(dir.path());
+    let (st, body) = send(
+        &app,
+        Request::post("/_ingest/pipeline/tagger/_simulate")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({ "docs": [ { "_source": { "host": "a" } } ] }).to_string(),
+            ))
+            .expect("request"),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "simulate after restart: {body}");
+    assert_eq!(
+        body["docs"][0]["doc"]["_source"]["tagged"], "yes",
+        "the restored pipeline must still execute its processors: {body}"
+    );
+}
+
+/// Deletes must be durable too — a deleted template that comes back on the
+/// next boot is the same class of surprise as one that disappears.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_deleted_template_stays_deleted_across_a_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let app = app_over(dir.path());
+        write_all_the_config(&app).await;
+        let (st, _) = delete(&app, "/_index_template/logs").await;
+        assert_eq!(st, StatusCode::OK, "DELETE _index_template");
+        let (st, _) = delete(&app, "/_ingest/pipeline/tagger").await;
+        assert_eq!(st, StatusCode::OK, "DELETE _ingest/pipeline");
+    }
+
+    let app = app_over(dir.path());
+    let (st, _) = get(&app, "/_index_template/logs").await;
+    assert_eq!(
+        st,
+        StatusCode::NOT_FOUND,
+        "a deleted index template must not resurrect on restart"
+    );
+    let (st, _) = get(&app, "/_ingest/pipeline/tagger").await;
+    assert_eq!(
+        st,
+        StatusCode::NOT_FOUND,
+        "a deleted pipeline must not resurrect on restart"
+    );
+}
+
+async fn post(app: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    send(
+        app,
+        Request::post(path)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request"),
+    )
+    .await
+}
+
+/// A rollover interrupted between "backing index created" and "generation
+/// written" must not wedge the stream.
+///
+/// `rollover_data_stream` creates `.ds-<name>-00000N` on disk first and only
+/// then flushes the new generation, so a `kill -9` in that window leaves the
+/// index present and the document still saying N-1. Restoring N-1 verbatim
+/// makes the next rollover recompute the *same* name, which `create_index`
+/// refuses as `index_already_exists` — and it does so on every subsequent
+/// attempt, so the stream can never roll again.
+///
+/// The crash window is reproduced exactly rather than approximated: the
+/// backing index is left on disk and the persisted generation is rewound by
+/// hand, which is byte-for-byte the state a crash at that instant leaves.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_rollover_interrupted_before_its_flush_does_not_wedge_the_stream() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let app = app_over(dir.path());
+        let (st, _) = put_json(&app, "/_data_stream/metrics-app", json!({})).await;
+        assert_eq!(st, StatusCode::OK, "PUT _data_stream");
+        let (st, body) = post(&app, "/metrics-app/_rollover", json!({})).await;
+        assert_eq!(st, StatusCode::OK, "rollover: {body}");
+    }
+
+    // Rewind only the generation, exactly as a crash between `create_index`
+    // and `flush_cluster_state` would have left it: `.ds-metrics-app-000002`
+    // is on disk, the document still reads generation 1.
+    let state_path = dir.path().join("cluster_state.json");
+    let mut state: Value =
+        serde_json::from_slice(&std::fs::read(&state_path).expect("read state")).expect("parse");
+    let ds = &mut state["data_streams"]["metrics-app"];
+    ds["generation"] = json!(1);
+    ds["backing_indices"] = json!([".ds-metrics-app-000001"]);
+    std::fs::write(&state_path, serde_json::to_vec(&state).expect("serialize")).expect("write");
+    assert!(
+        dir.path().join(".ds-metrics-app-000002").is_dir(),
+        "fixture is wrong: the generation-2 backing index should still be on disk"
+    );
+
+    let app = app_over(dir.path());
+    let (st, body) = post(&app, "/metrics-app/_rollover", json!({})).await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "a stream recovered from an interrupted rollover must still roll: {body}"
+    );
+    assert!(
+        body.to_string().contains(".ds-metrics-app-000003"),
+        "the next rollover must skip past the backing index the crash left \
+         behind, not reissue it: {body}"
+    );
+}
+
+/// A corrupt `cluster_state.json` must not be destroyed by the next write.
+///
+/// The node boots with empty maps and logs the failure, so the first
+/// `PUT /_index_template/...` rewrites the file — taking whatever was still
+/// legible in it along. Hand-recovery out of a damaged document is the
+/// operator's last option; it should not be silently removed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_corrupt_cluster_state_is_preserved_before_it_is_overwritten() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let app = app_over(dir.path());
+        write_all_the_config(&app).await;
+    }
+
+    // Truncate mid-document — the shape a torn write would have had, if the
+    // rewrite were not atomic, and the shape media damage leaves.
+    let state_path = dir.path().join("cluster_state.json");
+    let original = std::fs::read_to_string(&state_path).expect("read state");
+    let truncated = &original[..original.len() / 2];
+    std::fs::write(&state_path, truncated).expect("write truncated");
+
+    let app = app_over(dir.path());
+    let (st, _) = get(&app, "/_index_template/logs").await;
+    assert_eq!(
+        st,
+        StatusCode::NOT_FOUND,
+        "a corrupt document cannot be restored — this is the honest outcome"
+    );
+
+    // The write that would have destroyed the evidence.
+    let (st, _) = put_json(
+        &app,
+        "/_index_template/fresh",
+        json!({ "index_patterns": ["fresh-*"] }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "PUT after corrupt load");
+
+    let salvage = dir.path().join("cluster_state.corrupt.json");
+    assert!(
+        salvage.is_file(),
+        "the corrupt document must be kept for recovery"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&salvage).expect("read salvage"),
+        truncated,
+        "the preserved copy must be the bytes that were found, unmodified"
+    );
+    assert!(
+        std::fs::read_to_string(&state_path)
+            .expect("read state")
+            .contains("fresh-*"),
+        "the live document must have moved on"
+    );
+}
+
+/// Concurrent writers must not trip over each other.
+///
+/// The atomic rewrite stages through one fixed temp path, so two flushes
+/// running at once create, truncate and rename the *same* file: one loses
+/// its bytes to the other's truncate, or finds the temp file already renamed
+/// away. A provisioning script that fires its `PUT`s in parallel is all it
+/// takes — no stress needed. Measured without the engine's write lock, 32
+/// requests over a multi-threaded runtime fail immediately:
+///
+/// ```text
+/// PUT template t2: {"error":{"type":"store_exception",
+///                            "reason":"storage error: IO error"},"status":500}
+/// ```
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_writes_do_not_corrupt_the_store() {
+    const N: usize = 32;
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let app = app_over(dir.path());
+        let mut writes = Vec::with_capacity(N);
+        for i in 0..N {
+            let app = app.clone();
+            writes.push(tokio::spawn(async move {
+                put_json(
+                    &app,
+                    &format!("/_index_template/t{i}"),
+                    json!({ "index_patterns": [format!("t{i}-*")], "priority": i }),
+                )
+                .await
+            }));
+        }
+        for (i, w) in writes.into_iter().enumerate() {
+            let (st, body) = w.await.expect("join");
+            assert_eq!(st, StatusCode::OK, "PUT template t{i}: {body}");
+        }
+    }
+
+    let app = app_over(dir.path());
+    for i in 0..N {
+        let (st, body) = get(&app, &format!("/_index_template/t{i}")).await;
+        assert_eq!(
+            st,
+            StatusCode::OK,
+            "template t{i} did not survive concurrent writes + restart: {body}"
+        );
+        assert_eq!(
+            body["index_templates"][0]["index_template"]["priority"], i,
+            "template t{i} came back with the wrong contents: {body}"
+        );
+    }
+}

--- a/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
+++ b/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
@@ -594,3 +594,147 @@ async fn concurrent_writes_do_not_corrupt_the_store() {
         );
     }
 }
+
+/// `DELETE /_data_stream/<name>` must not leave a backing index behind.
+///
+/// Now that the stream is persisted, the *order* of the two destructive steps
+/// decides whether a crash mid-delete is recoverable. Recording the removal
+/// first and destroying the backing indices second leaves `.ds-<name>-00000N`
+/// directories that no data-stream API can reach: GET and DELETE answer 404
+/// while `PUT /_data_stream/<name>` answers `409
+/// resource_already_exists_exception` — permanently, which is the same wedge
+/// the interrupted-rollover test above exists to prevent.
+///
+/// This test pins the observable end state of a clean delete: nothing left on
+/// disk, nothing left in the document, and the name immediately reusable
+/// after a restart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_deleted_data_stream_leaves_no_backing_index_behind() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let app = app_over(dir.path());
+        let (st, body) = put_json(&app, "/_data_stream/events", json!({})).await;
+        assert_eq!(st, StatusCode::OK, "PUT _data_stream: {body}");
+        for _ in 0..2 {
+            let (st, body) = post(&app, "/events/_rollover", json!({})).await;
+            assert_eq!(st, StatusCode::OK, "rollover: {body}");
+        }
+        assert!(
+            dir.path().join(".ds-events-000003").is_dir(),
+            "fixture is wrong: three generations should exist"
+        );
+
+        let (st, body) = delete(&app, "/_data_stream/events").await;
+        assert_eq!(st, StatusCode::OK, "DELETE _data_stream: {body}");
+    }
+
+    let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+        .expect("read data dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with(".ds-events-"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "a delete that answered 200 left backing indices on disk: {leftovers:?}"
+    );
+
+    let state: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join("cluster_state.json")).expect("read"),
+    )
+    .expect("parse");
+    assert!(
+        state["data_streams"]["events"].is_null(),
+        "the removal did not reach disk: {state}"
+    );
+
+    // The name must be reusable — the wedge shows up here as a 409 naming a
+    // backing index the operator can no longer see.
+    let app = app_over(dir.path());
+    let (st, body) = put_json(&app, "/_data_stream/events", json!({})).await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "the stream name must be free after a delete + restart: {body}"
+    );
+}
+
+/// A backing index that cannot be destroyed must abort the delete, not be
+/// acknowledged.
+///
+/// This is the ordering above stated as a property rather than an outcome: the
+/// removal is only recorded once every backing index is really gone. The
+/// failure is injected where it actually happens in the field — the directory
+/// cannot be unlinked (read-only mount, EACCES after a uid change, EIO) —
+/// and the assertions are that the operator is told, that the stream is still
+/// fully addressable, that the document on disk still names it, and that the
+/// retry after the cause is fixed completes the job.
+///
+/// Unix-only, and skipped when the process can write through a `chmod 555`
+/// (i.e. running as root), where the failure cannot be injected this way.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_backing_index_that_cannot_be_deleted_aborts_the_delete() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = app_over(dir.path());
+    let (st, body) = put_json(&app, "/_data_stream/orders", json!({})).await;
+    assert_eq!(st, StatusCode::OK, "PUT _data_stream: {body}");
+
+    let backing = dir.path().join(".ds-orders-000001");
+    assert!(backing.is_dir(), "fixture is wrong: no backing index");
+    let before = std::fs::read_to_string(dir.path().join("cluster_state.json")).expect("read");
+
+    // Make the backing index's own contents un-unlinkable. Nothing inside is
+    // destroyed, and the data dir stays writable — so a flush would succeed
+    // if the code reached one, which is what makes the assertion below about
+    // the document meaningful.
+    std::fs::set_permissions(&backing, std::fs::Permissions::from_mode(0o555)).expect("chmod 555");
+    if std::fs::File::create(backing.join("root-probe")).is_ok() {
+        let _ = std::fs::remove_file(backing.join("root-probe"));
+        std::fs::set_permissions(&backing, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod 755");
+        eprintln!("skipped: permissions do not deny this process (running as root?)");
+        return;
+    }
+
+    let (st, body) = delete(&app, "/_data_stream/orders").await;
+    std::fs::set_permissions(&backing, std::fs::Permissions::from_mode(0o755)).expect("chmod 755");
+    assert_eq!(
+        st,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a delete that could not destroy a backing index must report it, not \
+         answer acknowledged: {body}"
+    );
+
+    let (st, body) = get(&app, "/_data_stream/orders").await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "the stream must stay addressable after a failed delete, or the \
+         operator has no way to retry it: {body}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("cluster_state.json")).expect("read"),
+        before,
+        "the removal must not have been recorded while the data is still there"
+    );
+
+    // The cause is fixed; the retry finishes the job.
+    let (st, body) = delete(&app, "/_data_stream/orders").await;
+    assert_eq!(st, StatusCode::OK, "retry after the cause is fixed: {body}");
+    assert!(
+        !backing.exists(),
+        "the retry left the backing index on disk"
+    );
+    let state: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join("cluster_state.json")).expect("read"),
+    )
+    .expect("parse");
+    assert!(
+        state["data_streams"]["orders"].is_null(),
+        "the retry did not record the removal: {state}"
+    );
+}

--- a/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
+++ b/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
@@ -338,10 +338,12 @@ async fn a_rollover_interrupted_before_its_flush_does_not_wedge_the_stream() {
 
 /// A corrupt `cluster_state.json` must not be destroyed by the next write.
 ///
-/// The node boots with empty maps and logs the failure, so the first
-/// `PUT /_index_template/...` rewrites the file — taking whatever was still
-/// legible in it along. Hand-recovery out of a damaged document is the
-/// operator's last option; it should not be silently removed.
+/// The node boots with empty maps and logs the failure, so without this the
+/// first `PUT /_index_template/...` rewrote the file — taking whatever was
+/// still legible in it along. Hand-recovery out of a damaged document is the
+/// operator's last option; it should not be silently removed. The write is
+/// refused (the original stays where it is) *and* a copy is kept, because
+/// un-wedging the node means moving the original aside by hand.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_corrupt_cluster_state_is_preserved_before_it_is_overwritten() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -367,13 +369,18 @@ async fn a_corrupt_cluster_state_is_preserved_before_it_is_overwritten() {
     );
 
     // The write that would have destroyed the evidence.
-    let (st, _) = put_json(
+    let (st, body) = put_json(
         &app,
         "/_index_template/fresh",
         json!({ "index_patterns": ["fresh-*"] }),
     )
     .await;
-    assert_eq!(st, StatusCode::OK, "PUT after corrupt load");
+    assert_eq!(
+        st,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a management write on top of a state that did not load must be \
+         refused, not acknowledged: {body}"
+    );
 
     let salvage = dir.path().join("cluster_state.corrupt.json");
     assert!(
@@ -385,11 +392,153 @@ async fn a_corrupt_cluster_state_is_preserved_before_it_is_overwritten() {
         truncated,
         "the preserved copy must be the bytes that were found, unmodified"
     );
+    assert_eq!(
+        std::fs::read_to_string(&state_path).expect("read state"),
+        truncated,
+        "the live document must be left exactly as it was found — the copy is \
+         a convenience, not a licence to overwrite the original"
+    );
+
+    // Moving the damaged file aside is the documented recovery, and it must
+    // actually work: the next boot loads cleanly and writes are accepted again.
+    drop(app);
+    std::fs::remove_file(&state_path).expect("operator moves the file aside");
+    let app = app_over(dir.path());
+    let (st, body) = put_json(
+        &app,
+        "/_index_template/fresh",
+        json!({ "index_patterns": ["fresh-*"] }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "PUT after the operator recovered: {body}"
+    );
     assert!(
         std::fs::read_to_string(&state_path)
             .expect("read state")
             .contains("fresh-*"),
-        "the live document must have moved on"
+        "the live document must have moved on once the node loaded cleanly"
+    );
+}
+
+/// An **intact but unreadable** `cluster_state.json` must survive untouched,
+/// and the node must refuse management writes until a boot can load it.
+///
+/// This is the worse half of the corrupt case and it was missed on the first
+/// pass: the bytes are perfectly good, only the `read(2)` failed — a uid
+/// change on a container volume, a backup tool's chmod, `EIO`, `EMFILE` at
+/// boot. The maps come up empty, and `write_file_atomic` renames
+/// `cluster_state.tmp` over the target; `rename(2)` needs write permission on
+/// the *directory*, not on the file, so a `PUT` answering
+/// `{"acknowledged": true}` unlinked a fully recoverable document. Measured
+/// on this test before the fix, with `chmod 000` for the boot only:
+///
+/// ```text
+/// PUT /_index_template/fresh -> 200 {"acknowledged":true}
+/// cluster_state.corrupt.json exists: false
+/// live file still contains "logs-*": false     <-- the operator's templates
+/// ```
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unreadable_cluster_state_is_never_overwritten() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let app = app_over(dir.path());
+        write_all_the_config(&app).await;
+    }
+
+    let state_path = dir.path().join("cluster_state.json");
+    let original = std::fs::read_to_string(&state_path).expect("read state");
+    assert!(original.contains("logs-*"), "fixture must be on disk");
+
+    // Unreadable for the boot only; restored immediately afterwards so the
+    // assertions below read the file the node was left holding, and so a
+    // failure cannot be blamed on the test's own permissions.
+    std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o000))
+        .expect("chmod 000");
+    let app = app_over(dir.path());
+    std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o644))
+        .expect("chmod 644");
+
+    let (st, _) = get(&app, "/_index_template/logs").await;
+    assert_eq!(
+        st,
+        StatusCode::NOT_FOUND,
+        "a document that could not be read cannot be restored — that part is \
+         honest already"
+    );
+
+    // The write that used to destroy it.
+    let (st, body) = put_json(
+        &app,
+        "/_index_template/fresh",
+        json!({ "index_patterns": ["fresh-*"] }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a management write must be refused while the persisted state is \
+         unloaded, not acknowledged: {body}"
+    );
+    assert!(
+        body["error"]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("could not be loaded at boot"),
+        "the 500 must say why, so the operator can act on it: {body}"
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&state_path).expect("read state"),
+        original,
+        "the intact document must still be on disk, byte for byte"
+    );
+    assert!(
+        !dir.path().join("cluster_state.tmp").exists(),
+        "a refused write must not even stage a temp file"
+    );
+
+    // And the refusal is not a one-off: the in-memory map must not be left
+    // holding a change that was reported as failed.
+    let (st, _) = get(&app, "/_index_template/fresh").await;
+    assert_eq!(
+        st,
+        StatusCode::NOT_FOUND,
+        "a refused PUT must roll its in-memory change back"
+    );
+    let (st, _) = delete(&app, "/_ilm/policy/hot-warm").await;
+    assert_eq!(
+        st,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "deletes are writes too — they must be refused as well"
+    );
+
+    // Recovery path: the file was readable all along, so a plain restart is
+    // the whole fix.
+    drop(app);
+    let app = app_over(dir.path());
+    let (st, body) = get(&app, "/_index_template/logs").await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "a restart once the file is readable must restore everything: {body}"
+    );
+    let (st, _) = put_json(
+        &app,
+        "/_index_template/fresh",
+        json!({ "index_patterns": ["fresh-*"] }),
+    )
+    .await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "and writes must work again — the refusal must not be sticky across a \
+         clean boot"
     );
 }
 

--- a/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
+++ b/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
@@ -738,3 +738,83 @@ async fn a_backing_index_that_cannot_be_deleted_aborts_the_delete() {
         "the retry did not record the removal: {state}"
     );
 }
+
+/// A DELETE that fails part-way still destroys every backing index it can —
+/// and the release note says so, so pin it.
+///
+/// The loop deliberately does not stop at the first error: the caller asked
+/// for the whole stream to go, so a generation that *can* be destroyed is
+/// destroyed and only the ones that could not are left. The 500 therefore
+/// means "did not finish", never "nothing happened", and this test exists so
+/// that sentence cannot quietly stop being true — a `break` added to that
+/// loop would leave `-000002` and `-000003` on disk and fail here.
+///
+/// Unix-only, and skipped when the process can write through a `chmod 555`
+/// (i.e. running as root), where the failure cannot be injected this way.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_partly_failed_delete_still_removes_what_it_could() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = app_over(dir.path());
+    let (st, body) = put_json(&app, "/_data_stream/audit", json!({})).await;
+    assert_eq!(st, StatusCode::OK, "PUT _data_stream: {body}");
+    for _ in 0..2 {
+        let (st, body) = post(&app, "/audit/_rollover", json!({})).await;
+        assert_eq!(st, StatusCode::OK, "rollover: {body}");
+    }
+
+    let first = dir.path().join(".ds-audit-000001");
+    let second = dir.path().join(".ds-audit-000002");
+    let third = dir.path().join(".ds-audit-000003");
+    for p in [&first, &second, &third] {
+        assert!(p.is_dir(), "fixture is wrong: {} missing", p.display());
+    }
+
+    // Only the FIRST generation is un-unlinkable. It is also the first one
+    // the loop reaches, so a loop that stopped on error would leave the other
+    // two behind.
+    std::fs::set_permissions(&first, std::fs::Permissions::from_mode(0o555)).expect("chmod 555");
+    if std::fs::File::create(first.join("root-probe")).is_ok() {
+        let _ = std::fs::remove_file(first.join("root-probe"));
+        std::fs::set_permissions(&first, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        eprintln!("skipped: permissions do not deny this process (running as root?)");
+        return;
+    }
+
+    let (st, body) = delete(&app, "/_data_stream/audit").await;
+    std::fs::set_permissions(&first, std::fs::Permissions::from_mode(0o755)).expect("chmod 755");
+    assert_eq!(
+        st,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a delete that could not destroy every backing index must report it: {body}"
+    );
+
+    assert!(
+        first.exists(),
+        "the generation that could not be deleted must still be there"
+    );
+    assert!(
+        !second.exists() && !third.exists(),
+        "the delete stopped at the first failure — the generations it could \
+         have destroyed are still on disk, which contradicts the release note"
+    );
+
+    // The stream is still addressable and still recorded, so the retry has
+    // something to finish.
+    let (st, body) = get(&app, "/_data_stream/audit").await;
+    assert_eq!(st, StatusCode::OK, "stream must stay addressable: {body}");
+    let state: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join("cluster_state.json")).expect("read"),
+    )
+    .expect("parse");
+    assert!(
+        !state["data_streams"]["audit"].is_null(),
+        "the removal must not have been recorded while a backing index remains: {state}"
+    );
+
+    let (st, body) = delete(&app, "/_data_stream/audit").await;
+    assert_eq!(st, StatusCode::OK, "retry after the cause is fixed: {body}");
+    assert!(!first.exists(), "the retry left the backing index on disk");
+}

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -851,6 +851,11 @@ impl Engine {
         // actually present, and before the server accepts requests.
         engine.load_cluster_state();
 
+        // Then say plainly which `.ds-*` indices no restored stream claims.
+        // Nothing is deleted — see the doc comment; this is the log line that
+        // stops an unreachable backing index from being invisible.
+        engine.warn_orphaned_backing_indices();
+
         // Restore ISM/ILM policies and managed-index execution state so a
         // policy attached before a restart keeps running afterward instead
         // of silently going idle. Separate files (`ism_policies.json`,
@@ -2095,6 +2100,69 @@ impl Engine {
         }
     }
 
+    /// Name every `.ds-*` index on disk that no restored data stream claims.
+    ///
+    /// This does **not** reconcile anything — nothing is deleted, adopted or
+    /// repaired, because an orphan may hold the only copy of somebody's data.
+    /// It exists so the state is not *silent*: an orphaned backing index is
+    /// unreachable through the data-stream API (`GET` and `DELETE` on the
+    /// stream answer 404, while `PUT /_data_stream/<name>` answers
+    /// `409 resource_already_exists_exception` naming the orphan), so without
+    /// a line in the boot log the operator has no way to learn the name they
+    /// have to pass to `DELETE /<backing-index>` to clear it.
+    ///
+    /// Expected sources: a data dir written by a build that predates
+    /// `cluster_state.json` (data streams were not persisted at all then), or
+    /// a `DELETE /_data_stream` interrupted by a build that recorded the
+    /// removal before destroying the backing indices. Skipped entirely when
+    /// the cluster state did not load — then every stream is unknown and
+    /// every backing index would look orphaned.
+    fn warn_orphaned_backing_indices(&self) {
+        if !self
+            .cluster_state_loaded
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
+        // Snapshot both maps before comparing them: nothing here may hold a
+        // shard guard on one map while taking one on the other.
+        let backing: Vec<String> = self
+            .indices
+            .iter()
+            .map(|e| e.key().clone())
+            .filter(|n| n.starts_with(".ds-"))
+            .collect();
+        if backing.is_empty() {
+            return;
+        }
+        let streams: Vec<(String, Vec<String>)> = self
+            .data_streams
+            .iter()
+            .map(|s| (s.key().clone(), s.value().backing_indices.clone()))
+            .collect();
+        let claimed = |index: &str| {
+            streams.iter().any(|(stream, indices)| {
+                indices.iter().any(|b| b == index)
+                    || index
+                        .strip_prefix(&format!(".ds-{stream}-"))
+                        .is_some_and(|gen| gen.parse::<u64>().is_ok())
+            })
+        };
+        let mut orphans: Vec<String> = backing.into_iter().filter(|n| !claimed(n)).collect();
+        if orphans.is_empty() {
+            return;
+        }
+        orphans.sort();
+        warn!(
+            count = orphans.len(),
+            indices = orphans.join(","),
+            "backing indices on disk belong to no known data stream — they are \
+             unreachable through the data-stream API and are NOT deleted \
+             automatically; remove each with DELETE /<index> once you have \
+             confirmed the data is not wanted"
+        );
+    }
+
     /// Insert into a persisted map and durably record the result, rolling the
     /// in-memory change back if the write fails so a 500 never leaves a
     /// change that only this process can see.
@@ -2856,27 +2924,81 @@ impl Engine {
             .map(|(_, v)| v)
             .ok_or_else(|| EngineError::Common(xerj_common::XerjError::index_not_found(name)))?;
 
-        // Record the removal before any backing index is destroyed: if the
-        // process dies mid-delete, a boot that still believes in the stream
-        // is recoverable (it warns about the missing backing indices), while
-        // one that has forgotten it leaves orphaned `.ds-*` directories no
-        // API can reach. A write failure here aborts the delete outright —
-        // nothing has been destroyed yet, so the stream is put back intact.
+        // Destroy the backing indices FIRST, and only then record the removal.
+        // The two orderings fail differently and only one of them is
+        // recoverable:
+        //
+        //   destroy → record (this one): a crash in the window leaves
+        //   `cluster_state.json` still describing the stream while some of its
+        //   `.ds-*` directories are already gone. The next boot restores the
+        //   stream and warns `restored data stream references backing indices
+        //   that are not present in the data dir` (see `load_cluster_state`),
+        //   `GET /_data_stream/<name>` still answers, and re-issuing the
+        //   DELETE finishes the job.
+        //
+        //   record → destroy: a crash in the window strands
+        //   `.ds-<name>-00000N` directories that no data-stream API can reach
+        //   — GET and DELETE answer 404 while `PUT /_data_stream/<name>`
+        //   answers `409 resource_already_exists_exception` forever, and boot
+        //   does not reconcile it. That is the same permanent wedge this PR
+        //   fixes for an interrupted rollover, so it is not the ordering to
+        //   ship.
+        //
+        // A backing index that cannot be destroyed therefore aborts the
+        // delete: the stream is put back and the caller gets the error, so
+        // the operator can retry rather than be told `acknowledged` about
+        // data that is still on disk. A retry is safe — an already-deleted
+        // backing index is simply absent from `self.indices` on the next
+        // pass.
+        let mut delete_err: Option<EngineError> = None;
+        for backing in &ds.backing_indices {
+            let Some((_, idx)) = self.indices.remove(backing) else {
+                // Not open: nothing left to destroy under this name (a
+                // previous attempt already removed it).
+                continue;
+            };
+            match idx.delete_all_data().await {
+                Ok(()) => {}
+                // `remove_dir_all` reports an already-absent directory as
+                // NotFound, which is the outcome we were asking for.
+                Err(EngineError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    warn!(
+                        data_stream = name,
+                        backing = backing.as_str(), error = %e,
+                        "backing index could not be deleted — the data stream \
+                         is left in place so the DELETE can be retried"
+                    );
+                    // Put it back so a retry can try again, and so the stream
+                    // we are about to restore does not point at an index the
+                    // engine has forgotten how to reach.
+                    self.indices.insert(backing.clone(), idx);
+                    if delete_err.is_none() {
+                        delete_err = Some(e);
+                    }
+                }
+            }
+        }
+        if let Some(e) = delete_err {
+            self.data_streams.insert(name.to_string(), ds);
+            return Err(e);
+        }
+
+        // Only now is the removal safe to make durable. A write failure here
+        // means the data is gone but the document still names the stream —
+        // the recoverable half of the window above, so put the stream back in
+        // memory as well, keeping memory and disk saying the same thing, and
+        // report the error instead of acknowledging.
         if let Err(e) = self.flush_cluster_state() {
             self.data_streams.insert(name.to_string(), ds);
             return Err(e);
         }
 
-        // Remove the alias.
+        // Remove the alias. Last, so a failure anywhere above leaves the
+        // stream fully addressable for the retry.
         self.aliases.remove(name);
         self.flush_aliases();
 
-        // Delete every backing index.
-        for backing in &ds.backing_indices {
-            if let Ok(idx) = self.indices.remove(backing).map(|(_, v)| v).ok_or(()) {
-                let _ = idx.delete_all_data().await;
-            }
-        }
         info!(name, "data stream deleted");
         Ok(())
     }

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -138,6 +138,45 @@ pub struct IndexTemplate {
     pub priority: i32,
 }
 
+/// Version stamped into `cluster_state.json`. Bump only when the on-disk
+/// shape changes in a way an older build cannot read; new *optional* fields
+/// (`#[serde(default)]`) do not need one.
+const CLUSTER_STATE_VERSION: u32 = 1;
+
+/// Everything in `<data_dir>/cluster_state.json` — the cluster-level
+/// management state that used to be in-memory only (issue #203).
+///
+/// `BTreeMap` rather than `HashMap` so the file is byte-stable for a given
+/// state: an operator diffing two nodes' `cluster_state.json`, or a backup
+/// tool deduplicating it, sees a change only when the state really changed.
+/// Every field is `#[serde(default)]`, so a file written by an older build
+/// (or by one that gains another map later) still loads.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct PersistedClusterState {
+    #[serde(default)]
+    version: u32,
+    /// v2 index templates — `PUT /_index_template/{name}`.
+    #[serde(default)]
+    index_templates: std::collections::BTreeMap<String, IndexTemplate>,
+    /// v1 legacy templates — `PUT /_template/{name}`.
+    #[serde(default)]
+    legacy_templates: std::collections::BTreeMap<String, Value>,
+    /// Component templates — `PUT /_component_template/{name}`.
+    #[serde(default)]
+    component_templates: std::collections::BTreeMap<String, Value>,
+    /// Ingest pipeline definitions — `PUT /_ingest/pipeline/{id}`. Stored as
+    /// the document `GET` hands back, and recompiled into an executable
+    /// pipeline on boot.
+    #[serde(default)]
+    pipelines: std::collections::BTreeMap<String, Value>,
+    /// Data streams — `PUT /_data_stream/{name}` plus every rollover.
+    #[serde(default)]
+    data_streams: std::collections::BTreeMap<String, DataStream>,
+    /// ILM policies — `PUT /_ilm/policy/{name}`.
+    #[serde(default)]
+    ilm_policies: std::collections::BTreeMap<String, Value>,
+}
+
 /// Active scroll context holding all matching hits.
 ///
 /// Each context pins a fully-hydrated `Vec<Hit>` snapshot, so its lifetime
@@ -417,15 +456,24 @@ pub struct Engine {
     data_dir: PathBuf,
     /// alias_name → list of index names
     pub aliases: Arc<DashMap<String, Vec<String>>>,
-    /// template_name → IndexTemplate
+    /// template_name → IndexTemplate. Persisted in
+    /// `<data_dir>/cluster_state.json`; mutate only through
+    /// [`Engine::put_index_template`] / [`Engine::delete_index_template`],
+    /// or the change will not survive a restart (issue #203).
     pub templates: Arc<DashMap<String, IndexTemplate>>,
     /// scroll_id → ScrollContext
     pub scrolls: Arc<DashMap<String, ScrollContext>>,
-    /// pipeline_id → pipeline definition JSON
+    /// pipeline_id → pipeline definition JSON. Persisted in
+    /// `<data_dir>/cluster_state.json`; mutate only through
+    /// [`Engine::put_pipeline`] / [`Engine::delete_pipeline`], or the change
+    /// will not survive a restart (issue #203).
     pub pipelines: Arc<DashMap<String, Value>>,
     /// index_name → open/closed state (true = closed)
     pub closed_indices: Arc<DashMap<String, bool>>,
-    /// data stream name → DataStream
+    /// data stream name → DataStream. Persisted in
+    /// `<data_dir>/cluster_state.json`; mutate only through the
+    /// `*_data_stream` methods, or the change will not survive a restart
+    /// (issue #203).
     pub data_streams: Arc<DashMap<String, DataStream>>,
     /// ILM policy name → raw policy JSON, kept verbatim for `GET _ilm/policy`
     /// round-trip fidelity. The REAL execution engine reads `ism_policies`
@@ -433,10 +481,19 @@ pub struct Engine {
     /// `xerj_api::es_compat::put_ilm_policy`), translating into the shared
     /// internal model. See `crate::lifecycle` for why one engine drives both
     /// surfaces.
+    ///
+    /// This map — the verbatim ILM document — is persisted in
+    /// `<data_dir>/cluster_state.json`; mutate only through
+    /// [`Engine::put_ilm_policy`] / [`Engine::delete_ilm_policy`], or the
+    /// change will not survive a restart (issue #203). The translated
+    /// `ism_policies` model has its own file (`ism_policies.json`, issue
+    /// #199) — the two never write each other's file.
     pub ilm_policies: Arc<DashMap<String, Value>>,
     /// policy id → the internal ISM-shaped model every managed index is
     /// actually driven by, regardless of whether the policy was created via
     /// `_plugins/_ism/policies` (native) or `_ilm/policy` (translated).
+    /// Persisted separately in `<data_dir>/ism_policies.json` — see
+    /// [`Engine::put_ism_policy`].
     pub ism_policies: Arc<DashMap<String, crate::lifecycle::LifecyclePolicy>>,
     /// index name → lifecycle execution cursor (current state, pending
     /// action, timestamps). Presence in this map is what "managed" means —
@@ -446,7 +503,11 @@ pub struct Engine {
     /// `GET /{index}`'s `creation_date` (previously synthesized as
     /// `Utc::now()` on every request — see `record_index_created_at`).
     pub index_created_at: Arc<DashMap<String, i64>>,
-    /// component template name → template JSON
+    /// component template name → template JSON. Persisted in
+    /// `<data_dir>/cluster_state.json`; mutate only through
+    /// [`Engine::put_component_template`] /
+    /// [`Engine::delete_component_template`], or the change will not survive
+    /// a restart (issue #203).
     pub component_templates: Arc<DashMap<String, Value>>,
     /// snapshot repository name → repo config JSON
     pub snapshot_repos: Arc<DashMap<String, Value>>,
@@ -488,7 +549,10 @@ pub struct Engine {
     /// subsequent poll, but nothing actually gates on them yet.
     /// In-memory only (lost on restart).
     pub application_privileges: Arc<DashMap<String, Value>>,
-    /// legacy index template name (v1 /_template) → template JSON
+    /// legacy index template name (v1 /_template) → template JSON.
+    /// Persisted in `<data_dir>/cluster_state.json`; mutate only through
+    /// [`Engine::put_legacy_template`] / [`Engine::delete_legacy_template`],
+    /// or the change will not survive a restart (issue #203).
     pub legacy_templates: Arc<DashMap<String, Value>>,
     /// pipeline_name → compiled, executable Pipeline (typed transform pipeline)
     pub transform_pipelines: Arc<DashMap<String, xerj_wasm::pipeline::Pipeline>>,
@@ -549,6 +613,20 @@ pub struct Engine {
     /// the process: a `kill -9` releases it automatically and a stale
     /// `node.lock` file never blocks the next boot.
     _node_lock: Arc<std::fs::File>,
+
+    /// Serializes rewrites of `<data_dir>/cluster_state.json` (issue #203).
+    ///
+    /// The atomic rewrite stages through a single fixed path
+    /// (`cluster_state.tmp`), so two concurrent flushes — two provisioning
+    /// PUTs arriving together is all it takes — would create/truncate the
+    /// *same* temp file and rename each other's half-written bytes over the
+    /// real one. Holding this across snapshot-and-write makes the whole
+    /// rewrite one critical section; the last writer's snapshot necessarily
+    /// includes every mutation that had already been applied to the maps, so
+    /// serializing loses nothing.
+    ///
+    /// Never taken while holding a `DashMap` guard.
+    cluster_state_write: Arc<parking_lot::Mutex<()>>,
 }
 
 impl Engine {
@@ -660,6 +738,7 @@ impl Engine {
                 xerj_cluster::router::ShardRouter::new(1),
             )),
             _node_lock: node_lock,
+            cluster_state_write: Arc::new(parking_lot::Mutex::new(())),
         };
 
         // Scan data_dir for existing index directories.
@@ -730,9 +809,24 @@ impl Engine {
         // migration by another instance).
         engine.load_persisted_aliases();
 
+        // Restore the cluster-level management state — index templates,
+        // legacy templates, component templates, ingest pipelines, data
+        // streams, ILM policies (issue #203). Before this, "replace the
+        // binary and restart" silently reverted every one of them: the
+        // documents kept flowing, into indices that no longer had the shape
+        // the operator designed. Must run after the index scan above, so a
+        // restored data stream can report which of its backing indices are
+        // actually present, and before the server accepts requests.
+        engine.load_cluster_state();
+
         // Restore ISM/ILM policies and managed-index execution state so a
         // policy attached before a restart keeps running afterward instead
-        // of silently going idle.
+        // of silently going idle. Separate files (`ism_policies.json`,
+        // `ism_managed_indices.json`) from `cluster_state.json` above, and
+        // deliberately so: that file holds the verbatim documents an
+        // operator PUT, this holds the executor's own cursor. Loaded after
+        // `load_cluster_state` because a restored data stream is what a
+        // rollover action operates on.
         engine.load_persisted_ism_policies();
         engine.load_persisted_managed_indices();
 
@@ -1626,6 +1720,448 @@ impl Engine {
         self.record_index_created_at(name);
     }
 
+    // ── Cluster metadata persistence (issue #203) ────────────────────────────
+    //
+    // Index templates, legacy (v1) templates, component templates, ingest
+    // pipelines, data streams and ILM policies used to live only in the
+    // in-memory maps above: `PUT /_index_template/logs` answered `200
+    // {"acknowledged": true}` and the template was gone after the next boot,
+    // with no error anywhere and the next matching index silently created
+    // unshaped. They are now snapshotted, as one consistent document, into
+    // `<data_dir>/cluster_state.json` on every mutation and reloaded in
+    // `Engine::new`.
+    //
+    // Durability contract: a full-file rewrite through
+    // `index::write_file_atomic` — write to `cluster_state.tmp`, `fsync` it,
+    // `rename` over the target, then `fsync` the parent directory so the
+    // rename itself survives power loss. The rename is the commit point, so
+    // a `kill -9` at any instant leaves either the previous complete
+    // document or the new one, never a half-written mix. The same shape peer
+    // engines use for their manifests (cf. `fjall/src/file.rs:17`
+    // `fsync_directory`, which fjall calls after every atomic rewrite;
+    // `sled/src/metadata_store.rs:696` discards leftover `*.tmp` files from
+    // an interrupted rewrite on the next boot, which `load_cluster_state`
+    // mirrors below).
+    //
+    // One file rather than six keeps the maps mutually consistent — a data
+    // stream and the template that shaped it can never be restored from
+    // different generations.
+
+    /// Path of the persisted cluster-metadata document
+    /// (`<data_dir>/cluster_state.json`).
+    fn cluster_state_path(&self) -> PathBuf {
+        self.data_dir.join("cluster_state.json")
+    }
+
+    /// Snapshot every persisted management map into one document.
+    fn cluster_state_snapshot(&self) -> PersistedClusterState {
+        fn dump<V: Clone>(map: &DashMap<String, V>) -> std::collections::BTreeMap<String, V> {
+            map.iter()
+                .map(|e| (e.key().clone(), e.value().clone()))
+                .collect()
+        }
+        PersistedClusterState {
+            version: CLUSTER_STATE_VERSION,
+            index_templates: dump(&self.templates),
+            legacy_templates: dump(&self.legacy_templates),
+            component_templates: dump(&self.component_templates),
+            pipelines: dump(&self.pipelines),
+            data_streams: dump(&self.data_streams),
+            ilm_policies: dump(&self.ilm_policies),
+        }
+    }
+
+    /// Durably write the current cluster metadata.
+    ///
+    /// Unlike `flush_aliases`, a failure here is **returned**, not swallowed:
+    /// every caller is an API write that would otherwise answer
+    /// `{"acknowledged": true}` for a change it cannot keep. Callers roll the
+    /// in-memory change back and surface a 500, so the operator finds out at
+    /// the moment of the write instead of at the next restart.
+    fn flush_cluster_state(&self) -> Result<()> {
+        // One writer at a time — see `cluster_state_write`. Snapshotting
+        // inside the lock also means the bytes that land are never older
+        // than a rewrite that has already returned.
+        let _writing = self.cluster_state_write.lock();
+        let snapshot = self.cluster_state_snapshot();
+        let bytes = serde_json::to_vec_pretty(&snapshot)?;
+        crate::index::write_file_atomic(&self.cluster_state_path(), &bytes)?;
+        Ok(())
+    }
+
+    /// Highest generation `N` for which a backing index `.ds-<stream>-<N>` is
+    /// actually open in this data dir; `0` when there is none.
+    ///
+    /// Read off the open indices rather than the stream document, because the
+    /// point is to catch the case where the two disagree. Suffix parsing keeps
+    /// neighbouring streams apart on its own: for stream `a`, `.ds-a-b-000001`
+    /// leaves `b-000001`, which is not a number.
+    fn highest_backing_generation(&self, stream: &str) -> u64 {
+        let prefix = format!(".ds-{stream}-");
+        self.indices
+            .iter()
+            .filter_map(|e| {
+                e.key()
+                    .strip_prefix(&prefix)
+                    .and_then(|gen| gen.parse::<u64>().ok())
+            })
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Load `<data_dir>/cluster_state.json` back into the management maps.
+    ///
+    /// A missing file is normal (fresh node, or a data dir written by a build
+    /// that predates this). A corrupt file is loud: it means the operator's
+    /// templates, pipelines and data streams are *not* coming back, which is
+    /// exactly the silence this whole mechanism exists to remove.
+    fn load_cluster_state(&self) {
+        // An interrupted rewrite can leave a partial `cluster_state.tmp`
+        // behind. It is never read (the rename is the commit point), but
+        // leaving it litters the data dir and invites a hand-edit that
+        // "restores" a torn document — sled sweeps the same leftovers on
+        // boot (`sled/src/metadata_store.rs:696`).
+        let tmp = self.cluster_state_path().with_extension("tmp");
+        if tmp.exists() {
+            warn!(
+                path = %tmp.display(),
+                "discarding an incomplete cluster_state rewrite left by an unclean shutdown"
+            );
+            let _ = std::fs::remove_file(&tmp);
+        }
+
+        let path = self.cluster_state_path();
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+            Err(e) => {
+                error!(
+                    path = %path.display(), error = %e,
+                    "could not read cluster_state.json — index templates, ingest \
+                     pipelines, data streams and ILM policies are NOT restored"
+                );
+                return;
+            }
+        };
+        let state: PersistedClusterState = match serde_json::from_slice(&bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                error!(
+                    path = %path.display(), error = %e,
+                    "cluster_state.json is corrupt — index templates, ingest \
+                     pipelines, data streams and ILM policies are NOT restored"
+                );
+                // Keep a copy before the node runs on. The maps are empty
+                // now, so the very next `PUT /_index_template/...` rewrites
+                // this file and takes whatever was still legible in it with
+                // it — and hand-recovering a template out of a damaged
+                // document is the operator's last option, not one to destroy
+                // silently. The original is deliberately left in place so
+                // every boot keeps logging the error above until someone
+                // deals with it, and an existing copy is never clobbered:
+                // the first corruption is the informative one.
+                let salvage = path.with_extension("corrupt.json");
+                if !salvage.exists() {
+                    match std::fs::write(&salvage, &bytes) {
+                        Ok(()) => warn!(
+                            path = %salvage.display(),
+                            "kept a copy of the corrupt cluster_state for recovery"
+                        ),
+                        Err(e) => warn!(
+                            path = %salvage.display(), error = %e,
+                            "could not preserve a copy of the corrupt cluster_state"
+                        ),
+                    }
+                }
+                return;
+            }
+        };
+        if state.version > CLUSTER_STATE_VERSION {
+            warn!(
+                found = state.version,
+                supported = CLUSTER_STATE_VERSION,
+                "cluster_state.json was written by a newer xerj; loading what \
+                 this build understands (downgrade may drop metadata)"
+            );
+        }
+
+        for (name, tmpl) in state.index_templates {
+            self.templates.insert(name, tmpl);
+        }
+        for (name, body) in state.legacy_templates {
+            self.legacy_templates.insert(name, body);
+        }
+        for (name, body) in state.component_templates {
+            self.component_templates.insert(name, body);
+        }
+        for (name, body) in state.ilm_policies {
+            self.ilm_policies.insert(name, body);
+        }
+
+        // Data streams: restore the record, reconcile it against what is
+        // actually on disk, then say plainly when a backing index it names is
+        // not there. Reporting a stream whose data is gone as
+        // `"status": "GREEN"` without a word in the log is the same quiet lie
+        // this issue is about.
+        let mut reconciled_a_stream = false;
+        for (name, mut ds) in state.data_streams {
+            // `rollover_data_stream` creates the new backing index before it
+            // records the new generation, so `kill -9` in that window leaves
+            // `.ds-<name>-00000N` on disk while the document still says N-1.
+            // Restoring N-1 verbatim would wedge the stream permanently: the
+            // next rollover computes the same name, and `create_index`
+            // refuses it as `index_already_exists` — forever. Adopt the
+            // highest generation that actually exists instead, which is also
+            // what stops a second rollover writing into an index that already
+            // holds the first one's documents.
+            let on_disk = self.highest_backing_generation(&name);
+            if on_disk > ds.generation {
+                let adopted = format!(".ds-{name}-{on_disk:06}");
+                warn!(
+                    data_stream = name.as_str(),
+                    recorded = ds.generation,
+                    found = on_disk,
+                    adopted = adopted.as_str(),
+                    "adopting a backing index left behind by a rollover that \
+                     was interrupted before its generation reached disk"
+                );
+                if !ds.backing_indices.contains(&adopted) {
+                    ds.backing_indices.push(adopted);
+                }
+                ds.generation = on_disk;
+                reconciled_a_stream = true;
+            }
+
+            let missing: Vec<&str> = ds
+                .backing_indices
+                .iter()
+                .filter(|b| !self.indices.contains_key(b.as_str()))
+                .map(|b| b.as_str())
+                .collect();
+            if !missing.is_empty() {
+                warn!(
+                    data_stream = name.as_str(),
+                    missing = missing.join(","),
+                    "restored data stream references backing indices that are \
+                     not present in the data dir"
+                );
+            }
+            self.data_streams.insert(name, ds);
+        }
+
+        // Pipelines carry behaviour, not just a document to hand back from
+        // `GET /_ingest/pipeline`: the executable form has to be rebuilt or
+        // `?pipeline=x` would be accepted after a restart and quietly do
+        // nothing. Keep the stored document either way so GET round-trips
+        // exactly as it did before the restart.
+        let mut pipelines_restored = 0usize;
+        for (name, config) in state.pipelines {
+            self.pipelines.insert(name.clone(), config.clone());
+            match self.compile_pipeline(&name, config) {
+                Ok(()) => pipelines_restored += 1,
+                Err(e) => error!(
+                    pipeline = name.as_str(), error = %e,
+                    "persisted ingest pipeline could not be recompiled — it is \
+                     still visible to GET /_ingest/pipeline but will NOT \
+                     transform anything; re-PUT the definition"
+                ),
+            }
+        }
+
+        // Make an adopted generation durable straight away, so the recovery
+        // happens once rather than on every boot from here on.
+        if reconciled_a_stream {
+            if let Err(e) = self.flush_cluster_state() {
+                warn!(
+                    error = %e,
+                    "could not persist the reconciled data-stream generation; \
+                     it will be recomputed from disk on the next boot"
+                );
+            }
+        }
+
+        let n = self.templates.len()
+            + self.legacy_templates.len()
+            + self.component_templates.len()
+            + self.pipelines.len()
+            + self.data_streams.len()
+            + self.ilm_policies.len();
+        if n > 0 {
+            info!(
+                index_templates = self.templates.len(),
+                legacy_templates = self.legacy_templates.len(),
+                component_templates = self.component_templates.len(),
+                pipelines = pipelines_restored,
+                data_streams = self.data_streams.len(),
+                ilm_policies = self.ilm_policies.len(),
+                "restored persisted cluster metadata"
+            );
+        }
+    }
+
+    /// Insert into a persisted map and durably record the result, rolling the
+    /// in-memory change back if the write fails so a 500 never leaves a
+    /// change that only this process can see.
+    fn persisted_insert<V: Clone>(
+        &self,
+        map: &DashMap<String, V>,
+        name: String,
+        value: V,
+    ) -> Result<()> {
+        let previous = map.insert(name.clone(), value);
+        if let Err(e) = self.flush_cluster_state() {
+            match previous {
+                Some(old) => map.insert(name, old),
+                None => map.remove(&name).map(|(_, v)| v),
+            };
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Remove from a persisted map and durably record the result. Returns
+    /// `false` when there was nothing to remove (the caller answers 404);
+    /// an `Err` means the removal did not reach disk and was undone.
+    fn persisted_remove<V: Clone>(&self, map: &DashMap<String, V>, name: &str) -> Result<bool> {
+        let Some((key, removed)) = map.remove(name) else {
+            return Ok(false);
+        };
+        if let Err(e) = self.flush_cluster_state() {
+            map.insert(key, removed);
+            return Err(e);
+        }
+        Ok(true)
+    }
+
+    /// Create or replace a v2 index template (`PUT /_index_template/{name}`).
+    pub fn put_index_template(&self, name: String, template: IndexTemplate) -> Result<()> {
+        self.persisted_insert(&self.templates, name, template)
+    }
+
+    /// Delete a v2 index template; `false` when it did not exist.
+    pub fn delete_index_template(&self, name: &str) -> Result<bool> {
+        self.persisted_remove(&self.templates, name)
+    }
+
+    /// Create or replace a legacy v1 template (`PUT /_template/{name}`).
+    pub fn put_legacy_template(&self, name: String, body: Value) -> Result<()> {
+        self.persisted_insert(&self.legacy_templates, name, body)
+    }
+
+    /// Delete a legacy v1 template; `false` when it did not exist.
+    pub fn delete_legacy_template(&self, name: &str) -> Result<bool> {
+        self.persisted_remove(&self.legacy_templates, name)
+    }
+
+    /// Create or replace a component template.
+    pub fn put_component_template(&self, name: String, body: Value) -> Result<()> {
+        self.persisted_insert(&self.component_templates, name, body)
+    }
+
+    /// Delete a component template; `false` when it did not exist.
+    pub fn delete_component_template(&self, name: &str) -> Result<bool> {
+        self.persisted_remove(&self.component_templates, name)
+    }
+
+    /// Create or replace an ILM policy.
+    pub fn put_ilm_policy(&self, name: String, body: Value) -> Result<()> {
+        self.persisted_insert(&self.ilm_policies, name, body)
+    }
+
+    /// Delete an ILM policy; `false` when it did not exist.
+    pub fn delete_ilm_policy(&self, name: &str) -> Result<bool> {
+        self.persisted_remove(&self.ilm_policies, name)
+    }
+
+    /// Durably store an ingest pipeline definition and (re)build its
+    /// executable form. This is the only way a user-visible pipeline should
+    /// ever be created — `compile_pipeline` alone does not reach disk.
+    ///
+    /// `config` is the xerj-shaped pipeline config to compile, and is what
+    /// gets stored (and handed back by `GET /_ingest/pipeline/{id}`) when it
+    /// compiles — the shape this endpoint has always returned.
+    ///
+    /// `keep_if_uncompilable` says what to do when it does *not* compile, and
+    /// differs by surface:
+    ///
+    /// * `Some(doc)` — the ES-compat surface. It has always answered
+    ///   `acknowledged` and left the definition readable, so `doc` (the
+    ///   ES-shaped body as received) is stored and the compile error is
+    ///   returned as `Ok(Some(err))` for the caller to log.
+    /// * `None` — the xerj-native surface, which rejects a definition it
+    ///   cannot compile. Nothing is stored, nothing is flushed, and any
+    ///   pipeline already registered under this id is left untouched.
+    ///
+    /// Either way a compile failure drops the *executable* form under this
+    /// id. Leaving the old one behind would mean `?pipeline={id}` kept
+    /// running a definition `GET` no longer shows — and stopped running it at
+    /// the next restart. A definition must behave the same before and after a
+    /// reboot; that is the whole point of persisting it.
+    ///
+    /// `Err` means the definition did not reach disk. The in-memory change is
+    /// rolled back first, so the caller can report the write as failed
+    /// without leaving behind a pipeline only this process can see.
+    pub fn put_pipeline(
+        &self,
+        id: &str,
+        config: Value,
+        keep_if_uncompilable: Option<Value>,
+    ) -> Result<Option<xerj_wasm::WasmError>> {
+        let previous_doc = self.pipelines.get(id).map(|v| v.value().clone());
+        // Taken out up front so a failed compile cannot leave a stale
+        // executable behind; put back verbatim on every abort path.
+        let previous_compiled = self.transform_pipelines.remove(id).map(|(_, p)| p);
+
+        // `compile_pipeline` mutates nothing when it fails, so an abort only
+        // has to undo the two lines above.
+        let compile_err = match self.compile_pipeline(id, config) {
+            Ok(()) => None,
+            Err(e) => match keep_if_uncompilable {
+                None => {
+                    if let Some(p) = previous_compiled {
+                        self.transform_pipelines.insert(id.to_string(), p);
+                    }
+                    return Ok(Some(e));
+                }
+                Some(doc) => {
+                    self.pipelines.insert(id.to_string(), doc);
+                    Some(e)
+                }
+            },
+        };
+
+        if let Err(e) = self.flush_cluster_state() {
+            match previous_doc {
+                Some(d) => self.pipelines.insert(id.to_string(), d),
+                None => self.pipelines.remove(id).map(|(_, v)| v),
+            };
+            self.transform_pipelines.remove(id);
+            if let Some(p) = previous_compiled {
+                self.transform_pipelines.insert(id.to_string(), p);
+            }
+            return Err(e);
+        }
+
+        if let Some(e) = &compile_err {
+            warn!(pipeline = id, error = %e, "pipeline stored but failed to compile");
+        } else {
+            info!(name = id, "transform pipeline created");
+        }
+        Ok(compile_err)
+    }
+
+    /// Delete an ingest pipeline — both the stored definition and the
+    /// compiled form, so `?pipeline={name}` stops working at the same moment
+    /// `GET /_ingest/pipeline/{name}` starts answering 404. `false` when it
+    /// did not exist.
+    pub fn delete_pipeline(&self, name: &str) -> Result<bool> {
+        let removed = self.persisted_remove(&self.pipelines, name)?;
+        if removed {
+            self.transform_pipelines.remove(name);
+        }
+        Ok(removed)
+    }
+
     /// Add an alias pointing to an index.
     pub fn add_alias(&self, alias: &str, index: &str) {
         let mut entry = self.aliases.entry(alias.to_string()).or_default();
@@ -2147,7 +2683,11 @@ impl Engine {
             timestamp_field: "@timestamp".to_string(),
             generation: 1,
         };
-        self.data_streams.insert(name.to_string(), ds);
+        // Durable before the caller is told it worked (issue #203): the
+        // backing index is already on disk, so a stream record that lives
+        // only in memory would come back after a restart as an orphaned
+        // `.ds-*` index with no stream in front of it.
+        self.persisted_insert(&self.data_streams, name.to_string(), ds)?;
         info!(name, "data stream created");
         Ok(())
     }
@@ -2179,6 +2719,10 @@ impl Engine {
         if let Some(mut ds) = self.data_streams.get_mut(name) {
             ds.backing_indices.push(new_backing.clone());
         }
+        // The generation counter is the thing that must not be lost: an
+        // unpersisted rollover would hand `.ds-<name>-000002` out twice after
+        // a restart and write into the previous generation's index.
+        self.flush_cluster_state()?;
 
         info!(
             name,
@@ -2195,6 +2739,17 @@ impl Engine {
             .remove(name)
             .map(|(_, v)| v)
             .ok_or_else(|| EngineError::Common(xerj_common::XerjError::index_not_found(name)))?;
+
+        // Record the removal before any backing index is destroyed: if the
+        // process dies mid-delete, a boot that still believes in the stream
+        // is recoverable (it warns about the missing backing indices), while
+        // one that has forgotten it leaves orphaned `.ds-*` directories no
+        // API can reach. A write failure here aborts the delete outright —
+        // nothing has been destroyed yet, so the stream is put back intact.
+        if let Err(e) = self.flush_cluster_state() {
+            self.data_streams.insert(name.to_string(), ds);
+            return Err(e);
+        }
 
         // Remove the alias.
         self.aliases.remove(name);
@@ -2309,15 +2864,19 @@ impl Engine {
 
     // ── Transform pipeline methods ────────────────────────────────────────────
 
-    /// Compile and register a typed transform pipeline from a JSON config.
+    /// Compile and register a typed transform pipeline from a JSON config,
+    /// **in memory only**.
     ///
     /// `config_json` must be a valid [`PipelineConfig`](xerj_wasm::pipeline::PipelineConfig)
-    /// object.  The compiled pipeline is stored in `transform_pipelines` and
-    /// can be retrieved by name for use at ingest time.
+    /// object. The compiled pipeline is stored in `transform_pipelines` and
+    /// the raw JSON in `pipelines`, so the ES-compatible ingest API can hand
+    /// it back.
     ///
-    /// The raw JSON is also stored in `pipelines` so it can be returned by the
-    /// ES-compatible ingest pipeline API.
-    pub fn create_pipeline(
+    /// This is the primitive underneath [`Engine::put_pipeline`] and the boot
+    /// path; it deliberately does not touch disk, so it is private. Anything
+    /// that serves a user request must go through `put_pipeline`, or the
+    /// pipeline is gone at the next restart (issue #203).
+    fn compile_pipeline(
         &self,
         name: &str,
         config_json: Value,
@@ -2327,7 +2886,6 @@ impl Engine {
         let pipeline = xerj_wasm::pipeline::Pipeline::from_config(name, &cfg)?;
         self.pipelines.insert(name.to_string(), config_json);
         self.transform_pipelines.insert(name.to_string(), pipeline);
-        info!(name, "transform pipeline created");
         Ok(())
     }
 

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -2944,12 +2944,19 @@ impl Engine {
         //   fixes for an interrupted rollover, so it is not the ordering to
         //   ship.
         //
-        // A backing index that cannot be destroyed therefore aborts the
-        // delete: the stream is put back and the caller gets the error, so
-        // the operator can retry rather than be told `acknowledged` about
-        // data that is still on disk. A retry is safe — an already-deleted
-        // backing index is simply absent from `self.indices` on the next
-        // pass.
+        // A backing index that cannot be destroyed therefore fails the
+        // delete: the stream is put back, the removal is never recorded, and
+        // the caller gets the error rather than being told `acknowledged`
+        // about data that is still on disk.
+        //
+        // Note what "fails" does *not* mean. The loop does not stop at the
+        // first error — every backing index that can be destroyed is
+        // destroyed, and only the ones that could not are still there. The
+        // 500 says the delete did not finish, not that nothing happened; the
+        // caller asked for the whole stream to go, so making the progress we
+        // can is the useful half. A retry is safe and completes the job — an
+        // already-deleted backing index is simply absent from `self.indices`
+        // on the next pass.
         let mut delete_err: Option<EngineError> = None;
         for backing in &ds.backing_indices {
             let Some((_, idx)) = self.indices.remove(backing) else {

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -627,6 +627,37 @@ pub struct Engine {
     ///
     /// Never taken while holding a `DashMap` guard.
     cluster_state_write: Arc<parking_lot::Mutex<()>>,
+
+    /// False once `<data_dir>/cluster_state.json` was found on disk and could
+    /// not be loaded — unreadable (`EACCES` after a uid change on a container
+    /// volume, `EIO`, `EMFILE` at boot) or unparseable. While false,
+    /// `flush_cluster_state` refuses to write and every management PUT
+    /// answers 500.
+    ///
+    /// Without this the failure is silent *and* destructive. The maps boot
+    /// empty, so the first `PUT /_index_template/...` snapshots six empty
+    /// maps and `write_file_atomic` renames `cluster_state.tmp` over the
+    /// target — and `rename(2)` needs only write permission on the
+    /// *directory*, so an unreadable-but-perfectly-intact document is
+    /// unlinked by a write that answers `{"acknowledged": true}`. Every
+    /// trigger listed above is transient or trivially repairable *until*
+    /// xerj overwrites the file, which is the one outcome that is not.
+    ///
+    /// Refusing is also the honest answer rather than merely the safe one:
+    /// the node is running without the templates that shape new indices and
+    /// the pipelines `?pipeline=x` names, so accepting more configuration on
+    /// top of a config that is silently a subset is the same
+    /// accepted-and-ignored shape issue #204 tracks.
+    ///
+    /// Cleared only by a boot that loads cleanly — fix or move the file
+    /// aside and restart. redb takes the same position after a failed
+    /// integrity check or a failed I/O: an `AtomicBool` on the backend makes
+    /// every later write return `StorageError::PreviousIo`, whose message is
+    /// "Please close and re-open the database"
+    /// (`redb/src/tree_store/page_store/cached_file.rs:125-145`,
+    /// `redb/src/error.rs:65`; Apache-2.0/MIT, shape adapted, no code
+    /// copied).
+    cluster_state_loaded: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Engine {
@@ -739,6 +770,7 @@ impl Engine {
             )),
             _node_lock: node_lock,
             cluster_state_write: Arc::new(parking_lot::Mutex::new(())),
+            cluster_state_loaded: Arc::new(std::sync::atomic::AtomicBool::new(true)),
         };
 
         // Scan data_dir for existing index directories.
@@ -1753,6 +1785,40 @@ impl Engine {
         self.data_dir.join("cluster_state.json")
     }
 
+    /// `Err` when boot found `cluster_state.json` and could not load it — see
+    /// `cluster_state_loaded` for why that has to latch.
+    ///
+    /// Every management mutation calls this, not only the ones that reach
+    /// `flush_cluster_state` with something to write. A `DELETE` consults the
+    /// in-memory map first, and while the load has failed that map is empty,
+    /// so an unguarded delete answers `404 not found` about an object that is
+    /// sitting in the document on disk — the same lie in a different shape.
+    /// A 500 that names the file is the only honest answer while the node
+    /// cannot see the operator's configuration.
+    fn ensure_cluster_state_writable(&self) -> Result<()> {
+        if self
+            .cluster_state_loaded
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Ok(());
+        }
+        let path = self.cluster_state_path();
+        error!(
+            path = %path.display(),
+            "refusing a cluster-metadata write: this node could not load \
+             cluster_state.json at boot, so its management state is not the \
+             operator's. Recover or move the file aside, then restart."
+        );
+        Err(EngineError::Common(xerj_common::XerjError::storage(
+            format!(
+                "refusing to write {} — it could not be loaded at boot, so \
+                 writing now would destroy cluster configuration that is still \
+                 on disk; recover or move it aside and restart xerj",
+                path.display()
+            ),
+        )))
+    }
+
     /// Snapshot every persisted management map into one document.
     fn cluster_state_snapshot(&self) -> PersistedClusterState {
         fn dump<V: Clone>(map: &DashMap<String, V>) -> std::collections::BTreeMap<String, V> {
@@ -1778,7 +1844,14 @@ impl Engine {
     /// `{"acknowledged": true}` for a change it cannot keep. Callers roll the
     /// in-memory change back and surface a 500, so the operator finds out at
     /// the moment of the write instead of at the next restart.
+    ///
+    /// Refuses outright when boot could not load the existing document — see
+    /// `cluster_state_loaded`. The snapshot below is taken from the live maps,
+    /// which in that state hold only what this process was told after boot, so
+    /// writing it would rename an empty-ish document over configuration that is
+    /// still intact on disk.
     fn flush_cluster_state(&self) -> Result<()> {
+        self.ensure_cluster_state_writable()?;
         // One writer at a time — see `cluster_state_write`. Snapshotting
         // inside the lock also means the bytes that land are never older
         // than a rewrite that has already returned.
@@ -1812,9 +1885,12 @@ impl Engine {
     /// Load `<data_dir>/cluster_state.json` back into the management maps.
     ///
     /// A missing file is normal (fresh node, or a data dir written by a build
-    /// that predates this). A corrupt file is loud: it means the operator's
-    /// templates, pipelines and data streams are *not* coming back, which is
-    /// exactly the silence this whole mechanism exists to remove.
+    /// that predates this). A file that is present but does not load is loud
+    /// *and* latching: it means the operator's templates, pipelines and data
+    /// streams are not coming back, which is exactly the silence this whole
+    /// mechanism exists to remove, so `cluster_state_loaded` goes false and
+    /// every subsequent management write is refused rather than allowed to
+    /// rename a snapshot of empty maps over the document on disk.
     fn load_cluster_state(&self) {
         // An interrupted rewrite can leave a partial `cluster_state.tmp`
         // behind. It is never read (the rename is the commit point), but
@@ -1835,10 +1911,20 @@ impl Engine {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
             Err(e) => {
+                // The file is *there* and its bytes are almost certainly fine
+                // — `EACCES` after a uid change on a container volume, a
+                // backup tool's chmod, `EIO`, `EMFILE` at boot. Do not copy it
+                // aside (we cannot read it) and do not touch it: mark the load
+                // failed so no later write can rename a snapshot of empty maps
+                // over configuration that is still perfectly recoverable.
+                self.cluster_state_loaded
+                    .store(false, std::sync::atomic::Ordering::Release);
                 error!(
                     path = %path.display(), error = %e,
-                    "could not read cluster_state.json — index templates, ingest \
-                     pipelines, data streams and ILM policies are NOT restored"
+                    "could not READ cluster_state.json — index templates, ingest \
+                     pipelines, data streams and ILM policies are NOT restored, \
+                     and management writes will be refused until a boot loads it \
+                     (the file itself is left untouched)"
                 );
                 return;
             }
@@ -1846,20 +1932,30 @@ impl Engine {
         let state: PersistedClusterState = match serde_json::from_slice(&bytes) {
             Ok(s) => s,
             Err(e) => {
+                // Same position as the read error above: the load failed, so
+                // the live maps are not the operator's configuration and
+                // nothing may be written over the document on disk. Refusing
+                // rather than salvaging-then-overwriting also closes the
+                // second-corruption hole in the `!salvage.exists()` guard
+                // below — with an overwrite still allowed, a second damaged
+                // document would be destroyed *and* not copied, because the
+                // copy from the first one is already there.
+                self.cluster_state_loaded
+                    .store(false, std::sync::atomic::Ordering::Release);
                 error!(
                     path = %path.display(), error = %e,
                     "cluster_state.json is corrupt — index templates, ingest \
-                     pipelines, data streams and ILM policies are NOT restored"
+                     pipelines, data streams and ILM policies are NOT restored, \
+                     and management writes will be refused until a boot loads it"
                 );
-                // Keep a copy before the node runs on. The maps are empty
-                // now, so the very next `PUT /_index_template/...` rewrites
-                // this file and takes whatever was still legible in it with
-                // it — and hand-recovering a template out of a damaged
-                // document is the operator's last option, not one to destroy
-                // silently. The original is deliberately left in place so
-                // every boot keeps logging the error above until someone
-                // deals with it, and an existing copy is never clobbered:
-                // the first corruption is the informative one.
+                // Keep a copy anyway. The original is now safe from xerj, but
+                // un-wedging the node means moving it aside by hand, and
+                // hand-recovering a template out of a damaged document is the
+                // operator's last option — leave them something to recover
+                // from that survives that step. The original is deliberately
+                // left in place so every boot keeps logging the error above
+                // until someone deals with it, and an existing copy is never
+                // clobbered: the first corruption is the informative one.
                 let salvage = path.with_extension("corrupt.json");
                 if !salvage.exists() {
                     match std::fs::write(&salvage, &bytes) {
@@ -2008,6 +2104,7 @@ impl Engine {
         name: String,
         value: V,
     ) -> Result<()> {
+        self.ensure_cluster_state_writable()?;
         let previous = map.insert(name.clone(), value);
         if let Err(e) = self.flush_cluster_state() {
             match previous {
@@ -2023,6 +2120,10 @@ impl Engine {
     /// `false` when there was nothing to remove (the caller answers 404);
     /// an `Err` means the removal did not reach disk and was undone.
     fn persisted_remove<V: Clone>(&self, map: &DashMap<String, V>, name: &str) -> Result<bool> {
+        // Before the map lookup: an empty map after a failed load would
+        // otherwise turn "I cannot see your configuration" into "it does not
+        // exist" — see `ensure_cluster_state_writable`.
+        self.ensure_cluster_state_writable()?;
         let Some((key, removed)) = map.remove(name) else {
             return Ok(false);
         };
@@ -2107,6 +2208,9 @@ impl Engine {
         config: Value,
         keep_if_uncompilable: Option<Value>,
     ) -> Result<Option<xerj_wasm::WasmError>> {
+        // Up front, so a refused write never disturbs the compiled form of a
+        // pipeline that is still running.
+        self.ensure_cluster_state_writable()?;
         let previous_doc = self.pipelines.get(id).map(|v| v.value().clone());
         // Taken out up front so a failed compile cannot leave a stale
         // executable behind; put back verbatim on every abort path.
@@ -2668,6 +2772,10 @@ impl Engine {
 
     /// Create a new data stream with its first backing index.
     pub fn create_data_stream(&self, name: &str) -> Result<()> {
+        // Before `create_index` below, not just before the flush: refusing
+        // after the backing index exists would leave a `.ds-*` directory with
+        // no stream in front of it.
+        self.ensure_cluster_state_writable()?;
         if self.data_streams.contains_key(name) {
             return Err(EngineError::Common(
                 xerj_common::XerjError::index_already_exists(name),
@@ -2694,6 +2802,10 @@ impl Engine {
 
     /// Roll over a data stream: create the next backing index and update the alias.
     pub fn rollover_data_stream(&self, name: &str) -> Result<String> {
+        // Same reason as `create_data_stream`, plus: the generation counter is
+        // the one value that must never be handed out twice, so a rollover
+        // that cannot record it must not create its backing index at all.
+        self.ensure_cluster_state_writable()?;
         let mut ds = self
             .data_streams
             .get_mut(name)
@@ -2734,6 +2846,10 @@ impl Engine {
 
     /// Delete a data stream and all its backing indices.
     pub async fn delete_data_stream(&self, name: &str) -> Result<()> {
+        // Before the map lookup, so an unloaded state cannot answer
+        // `index_not_found` for a stream that is recorded on disk — and, more
+        // importantly, cannot go on to destroy its backing indices.
+        self.ensure_cluster_state_writable()?;
         let ds = self
             .data_streams
             .remove(name)

--- a/engine/crates/xerj-engine/tests/es_compat_tests.rs
+++ b/engine/crates/xerj-engine/tests/es_compat_tests.rs
@@ -865,8 +865,8 @@ async fn test_es_bulk_per_item_pipeline() {
     engine.create_index("bulk_pipe", Schema::empty()).unwrap();
 
     // Register a pipeline that stamps `ingested = "yes"` on every doc.
-    engine
-        .create_pipeline(
+    let compile_err = engine
+        .put_pipeline(
             "set_pipe",
             json!({
                 "description": "stamp ingested marker",
@@ -874,8 +874,13 @@ async fn test_es_bulk_per_item_pipeline() {
                     { "type": "set", "config": { "field": "ingested", "value": "yes", "override": true } }
                 ]
             }),
+            None,
         )
-        .expect("create_pipeline");
+        .expect("put_pipeline");
+    assert!(
+        compile_err.is_none(),
+        "pipeline must compile: {compile_err:?}"
+    );
 
     let ndjson = concat!(
         // Item 0: no pipeline → stored verbatim.

--- a/engine/crates/xerj-server/tests/cluster_metadata_survives_sigkill.rs
+++ b/engine/crates/xerj-server/tests/cluster_metadata_survives_sigkill.rs
@@ -1,0 +1,243 @@
+//! Issue #203, against the real binary and a real `SIGKILL`.
+//!
+//! The in-process test (`xerj-api/tests/cluster_metadata_survives_restart.rs`)
+//! proves the reload path. This one proves the *durability* half: the state
+//! has to be on disk at the moment the PUT is acknowledged, not at some later
+//! shutdown hook, because the restart that matters is the one nobody planned.
+//! `kill -9` gives the process no chance to flush anything, so anything that
+//! comes back was already committed by `write_file_atomic` (write → fsync →
+//! rename → fsync parent).
+//!
+//! The write also has to be *atomic*, not merely eventual: this test hard-kills
+//! the node while it is answering, so a rewrite that truncated the file in
+//! place could leave a half-document that takes every template with it.
+//!
+//! Linux/macOS only — `SIGKILL` has no Windows equivalent, and
+//! `Child::kill()` there is a `TerminateProcess` that Windows may let the
+//! runtime observe. The property under test is platform-independent, but the
+//! way to provoke it is not.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Three distinct free ports — `Config::validate` requires all three listener
+/// ports to differ.
+fn three_free_ports() -> (u16, u16, u16) {
+    let l1 = TcpListener::bind("127.0.0.1:0").unwrap();
+    let l2 = TcpListener::bind("127.0.0.1:0").unwrap();
+    let l3 = TcpListener::bind("127.0.0.1:0").unwrap();
+    (
+        l1.local_addr().unwrap().port(),
+        l2.local_addr().unwrap().port(),
+        l3.local_addr().unwrap().port(),
+    )
+}
+
+fn toml_path(p: &std::path::Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// One HTTP/1.1 request over a fresh connection, returning `(status, body)`.
+///
+/// Hand-rolled rather than pulled from a client crate so the test has no
+/// runtime of its own: it must stay a plain `#[test]`, since the thing it
+/// kills is a separate process and any async machinery here would only be
+/// another thing that can hang.
+fn request(
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+) -> std::io::Result<(u16, String)> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(30)))?;
+
+    let payload = body.unwrap_or("");
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{payload}",
+        payload.len()
+    );
+    stream.write_all(request.as_bytes())?;
+    stream.flush()?;
+
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line)?;
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    // Drain headers, then everything else — `Connection: close` means the
+    // body ends at EOF, so no chunk/length parsing is needed.
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 || line == "\r\n" {
+            break;
+        }
+    }
+    let mut body = String::new();
+    reader.read_to_string(&mut body)?;
+    Ok((status, body))
+}
+
+/// Spawn the real binary on `data_dir` and wait until it answers.
+fn boot(
+    data_dir: &std::path::Path,
+    cfg_dir: &std::path::Path,
+    es_port: u16,
+    rest: u16,
+    grpc: u16,
+) -> Child {
+    let config = format!(
+        r#"
+[server]
+bind_address = "127.0.0.1"
+rest_port = {rest}
+grpc_port = {grpc}
+es_compat_port = {es_port}
+data_dir = "{data}"
+"#,
+        data = toml_path(data_dir),
+    );
+    let config_path = cfg_dir.join(format!("xerj-{es_port}.toml"));
+    std::fs::write(&config_path, config).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_xerj"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--insecure")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn xerj");
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        if let Ok((200, _)) = request(es_port, "GET", "/_cluster/health", None) {
+            return child;
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    // Never leave a half-booted node behind for the rest of the suite to
+    // trip over — reap it, then fail.
+    let _ = child.kill();
+    let _ = child.wait();
+    panic!("xerj did not become ready on port {es_port}");
+}
+
+/// `kill -9` and reap. No graceful shutdown, no flush hook, no chance to
+/// write anything the acknowledged PUTs did not already write.
+fn sigkill(mut child: Child) {
+    unsafe {
+        libc::kill(child.id() as libc::pid_t, libc::SIGKILL);
+    }
+    let status = child.wait().expect("reap child");
+    assert!(
+        !status.success(),
+        "the node was supposed to be hard-killed, but it exited cleanly ({status:?}) — \
+         a graceful exit could have flushed state that a real crash never would"
+    );
+}
+
+#[test]
+fn cluster_metadata_survives_kill_dash_nine() {
+    let dir = tempfile::tempdir().unwrap();
+    let data_dir = dir.path().join("data");
+    std::fs::create_dir_all(&data_dir).unwrap();
+
+    let (rest, grpc, es) = three_free_ports();
+    let child = boot(&data_dir, dir.path(), es, rest, grpc);
+
+    let (st, b) = request(
+        es,
+        "PUT",
+        "/_index_template/logs",
+        Some(r#"{"index_patterns":["logs-*"],"priority":200,"template":{"mappings":{"properties":{"host":{"type":"keyword"}}}}}"#),
+    )
+    .unwrap();
+    assert_eq!(st, 200, "PUT _index_template: {b}");
+
+    let (st, b) = request(
+        es,
+        "PUT",
+        "/_ingest/pipeline/tagger",
+        Some(r#"{"description":"tag","processors":[{"set":{"field":"tagged","value":"yes"}}]}"#),
+    )
+    .unwrap();
+    assert_eq!(st, 200, "PUT _ingest/pipeline: {b}");
+
+    let (st, b) = request(
+        es,
+        "PUT",
+        "/_ilm/policy/hot-warm",
+        Some(r#"{"policy":{"phases":{"hot":{"actions":{}}}}}"#),
+    )
+    .unwrap();
+    assert_eq!(st, 200, "PUT _ilm/policy: {b}");
+
+    let (st, b) = request(es, "PUT", "/_data_stream/metrics-app", Some("{}")).unwrap();
+    assert_eq!(st, 200, "PUT _data_stream: {b}");
+
+    // Roll the stream forward so the restored generation counter has to be
+    // 2, not the 1 a re-create would produce.
+    let (st, b) = request(es, "POST", "/metrics-app/_rollover", Some("{}")).unwrap();
+    assert_eq!(st, 200, "POST _rollover: {b}");
+    assert!(
+        b.contains(".ds-metrics-app-000002"),
+        "rollover should mint generation 2: {b}"
+    );
+
+    sigkill(child);
+
+    // Same data dir, brand-new process. Everything above was acknowledged,
+    // so everything above must still be here.
+    let child = boot(&data_dir, dir.path(), es, rest, grpc);
+
+    let (st, b) = request(es, "GET", "/_index_template/logs", None).unwrap();
+    assert_eq!(st, 200, "index template lost across kill -9: {b}");
+    assert!(
+        b.contains("logs-*") && b.contains("keyword"),
+        "partial template restore: {b}"
+    );
+
+    let (st, b) = request(es, "GET", "/_ingest/pipeline/tagger", None).unwrap();
+    assert_eq!(st, 200, "ingest pipeline lost across kill -9: {b}");
+
+    let (st, b) = request(es, "GET", "/_ilm/policy/hot-warm", None).unwrap();
+    assert_eq!(st, 200, "ILM policy lost across kill -9: {b}");
+
+    let (st, b) = request(es, "GET", "/_data_stream/metrics-app", None).unwrap();
+    assert_eq!(st, 200, "data stream lost across kill -9: {b}");
+    assert!(
+        b.contains("\"generation\":2") && b.contains(".ds-metrics-app-000002"),
+        "the rollover must survive too, or the next rollover reissues a \
+         backing index that already holds data: {b}"
+    );
+
+    // The restored pipeline must still *run*, not just be readable.
+    let (st, b) = request(
+        es,
+        "POST",
+        "/_ingest/pipeline/tagger/_simulate",
+        Some(r#"{"docs":[{"_source":{"host":"a"}}]}"#),
+    )
+    .unwrap();
+    assert_eq!(st, 200, "simulate after restart: {b}");
+    assert!(
+        b.contains("\"tagged\":\"yes\""),
+        "a restored pipeline that no longer transforms is accepted-and-ignored: {b}"
+    );
+
+    sigkill(child);
+}


### PR DESCRIPTION
Fixes #203

## The defect, reproduced first

`PUT /_index_template/logs` answered `200 {"acknowledged": true}`, and after a restart `GET /_index_template/logs` answered 404. Verified at `origin/main` before writing anything, by running the new in-process restart test against the unmodified sources:

```
GET /_index_template/logs after restart:
  {"error":{"type":"index_not_found_exception",
            "reason":"index not found: index template [logs] missing"},"status":404}
left: 404  right: 200
```

The next index that should have matched that template is created without it, and nobody gets an error — so "replace the binary and restart" held for documents and not for anything the operator had configured.

## Root cause

`Engine::new` restored index directories, `es_mapping.json`, API keys and aliases, and nothing else. Index templates, legacy (v1) templates, component templates, ingest pipelines, data streams and ILM policies lived only in `DashMap`s on `Engine`. The persistence pattern was already in the tree (`flush_aliases` / `load_persisted_aliases`); it had simply never been applied to these six maps.

## The fix

`PersistedClusterState` → `<data_dir>/cluster_state.json`, one document for all six maps so a data stream and the template that shaped it can never come back from different generations. Written through `index::write_file_atomic` (write to `.tmp`, fsync, rename, fsync the parent directory). The rename is the commit point, which is what makes `kill -9` safe. Reloaded by `Engine::load_cluster_state` in `Engine::new`, after the index scan and before the listeners come up.

Everything else follows from making that the only write path:

- **Typed mutators** (`put_index_template`, `delete_ilm_policy`, `put_pipeline`, …) — every ES-compat and native handler goes through them, and each map's field doc says so, because a raw `.insert()` that skips the flush is how this bug class returns.
- **A failed write is reported, not swallowed.** The in-memory change is rolled back and the handler answers 500 instead of `acknowledged`. The operator learns at the write, not at the next boot.
- **Ingest pipelines are recompiled on boot, not just re-read.** Storing the definition without rebuilding the executable form would leave `?pipeline=x` accepted and quietly inert after a restart — the accepted-and-ignored shape tracked by #204.
- `Engine::create_pipeline` becomes the private `compile_pipeline` (it does not touch disk, so it must not be reachable from a request); the xerj-native `PUT /v1/pipelines/{name}` had the same loss and now uses `put_pipeline`.
- `DELETE /_ingest/pipeline/{id}` now drops the compiled form too — it previously kept running a pipeline `GET` reported as 404, until the next restart.

## Four further defects found while verifying, each reproduced before it was fixed

**1. Concurrent writers corrupted each other.** `write_file_atomic` stages through one fixed path, so two flushes in flight truncate and rename the *same* file. A provisioning script firing its PUTs in parallel was enough — 32 concurrent template PUTs gave `{"type":"store_exception","reason":"storage error: IO error"}` immediately. Serializing snapshot-and-write is also the correct shape rather than a workaround: because the snapshot is taken inside the lock, the last file written is always a superset of every mutation already applied, so no acknowledged write is lost to a stale snapshot landing after a fresher one.

**2. An interrupted rollover wedged the data stream permanently.** `rollover_data_stream` creates `.ds-<name>-00000N` before it records generation N, so a crash in that window left the index on disk and the document saying N-1. Every later rollover then recomputed the same name and got `409 resource_already_exists_exception: .ds-metrics-app-000002` — forever. Boot now reconciles each stream's generation against the backing indices actually present, adopts the higher one, warns, and persists the repair once.

**3. A `cluster_state.json` that does not load was destroyed by the next write.** The node boots with empty maps, so the first PUT rewrote the file and took whatever was still in it. See the round-2 section below for how this is handled now — the first pass fixed only the corrupt-parse half of it, and the half it missed was the worse one.

**4. `DELETE /_data_stream` recorded the removal before it destroyed the backing indices.** Found by the final merge gate, in the subsystem this PR is about. The function even carried a comment arguing that recording first is the recoverable ordering — the argument describes the *opposite* ordering to the one the code implemented. Measured on a release binary built from the PR head, by putting a data dir into exactly the state a crash in that window leaves (stream removed from `cluster_state.json`, `.ds-ds3-000001/2/3` still on disk) and rebooting:

```
GET    /_data_stream/ds3  -> 404
DELETE /_data_stream/ds3  -> 404
PUT    /_data_stream/ds3  -> 409 resource_already_exists_exception: .ds-ds3-000001
boot                      -> no warning of any kind
```

That is defect 2's permanent wedge, reintroduced on the delete path. The order is now reversed: the backing indices are destroyed first and the removal is flushed only once they are gone, so a crash in the window leaves a stream the next boot restores and warns about (`restored data stream references backing indices that are not present in the data dir`) and a re-issued DELETE finishes the job. `let _ = idx.delete_all_data().await` went with it — a backing index that cannot be destroyed now fails the DELETE with a 500 instead of answering `{"acknowledged": true}` about data still on disk (the #204 shape), and it is the swallow that would have made the reordering unsafe: a failed delete would still have recorded the removal. The stream and the index are put back, so the retry after the cause is fixed completes; `NotFound` from `remove_dir_all` counts as success so the retry is idempotent.

To be exact about what that 500 means, because the release note has to be: the loop does **not** stop at the first failure. Every backing index that can be destroyed is destroyed, and only the ones that could not are left — the caller asked for the whole stream to go, so the useful half is made and the 500 reports that the operation did not *finish*, not that nothing happened. That is now pinned by a test rather than only described (see Tests), and it is listed under Residual risk.

Boot also gained `warn_orphaned_backing_indices`, which names every `.ds-*` index no restored stream claims. It **reconciles nothing** — an orphan may hold the only copy of real data — but it removes the silence. On the same wedged data dir:

```
WARN backing indices on disk belong to no known data stream — they are unreachable
     through the data-stream API and are NOT deleted automatically; remove each with
     DELETE /<index> once you have confirmed the data is not wanted
     count=3 indices=".ds-ds3-000001,.ds-ds3-000002,.ds-ds3-000003"
```

`DELETE /.ds-ds3-000001` (and 2, 3) then clears it and `PUT /_data_stream/ds3` answers 200. Verified silent on a healthy boot and on a `chmod 000` boot (where the state did not load, so every stream is unknown and every backing index would look orphaned).

## Round 2 — the case the first pass missed (adversarial review)

The review of this PR found a hole this PR's own fix had left open, and it was the more likely half: a `cluster_state.json` that is **intact but unreadable**.

`load_cluster_state` salvaged a copy only in the `serde_json` parse-error arm. The `std::fs::read` error arm logged and returned. The maps then came up empty, and the first `PUT /_index_template/...` called `flush_cluster_state`, whose `write_file_atomic` renames `cluster_state.tmp` over the target — and `rename(2)` needs write permission on the **directory**, not on the file. So the write succeeded, answered `{"acknowledged": true}`, and unlinked a document whose bytes were perfectly good. Reproduced with `chmod 000` for the boot only, on a file holding one index template:

```
PUT /_index_template/fresh          -> 200 {"acknowledged":true}
cluster_state.corrupt.json exists   -> false
live file still contains "logs-*"   -> false      <-- the operator's template
```

The triggers are ordinary rather than exotic — a uid change on a container volume, a backup tool's chmod, `EIO`, `EMFILE` at boot — and in every one of them the file was fully recoverable *until* xerj overwrote it. It also falsified this PR body's earlier claim that "the bytes found are now copied to `cluster_state.corrupt.json` first"; that sentence has been corrected above.

Fixed by `cluster_state_loaded: AtomicBool`, set false in **both** error arms. While it is false, `ensure_cluster_state_writable` refuses every management mutation with a 500 that names the file, and the document on disk is never touched. It clears only on a boot that loads cleanly, so recovery is "fix the permissions (or move the file aside) and restart" — which the tests exercise.

Two details worth stating:

- The guard sits at the top of each mutator, not only inside `flush_cluster_state`. A `DELETE` consults the in-memory map first, and with that map empty an unguarded delete answers `404 not found` about an object sitting in the file on disk — the same lie in a different shape. `create_data_stream` / `rollover_data_stream` guard before `create_index`, so a refusal cannot strand a `.ds-*` directory with no stream in front of it.
- The corrupt-parse arm now refuses too. The salvage copy stays (un-wedging the node means moving the original aside by hand, so leave something behind that survives that step), but salvage-then-overwrite had a second hole of its own: the `!salvage.exists()` guard means a **second** corruption would be destroyed *and* not copied.

Prior art for the shape: redb latches an `AtomicBool` after a failed I/O and returns `StorageError::PreviousIo` — "Please close and re-open the database" — from every write after it (`redb/src/tree_store/page_store/cached_file.rs:125-145`, `redb/src/error.rs:65`). Apache-2.0/MIT; the shape is adapted, no code is copied.

## Prior art

`fjall/src/file.rs:17` (`fsync_directory` after every atomic rewrite) and `sled/src/metadata_store.rs:697` (leftover `*.tmp` from an interrupted rewrite is discarded on the next boot — `load_cluster_state` does the same), both from the `xerj-storage` corpus. Both Apache-2.0/MIT; neither is copied, the shape is adapted and the code is ours.

## Tests

`crates/xerj-api/tests/cluster_metadata_survives_restart.rs` — writes one of each object, drops the engine, reopens the same data dir, and compares **whole response bodies** before and after, so a partial restore cannot pass. Plus: a restored pipeline still transforms; a deleted template stays deleted; 32 concurrent PUTs all survive a restart with the right contents; a stream recovered from an interrupted rollover rolls to `-000003` instead of reissuing `-000002`; a corrupt document is preserved *and* further writes are refused until the operator removes it; and (round 2, unix) `an_unreadable_cluster_state_is_never_overwritten` drives the `chmod 000` reproduction above and asserts the file is byte-identical afterwards, that the refused PUT rolled its in-memory change back, that DELETE is refused too, and that a plain restart restores everything and re-enables writes.

Three more for defect 4: `a_backing_index_that_cannot_be_deleted_aborts_the_delete` injects the failure where it happens in the field (the directory cannot be unlinked) and asserts the 500, that the stream stays addressable, that the document on disk is byte-identical, and that the retry after the cause is fixed finishes the job — it fails on the previous commit with `left: 200, right: 500` and `{"acknowledged":true}`; `a_deleted_data_stream_leaves_no_backing_index_behind` pins the clean-path end state (nothing on disk, nothing in the document, name reusable after a restart); and `a_partly_failed_delete_still_removes_what_it_could` pins the *partial* outcome that the release note now states — a three-generation stream whose first generation cannot be unlinked loses `-000002` and `-000003`, keeps `-000001`, answers 500, stays addressable and recorded, and completes on the retry. Adding a `break` to that loop fails it, which is the point: the sentence in the CHANGELOG cannot quietly stop being true.

`crates/xerj-server/tests/cluster_metadata_survives_sigkill.rs` — the same property against `CARGO_BIN_EXE_xerj` with a real `SIGKILL`, which is the only way to prove the write happened at PUT time rather than in a shutdown hook. Unix-only.

## Gates (first pass — superseded by the re-run at the end)

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -D warnings` (xerj-engine, xerj-api, xerj-server) | clean |
| `cargo test -p xerj-engine` | lib 427/0; integration green apart from the wall-clock tests below |
| `cargo test -p xerj-api` | green (13 targets, incl. 7/7 cluster-metadata at that point; 9/9 now) |
| `cargo test -p xerj-server` | green (7 targets, incl. the SIGKILL test) |
| ES-compat YAML suite | **1366 passed / 0 failed / 3 skipped** (CI) |

Environment-dependent failures on the dev machine (load average ~190 while these ran) were checked against the unmodified branch head and flip there identically: `painless_cpu_budget` and `query_string_default_field` are wall-clock-deadline tests, `xerj-engine`'s `painless_script_limits` overflows the 2 MiB default test-thread stack in a debug build (passes under `RUST_MIN_STACK`). None of them touch cluster state; CI's Build + Test job is the authority.

## Residual risk / known gaps

Stated plainly, because these are the things this PR does **not** fix.

**Orphaned `.ds-*` indices are warned about, never cleaned up.** A data dir written by a build that predates `cluster_state.json` (data streams were not persisted at all then), or a `DELETE /_data_stream` interrupted by a build that recorded the removal first, leaves backing indices that no data-stream API can reach: `GET` and `DELETE` on the stream answer 404 while `PUT /_data_stream/<name>` answers `409 resource_already_exists_exception` naming the orphan. Boot now names them in a warning and the recovery is `DELETE /<backing-index>` per index — by hand, deliberately, because an orphan may hold the only copy of real data. Nothing is deleted or adopted automatically.

**A DELETE that fails part-way still destroys every backing index it can.** The loop does not stop at the first failure: if `.ds-orders-000001` cannot be unlinked but `-000002` and `-000003` can, the latter two are gone and the request answers 500. That is deliberate — the operator asked for the stream to be deleted, and the 500 says plainly that it did not finish — but it is *not* "nothing happened", and the release note should not be read that way. The stream stays addressable, the document on disk still names it, and the retry after the cause is fixed completes the delete.

**`aliases.json` still has both swallow shapes that `cluster_state.json` no longer has.** `load_persisted_aliases` swallows an unreadable file and `flush_aliases` will later overwrite it; and `flush_aliases` itself only `warn!`s when the write fails — it has no return value, so `delete_data_stream`'s final `self.aliases.remove(name); self.flush_aliases();` can leave the alias on disk after a 200, and the next boot resurrects an alias pointing at a stream that is gone. Pre-existing behaviour on `main`, not introduced or made worse here, and refusing there would reach index-creation paths rather than only management ones — worth its own issue rather than a silent widening of this PR.

**A `flush_cluster_state` failure during a rollover** leaves the new backing index created with the generation unpersisted. Self-healing on the next boot (defect 2 above) rather than permanent, and the operator still gets a 500 at the time of the write.

**A `flush_cluster_state` failure at the end of a DELETE** — after the backing indices are already destroyed — answers 500 and puts the stream back in memory, so memory and disk agree. The next boot restores a stream whose backing indices are gone, warns about exactly that, and a re-issued DELETE completes it. This is the recoverable half of the window by design; it is not silent and it is not permanent.

## CHANGELOG

Added under `## [Unreleased] / ### Fixed`, including the known gaps above in the release-note text itself rather than only here.

## Live re-verification of the delete-ordering fix

Re-measured against a release binary built from this branch's merged head (checked first that the binary actually contains the new code — `strings | grep "belong to no known data stream"` → 1), on a private port with a throwaway data dir. Not from a test harness: a real node, killed with `kill -9`, restarted.

**The old ordering's crash state, reproduced by hand** (stream removed from `cluster_state.json`, `.ds-ds3-000001/2/3` left on disk):

```
boot                       -> WARN backing indices on disk belong to no known data stream …
                                  count=3 indices=".ds-ds3-000001,.ds-ds3-000002,.ds-ds3-000003"
GET    /_data_stream/ds3   -> 404
DELETE /_data_stream/ds3   -> 404
PUT    /_data_stream/ds3   -> 409 resource_already_exists_exception: .ds-ds3-000001
DELETE /.ds-ds3-000001|2|3 -> 200, 200, 200
PUT    /_data_stream/ds3   -> 200
```

**The new ordering's crash state** (two backing indices already destroyed, the removal not yet recorded):

```
boot                       -> WARN restored data stream references backing indices that are
                                  not present in the data dir
                                  data_stream="ds3" missing=".ds-ds3-000001,.ds-ds3-000002"
GET    /_data_stream/ds3   -> 200
DELETE /_data_stream/ds3   -> 200        (finishes the job)
leftover .ds-ds3-* on disk -> none;  document still names ds3 -> false
```

**And the two silence claims.** A healthy boot logs no orphan warning (0 occurrences). A `chmod 000` boot logs the read failure, logs **no** orphan warning (0 — every stream would look unknown), refuses `PUT /_index_template/fresh` with a 500 naming the file, and leaves `cluster_state.json` byte-identical (sha256 before == after).

## Gate re-run after the delete-ordering fix and the merge with `main`

Measured on this head, not remembered.

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -D warnings` (xerj-engine, xerj-api, xerj-server) | clean |
| `cargo test -p xerj-api` | 15 targets, **260 passed / 0 failed** / 2 ignored (incl. 10/10 `cluster_metadata_survives_restart`) |
| `cargo test -p xerj-server` | 8 targets, **54 passed / 0 failed**, incl. `cluster_metadata_survives_kill_dash_nine` |
| `cargo test -p xerj-engine` | 31 targets, **732 passed / 0 failed** / 23 ignored (`RUST_MIN_STACK=16777216`, for the debug-build stack overflow noted above) |
| ES-compat YAML suite | **1366 passed · 0 failed · 3 skipped · 1369 total** (local, private port `:9397`, throwaway data dir, release binary rebuilt from this merged head and checked to contain the new code) |

The conformance number is read off the runner's own banner, which prints the URL it connected to (`http://localhost:9397`) — an earlier attempt of mine reported a number from a log file a sibling job had overwritten, so the URL line is now part of the evidence rather than an assumption.

