### PR TITLE
fix(search): real positional phrase semantics for multi_match (#230)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -27075,6 +27075,8 @@ fn strip_nested_path_in_query(q: &QueryNode, path: &str) -> QueryNode {
             operator,
             analyzer,
             boost,
+            slop,
+            max_expansions,
         } => QueryNode::MultiMatch {
             fields: fields.iter().map(|f| strip(f)).collect(),
             query: query.clone(),
@@ -27082,6 +27084,8 @@ fn strip_nested_path_in_query(q: &QueryNode, path: &str) -> QueryNode {
             operator: *operator,
             analyzer: analyzer.clone(),
             boost: *boost,
+            slop: *slop,
+            max_expansions: *max_expansions,
         },
         QueryNode::GeoDistance {
             field,
@@ -28122,6 +28126,143 @@ fn geo_coord(v: &Value) -> Option<f64> {
         .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
 }
 
+/// Split raw field/query text into the lowercase alphanumeric token stream
+/// the stored-doc evaluator treats as "positions". It is the stored-scan
+/// counterpart of the standard analyzer's token stream: the analyzer drops
+/// punctuation and lowercases, so `merge, policy` yields `[merge, policy]`
+/// — two ADJACENT positions, which is why a positional phrase matches it
+/// and raw-substring containment does not (issue #230).
+fn phrase_tokens(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// True when `query_tokens` occur in `field_tokens` in order with at most
+/// `slop` intervening positions in total — the stored-scan twin of
+/// `xerj_fts::search`'s `phrase_positions_match`, which evaluates the same
+/// predicate over the segment's real term positions.
+///
+/// `slop == 0` is exact adjacency (a window compare); `slop > 0` anchors on
+/// EVERY occurrence of the first term and walks each later term to its
+/// earliest position after the previous match, summing the gaps — the same
+/// greedy walk `phrase_positions_match` runs over segment positions.
+///
+/// Anchoring on every occurrence is load-bearing: the previous stored-scan
+/// walk anchored only on the FIRST occurrence of the leading term, so
+/// `[a, x, x, x, a, b]` rejected the slop-1 phrase `a b` that both ES and
+/// the segment path accept (anchor at the second `a`).
+fn phrase_positions_in_tokens(field_tokens: &[String], query_tokens: &[String], slop: u32) -> bool {
+    if query_tokens.is_empty() {
+        return true;
+    }
+    if query_tokens.len() > field_tokens.len() {
+        return false;
+    }
+    if slop == 0 {
+        return field_tokens
+            .windows(query_tokens.len())
+            .any(|w| w == query_tokens);
+    }
+    for (start, tok) in field_tokens.iter().enumerate() {
+        if tok != &query_tokens[0] {
+            continue;
+        }
+        let mut current = start;
+        let mut total_gaps: u32 = 0;
+        let mut ok = true;
+        for qt in &query_tokens[1..] {
+            match field_tokens[current + 1..].iter().position(|ft| ft == qt) {
+                Some(off) => {
+                    let next = current + 1 + off;
+                    total_gaps += (next - current - 1) as u32;
+                    if total_gaps > slop {
+                        ok = false;
+                        break;
+                    }
+                    current = next;
+                }
+                None => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if ok {
+            return true;
+        }
+    }
+    false
+}
+
+/// True when the leading `query_tokens[..n-1]` form an adjacent in-order
+/// phrase whose next position starts with `query_tokens[n-1]` — ES
+/// `match_phrase_prefix` semantics over the token stream. A single token
+/// degrades to "any token starts with it".
+///
+/// This is TERM-level, not substring-level: `merge poli` matches the token
+/// stream `[merge, policy]` (so it matches raw text `merge, policy` too),
+/// while `merge polic` does NOT satisfy the exact-phrase variant, because
+/// `polic` is not the term `policy`.
+fn phrase_prefix_positions_in_tokens(field_tokens: &[String], query_tokens: &[String]) -> bool {
+    let (last, head) = match query_tokens.split_last() {
+        Some(pair) => pair,
+        None => return true,
+    };
+    if head.is_empty() {
+        return field_tokens.iter().any(|t| t.starts_with(last.as_str()));
+    }
+    if head.len() >= field_tokens.len() {
+        return false;
+    }
+    field_tokens.windows(head.len()).enumerate().any(|(i, w)| {
+        w == head
+            && field_tokens
+                .get(i + head.len())
+                .is_some_and(|t| t.starts_with(last.as_str()))
+    })
+}
+
+/// Per-field phrase predicate for the phrase-shaped `multi_match` types,
+/// shared by the membership (`doc_matches_query`) and scoring
+/// (`score_query_against_doc`) arms so an admitted doc can never score 0.
+///
+/// `phrase_prefix` treats the trailing token as a prefix; `phrase` requires
+/// whole terms and honours `slop`. `slop` is deliberately unread on the
+/// prefix arm — the parser REFUSES a non-zero `slop` with
+/// `type: phrase_prefix` (neither this walk nor the segment's
+/// `PhrasePrefixQuery` can honour it), so the only value that reaches here
+/// is 0. Reading it would imply support that does not exist.
+///
+/// `field_text_lc` is the field's text as the rest of the `multi_match` arms
+/// see it — an array-valued field arrives already joined with a space.
+/// That means a phrase CAN span two array elements, which ES prevents with a
+/// `position_increment_gap`. XERJ has no such gap anywhere: the indexing
+/// path flattens an array to one space-joined string before the FTS layer
+/// ever sees it (`extract_field_text`), so the segment's positions have no
+/// gap either. Evaluating per element here would therefore FIX the memtable
+/// and leave the segment as it is — reintroducing the flush-variant hit set
+/// this fix exists to remove. The gap belongs in the indexing path; it is
+/// deliberately not attempted here.
+fn multi_match_phrase_hit(
+    field_text_lc: &str,
+    query_tokens: &[String],
+    is_prefix: bool,
+    slop: u32,
+) -> bool {
+    if query_tokens.is_empty() {
+        return true;
+    }
+    let field_tokens = phrase_tokens(field_text_lc);
+    if is_prefix {
+        phrase_prefix_positions_in_tokens(&field_tokens, query_tokens)
+    } else {
+        phrase_positions_in_tokens(&field_tokens, query_tokens, slop)
+    }
+}
+
 /// Evaluate a query against a single stored document source value.
 ///
 /// Returns true if the document matches the query.
@@ -28645,7 +28786,7 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
         // operator and match_type. `operator: and` + `cross_fields` (used
         // by `combined_fields`) requires every query token to appear in
         // at least one of the listed fields. The default (operator: or)
-        // admits the hit when any query substring hits any field.
+        // admits the hit when any query token equals a token of one field.
         //
         // Field specs may carry a boost factor (`"title^3"`); strip it for matching.
         QueryNode::MultiMatch {
@@ -28653,6 +28794,7 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
             query,
             match_type,
             operator,
+            slop,
             ..
         } => {
             let q_lower = query.to_lowercase();
@@ -28667,6 +28809,8 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                 xerj_query::ast::MultiMatchType::Phrase
                     | xerj_query::ast::MultiMatchType::PhrasePrefix
             );
+            let is_phrase_prefix =
+                matches!(match_type, xerj_query::ast::MultiMatchType::PhrasePrefix);
             let is_and = matches!(operator, Some(xerj_query::ast::BoolOperator::And));
             let field_texts: Vec<String> = fields
                 .iter()
@@ -28693,7 +28837,34 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                     }
                 })
                 .collect();
-            if is_cross && is_and && !tokens.is_empty() {
+            if is_phrase && !tokens.is_empty() {
+                // phrase / phrase_prefix: POSITIONAL, per field (issue
+                // #230). ES lowers these types to a dis_max over per-field
+                // `match_phrase`/`match_phrase_prefix`, so the predicate is
+                // the same positional walk `MatchPhrase` uses — the query
+                // terms must occur in order in ONE field's analyzed token
+                // stream, within `slop` intervening positions (0 = exact
+                // adjacency), the trailing term treated as a prefix for
+                // `phrase_prefix`.
+                //
+                // Pre-fix this branch was `ft.contains(&q_lower)` — raw
+                // lowercase substring containment, which both UNDER-matched
+                // (`"merge policy"` missed the doc `merge, policy`, whose
+                // analyzed terms are adjacent) and OVER-matched (`"merge
+                // polic"` matched `merge policy`, where no such term
+                // exists). The segment path evaluates the same positions,
+                // now via `FtsQuery::Phrase`/`PhrasePrefix`, so the hit set
+                // stays flush-invariant.
+                //
+                // Tested FIRST, ahead of the operator branches: `operator`
+                // is meaningless for a phrase in ES (its phrase parser never
+                // consults it), and pre-fix `{"type":"phrase","operator":
+                // "and"}` fell into the token-AND branch below and silently
+                // stopped being a phrase at all.
+                field_texts
+                    .iter()
+                    .any(|ft| multi_match_phrase_hit(ft, &tokens, is_phrase_prefix, *slop))
+            } else if is_cross && is_and && !tokens.is_empty() {
                 // cross_fields + operator AND: every token must appear in
                 // at least one listed field (combined perspective).
                 let combined = field_texts.join(" ");
@@ -28726,13 +28897,10 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                         .collect();
                     tokens.iter().all(|t| ft_tokens.contains(t.as_str()))
                 })
-            } else if is_phrase || tokens.is_empty() {
-                // phrase / phrase_prefix: the whole query must appear
-                // contiguously — substring approximation of phrase
-                // matching, shared with the segment path (whose FTS
-                // projection declines these types, so BOTH states evaluate
-                // this predicate and the hit set is flush-invariant). Also
-                // the fallback when the query has no alphanumeric tokens.
+            } else if tokens.is_empty() {
+                // No alphanumeric tokens at all (e.g. a punctuation-only
+                // query): the analyzer yields nothing, so fall back to raw
+                // containment rather than admitting every document.
                 field_texts.iter().any(|ft| ft.contains(&q_lower))
             } else {
                 // best_fields / most_fields with the default operator (OR,
@@ -28781,58 +28949,22 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
             // `match_phrase`/`match_phrase_prefix`): that fix stops the
             // crash on `{query: true}`, but without this one the
             // (now-valid) query still silently matched 0 documents.
+            //
+            // The positional walk itself lives in
+            // `phrase_positions_in_tokens` so the `multi_match` phrase arm
+            // evaluates the SAME predicate (issue #230) instead of its own
+            // substring approximation.
             fn matches_scalar(v: &Value, query_tokens: &[String], slop: u32) -> Option<bool> {
                 let s = match v {
                     Value::String(s) => s.clone(),
                     Value::Bool(_) | Value::Number(_) => v.to_string(),
                     _ => return None,
                 };
-                let field_tokens: Vec<String> = s
-                    .to_lowercase()
-                    .split(|c: char| !c.is_alphanumeric())
-                    .filter(|t| !t.is_empty())
-                    .map(str::to_string)
-                    .collect();
-                if query_tokens.is_empty() {
-                    return Some(true);
-                }
-                if query_tokens.len() > field_tokens.len() {
-                    return Some(false);
-                }
-                // slop=0: exact contiguous phrase match in order.
-                if slop == 0 {
-                    let found = field_tokens
-                        .windows(query_tokens.len())
-                        .any(|w| w == query_tokens);
-                    return Some(found);
-                }
-                // slop>0: ES enforces in-order positions with at most
-                // `slop` intervening tokens between adjacent query tokens.
-                // Find each query token AFTER the previous one and sum the
-                // gaps.
-                let mut last_pos: Option<usize> = None;
-                let mut total_gaps: i64 = 0;
-                let mut ordered_ok = true;
-                for qt in query_tokens {
-                    let search_start = last_pos.map(|p| p + 1).unwrap_or(0);
-                    match field_tokens[search_start..]
-                        .iter()
-                        .position(|ft| ft == qt)
-                        .map(|off| search_start + off)
-                    {
-                        Some(pos) => {
-                            if let Some(prev) = last_pos {
-                                total_gaps += (pos as i64 - prev as i64 - 1).max(0);
-                            }
-                            last_pos = Some(pos);
-                        }
-                        None => {
-                            ordered_ok = false;
-                            break;
-                        }
-                    }
-                }
-                Some(ordered_ok && total_gaps <= slop as i64)
+                Some(phrase_positions_in_tokens(
+                    &phrase_tokens(&s),
+                    query_tokens,
+                    slop,
+                ))
             }
             get_field_value(source, field)
                 .and_then(|v| match &v {
@@ -28949,36 +29081,22 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
         }
 
         QueryNode::MatchPhrasePrefix { field, query, .. } => {
+            // POSITIONAL, not substring (issue #230). Pre-fix this arm found
+            // the head phrase as a raw substring (`s_lower.find(head)`) and
+            // required the prefix to follow it in the raw text — so
+            // punctuation INSIDE the phrase (`merge, policy`) defeated it,
+            // while the segment path (`FtsQuery::PhrasePrefix`) matched over
+            // the analyzed positions. The two states disagreed at `_flush`.
+            // Both now walk the same analyzed token stream.
             fn matches_str(s: &str, query: &str) -> Option<bool> {
-                let tokens: Vec<&str> = query.split_whitespace().collect();
-                if tokens.is_empty() {
+                let query_tokens = phrase_tokens(query);
+                if query_tokens.is_empty() {
                     return Some(true);
                 }
-                let s_lower = s.to_lowercase();
-                let (prefix, exact_tokens) = match tokens.split_last() {
-                    Some(pair) => pair,
-                    None => return Some(true),
-                };
-                // All tokens except the last must appear as an ordered substring.
-                // Last token is a prefix match.
-                let phrase_without_last = exact_tokens.join(" ").to_lowercase();
-                let last_lower = prefix.to_lowercase();
-                if exact_tokens.is_empty() {
-                    // Only one token — prefix match on the whole query.
-                    Some(
-                        s_lower
-                            .split_whitespace()
-                            .any(|w| w.starts_with(last_lower.as_str())),
-                    )
-                } else {
-                    // Multi-token: check phrase prefix.
-                    if let Some(pos) = s_lower.find(&phrase_without_last) {
-                        let after = &s_lower[pos + phrase_without_last.len()..].trim_start();
-                        Some(after.starts_with(last_lower.as_str()))
-                    } else {
-                        Some(false)
-                    }
-                }
+                Some(phrase_prefix_positions_in_tokens(
+                    &phrase_tokens(s),
+                    &query_tokens,
+                ))
             }
             get_field_value(source, field)
                 .and_then(|v| match &v {
@@ -30417,6 +30535,7 @@ fn score_query_against_doc(q: &QueryNode, source: &Value) -> f32 {
             boost,
             match_type,
             operator,
+            slop,
             ..
         } => {
             let q_lower = query.to_lowercase();
@@ -30427,20 +30546,26 @@ fn score_query_against_doc(q: &QueryNode, source: &Value) -> f32 {
                 xerj_query::ast::MultiMatchType::Phrase
                     | xerj_query::ast::MultiMatchType::PhrasePrefix
             );
+            let is_phrase_prefix =
+                matches!(match_type, xerj_query::ast::MultiMatchType::PhrasePrefix);
             let is_and = matches!(operator, Some(xerj_query::ast::BoolOperator::And));
             // Per-field hit test mirroring `doc_matches_query` (issue #218):
-            // token-level OR by default / AND on request; phrase types keep
-            // whole-query substring containment. Pre-fix this arm tested
-            // `contains(whole query)`, so a memtable doc admitted by the
-            // membership check could still score 0.0 and be dropped by
-            // scored paths / rescore.
+            // token-level OR by default / AND on request; phrase types run
+            // the same POSITIONAL predicate the membership arm uses (issue
+            // #230 — this copy used to test whole-query substring
+            // containment). Pre-fix this arm tested `contains(whole query)`,
+            // so a memtable doc admitted by the membership check could still
+            // score 0.0 and be dropped by scored paths / rescore.
             let q_tokens: Vec<String> = q_lower
                 .split(|c: char| !c.is_alphanumeric())
                 .filter(|t| !t.is_empty())
                 .map(str::to_string)
                 .collect();
             let field_hit = |text_lc: &str| -> bool {
-                if is_phrase || q_tokens.is_empty() {
+                if is_phrase && !q_tokens.is_empty() {
+                    return multi_match_phrase_hit(text_lc, &q_tokens, is_phrase_prefix, *slop);
+                }
+                if q_tokens.is_empty() {
                     return text_lc.contains(&q_lower);
                 }
                 let ft_tokens: std::collections::HashSet<&str> = text_lc
@@ -32808,26 +32933,28 @@ fn query_node_to_fts(
             match_type,
             operator,
             boost,
-            ..
+            slop,
+            max_expansions,
+            analyzer,
         } => {
-            // The memtable evaluator (`doc_matches_query`) gives phrase /
-            // phrase_prefix multi_match whole-query-containment semantics,
-            // which is not expressible as this per-field token bool —
-            // projecting them as an OR over tokens made the segment path
-            // OVER-match (the reverse of issue #218's memtable under-match:
-            // a reversed phrase started matching at _flush).
-            // Decline the projection instead; the stored-doc scan then
-            // evaluates the same `doc_matches_query` predicate the memtable
-            // uses, keeping the matched set flush-invariant.
-            // (cross_fields + `operator: and` is declined too — see the
+            // phrase / phrase_prefix are POSITIONAL (issue #230): they lower
+            // to one positional clause per field, combined by dis_max — the
+            // shape ES builds (`MultiMatchQueryParser.buildFieldQueries` +
+            // `combineGrouped` → `DisjunctionMaxQuery`, tie_breaker 0.0 for
+            // both phrase types; AGPL, read for semantics only, no code
+            // copied).  This used to `return None`, which forced an O(N)
+            // stored-doc scan per segment AND left the (substring) memtable
+            // predicate as the definition of "phrase".
+            // (cross_fields + `operator: and` is still declined — see the
             // `is_and` guard below, which needs the analyzed token count.)
-            if matches!(
+            let is_phrase_type = matches!(
                 match_type,
                 xerj_query::ast::MultiMatchType::Phrase
                     | xerj_query::ast::MultiMatchType::PhrasePrefix
-            ) {
-                return None;
-            }
+            );
+            let is_phrase_prefix =
+                matches!(match_type, xerj_query::ast::MultiMatchType::PhrasePrefix);
+            let query_analyzer_name = analyzer.as_deref();
             let registry = AnalyzerRegistry::default();
             let analyzer = registry.get_analyzer("standard")?;
             let tokens = analyzer.analyze(query);
@@ -32866,6 +32993,73 @@ fn query_node_to_fts(
             // MultiMatch), which finds no such fields in any document.
             if field_specs.is_empty() {
                 return None;
+            }
+            // ── phrase / phrase_prefix: one positional clause per field ──
+            if is_phrase_type {
+                let terms: Vec<String> = tokens.iter().map(|t| t.text.clone()).collect();
+                // Every listed field must be an ANALYZED TEXT field with a
+                // positions side-car, and the query must analyze to at least
+                // one term, or the projection is declined WHOLE and the
+                // stored-doc scan — which now evaluates the same positional
+                // predicate — answers instead. Three reasons to bail:
+                //   * a keyword/exact field indexes ONE case-preserved
+                //     whole-value term, which the schema-blind stored-scan
+                //     evaluator (it tokenizes every field) cannot model — a
+                //     Term projection there would change the hit set at
+                //     `_flush`, the exact regression class of #218;
+                //   * a dotted multi-field path (`title.raw`) or a non-text
+                //     mapped type has no positions to intersect;
+                //   * a non-standard query `analyzer` produces terms this
+                //     projection does not reproduce (the `match_phrase` arm
+                //     declines on the same condition).
+                // Dropping just the offending field instead would shrink the
+                // disjunction and under-match.
+                if terms.is_empty()
+                    || !matches!(query_analyzer_name, None | Some("standard"))
+                    || field_specs.iter().any(|(f, _)| {
+                        exact_fields.contains(f.as_str()) || !text_fields.iter().any(|t| t == f)
+                    })
+                {
+                    return None;
+                }
+                let outer = boost.unwrap_or(1.0);
+                let mut per_field: Vec<FtsQuery> = Vec::with_capacity(field_specs.len());
+                for (field, fb) in &field_specs {
+                    per_field.push(if is_phrase_prefix {
+                        FtsQuery::PhrasePrefix(xerj_fts::search::PhrasePrefixQuery {
+                            field: field.clone(),
+                            terms: terms.clone(),
+                            max_expansions: *max_expansions as usize,
+                            boost: *fb,
+                        })
+                    } else if terms.len() == 1 {
+                        // A one-term phrase is just a term query — and scores
+                        // identically to `match_phrase` on that field.
+                        FtsQuery::Term(FtsTerm::boosted(field.as_str(), &terms[0], *fb))
+                    } else {
+                        FtsQuery::Phrase(xerj_fts::search::PhraseQuery {
+                            field: field.clone(),
+                            terms: terms.clone(),
+                            slop: *slop,
+                            boost: *fb,
+                        })
+                    });
+                }
+                if per_field.is_empty() {
+                    return None;
+                }
+                // ES combines the per-field phrase clauses with dis_max
+                // (tie_breaker 0.0 for phrase and phrase_prefix alike).
+                let combined = if per_field.len() == 1 {
+                    per_field.pop().unwrap()
+                } else {
+                    FtsQuery::DisMax(Box::new(FtsDisMax::new(per_field)))
+                };
+                return Some(if (outer - 1.0).abs() > f32::EPSILON {
+                    FtsQuery::Bool(Box::new(FtsBool::new().should(combined).boost(outer)))
+                } else {
+                    combined
+                });
             }
             // `operator: and` binds PER FIELD for the field-centric types
             // (ES best_fields/most_fields build one match query per field
@@ -35548,6 +35742,8 @@ mod fts_projection_tests {
             operator: None,
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         };
         let fq = query_node_to_fts(&q, &[], &kw(&["model", "top_doc"])).expect("projects");
         match fq {
@@ -35576,6 +35772,8 @@ mod fts_projection_tests {
             operator: None,
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         };
         let fq = query_node_to_fts(&q, &["title".to_string()], &kw(&["model"])).expect("projects");
         match fq {
@@ -35626,6 +35824,8 @@ mod fts_projection_tests {
             operator: None,
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         }
     }
 
@@ -35737,6 +35937,8 @@ mod fts_projection_tests {
             operator: Some(xerj_query::ast::BoolOperator::And),
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         };
         let fq = query_node_to_fts(&q, &["body".to_string(), "title".to_string()], &kw(&[]))
             .expect("projects");
@@ -35770,9 +35972,108 @@ mod fts_projection_tests {
             operator: Some(xerj_query::ast::BoolOperator::And),
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         };
         assert!(
             query_node_to_fts(&q, &["body".to_string(), "title".to_string()], &kw(&[]),).is_none()
+        );
+    }
+
+    /// #230 — `multi_match` phrase types project to POSITIONAL per-field
+    /// clauses combined by dis_max (the shape ES builds), instead of
+    /// declining the projection and forcing an O(N) stored-doc scan per
+    /// segment. `slop` rides along into the phrase clause.
+    #[test]
+    fn multi_match_phrase_projects_positional_dis_max() {
+        let mut q = QueryNode::MultiMatch {
+            fields: vec!["body".into(), "title^3".into()],
+            query: "merge policy".into(),
+            match_type: xerj_query::ast::MultiMatchType::Phrase,
+            operator: None,
+            analyzer: None,
+            boost: None,
+            slop: 2,
+            max_expansions: 50,
+        };
+        let text = vec!["body".to_string(), "title".to_string()];
+        match query_node_to_fts(&q, &text, &kw(&[])).expect("phrase projects") {
+            FtsQuery::DisMax(d) => {
+                assert_eq!(d.queries.len(), 2, "one phrase clause per field");
+                for clause in &d.queries {
+                    match clause {
+                        FtsQuery::Phrase(p) => {
+                            assert_eq!(p.terms, vec!["merge".to_string(), "policy".to_string()]);
+                            assert_eq!(p.slop, 2, "slop must reach the positional clause");
+                            if p.field == "title" {
+                                assert_eq!(p.boost, 3.0, "^3 field boost preserved");
+                            }
+                        }
+                        other => panic!("expected positional phrase clause, got {other:?}"),
+                    }
+                }
+            }
+            other => panic!("expected dis_max of phrase clauses, got {other:?}"),
+        }
+
+        // phrase_prefix lowers to the positional prefix clause, carrying
+        // `max_expansions`.
+        q = QueryNode::MultiMatch {
+            fields: vec!["body".into()],
+            query: "merge poli".into(),
+            match_type: xerj_query::ast::MultiMatchType::PhrasePrefix,
+            operator: None,
+            analyzer: None,
+            boost: None,
+            slop: 0,
+            max_expansions: 7,
+        };
+        match query_node_to_fts(&q, &text, &kw(&[])).expect("phrase_prefix projects") {
+            FtsQuery::PhrasePrefix(p) => {
+                assert_eq!(p.terms, vec!["merge".to_string(), "poli".to_string()]);
+                assert_eq!(p.max_expansions, 7);
+            }
+            other => panic!("expected phrase-prefix clause, got {other:?}"),
+        }
+    }
+
+    /// #230 parity guard — a KEYWORD field in a phrase `multi_match` declines
+    /// the projection. The keyword FST holds one case-preserved whole-value
+    /// term, which the schema-blind stored-scan evaluator (it tokenizes every
+    /// field) cannot model; projecting it would make the hit set change at
+    /// `_flush`, the regression class of #218. Same for a dotted multi-field
+    /// path, which has no positions side-car at all.
+    #[test]
+    fn multi_match_phrase_declines_non_positional_fields() {
+        let text = vec!["body".to_string()];
+        let keyword_field = QueryNode::MultiMatch {
+            fields: vec!["body".into(), "tags".into()],
+            query: "merge policy".into(),
+            match_type: xerj_query::ast::MultiMatchType::Phrase,
+            operator: None,
+            analyzer: None,
+            boost: None,
+            slop: 0,
+            max_expansions: 50,
+        };
+        assert!(
+            query_node_to_fts(&keyword_field, &text, &kw(&["tags"])).is_none(),
+            "keyword field must keep the stored-scan path"
+        );
+
+        let dotted = QueryNode::MultiMatch {
+            fields: vec!["body.raw".into()],
+            query: "merge policy".into(),
+            match_type: xerj_query::ast::MultiMatchType::Phrase,
+            operator: None,
+            analyzer: None,
+            boost: None,
+            slop: 0,
+            max_expansions: 50,
+        };
+        assert!(
+            query_node_to_fts(&dotted, &text, &kw(&[])).is_none(),
+            "dotted multi-field path must keep the stored-scan path"
         );
     }
 
@@ -36623,6 +36924,8 @@ mod lexical_passage_tests {
             operator: None,
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         };
         let hit = Hit {
             id: "doc-1".into(),
@@ -36677,6 +36980,8 @@ mod lexical_passage_tests {
             operator: None,
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         };
         let hit = Hit {
             id: "doc-1".into(),

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -27050,10 +27050,12 @@ fn strip_nested_path_in_query(q: &QueryNode, path: &str) -> QueryNode {
             field,
             query,
             max_expansions,
+            slop,
         } => QueryNode::MatchPhrasePrefix {
             field: strip(field),
             query: query.clone(),
             max_expansions: *max_expansions,
+            slop: *slop,
         },
         QueryNode::Fuzzy {
             field,
@@ -28126,18 +28128,40 @@ fn geo_coord(v: &Value) -> Option<f64> {
         .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
 }
 
-/// Split raw field/query text into the lowercase alphanumeric token stream
-/// the stored-doc evaluator treats as "positions". It is the stored-scan
-/// counterpart of the standard analyzer's token stream: the analyzer drops
+/// The analyzed token stream the stored-doc evaluator treats as "positions".
+///
+/// It runs the **standard analyzer** — the same pipeline the indexing path
+/// and `query_node_to_fts` use — so the stored-scan/memtable evaluator and
+/// the positional segment clause answer the same query. The analyzer drops
 /// punctuation and lowercases, so `merge, policy` yields `[merge, policy]`
 /// — two ADJACENT positions, which is why a positional phrase matches it
 /// and raw-substring containment does not (issue #230).
+///
+/// It must not be hand-rolled. An earlier revision of this fix split on
+/// `!char::is_alphanumeric()`, which is NOT the standard tokenizer:
+/// UAX#29 (`unicode_words()`) keeps intra-word `.`, `'` and `_` inside one
+/// word, so `3.14`, `don't` and `foo_bar` are ONE term each on the segment
+/// side but two or three under the split. Measured at that revision, with an
+/// explicit `_flush` between the two probes of one index:
+///
+/// | query (`multi_match`, `type: phrase`) | doc | pre-flush | post-flush |
+/// |---|---|---|---|
+/// | `"release 3"` | `release 3.14 notes here` | hit | miss |
+/// | `"don t"`     | `we don't stop now`       | hit | miss |
+/// | `"foo bar"`   | `the foo_bar baz`         | hit | miss |
+///
+/// — a flush-variant hit set, the regression class #218/#222 removed and
+/// that issue #230 names as the standing invariant; and the pre-flush answer
+/// was also the wrong one (ES's standard analyzer keeps `don't` whole).
+///
+/// Callers pass field text that upstream has already lowercased; the
+/// pipeline's lowercase filter is idempotent, so that is harmless.
 fn phrase_tokens(text: &str) -> Vec<String> {
-    text.to_lowercase()
-        .split(|c: char| !c.is_alphanumeric())
-        .filter(|t| !t.is_empty())
-        .map(str::to_string)
-        .collect()
+    static STANDARD: std::sync::OnceLock<std::sync::Arc<xerj_fts::analyzer::AnalyzerPipeline>> =
+        std::sync::OnceLock::new();
+    STANDARD
+        .get_or_init(|| AnalyzerRegistry::default().standard())
+        .analyze_to_terms(text)
 }
 
 /// True when `query_tokens` occur in `field_tokens` in order with at most
@@ -28155,28 +28179,59 @@ fn phrase_tokens(text: &str) -> Vec<String> {
 /// `[a, x, x, x, a, b]` rejected the slop-1 phrase `a b` that both ES and
 /// the segment path accept (anchor at the second `a`).
 fn phrase_positions_in_tokens(field_tokens: &[String], query_tokens: &[String], slop: u32) -> bool {
+    phrase_walk(field_tokens, query_tokens, slop, false)
+}
+
+/// The one positional walk behind both `phrase_positions_in_tokens` and
+/// `phrase_prefix_positions_in_tokens`. `last_is_prefix` makes the FINAL
+/// query token match by `starts_with` instead of equality, which is exactly
+/// what the segment side computes: `execute_phrase_prefix` expands the
+/// trailing prefix against the term dictionary and unions one sloppy phrase
+/// query per expansion, and "some expansion term sits here" is the same
+/// predicate as "this token starts with the prefix".
+///
+/// Keeping one walk (rather than two look-alike ones) is deliberate: the
+/// two evaluators must not be able to drift apart the way the slop-0-only
+/// prefix walk had already drifted from the sloppy phrase walk.
+fn phrase_walk(
+    field_tokens: &[String],
+    query_tokens: &[String],
+    slop: u32,
+    last_is_prefix: bool,
+) -> bool {
     if query_tokens.is_empty() {
         return true;
     }
     if query_tokens.len() > field_tokens.len() {
         return false;
     }
-    if slop == 0 {
-        return field_tokens
-            .windows(query_tokens.len())
-            .any(|w| w == query_tokens);
+    let n = query_tokens.len();
+    let matches_at = |idx: usize, qi: usize| -> bool {
+        let ft = &field_tokens[idx];
+        if last_is_prefix && qi == n - 1 {
+            ft.starts_with(query_tokens[qi].as_str())
+        } else {
+            ft == &query_tokens[qi]
+        }
+    };
+    // Exact-adjacency fast path for the whole-term case (the common one).
+    if slop == 0 && !last_is_prefix {
+        return field_tokens.windows(n).any(|w| w == query_tokens);
     }
-    for (start, tok) in field_tokens.iter().enumerate() {
-        if tok != &query_tokens[0] {
+    for start in 0..field_tokens.len() {
+        if !matches_at(start, 0) {
             continue;
         }
         let mut current = start;
         let mut total_gaps: u32 = 0;
         let mut ok = true;
-        for qt in &query_tokens[1..] {
-            match field_tokens[current + 1..].iter().position(|ft| ft == qt) {
-                Some(off) => {
-                    let next = current + 1 + off;
+        for qi in 1..n {
+            // Earliest match after `current` minimises the running gap sum,
+            // so the greedy walk is optimal for an in-order phrase — the
+            // same walk `xerj_fts::search::phrase_positions_match` runs over
+            // segment positions.
+            match (current + 1..field_tokens.len()).find(|&i| matches_at(i, qi)) {
+                Some(next) => {
                     total_gaps += (next - current - 1) as u32;
                     if total_gaps > slop {
                         ok = false;
@@ -28197,32 +28252,26 @@ fn phrase_positions_in_tokens(field_tokens: &[String], query_tokens: &[String], 
     false
 }
 
-/// True when the leading `query_tokens[..n-1]` form an adjacent in-order
-/// phrase whose next position starts with `query_tokens[n-1]` — ES
-/// `match_phrase_prefix` semantics over the token stream. A single token
-/// degrades to "any token starts with it".
+/// True when the leading `query_tokens[..n-1]` form an in-order phrase whose
+/// next position starts with `query_tokens[n-1]`, with at most `slop`
+/// intervening positions in total — ES `match_phrase_prefix` semantics over
+/// the token stream. A single token degrades to "any token starts with it".
 ///
 /// This is TERM-level, not substring-level: `merge poli` matches the token
 /// stream `[merge, policy]` (so it matches raw text `merge, policy` too),
 /// while `merge polic` does NOT satisfy the exact-phrase variant, because
 /// `polic` is not the term `policy`.
-fn phrase_prefix_positions_in_tokens(field_tokens: &[String], query_tokens: &[String]) -> bool {
-    let (last, head) = match query_tokens.split_last() {
-        Some(pair) => pair,
-        None => return true,
-    };
-    if head.is_empty() {
-        return field_tokens.iter().any(|t| t.starts_with(last.as_str()));
-    }
-    if head.len() >= field_tokens.len() {
-        return false;
-    }
-    field_tokens.windows(head.len()).enumerate().any(|(i, w)| {
-        w == head
-            && field_tokens
-                .get(i + head.len())
-                .is_some_and(|t| t.starts_with(last.as_str()))
-    })
+///
+/// `slop` spans the whole phrase, trailing prefix term included — the same
+/// thing ES's `MultiPhrasePrefixQuery.setSlop` does and the same thing
+/// `execute_phrase_prefix` now does by carrying `PhrasePrefixQuery.slop`
+/// into each expansion's phrase query.
+fn phrase_prefix_positions_in_tokens(
+    field_tokens: &[String],
+    query_tokens: &[String],
+    slop: u32,
+) -> bool {
+    phrase_walk(field_tokens, query_tokens, slop, true)
 }
 
 /// Per-field phrase predicate for the phrase-shaped `multi_match` types,
@@ -28230,11 +28279,12 @@ fn phrase_prefix_positions_in_tokens(field_tokens: &[String], query_tokens: &[St
 /// (`score_query_against_doc`) arms so an admitted doc can never score 0.
 ///
 /// `phrase_prefix` treats the trailing token as a prefix; `phrase` requires
-/// whole terms and honours `slop`. `slop` is deliberately unread on the
-/// prefix arm — the parser REFUSES a non-zero `slop` with
-/// `type: phrase_prefix` (neither this walk nor the segment's
-/// `PhrasePrefixQuery` can honour it), so the only value that reaches here
-/// is 0. Reading it would imply support that does not exist.
+/// whole terms. Both honour `slop`, as ES does for both types.
+///
+/// `query_tokens` MUST come from `phrase_tokens` (the standard analyzer),
+/// not from a hand-rolled split: `3.14` is one analyzed term and two split
+/// ones, so a split query and an analyzed segment clause ask different
+/// questions and the hit set changes at `_flush`.
 ///
 /// `field_text_lc` is the field's text as the rest of the `multi_match` arms
 /// see it — an array-valued field arrives already joined with a space.
@@ -28257,7 +28307,7 @@ fn multi_match_phrase_hit(
     }
     let field_tokens = phrase_tokens(field_text_lc);
     if is_prefix {
-        phrase_prefix_positions_in_tokens(&field_tokens, query_tokens)
+        phrase_prefix_positions_in_tokens(&field_tokens, query_tokens, slop)
     } else {
         phrase_positions_in_tokens(&field_tokens, query_tokens, slop)
     }
@@ -28812,6 +28862,17 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
             let is_phrase_prefix =
                 matches!(match_type, xerj_query::ast::MultiMatchType::PhrasePrefix);
             let is_and = matches!(operator, Some(xerj_query::ast::BoolOperator::And));
+            // The phrase arms need ANALYZER tokens, not the alphanumeric
+            // split above: `query_node_to_fts` builds the segment clause
+            // from `analyzer.analyze(query)`, and `3.14` is one analyzed
+            // term but two split ones. Only the phrase arms switch — the
+            // cross_fields / AND / OR arms below intentionally keep the
+            // split, which is what they have always matched with.
+            let phrase_q_tokens: Vec<String> = if is_phrase {
+                phrase_tokens(query)
+            } else {
+                Vec::new()
+            };
             let field_texts: Vec<String> = fields
                 .iter()
                 .filter_map(|field_spec| {
@@ -28837,7 +28898,7 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                     }
                 })
                 .collect();
-            if is_phrase && !tokens.is_empty() {
+            if is_phrase && !phrase_q_tokens.is_empty() {
                 // phrase / phrase_prefix: POSITIONAL, per field (issue
                 // #230). ES lowers these types to a dis_max over per-field
                 // `match_phrase`/`match_phrase_prefix`, so the predicate is
@@ -28852,9 +28913,11 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                 // (`"merge policy"` missed the doc `merge, policy`, whose
                 // analyzed terms are adjacent) and OVER-matched (`"merge
                 // polic"` matched `merge policy`, where no such term
-                // exists). The segment path evaluates the same positions,
-                // now via `FtsQuery::Phrase`/`PhrasePrefix`, so the hit set
-                // stays flush-invariant.
+                // exists). The hit set stays flush-invariant because the
+                // segment either evaluates the SAME positions via
+                // `FtsQuery::Phrase` (type `phrase`, same standard-analyzer
+                // token stream on both sides) or declines the projection
+                // and runs this very predicate (type `phrase_prefix`).
                 //
                 // Tested FIRST, ahead of the operator branches: `operator`
                 // is meaningless for a phrase in ES (its phrase parser never
@@ -28863,7 +28926,7 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                 // stopped being a phrase at all.
                 field_texts
                     .iter()
-                    .any(|ft| multi_match_phrase_hit(ft, &tokens, is_phrase_prefix, *slop))
+                    .any(|ft| multi_match_phrase_hit(ft, &phrase_q_tokens, is_phrase_prefix, *slop))
             } else if is_cross && is_and && !tokens.is_empty() {
                 // cross_fields + operator AND: every token must appear in
                 // at least one listed field (combined perspective).
@@ -29080,7 +29143,9 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                 .unwrap_or(false)
         }
 
-        QueryNode::MatchPhrasePrefix { field, query, .. } => {
+        QueryNode::MatchPhrasePrefix {
+            field, query, slop, ..
+        } => {
             // POSITIONAL, not substring (issue #230). Pre-fix this arm found
             // the head phrase as a raw substring (`s_lower.find(head)`) and
             // required the prefix to follow it in the raw text — so
@@ -29088,7 +29153,7 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
             // while the segment path (`FtsQuery::PhrasePrefix`) matched over
             // the analyzed positions. The two states disagreed at `_flush`.
             // Both now walk the same analyzed token stream.
-            fn matches_str(s: &str, query: &str) -> Option<bool> {
+            fn matches_str(s: &str, query: &str, slop: u32) -> Option<bool> {
                 let query_tokens = phrase_tokens(query);
                 if query_tokens.is_empty() {
                     return Some(true);
@@ -29096,11 +29161,12 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                 Some(phrase_prefix_positions_in_tokens(
                     &phrase_tokens(s),
                     &query_tokens,
+                    slop,
                 ))
             }
             get_field_value(source, field)
                 .and_then(|v| match &v {
-                    Value::String(s) => matches_str(s, query),
+                    Value::String(s) => matches_str(s, query, *slop),
                     // Multi-valued field: ES matches if ANY element
                     // satisfies the phrase-prefix — pre-fix this arm only
                     // handled a scalar string, so a `match_phrase_prefix`
@@ -29110,7 +29176,7 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
                     Value::Array(arr) => {
                         if arr.iter().any(|e| {
                             e.as_str()
-                                .and_then(|s| matches_str(s, query))
+                                .and_then(|s| matches_str(s, query, *slop))
                                 .unwrap_or(false)
                         }) {
                             Some(true)
@@ -30561,9 +30627,23 @@ fn score_query_against_doc(q: &QueryNode, source: &Value) -> f32 {
                 .filter(|t| !t.is_empty())
                 .map(str::to_string)
                 .collect();
+            // Phrase arms tokenize with the ANALYZER, matching both
+            // `doc_matches_query` and the segment clause built by
+            // `query_node_to_fts` — see `phrase_tokens`. The non-phrase arms
+            // keep `q_tokens` (the alphanumeric split) unchanged.
+            let phrase_q_tokens: Vec<String> = if is_phrase {
+                phrase_tokens(query)
+            } else {
+                Vec::new()
+            };
             let field_hit = |text_lc: &str| -> bool {
-                if is_phrase && !q_tokens.is_empty() {
-                    return multi_match_phrase_hit(text_lc, &q_tokens, is_phrase_prefix, *slop);
+                if is_phrase && !phrase_q_tokens.is_empty() {
+                    return multi_match_phrase_hit(
+                        text_lc,
+                        &phrase_q_tokens,
+                        is_phrase_prefix,
+                        *slop,
+                    );
                 }
                 if q_tokens.is_empty() {
                     return text_lc.contains(&q_lower);
@@ -32934,11 +33014,14 @@ fn query_node_to_fts(
             operator,
             boost,
             slop,
-            max_expansions,
+            // Unused HERE on purpose: `phrase_prefix` declines the
+            // projection (see below), so nothing in this function expands a
+            // prefix and nothing needs the bound.
+            max_expansions: _,
             analyzer,
         } => {
-            // phrase / phrase_prefix are POSITIONAL (issue #230): they lower
-            // to one positional clause per field, combined by dis_max — the
+            // phrase is POSITIONAL (issue #230): it lowers to one positional
+            // clause per field, combined by dis_max — the
             // shape ES builds (`MultiMatchQueryParser.buildFieldQueries` +
             // `combineGrouped` → `DisjunctionMaxQuery`, tie_breaker 0.0 for
             // both phrase types; AGPL, read for semantics only, no code
@@ -32994,8 +33077,28 @@ fn query_node_to_fts(
             if field_specs.is_empty() {
                 return None;
             }
-            // ── phrase / phrase_prefix: one positional clause per field ──
+            // ── phrase: one positional clause per field ──
             if is_phrase_type {
+                // `phrase_prefix` deliberately keeps the DECLINED /
+                // stored-scan routing it has on `main`. The segment clause
+                // (`FtsQuery::PhrasePrefix`) bounds the trailing prefix to
+                // `max_expansions` terms taken from the field's term
+                // dictionary; the stored-doc walk has no term dictionary and
+                // uses an unbounded `starts_with`. Projecting it therefore
+                // makes the hit set change at `_flush` — measured on one
+                // index: `{type: phrase_prefix, query: "merge pol",
+                // max_expansions: 1}` returned 5 docs in the memtable and 4
+                // after `_flush`. That is the #218 regression class, and
+                // #230 names flush invariance as the standing invariant, so
+                // the invariant wins over the projection. Consequence,
+                // stated plainly: `max_expansions` does not bind on
+                // `multi_match` (it never did on `main` either — the
+                // parameter was dropped in the parser), and phrase_prefix
+                // keeps the O(N) stored scan. `phrase` — where the measured
+                // 5.7× win is — still projects.
+                if is_phrase_prefix {
+                    return None;
+                }
                 let terms: Vec<String> = tokens.iter().map(|t| t.text.clone()).collect();
                 // Every listed field must be an ANALYZED TEXT field with a
                 // positions side-car, and the query must analyze to at least
@@ -33025,14 +33128,7 @@ fn query_node_to_fts(
                 let outer = boost.unwrap_or(1.0);
                 let mut per_field: Vec<FtsQuery> = Vec::with_capacity(field_specs.len());
                 for (field, fb) in &field_specs {
-                    per_field.push(if is_phrase_prefix {
-                        FtsQuery::PhrasePrefix(xerj_fts::search::PhrasePrefixQuery {
-                            field: field.clone(),
-                            terms: terms.clone(),
-                            max_expansions: *max_expansions as usize,
-                            boost: *fb,
-                        })
-                    } else if terms.len() == 1 {
+                    per_field.push(if terms.len() == 1 {
                         // A one-term phrase is just a term query — and scores
                         // identically to `match_phrase` on that field.
                         FtsQuery::Term(FtsTerm::boosted(field.as_str(), &terms[0], *fb))
@@ -33398,6 +33494,7 @@ fn query_node_to_fts(
             field,
             query,
             max_expansions,
+            slop,
         } => {
             // match_phrase_prefix on a KEYWORD field: single whole-value token
             // whose last (only) term is a prefix → a prefix query over the
@@ -33432,6 +33529,10 @@ fn query_node_to_fts(
                         field: field.clone(),
                         terms: tokens.iter().map(|t| t.text.clone()).collect(),
                         max_expansions: *max_expansions as usize,
+                        // `slop` used to be dropped on the floor here, so a
+                        // sloppy `match_phrase_prefix` silently answered as
+                        // slop 0 (#204 class).
+                        slop: *slop,
                         boost: 1.0,
                     },
                 ));
@@ -36016,8 +36117,13 @@ mod fts_projection_tests {
             other => panic!("expected dis_max of phrase clauses, got {other:?}"),
         }
 
-        // phrase_prefix lowers to the positional prefix clause, carrying
-        // `max_expansions`.
+        // phrase_prefix DECLINES the projection on purpose (#230 review): a
+        // positional prefix clause bounds the trailing prefix to
+        // `max_expansions` terms from the segment's term dictionary, while
+        // the stored-doc walk that answers for the memtable has no term
+        // dictionary and expands unbounded — so projecting it makes the hit
+        // set shrink at `_flush`, the #218 regression class. Declining keeps
+        // one evaluator for both states.
         q = QueryNode::MultiMatch {
             fields: vec!["body".into()],
             query: "merge poli".into(),
@@ -36028,13 +36134,11 @@ mod fts_projection_tests {
             slop: 0,
             max_expansions: 7,
         };
-        match query_node_to_fts(&q, &text, &kw(&[])).expect("phrase_prefix projects") {
-            FtsQuery::PhrasePrefix(p) => {
-                assert_eq!(p.terms, vec!["merge".to_string(), "poli".to_string()]);
-                assert_eq!(p.max_expansions, 7);
-            }
-            other => panic!("expected phrase-prefix clause, got {other:?}"),
-        }
+        assert!(
+            query_node_to_fts(&q, &text, &kw(&[])).is_none(),
+            "multi_match phrase_prefix must decline the projection so the \
+             memtable and the segment stay on one predicate"
+        );
     }
 
     /// #230 parity guard — a KEYWORD field in a phrase `multi_match` declines
@@ -36198,6 +36302,7 @@ mod fts_projection_tests {
             field: "body".into(),
             query: "status ok log".into(),
             max_expansions: 50,
+            slop: 0,
         };
         match query_node_to_fts(&q, &tf, &kw(&[])).expect("text mpp projects") {
             FtsQuery::PhrasePrefix(p) => {
@@ -36216,6 +36321,7 @@ mod fts_projection_tests {
             field: "top_doc".into(),
             query: "runbook/on".into(),
             max_expansions: 50,
+            slop: 0,
         };
         let fq = query_node_to_fts(&q, &[], &kw(&["top_doc"])).expect("keyword prefix projects");
         match fq {

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -28193,6 +28193,20 @@ fn phrase_positions_in_tokens(field_tokens: &[String], query_tokens: &[String], 
 /// Keeping one walk (rather than two look-alike ones) is deliberate: the
 /// two evaluators must not be able to drift apart the way the slop-0-only
 /// prefix walk had already drifted from the sloppy phrase walk.
+///
+/// KNOWN DIVERGENCE FROM ES, not closed by #230: this walk is **in-order
+/// only**.  Lucene's sloppy phrase admits a transposition at a distance
+/// cost — its own javadoc: «for query "a b"~2, a document "x a b a y" can
+/// be matched twice: once for "a b" (distance=0), and once for "b a"
+/// (distance=2)» (`lucene/core/.../search/SloppyPhraseMatcher.java`, class
+/// javadoc; Apache-2.0) — so ES answers `match_phrase {"query": "policy
+/// merge", "slop": 2}` on a document reading `merge policy`, and XERJ
+/// answers it with zero hits.  That is the pre-existing semantics of
+/// `xerj_fts::search::phrase_positions_match`, which the segment side has
+/// always used and which this walk deliberately mirrors: matching ES here
+/// means changing BOTH evaluators together, and mirroring the existing one
+/// is what keeps the hit set flush-invariant today.  Measured, not assumed
+/// (5-doc index, `"policy merge"` slop 2 and slop 3 → `[]` in both states).
 fn phrase_walk(
     field_tokens: &[String],
     query_tokens: &[String],

--- a/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
+++ b/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
@@ -1,0 +1,355 @@
+//! Regression tests for issue #230: `multi_match` with `type: phrase` /
+//! `phrase_prefix` must evaluate REAL positional phrase semantics — term
+//! positions in the analyzed token stream — not whole-query lowercase
+//! substring containment on the raw field text.
+//!
+//! Pre-fix both the memtable arm of `doc_matches_query` and the scoring
+//! arm of `score_query_against_doc` tested `field_text.contains(query)`,
+//! and the segment FTS projection DECLINED phrase types outright so the
+//! stored-doc scan evaluated the same substring predicate. Substring
+//! containment diverges from ES in both directions:
+//!
+//! * under-match — the analyzer strips punctuation, so ES's positional
+//!   phrase matches `"merge policy"` against `merge, policy`; the raw
+//!   text has no `"merge policy"` substring, so XERJ returned 0 hits;
+//! * over-match — substring containment ignores token boundaries, so
+//!   `"merge polic"` matched the doc `merge policy`, where ES's phrase
+//!   terms (`merge`, `polic`) never line up;
+//! * `slop` was parsed away entirely, so `{"type":"phrase","slop":2}`
+//!   silently behaved as slop 0.
+//!
+//! Every case is asserted BOTH pre-flush (memtable) and post-flush
+//! (segment), and cross-checked against the single-field `match_phrase` /
+//! `match_phrase_prefix` queries, which have always been positional — ES
+//! lowers `multi_match` phrase types to exactly a dis_max over per-field
+//! `match_phrase` clauses.
+
+use std::collections::BTreeSet;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+use xerj_engine::{Engine, Index};
+use xerj_query::parse_request;
+
+fn make_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    Engine::new(config).expect("engine::new")
+}
+
+fn req(q: Value) -> xerj_query::ast::SearchRequest {
+    parse_request(&json!({ "query": q, "size": 50 })).expect("parse_request")
+}
+
+async fn ids(idx: &Index, q: &Value) -> BTreeSet<String> {
+    idx.search(&req(q.clone()))
+        .await
+        .unwrap()
+        .hits
+        .iter()
+        .map(|h| h.id.clone())
+        .collect()
+}
+
+fn set(ids: &[&str]) -> BTreeSet<String> {
+    ids.iter().map(|s| s.to_string()).collect()
+}
+
+/// Run every case against the memtable, flush once, run every case again
+/// against the segment, and assert the hit set is the expected one in both
+/// states — semantics AND flush-invariance in one assertion.
+async fn assert_both_states(idx: &std::sync::Arc<Index>, cases: &[(Value, &[&str], &str)]) {
+    for (q, exp, label) in cases {
+        let pre = ids(idx, q).await;
+        assert_eq!(
+            pre,
+            set(exp),
+            "{label}: PRE-flush (memtable) hit set for {q}"
+        );
+    }
+    idx.flush().await.unwrap();
+    for (q, exp, label) in cases {
+        let post = ids(idx, q).await;
+        assert_eq!(
+            post,
+            set(exp),
+            "{label}: POST-flush (segment) hit set for {q}"
+        );
+    }
+}
+
+/// Doc 1 carries punctuation INSIDE the phrase (`merge, policy`) — the
+/// standard analyzer drops it, so the phrase terms are adjacent even
+/// though the raw text has no `"merge policy"` substring.
+/// Doc 2 carries the bare phrase, so it exercises the over-match direction.
+/// Doc 3 is a control that must never match.
+async fn seed(engine: &Engine, name: &str) -> std::sync::Arc<Index> {
+    engine.create_index(name, Schema::empty()).unwrap();
+    let idx = engine.get_index(name).unwrap();
+    idx.index_document(
+        Some("1".into()),
+        json!({
+            "body": "the log merge, policy groups segments into buckets",
+            "title": "log structured merge"
+        }),
+    )
+    .await
+    .unwrap();
+    idx.index_document(
+        Some("2".into()),
+        json!({"body": "a tiered merge policy compacts segments", "title": "merge policy"}),
+    )
+    .await
+    .unwrap();
+    idx.index_document(
+        Some("3".into()),
+        json!({"body": "quick brown fox", "title": "animals"}),
+    )
+    .await
+    .unwrap();
+    idx
+}
+
+/// UNDER-MATCH: the analyzer strips the comma, so ES's positional phrase
+/// matches doc 1. Pre-fix the substring test missed it in both states.
+/// `match_phrase` on the same field is the in-repo oracle: it has always
+/// been positional, and ES lowers `multi_match` phrase to exactly that.
+#[tokio::test]
+async fn phrase_matches_across_stripped_punctuation() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_punct").await;
+
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"match_phrase": {"body": "merge policy"}}),
+                &["1", "2"],
+                "oracle match_phrase",
+            ),
+            (
+                json!({"multi_match": {"query": "merge policy", "fields": ["body"],
+                                       "type": "phrase"}}),
+                &["1", "2"],
+                "multi_match phrase, single field",
+            ),
+            (
+                json!({"multi_match": {"query": "merge policy", "fields": ["body", "title"],
+                                       "type": "phrase"}}),
+                &["1", "2"],
+                "multi_match phrase, two fields",
+            ),
+        ],
+    )
+    .await;
+}
+
+/// OVER-MATCH: `"merge polic"` is a substring of `merge policy` but the
+/// analyzed terms never line up, so ES matches nothing. Pre-fix XERJ
+/// returned doc 2 (and doc 1 for the `body` variant is impossible either
+/// way — its raw text has no such substring).
+#[tokio::test]
+async fn phrase_does_not_match_partial_trailing_token() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_partial").await;
+
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"match_phrase": {"title": "merge polic"}}),
+                &[],
+                "oracle match_phrase partial token",
+            ),
+            (
+                json!({"multi_match": {"query": "merge polic", "fields": ["title"],
+                                       "type": "phrase"}}),
+                &[],
+                "multi_match phrase partial token",
+            ),
+            // Reversed phrase must not match either (positional order).
+            (
+                json!({"multi_match": {"query": "policy merge", "fields": ["title", "body"],
+                                       "type": "phrase"}}),
+                &[],
+                "multi_match phrase reversed",
+            ),
+        ],
+    )
+    .await;
+}
+
+/// `operator` is meaningless for a phrase in ES — its phrase parser never
+/// consults it. Pre-fix `{"type":"phrase","operator":"and"}` fell into the
+/// memtable's token-AND branch (tested before the phrase branch) and
+/// silently stopped being a phrase: the reversed, non-adjacent query below
+/// matched because both tokens were merely present in the same field.
+#[tokio::test]
+async fn operator_does_not_override_phrase_semantics() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_operator").await;
+
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"multi_match": {"query": "policy merge", "fields": ["title", "body"],
+                                       "type": "phrase", "operator": "and"}}),
+                &[],
+                "phrase + operator:and stays a phrase (reversed → no hit)",
+            ),
+            (
+                json!({"multi_match": {"query": "merge policy", "fields": ["body"],
+                                       "type": "phrase", "operator": "and"}}),
+                &["1", "2"],
+                "phrase + operator:and stays a phrase (in order → hit)",
+            ),
+        ],
+    )
+    .await;
+}
+
+/// `phrase_prefix`: head terms form an ordered phrase, the LAST term is a
+/// prefix over the analyzed term dictionary. Pre-fix the memtable arm used
+/// substring containment, so the punctuated doc was missed.
+#[tokio::test]
+async fn phrase_prefix_is_positional() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_prefix").await;
+
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"multi_match": {"query": "merge poli", "fields": ["body"],
+                                       "type": "phrase_prefix"}}),
+                &["1", "2"],
+                "multi_match phrase_prefix across punctuation",
+            ),
+            (
+                json!({"match_phrase_prefix": {"body": "merge poli"}}),
+                &["1", "2"],
+                "oracle match_phrase_prefix across punctuation",
+            ),
+            // The head phrase still has to be an ordered adjacent phrase.
+            (
+                json!({"multi_match": {"query": "policy mer", "fields": ["body", "title"],
+                                       "type": "phrase_prefix"}}),
+                &[],
+                "multi_match phrase_prefix reversed head",
+            ),
+        ],
+    )
+    .await;
+}
+
+/// `slop` was parsed away by `parse_multi_match`, so a sloppy phrase
+/// silently behaved as an exact one. Doc 1's `body` analyses to
+/// [the, log, merge, policy, …]: `"log policy"` needs slop >= 1.
+#[tokio::test]
+async fn phrase_slop_is_honoured() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_slop").await;
+
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"multi_match": {"query": "log policy", "fields": ["body"],
+                                       "type": "phrase"}}),
+                &[],
+                "slop 0 (default): one intervening token → no match",
+            ),
+            (
+                json!({"multi_match": {"query": "log policy", "fields": ["body"],
+                                       "type": "phrase", "slop": 1}}),
+                &["1"],
+                "slop 1: one intervening token → match",
+            ),
+            (
+                json!({"multi_match": {"query": "log policy", "fields": ["body"],
+                                       "type": "phrase", "slop": 5}}),
+                &["1"],
+                "slop 5: match",
+            ),
+        ],
+    )
+    .await;
+}
+
+/// A memtable phrase hit must also SCORE above zero — `score_query_against_doc`
+/// carried its own copy of the substring predicate, so a doc admitted by the
+/// (fixed) membership test would still score 0.0 and be dropped by scored paths.
+#[tokio::test]
+async fn memtable_phrase_hit_scores_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_score").await;
+
+    let r = idx
+        .search(&req(json!({
+            "multi_match": {"query": "merge policy", "fields": ["body", "title"],
+                            "type": "phrase"}
+        })))
+        .await
+        .unwrap();
+    assert_eq!(r.total.value, 2, "memtable phrase hit count");
+    for h in &r.hits {
+        assert!(
+            h.score > 0.0,
+            "memtable multi_match phrase hit {} scored {} (expected > 0)",
+            h.id,
+            h.score
+        );
+    }
+}
+
+/// `slop` on a `phrase_prefix` cannot be honoured by either evaluator —
+/// the segment clause (`xerj_fts::search::PhrasePrefixQuery`) carries no
+/// slop, and the stored-doc walk requires an adjacent head phrase. ES does
+/// honour it, so accepting the parameter and answering an exact phrase
+/// would silently answer a different query (#204's defect class). It must
+/// be refused, loudly.
+#[test]
+fn slop_on_phrase_prefix_is_refused_not_ignored() {
+    let err = parse_request(&json!({
+        "query": {"multi_match": {"query": "merge poli", "fields": ["body"],
+                                  "type": "phrase_prefix", "slop": 2}}
+    }))
+    .expect_err("slop on phrase_prefix must be refused, not silently dropped");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("slop") && msg.contains("phrase_prefix"),
+        "error must name both the parameter and the type, got: {msg}"
+    );
+
+    // slop 0 is the default and stays accepted.
+    parse_request(&json!({
+        "query": {"multi_match": {"query": "merge poli", "fields": ["body"],
+                                  "type": "phrase_prefix", "slop": 0}}
+    }))
+    .expect("slop 0 on phrase_prefix is the default and must parse");
+}
+
+/// A negative `slop` is a client error in ES; accepting it silently would
+/// be another accept-and-ignore. Assert the parser rejects it.
+#[test]
+fn negative_slop_is_rejected() {
+    let err = parse_request(&json!({
+        "query": {"multi_match": {"query": "merge policy", "fields": ["body"],
+                                  "type": "phrase", "slop": -1}}
+    }))
+    .expect_err("negative slop must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("slop"),
+        "error should name the offending parameter, got: {msg}"
+    );
+}

--- a/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
+++ b/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
@@ -31,6 +31,7 @@ use tempfile::TempDir;
 use xerj_common::config::Config;
 use xerj_common::types::Schema;
 use xerj_engine::{Engine, Index};
+use xerj_query::ast::QueryNode;
 use xerj_query::parse_request;
 
 fn make_engine(dir: &TempDir) -> Engine {
@@ -357,12 +358,22 @@ async fn phrase_prefix_slop_is_honoured_at_both_entry_points() {
     .await;
 }
 
-/// A negative `slop` is a client error in ES from EVERY builder, so every
-/// entry point must answer alike — a 400 from one spelling and a silently
-/// coerced 0 from the other is the same accept-and-ignore defect wearing a
-/// different hat.
+/// A negative `slop` is a client error in ES from all three *phrase* builders
+/// (`MatchPhraseQueryBuilder` / `MatchPhrasePrefixQueryBuilder:103` /
+/// `MultiMatchQueryBuilder:350`, all "No negative slop allowed"), so all three
+/// must answer alike here — a 400 from one spelling and a silently coerced 0
+/// from the other is the same accept-and-ignore defect wearing a different hat.
+///
+/// SCOPE, stated so the name cannot be read as more than it is: these three
+/// query types are the whole of it. `span_near` also takes a `slop` and is
+/// **not** covered — it keeps `as_u64().unwrap_or(0)`, so `span_near` with
+/// `slop: -1` returns 200 with the value silently 0. That is a pre-existing
+/// gap, recorded at `parse_span_near`, and it is left alone because ES applies
+/// no validation to `span_near.slop` either
+/// (`SpanNearQueryBuilder.java:62`) — rejecting it would break a query ES
+/// answers.
 #[test]
-fn negative_slop_is_rejected_at_every_entry_point() {
+fn negative_slop_is_rejected_at_the_three_phrase_entry_points() {
     for bad in [
         json!({"multi_match": {"query": "merge policy", "fields": ["body"],
                                "type": "phrase", "slop": -1}}),
@@ -375,6 +386,54 @@ fn negative_slop_is_rejected_at_every_entry_point() {
             err.to_string().contains("slop"),
             "error should name the offending parameter, got: {err}"
         );
+    }
+}
+
+/// A float-encoded `slop` (`2.0`) must be honoured as 2, not refused and not
+/// dropped. ES reads slop with `XContentParser.intValue()` under its default
+/// coercing policy, which truncates a float token and narrows a numeric string
+/// (`AbstractXContentParser.java:74`/`:162`/`:177`), so `{"slop": 2.0}` is a
+/// query ES answers with slop 2.
+///
+/// This test exists because an earlier revision of this branch tightened the
+/// parse to `as_i64()` and turned `2.0` into a 400 — a new refusal on a
+/// request `main` answered, which is exactly the wire break this PR declined
+/// to make elsewhere. The two wrong answers are symmetrical: refusing the
+/// value, or silently substituting 0 as `main` did.
+#[test]
+fn float_and_string_encoded_slop_are_coerced_like_es() {
+    for (body, want) in [
+        (json!({"query": "merge policy", "slop": 2.0}), 2u32),
+        (json!({"query": "merge policy", "slop": 2.7}), 2),
+        (json!({"query": "merge policy", "slop": "2"}), 2),
+    ] {
+        let q = json!({"match_phrase": {"body": body.clone()}});
+        let parsed = parse_request(&json!({ "query": q }))
+            .unwrap_or_else(|e| panic!("ES coerces this slop, so it must parse: {body} -> {e}"));
+        match parsed.query {
+            QueryNode::MatchPhrase { slop, .. } => {
+                assert_eq!(slop, want, "expected slop {want} from {body}, got {slop}")
+            }
+            other => panic!("expected a MatchPhrase node, got {other:?}"),
+        }
+    }
+
+    // The same coercion, and the same refusal to ignore, on `max_expansions`:
+    // a float is read, and a value that cannot be read is a 400 rather than
+    // a silent fall back to 50 (which is what `main` did here).
+    let parsed = parse_request(&json!({"query": {"match_phrase_prefix": {
+        "body": {"query": "merge poli", "max_expansions": 7.0}}}}))
+    .expect("float max_expansions is coerced, not refused");
+    match parsed.query {
+        QueryNode::MatchPhrasePrefix { max_expansions, .. } => assert_eq!(max_expansions, 7),
+        other => panic!("expected a MatchPhrasePrefix node, got {other:?}"),
+    }
+    for bad in [
+        json!({"match_phrase_prefix": {"body": {"query": "merge poli", "max_expansions": -1}}}),
+        json!({"match_phrase_prefix": {"body": {"query": "merge poli",
+                                                "max_expansions": "seven"}}}),
+    ] {
+        parse_request(&json!({ "query": bad.clone() })).unwrap_err();
     }
 }
 

--- a/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
+++ b/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
@@ -311,45 +311,191 @@ async fn memtable_phrase_hit_scores_nonzero() {
     }
 }
 
-/// `slop` on a `phrase_prefix` cannot be honoured by either evaluator —
-/// the segment clause (`xerj_fts::search::PhrasePrefixQuery`) carries no
-/// slop, and the stored-doc walk requires an adjacent head phrase. ES does
-/// honour it, so accepting the parameter and answering an exact phrase
-/// would silently answer a different query (#204's defect class). It must
-/// be refused, loudly.
-#[test]
-fn slop_on_phrase_prefix_is_refused_not_ignored() {
-    let err = parse_request(&json!({
-        "query": {"multi_match": {"query": "merge poli", "fields": ["body"],
-                                  "type": "phrase_prefix", "slop": 2}}
-    }))
-    .expect_err("slop on phrase_prefix must be refused, not silently dropped");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("slop") && msg.contains("phrase_prefix"),
-        "error must name both the parameter and the type, got: {msg}"
-    );
+/// `slop` on a `phrase_prefix` is HONOURED, at both entry points and in
+/// both states. ES honours it (`TextFieldMapper.createPhrasePrefixQuery`
+/// builds a `MultiPhrasePrefixQuery` and calls `setSlop`), so refusing it
+/// would break clients, and dropping it — which `parse_match_phrase_prefix`
+/// did — is the accept-and-ignore defect class of #204: the `multi_match`
+/// and `match_phrase_prefix` spellings of the same query must not disagree.
+///
+/// Doc 1's `body` analyses to [the, log, merge, policy, …]: the phrase
+/// `log poli*` needs one intervening position, so slop 0 misses and slop 1
+/// hits.
+#[tokio::test]
+async fn phrase_prefix_slop_is_honoured_at_both_entry_points() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_prefix_slop").await;
 
-    // slop 0 is the default and stays accepted.
-    parse_request(&json!({
-        "query": {"multi_match": {"query": "merge poli", "fields": ["body"],
-                                  "type": "phrase_prefix", "slop": 0}}
-    }))
-    .expect("slop 0 on phrase_prefix is the default and must parse");
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"multi_match": {"query": "log poli", "fields": ["body"],
+                                       "type": "phrase_prefix"}}),
+                &[],
+                "phrase_prefix slop 0 (default): one intervening token → no match",
+            ),
+            (
+                json!({"multi_match": {"query": "log poli", "fields": ["body"],
+                                       "type": "phrase_prefix", "slop": 1}}),
+                &["1"],
+                "phrase_prefix slop 1: one intervening token → match",
+            ),
+            (
+                json!({"match_phrase_prefix": {"body": {"query": "log poli", "slop": 1}}}),
+                &["1"],
+                "oracle match_phrase_prefix slop 1 answers the same query",
+            ),
+            (
+                json!({"match_phrase_prefix": {"body": {"query": "log poli"}}}),
+                &[],
+                "oracle match_phrase_prefix slop 0",
+            ),
+        ],
+    )
+    .await;
 }
 
-/// A negative `slop` is a client error in ES; accepting it silently would
-/// be another accept-and-ignore. Assert the parser rejects it.
+/// A negative `slop` is a client error in ES from EVERY builder, so every
+/// entry point must answer alike — a 400 from one spelling and a silently
+/// coerced 0 from the other is the same accept-and-ignore defect wearing a
+/// different hat.
 #[test]
-fn negative_slop_is_rejected() {
-    let err = parse_request(&json!({
-        "query": {"multi_match": {"query": "merge policy", "fields": ["body"],
-                                  "type": "phrase", "slop": -1}}
-    }))
-    .expect_err("negative slop must be rejected");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("slop"),
-        "error should name the offending parameter, got: {msg}"
-    );
+fn negative_slop_is_rejected_at_every_entry_point() {
+    for bad in [
+        json!({"multi_match": {"query": "merge policy", "fields": ["body"],
+                               "type": "phrase", "slop": -1}}),
+        json!({"match_phrase": {"body": {"query": "merge policy", "slop": -1}}}),
+        json!({"match_phrase_prefix": {"body": {"query": "merge poli", "slop": -1}}}),
+    ] {
+        let err = parse_request(&json!({"query": bad}))
+            .expect_err("negative slop must be rejected, not coerced to 0");
+        assert!(
+            err.to_string().contains("slop"),
+            "error should name the offending parameter, got: {err}"
+        );
+    }
+}
+
+/// The stored-scan/memtable evaluator and the positional segment clause
+/// must tokenize with the SAME analyzer, or they answer different queries
+/// and the hit set changes at `_flush` — the regression class #218/#222
+/// removed and that #230 names as the standing invariant.
+///
+/// An earlier revision of this fix tokenized the memtable side by splitting
+/// on `!char::is_alphanumeric()` while the segment clause was built from the
+/// `standard` analyzer (UAX#29 `unicode_words()`). The two disagree on
+/// intra-word `.`, `'` and `_`: `3.14`, `don't` and `foo_bar` are ONE
+/// analyzed term each and two-or-three split ones. Each case below returned
+/// a hit pre-flush and none post-flush at that revision; the analyzed answer
+/// (no hit — the terms never line up) is also the one ES gives.
+#[tokio::test]
+async fn phrase_tokenizer_matches_the_segment_analyzer() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("mmpp_tok", Schema::empty()).unwrap();
+    let idx = engine.get_index("mmpp_tok").unwrap();
+    for (id, body) in [
+        ("n1", "release 3.14 notes here"),
+        ("d1", "we don't stop now"),
+        ("u1", "the foo_bar baz"),
+    ] {
+        idx.index_document(Some(id.into()), json!({ "body": body }))
+            .await
+            .unwrap();
+    }
+
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"multi_match": {"query": "release 3", "fields": ["body"],
+                                       "type": "phrase"}}),
+                &[],
+                "`3.14` is ONE analyzed term, so `release 3` is not a phrase in it",
+            ),
+            (
+                json!({"match_phrase": {"body": "release 3"}}),
+                &[],
+                "oracle match_phrase agrees",
+            ),
+            (
+                json!({"multi_match": {"query": "don t", "fields": ["body"],
+                                       "type": "phrase"}}),
+                &[],
+                "`don't` is ONE analyzed term, so `don t` is not a phrase in it",
+            ),
+            (
+                json!({"multi_match": {"query": "foo bar", "fields": ["body"],
+                                       "type": "phrase"}}),
+                &[],
+                "`foo_bar` is ONE analyzed term, so `foo bar` is not a phrase in it",
+            ),
+            // The whole analyzed term still matches, in both states.
+            (
+                json!({"multi_match": {"query": "release 3.14", "fields": ["body"],
+                                       "type": "phrase"}}),
+                &["n1"],
+                "the analyzed term itself matches",
+            ),
+            (
+                json!({"multi_match": {"query": "we don't", "fields": ["body"],
+                                       "type": "phrase"}}),
+                &["d1"],
+                "the analyzed term itself matches (apostrophe)",
+            ),
+        ],
+    )
+    .await;
+}
+
+/// `max_expansions` is why `phrase_prefix` keeps the declined/stored-scan
+/// routing on `multi_match`: the segment clause bounds the trailing prefix
+/// to `max_expansions` terms from the field's term dictionary, and the
+/// stored-doc walk — which has no term dictionary — cannot. Projecting it
+/// made the hit set shrink at `_flush`.
+///
+/// This asserts the INVARIANT (same answer either side of the flush), not
+/// ES parity: XERJ does not bind `max_expansions` on `multi_match`, so both
+/// states return the unbounded answer. Stated plainly rather than papered
+/// over — flush invariance is the property #230 asks for.
+///
+/// HONEST LIMIT of this test: it also passes against the revision that DID
+/// project `phrase_prefix` (checked out and run — 7 passed, 3 failed, and
+/// this was not one of the three), so it is an invariant assertion, not a
+/// regression catcher. This in-process fixture does not reliably route the
+/// query through the bounded segment clause the way a mapped index on a
+/// live server does, which is where the review measured the shrink
+/// (pre {p1,p2,p3,p4,s1} / post {p1,p2,p3,p4}). The discriminating guard
+/// for the routing decision is the unit test
+/// `index::fts_projection_tests::multi_match_phrase_projects_positional_dis_max`,
+/// which asserts `query_node_to_fts` returns `None` for `phrase_prefix`.
+#[tokio::test]
+async fn phrase_prefix_max_expansions_does_not_change_the_hit_set_at_flush() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("mmpp_maxexp", Schema::empty()).unwrap();
+    let idx = engine.get_index("mmpp_maxexp").unwrap();
+    // `pol*` expands to two dictionary terms — `polar` sorts first, so a
+    // max_expansions of 1 would keep only it on a bounded segment clause.
+    for (id, body) in [
+        ("p1", "a tiered merge policy compacts segments"),
+        ("p2", "the merge polar route"),
+    ] {
+        idx.index_document(Some(id.into()), json!({ "body": body }))
+            .await
+            .unwrap();
+    }
+
+    assert_both_states(
+        &idx,
+        &[(
+            json!({"multi_match": {"query": "merge pol", "fields": ["body"],
+                                   "type": "phrase_prefix", "max_expansions": 1}}),
+            &["p1", "p2"],
+            "multi_match phrase_prefix hit set is the same before and after _flush",
+        )],
+    )
+    .await;
 }

--- a/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
+++ b/engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs
@@ -285,6 +285,57 @@ async fn phrase_slop_is_honoured() {
     .await;
 }
 
+/// PINS A KNOWN DIVERGENCE FROM ES, so nothing in this PR can be read as
+/// claiming it away: XERJ's sloppy phrase is **in-order only**, at every
+/// entry point and in both states.
+///
+/// Lucene's is not. `SloppyPhraseMatcher`'s class javadoc: «for query "a
+/// b"~2, a document "x a b a y" can be matched twice: once for "a b"
+/// (distance=0), and once for "b a" (distance=2)» — so ES answers
+/// `{"query": "policy merge", "slop": 2}` with docs 1 and 2, and XERJ
+/// answers with none. That is the pre-existing behaviour of
+/// `xerj_fts::search::phrase_positions_match` (which single-field
+/// `match_phrase` has always used) and the stored-scan walk added by #230
+/// mirrors it deliberately, because the two evaluators disagreeing is the
+/// flush-variance class this PR exists to remove.
+///
+/// It is NOT a regression: before #230 the `multi_match` phrase arms tested
+/// raw-substring containment, which does not match a transposition either.
+/// When the walk learns transpositions, both evaluators change together and
+/// this test flips — that is the point of pinning it.
+#[tokio::test]
+async fn sloppy_phrase_is_in_order_only_unlike_lucene() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let idx = seed(&engine, "mmpp_inorder").await;
+
+    assert_both_states(
+        &idx,
+        &[
+            (
+                json!({"multi_match": {"query": "policy merge", "fields": ["body"],
+                                       "type": "phrase", "slop": 2}}),
+                &[],
+                "transposed phrase, slop 2: ES matches, XERJ does not",
+            ),
+            (
+                json!({"match_phrase": {"body": {"query": "policy merge", "slop": 3}}}),
+                &[],
+                "transposed phrase, slop 3, single-field spelling: same answer",
+            ),
+            // The in-order control, so the case above cannot pass by
+            // accident (e.g. if slop stopped being honoured at all).
+            (
+                json!({"multi_match": {"query": "log policy", "fields": ["body"],
+                                       "type": "phrase", "slop": 2}}),
+                &["1"],
+                "in-order control at the same slop: matches",
+            ),
+        ],
+    )
+    .await;
+}
+
 /// A memtable phrase hit must also SCORE above zero — `score_query_against_doc`
 /// carried its own copy of the substring predicate, so a doc admitted by the
 /// (fixed) membership test would still score 0.0 and be dropped by scored paths.
@@ -392,7 +443,8 @@ fn negative_slop_is_rejected_at_the_three_phrase_entry_points() {
 /// A float-encoded `slop` (`2.0`) must be honoured as 2, not refused and not
 /// dropped. ES reads slop with `XContentParser.intValue()` under its default
 /// coercing policy, which truncates a float token and narrows a numeric string
-/// (`AbstractXContentParser.java:74`/`:162`/`:177`), so `{"slop": 2.0}` is a
+/// (`AbstractXContentParser.java:171` `intValue(coerce)` → `:162` `parseInt`,
+/// with the truncation note at `:70`), so `{"slop": 2.0}` is a
 /// query ES answers with slop 2.
 ///
 /// This test exists because an earlier revision of this branch tightened the

--- a/engine/crates/xerj-fts/src/search.rs
+++ b/engine/crates/xerj-fts/src/search.rs
@@ -331,8 +331,9 @@ pub struct PhrasePrefixQuery {
     /// `match_phrase_prefix`: `TextFieldMapper.createPhrasePrefixQuery` builds
     /// a `MultiPhrasePrefixQuery` and calls `setSlop(slop)` alongside
     /// `setMaxExpansions` (elasticsearch/server/src/main/java/org/
-    /// elasticsearch/index/mapper/TextFieldMapper.java:1269 — AGPL, read for
-    /// semantics only, no code copied).  Defaults to 0 (adjacency), which is
+    /// elasticsearch/index/mapper/TextFieldMapper.java:2019, the two setters
+    /// at :2028-:2029, reached from `phrasePrefixQuery` at :1269 — AGPL, read
+    /// for semantics only, no code copied).  Defaults to 0 (adjacency), which is
     /// the pre-existing behaviour for every caller that does not set it.
     #[serde(default)]
     pub slop: u32,

--- a/engine/crates/xerj-fts/src/search.rs
+++ b/engine/crates/xerj-fts/src/search.rs
@@ -314,7 +314,8 @@ impl FuzzyQuery {
 /// LAST element is treated as a **prefix** that expands against the field's
 /// analyzed term dictionary (bounded by `max_expansions`, in FST/lexicographic
 /// order — the same order ES takes its first `max_expansions` terms).  A doc
-/// matches when the head phrase is immediately followed by any expansion term.
+/// matches when any expansion term follows a head-phrase occurrence within
+/// `slop` intervening positions (`slop == 0`, the default, means immediately).
 /// `terms` are already analyzed by the caller (standard analyzer → lowercased),
 /// so the prefix expansion is a plain case-sensitive `starts_with` against the
 /// (lowercased) term dictionary — byte-identical to ES, whose analyzer
@@ -325,6 +326,16 @@ pub struct PhrasePrefixQuery {
     pub terms: Vec<String>,
     #[serde(default = "default_max_expansions")]
     pub max_expansions: usize,
+    /// Allowed number of intervening positions across the WHOLE phrase,
+    /// including the expanded trailing prefix term.  ES honours `slop` on
+    /// `match_phrase_prefix`: `TextFieldMapper.createPhrasePrefixQuery` builds
+    /// a `MultiPhrasePrefixQuery` and calls `setSlop(slop)` alongside
+    /// `setMaxExpansions` (elasticsearch/server/src/main/java/org/
+    /// elasticsearch/index/mapper/TextFieldMapper.java:1269 — AGPL, read for
+    /// semantics only, no code copied).  Defaults to 0 (adjacency), which is
+    /// the pre-existing behaviour for every caller that does not set it.
+    #[serde(default)]
+    pub slop: u32,
     #[serde(default = "default_boost")]
     pub boost: f32,
 }
@@ -814,7 +825,11 @@ impl FtsSearcher {
             let pq = PhraseQuery {
                 field: ppq.field.clone(),
                 terms,
-                slop: 0,
+                // `slop` spans the whole phrase INCLUDING the expanded
+                // trailing term — ES's `MultiPhrasePrefixQuery.setSlop`
+                // applies to the multi-term position too, so the union of
+                // per-expansion sloppy phrase queries is the same hit set.
+                slop: ppq.slop,
                 boost: ppq.boost,
             };
             for hit in self.execute_phrase(&pq, explain)? {

--- a/engine/crates/xerj-query/src/ast.rs
+++ b/engine/crates/xerj-query/src/ast.rs
@@ -558,6 +558,13 @@ pub enum QueryNode {
         query: String,
         #[serde(default = "default_max_expansions")]
         max_expansions: u32,
+        /// Allowed intervening positions across the whole phrase, trailing
+        /// prefix term included.  ES accepts and honours `slop` here
+        /// (`MatchPhrasePrefixQueryBuilder` parses it and passes it to
+        /// `MatchQueryParser.setPhraseSlop`), so dropping it would be
+        /// accept-and-ignore (#204 class).
+        #[serde(default)]
+        slop: u32,
     },
 
     /// Simple query string — splits on `+`/`|`/`-` operators, converted to a Bool query.

--- a/engine/crates/xerj-query/src/ast.rs
+++ b/engine/crates/xerj-query/src/ast.rs
@@ -428,6 +428,16 @@ pub enum QueryNode {
         analyzer: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         boost: Option<f32>,
+        /// Phrase slop — the number of intervening positions tolerated
+        /// between adjacent phrase terms. Applies to `match_type: Phrase`
+        /// only (ES: `slop` is a phrase parameter; the field-centric and
+        /// term-centric types ignore it). Default 0 = exact adjacency.
+        #[serde(default)]
+        slop: u32,
+        /// Prefix-expansion cap for `match_type: PhrasePrefix` — how many
+        /// terms the trailing prefix may expand to (ES default 50).
+        #[serde(default = "default_max_expansions")]
+        max_expansions: u32,
     },
 
     /// Lucene query-string syntax (e.g. `"title:(foo AND bar) OR body:baz"`).

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -536,7 +536,7 @@ fn parse_match_phrase(params: &Value) -> Result<QueryNode> {
         .get("query")
         .and_then(scalar_to_string)
         .ok_or_else(|| qerr("`match_phrase.query` must be a non-empty scalar"))?;
-    let slop = vobj.get("slop").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    let slop = parse_phrase_slop(vobj.get("slop"), "match_phrase")?;
     let analyzer = vobj
         .get("analyzer")
         .and_then(|v| v.as_str())
@@ -555,6 +555,33 @@ fn parse_match_phrase(params: &Value) -> Result<QueryNode> {
         boost,
     };
     Ok(maybe_named(node, name))
+}
+
+/// Parse the `slop` parameter of a phrase-shaped query, identically for every
+/// entry point that accepts one (`match_phrase`, `match_phrase_prefix`,
+/// `multi_match`).  Sharing it is the point: the same JSON value must produce
+/// the same answer whichever query wraps it, or a client gets a 400 from one
+/// form and a silently different answer from the semantically identical other
+/// form.
+///
+/// ES rejects a negative slop from every builder
+/// (`MatchPhraseQueryBuilder.slop` / `MatchPhrasePrefixQueryBuilder.slop:103`
+/// / `MultiMatchQueryBuilder.slop:350` all throw "No negative slop allowed";
+/// AGPL, read for semantics only).  `u32::try_from` rather than `as u32`
+/// because a wrapping cast turns an out-of-range slop into a small honoured
+/// one — a silently wrong answer, which is worse than a 400.
+fn parse_phrase_slop(v: Option<&Value>, ctx: &str) -> Result<u32> {
+    match v {
+        None | Some(Value::Null) => Ok(0),
+        Some(v) => match v
+            .as_i64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        {
+            Some(n) if n < 0 => invalid(format!("`{ctx}.slop` must not be negative")),
+            Some(n) => u32::try_from(n).map_err(|_| qerr(format!("`{ctx}.slop` is out of range"))),
+            None => invalid(format!("`{ctx}.slop` must be an integer")),
+        },
+    }
 }
 
 /// ES `combined_fields` query — introduced in 7.13, treats N text fields as a
@@ -608,22 +635,7 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
     // and reject the values ES rejects instead of quietly mis-answering.
     // ES: negative slop and non-positive max_expansions are 400s, and
     // `slop` is not allowed with `type: bool_prefix`.
-    // `u32::try_from` rather than `as u32`: a wrapping cast would turn an
-    // out-of-range slop into a small honoured one — a silently wrong answer.
-    let slop: u32 = match obj.get("slop") {
-        None | Some(Value::Null) => 0,
-        Some(v) => match v
-            .as_i64()
-            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        {
-            Some(n) if n < 0 => return invalid("`multi_match.slop` must not be negative"),
-            Some(n) => match u32::try_from(n) {
-                Ok(s) => s,
-                Err(_) => return invalid("`multi_match.slop` is out of range"),
-            },
-            None => return invalid("`multi_match.slop` must be an integer"),
-        },
-    };
+    let slop: u32 = parse_phrase_slop(obj.get("slop"), "multi_match")?;
     let max_expansions: u32 = match obj.get("max_expansions") {
         None | Some(Value::Null) => 50,
         Some(v) => match v
@@ -644,20 +656,19 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
         // fail, so this arm passed while XERJ silently ignored `slop`.
         return invalid("[slop] not allowed for type [bool_prefix]");
     }
-    if slop != 0 && type_str == "phrase_prefix" {
-        // FAIL LOUDLY rather than accept-and-ignore (#204). XERJ evaluates a
-        // `phrase_prefix` as an ADJACENT head phrase plus a trailing prefix
-        // term, in both the positional segment clause
-        // (`xerj_fts::search::PhrasePrefixQuery`, which carries no slop) and
-        // the stored-doc walk. ES does honour slop here, so silently
-        // dropping it would answer a different query than the one asked —
-        // exactly the class of defect this fix exists to remove.
-        return invalid(
-            "`multi_match.slop` is not supported for type [phrase_prefix]: xerj matches a \
-             phrase_prefix as an adjacent phrase plus a trailing prefix term. Remove [slop], \
-             or use type [phrase]",
-        );
-    }
+    // `slop` with `type: phrase_prefix` is ACCEPTED and HONOURED, because ES
+    // honours it: `MultiMatchQueryBuilder` rejects slop only for
+    // `bool_prefix` (…/index/query/MultiMatchQueryBuilder.java:673) and
+    // `TextFieldMapper.createPhrasePrefixQuery` calls
+    // `MultiPhrasePrefixQuery.setSlop(slop)` (…/index/mapper/
+    // TextFieldMapper.java:1269 — AGPL, read for semantics only). Both XERJ
+    // evaluators now carry it: `PhrasePrefixQuery.slop` on the segment side
+    // and the sloppy prefix walk in the stored-doc scan. Refusing it here
+    // would have been a wire-compat break on a query ES answers, and would
+    // have left the semantically identical single-field
+    // `{"match_phrase_prefix": {"f": {"query": …, "slop": N}}}` — which
+    // `parse_match_phrase_prefix` accepts — answering a different query.
+    //
     // `slop` on the FIELD-CENTRIC types (best_fields / most_fields /
     // cross_fields) is accepted and unused, which is also what ES does:
     // those types lower to a BOOLEAN match query, and only the PHRASE and
@@ -1981,6 +1992,7 @@ fn parse_match_phrase_prefix(params: &Value) -> Result<QueryNode> {
             field,
             query,
             max_expansions: 50,
+            slop: 0,
         });
     }
 
@@ -2000,11 +2012,21 @@ fn parse_match_phrase_prefix(params: &Value) -> Result<QueryNode> {
         .get("max_expansions")
         .and_then(Value::as_u64)
         .unwrap_or(50) as u32;
+    // `slop` used to be read nowhere here, so
+    // `{"match_phrase_prefix": {"f": {"query": …, "slop": 2}}}` was accepted
+    // and answered as slop 0 — accept-and-ignore (#204 class), and a silent
+    // disagreement with the `multi_match` form of the same query. ES parses
+    // and honours it (`MatchPhrasePrefixQueryBuilder.fromXContent` →
+    // `MatchQueryParser.setPhraseSlop`), and both XERJ evaluators now carry
+    // it: `PhrasePrefixQuery.slop` on segments, the sloppy prefix walk in
+    // the stored-doc scan.
+    let slop = parse_phrase_slop(inner.get("slop"), "match_phrase_prefix")?;
 
     Ok(QueryNode::MatchPhrasePrefix {
         field,
         query,
         max_expansions,
+        slop,
     })
 }
 
@@ -4466,18 +4488,59 @@ mod tests {
                                    "type": "phrase", "slop": 4294967296i64}}),
             json!({"multi_match": {"query": "a b", "fields": ["body"],
                                    "type": "phrase_prefix", "max_expansions": 0}}),
+            // ES rejects slop for bool_prefix ONLY
+            // (MultiMatchQueryBuilder.java:673).
             json!({"multi_match": {"query": "a b", "fields": ["body"],
                                    "type": "bool_prefix", "slop": 2}}),
-            // Accepted-and-ignored is the defect class of #204: xerj cannot
-            // honour slop on a phrase_prefix, so it must refuse it.
-            json!({"multi_match": {"query": "a b", "fields": ["body"],
-                                   "type": "phrase_prefix", "slop": 2}}),
+            // The same values are rejected on the single-field phrase
+            // entry points — one JSON value, one answer, whichever query
+            // wraps it.
+            json!({"match_phrase": {"body": {"query": "a b", "slop": -1}}}),
+            json!({"match_phrase_prefix": {"body": {"query": "a b", "slop": -1}}}),
+            json!({"match_phrase_prefix": {"body": {"query": "a b", "slop": 4294967296i64}}}),
         ] {
             assert!(
                 parse_query(&bad).is_err(),
                 "expected a parse error for {bad}"
             );
         }
+    }
+
+    /// `slop` + `type: phrase_prefix` is ACCEPTED and carried, at BOTH
+    /// entry points. ES honours it (`MultiMatchQueryBuilder` rejects slop
+    /// only for `bool_prefix`; `TextFieldMapper.createPhrasePrefixQuery`
+    /// calls `MultiPhrasePrefixQuery.setSlop`), so refusing it would be a
+    /// wire-compat break — and dropping it, as `parse_match_phrase_prefix`
+    /// used to, is the accept-and-ignore defect class of #204.
+    #[test]
+    fn test_phrase_prefix_slop_is_carried_at_both_entry_points() {
+        let node = q(json!({
+            "multi_match": {"query": "quick fo", "fields": ["body"],
+                            "type": "phrase_prefix", "slop": 2}
+        }));
+        assert!(
+            matches!(
+                node,
+                QueryNode::MultiMatch {
+                    match_type: MultiMatchType::PhrasePrefix,
+                    slop: 2,
+                    ..
+                }
+            ),
+            "multi_match phrase_prefix must carry slop, got {node:?}"
+        );
+
+        let node = q(json!({
+            "match_phrase_prefix": {"body": {"query": "quick fo", "slop": 2}}
+        }));
+        assert!(
+            matches!(node, QueryNode::MatchPhrasePrefix { slop: 2, .. }),
+            "match_phrase_prefix must carry slop, got {node:?}"
+        );
+
+        // Absent slop is 0 at both entry points.
+        let node = q(json!({"match_phrase_prefix": {"body": "quick fo"}}));
+        assert!(matches!(node, QueryNode::MatchPhrasePrefix { slop: 0, .. }));
     }
 
     // ── term ──────────────────────────────────────────────────────────────────

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -561,10 +561,12 @@ fn parse_match_phrase(params: &Value) -> Result<QueryNode> {
 /// does under its default number policy (`DEFAULT_NUMBER_COERCE_POLICY = true`):
 /// an integer is taken as written, a **float is truncated** toward zero, and a
 /// numeric **string** is read as a double and then narrowed
-/// (`libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java:74`
-/// — "the 3rd party parsers we rely on are known to silently truncate
-/// fractions" — plus `:162` `parseInt` and `:177` `intValue`; AGPL, read for
-/// semantics only, nothing copied).
+/// (`libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java`:
+/// `:70` — "the 3rd party parsers we rely on are known to silently truncate
+/// fractions", guarding `ensureNumberConversion` at `:74`, which only raises
+/// when `coerce == false`; `:171` `intValue(coerce)`, whose `VALUE_STRING`
+/// arm calls `:162` `parseInt`, itself a `Double.parseDouble` narrowed with
+/// `(int)`; AGPL, read for semantics only, nothing copied).
 ///
 /// Why it exists: JSON encoders that carry every number as a double emit
 /// `"slop": 2.0`, and ES answers that query with slop 2. Reading it with
@@ -714,7 +716,9 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
     // `bool_prefix` (…/index/query/MultiMatchQueryBuilder.java:673) and
     // `TextFieldMapper.createPhrasePrefixQuery` calls
     // `MultiPhrasePrefixQuery.setSlop(slop)` (…/index/mapper/
-    // TextFieldMapper.java:1269 — AGPL, read for semantics only). Both XERJ
+    // TextFieldMapper.java:2019, `setSlop` at :2028, reached from the
+    // `phrasePrefixQuery` entry at :1269 — AGPL, read for semantics only).
+    // Both XERJ
     // evaluators now carry it: `PhrasePrefixQuery.slop` on the segment side
     // and the sloppy prefix walk in the stored-doc scan. Refusing it here
     // would have been a wire-compat break on a query ES answers, and would
@@ -4590,7 +4594,8 @@ mod tests {
     /// Values ES *accepts by coercing* must be accepted here too. ES reads
     /// `slop` and `max_expansions` with `XContentParser.intValue()` under the
     /// default coercing policy, which truncates a float token and narrows a
-    /// numeric string (`AbstractXContentParser.java:74`/`:162`/`:177`), so
+    /// numeric string (`AbstractXContentParser.java:171` `intValue(coerce)`,
+    /// `:162` `parseInt`, `:70`), so
     /// `{"slop": 2.0}` is a request ES answers with slop 2. Refusing it would
     /// be a new 400 on a query that works today, and reading it as 0 would be
     /// the accept-and-ignore this parser exists to remove — both are wrong.

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -557,14 +557,53 @@ fn parse_match_phrase(params: &Value) -> Result<QueryNode> {
     Ok(maybe_named(node, name))
 }
 
-/// Parse the `slop` parameter of a phrase-shaped query, identically for every
-/// entry point that accepts one (`match_phrase`, `match_phrase_prefix`,
-/// `multi_match`).  Sharing it is the point: the same JSON value must produce
-/// the same answer whichever query wraps it, or a client gets a 400 from one
-/// form and a silently different answer from the semantically identical other
-/// form.
+/// Coerce a JSON scalar to an integer the way ES's `XContentParser.intValue()`
+/// does under its default number policy (`DEFAULT_NUMBER_COERCE_POLICY = true`):
+/// an integer is taken as written, a **float is truncated** toward zero, and a
+/// numeric **string** is read as a double and then narrowed
+/// (`libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java:74`
+/// — "the 3rd party parsers we rely on are known to silently truncate
+/// fractions" — plus `:162` `parseInt` and `:177` `intValue`; AGPL, read for
+/// semantics only, nothing copied).
 ///
-/// ES rejects a negative slop from every builder
+/// Why it exists: JSON encoders that carry every number as a double emit
+/// `"slop": 2.0`, and ES answers that query with slop 2. Reading it with
+/// `as_i64()` alone leaves two bad options — a 400 on a request ES answers, or
+/// a silent fall back to the default, which is the accept-and-ignore (#204)
+/// this parser exists to remove.
+///
+/// The `as i64` cast saturates on an out-of-range float, so an absurd value
+/// lands on the bound and the caller's range check turns it into a 400 rather
+/// than a wrapped, silently honoured small number.
+fn coerce_es_int(v: &Value) -> Option<i64> {
+    if let Some(n) = v.as_i64() {
+        return Some(n);
+    }
+    let d = match v {
+        Value::Number(_) => v.as_f64()?,
+        Value::String(s) => s.trim().parse::<f64>().ok()?,
+        _ => return None,
+    };
+    d.is_finite().then(|| d.trunc() as i64)
+}
+
+/// Parse the `slop` parameter of a phrase-shaped query, identically at each of
+/// the three entry points that accept one and lower it to a phrase:
+/// `match_phrase`, `match_phrase_prefix`, `multi_match`.  Sharing it is the
+/// point: the same JSON value must produce the same answer whichever of those
+/// three wraps it, or a client gets a 400 from one spelling and a silently
+/// different answer from the semantically identical other.
+///
+/// Deliberately **not** covered: `span_near`, which also takes a `slop` and
+/// keeps its own `as_u64().unwrap_or(0)` read (see `parse_span_near`).  ES
+/// applies no validation there either — `SpanNearQueryBuilder` stores the int
+/// unchecked (`.../index/query/SpanNearQueryBuilder.java:62`), so a negative
+/// `span_near` slop is a query ES *answers*, and routing it through here would
+/// turn a 200 into a 400.  XERJ still coerces it to 0 instead of honouring it,
+/// which is a real (pre-existing) gap — recorded in `parse_span_near`, not
+/// papered over here.
+///
+/// ES rejects a negative slop from all three phrase builders
 /// (`MatchPhraseQueryBuilder.slop` / `MatchPhrasePrefixQueryBuilder.slop:103`
 /// / `MultiMatchQueryBuilder.slop:350` all throw "No negative slop allowed";
 /// AGPL, read for semantics only).  `u32::try_from` rather than `as u32`
@@ -573,16 +612,42 @@ fn parse_match_phrase(params: &Value) -> Result<QueryNode> {
 fn parse_phrase_slop(v: Option<&Value>, ctx: &str) -> Result<u32> {
     match v {
         None | Some(Value::Null) => Ok(0),
-        Some(v) => match v
-            .as_i64()
-            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        {
+        Some(v) => match coerce_es_int(v) {
             Some(n) if n < 0 => invalid(format!("`{ctx}.slop` must not be negative")),
             Some(n) => u32::try_from(n).map_err(|_| qerr(format!("`{ctx}.slop` is out of range"))),
-            None => invalid(format!("`{ctx}.slop` must be an integer")),
+            None => invalid(format!("`{ctx}.slop` must be a number")),
         },
     }
 }
+
+/// Parse `max_expansions`, with the same refusal-to-ignore as
+/// [`parse_phrase_slop`]: a value XERJ cannot read is a 400, never a silent
+/// fall back to the default of 50.
+///
+/// The floor differs between the two entry points, and that asymmetry is ES's
+/// rather than an oversight here: `MultiMatchQueryBuilder.maxExpansions`
+/// throws on `<= 0` (`.../index/query/MultiMatchQueryBuilder.java:389`) while
+/// `MatchPhrasePrefixQueryBuilder.maxExpansions` throws only on `< 0`
+/// (`.../index/query/MatchPhrasePrefixQueryBuilder.java:118`, "No negative
+/// maxExpansions allowed").  So `0` is a 400 on `multi_match` and an accepted
+/// (expand-nothing) value on `match_phrase_prefix`; `allow_zero` carries that
+/// distinction instead of us inventing one ES does not have.
+fn parse_max_expansions(v: Option<&Value>, ctx: &str, allow_zero: bool) -> Result<u32> {
+    match v {
+        None | Some(Value::Null) => Ok(DEFAULT_MAX_EXPANSIONS),
+        Some(v) => match coerce_es_int(v) {
+            Some(n) if n < 0 => invalid(format!("`{ctx}.max_expansions` must not be negative")),
+            Some(0) if !allow_zero => invalid(format!("`{ctx}.max_expansions` must be positive")),
+            Some(n) => u32::try_from(n)
+                .map_err(|_| qerr(format!("`{ctx}.max_expansions` is out of range"))),
+            None => invalid(format!("`{ctx}.max_expansions` must be a number")),
+        },
+    }
+}
+
+/// ES's `FuzzyQuery.defaultMaxExpansions`, which both phrase-prefix builders
+/// default to.
+const DEFAULT_MAX_EXPANSIONS: u32 = 50;
 
 /// ES `combined_fields` query — introduced in 7.13, treats N text fields as a
 /// single virtual field for term-frequency scoring. Our approximation routes
@@ -636,20 +701,8 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
     // ES: negative slop and non-positive max_expansions are 400s, and
     // `slop` is not allowed with `type: bool_prefix`.
     let slop: u32 = parse_phrase_slop(obj.get("slop"), "multi_match")?;
-    let max_expansions: u32 = match obj.get("max_expansions") {
-        None | Some(Value::Null) => 50,
-        Some(v) => match v
-            .as_i64()
-            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        {
-            Some(n) if n <= 0 => return invalid("`multi_match.max_expansions` must be positive"),
-            Some(n) => match u32::try_from(n) {
-                Ok(m) => m,
-                Err(_) => return invalid("`multi_match.max_expansions` is out of range"),
-            },
-            None => return invalid("`multi_match.max_expansions` must be an integer"),
-        },
-    };
+    let max_expansions: u32 =
+        parse_max_expansions(obj.get("max_expansions"), "multi_match", false)?;
     if slop != 0 && type_str == "bool_prefix" {
         // ES's own wording — `310_match_bool_prefix.yml` catches this exact
         // regex. The suite's runner only checks that the call is allowed to
@@ -2008,10 +2061,17 @@ fn parse_match_phrase_prefix(params: &Value) -> Result<QueryNode> {
         .get("query")
         .and_then(scalar_to_string)
         .ok_or_else(|| qerr("`match_phrase_prefix.query` must be a non-empty scalar"))?;
-    let max_expansions = inner
-        .get("max_expansions")
-        .and_then(Value::as_u64)
-        .unwrap_or(50) as u32;
+    // `max_expansions` used to be read with `as_u64().unwrap_or(50)`, so
+    // `-1`, `"7"` and `7.0` all silently became 50 — the same accept-and-ignore
+    // (#204) as the dropped `slop` below, one line apart. It is now the shared
+    // parse: a value we cannot read is a 400, and `0` stays accepted because
+    // ES accepts it *here* (it rejects it on `multi_match`; the asymmetry is
+    // ES's own, see `parse_max_expansions`).
+    let max_expansions = parse_max_expansions(
+        inner.get("max_expansions"),
+        "match_phrase_prefix",
+        /* allow_zero */ true,
+    )?;
     // `slop` used to be read nowhere here, so
     // `{"match_phrase_prefix": {"f": {"query": …, "slop": 2}}}` was accepted
     // and answered as slop 0 — accept-and-ignore (#204 class), and a silent
@@ -3467,6 +3527,20 @@ fn parse_span_near(params: &Value) -> Result<QueryNode> {
         return Ok(QueryNode::MatchNone);
     }
 
+    // KNOWN GAP (pre-existing, deliberately not changed by #230): this read
+    // accepts anything and silently substitutes 0 — `slop: -1`, `slop: 2.0`
+    // and `slop: "2"` all answer as slop 0. It is NOT routed through
+    // `parse_phrase_slop`, and the phrase work in #230 does not cover it.
+    //
+    // It is left alone rather than "fixed" because ES applies no validation
+    // here either: `SpanNearQueryBuilder` takes the int unchecked
+    // (`.../index/query/SpanNearQueryBuilder.java:62`, no negative test)
+    // while every phrase builder throws on a negative slop. So a negative
+    // `span_near` slop is a query ES answers, and rejecting it would be a
+    // wire-compat break on a request that works today. Closing it properly
+    // means honouring the value (float coercion via `coerce_es_int`, and a
+    // decision about what a negative span slop should match), which is a
+    // span-query change, not a phrase one.
     let slop = obj.get("slop").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
     let in_order = obj
         .get("in_order")
@@ -4498,12 +4572,63 @@ mod tests {
             json!({"match_phrase": {"body": {"query": "a b", "slop": -1}}}),
             json!({"match_phrase_prefix": {"body": {"query": "a b", "slop": -1}}}),
             json!({"match_phrase_prefix": {"body": {"query": "a b", "slop": 4294967296i64}}}),
+            // `max_expansions` used to be read here as
+            // `as_u64().unwrap_or(50)`, so both of these were accepted and
+            // silently answered with 50 (#204 class).  ES throws "No negative
+            // maxExpansions allowed" (MatchPhrasePrefixQueryBuilder.java:118).
+            json!({"match_phrase_prefix": {"body": {"query": "a b", "max_expansions": -1}}}),
+            json!({"match_phrase_prefix": {"body": {"query": "a b", "max_expansions": "many"}}}),
+            json!({"match_phrase": {"body": {"query": "a b", "slop": "two"}}}),
         ] {
             assert!(
                 parse_query(&bad).is_err(),
                 "expected a parse error for {bad}"
             );
         }
+    }
+
+    /// Values ES *accepts by coercing* must be accepted here too. ES reads
+    /// `slop` and `max_expansions` with `XContentParser.intValue()` under the
+    /// default coercing policy, which truncates a float token and narrows a
+    /// numeric string (`AbstractXContentParser.java:74`/`:162`/`:177`), so
+    /// `{"slop": 2.0}` is a request ES answers with slop 2. Refusing it would
+    /// be a new 400 on a query that works today, and reading it as 0 would be
+    /// the accept-and-ignore this parser exists to remove — both are wrong.
+    #[test]
+    fn test_phrase_params_are_coerced_like_es() {
+        for (v, want) in [(json!(2.0), 2u32), (json!(2.9), 2), (json!("2"), 2)] {
+            let node = q(json!({"match_phrase": {"body": {"query": "a b", "slop": v}}}));
+            assert!(
+                matches!(node, QueryNode::MatchPhrase { slop, .. } if slop == want),
+                "slop {v} must coerce to {want}, parsed to {node:?}"
+            );
+            let node = q(json!({"multi_match": {"query": "a b", "fields": ["body"],
+                                                "type": "phrase", "slop": v}}));
+            assert!(
+                matches!(node, QueryNode::MultiMatch { slop, .. } if slop == want),
+                "multi_match slop {v} must coerce to {want}, parsed to {node:?}"
+            );
+        }
+
+        // `max_expansions: 0` is a 400 on `multi_match`
+        // (MultiMatchQueryBuilder.java:389 rejects `<= 0`) and ACCEPTED on
+        // `match_phrase_prefix` (MatchPhrasePrefixQueryBuilder.java:118
+        // rejects only `< 0`). The asymmetry is ES's; XERJ mirrors it rather
+        // than inventing a rule ES does not have.
+        let node = q(json!({"match_phrase_prefix": {"body": {"query": "a b",
+                                                             "max_expansions": 0}}}));
+        assert!(
+            matches!(node, QueryNode::MatchPhrasePrefix { max_expansions, .. }
+                     if max_expansions == 0),
+            "ES accepts max_expansions 0 on match_phrase_prefix, parsed to {node:?}"
+        );
+        assert!(
+            parse_query(&json!({"multi_match": {"query": "a b", "fields": ["body"],
+                                                "type": "phrase_prefix",
+                                                "max_expansions": 0}}))
+            .is_err(),
+            "ES rejects max_expansions 0 on multi_match"
+        );
     }
 
     /// `slop` + `type: phrase_prefix` is ACCEPTED and carried, at BOTH

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -602,6 +602,71 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
         .and_then(|v| v.as_str())
         .unwrap_or("best_fields");
 
+    // `slop` / `max_expansions` are the phrase parameters of `multi_match`.
+    // They used to be dropped here, so `{"type":"phrase","slop":2}` was
+    // accepted and silently evaluated as slop 0 (issue #230) — parse them
+    // and reject the values ES rejects instead of quietly mis-answering.
+    // ES: negative slop and non-positive max_expansions are 400s, and
+    // `slop` is not allowed with `type: bool_prefix`.
+    // `u32::try_from` rather than `as u32`: a wrapping cast would turn an
+    // out-of-range slop into a small honoured one — a silently wrong answer.
+    let slop: u32 = match obj.get("slop") {
+        None | Some(Value::Null) => 0,
+        Some(v) => match v
+            .as_i64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        {
+            Some(n) if n < 0 => return invalid("`multi_match.slop` must not be negative"),
+            Some(n) => match u32::try_from(n) {
+                Ok(s) => s,
+                Err(_) => return invalid("`multi_match.slop` is out of range"),
+            },
+            None => return invalid("`multi_match.slop` must be an integer"),
+        },
+    };
+    let max_expansions: u32 = match obj.get("max_expansions") {
+        None | Some(Value::Null) => 50,
+        Some(v) => match v
+            .as_i64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        {
+            Some(n) if n <= 0 => return invalid("`multi_match.max_expansions` must be positive"),
+            Some(n) => match u32::try_from(n) {
+                Ok(m) => m,
+                Err(_) => return invalid("`multi_match.max_expansions` is out of range"),
+            },
+            None => return invalid("`multi_match.max_expansions` must be an integer"),
+        },
+    };
+    if slop != 0 && type_str == "bool_prefix" {
+        // ES's own wording — `310_match_bool_prefix.yml` catches this exact
+        // regex. The suite's runner only checks that the call is allowed to
+        // fail, so this arm passed while XERJ silently ignored `slop`.
+        return invalid("[slop] not allowed for type [bool_prefix]");
+    }
+    if slop != 0 && type_str == "phrase_prefix" {
+        // FAIL LOUDLY rather than accept-and-ignore (#204). XERJ evaluates a
+        // `phrase_prefix` as an ADJACENT head phrase plus a trailing prefix
+        // term, in both the positional segment clause
+        // (`xerj_fts::search::PhrasePrefixQuery`, which carries no slop) and
+        // the stored-doc walk. ES does honour slop here, so silently
+        // dropping it would answer a different query than the one asked —
+        // exactly the class of defect this fix exists to remove.
+        return invalid(
+            "`multi_match.slop` is not supported for type [phrase_prefix]: xerj matches a \
+             phrase_prefix as an adjacent phrase plus a trailing prefix term. Remove [slop], \
+             or use type [phrase]",
+        );
+    }
+    // `slop` on the FIELD-CENTRIC types (best_fields / most_fields /
+    // cross_fields) is accepted and unused, which is also what ES does:
+    // those types lower to a BOOLEAN match query, and only the PHRASE and
+    // PHRASE_PREFIX types lower to a phrase query that reads slop
+    // (`MultiMatchQueryBuilder.Type`, elasticsearch/server/src/main/java/
+    // org/elasticsearch/index/query/MultiMatchQueryBuilder.java:91 — AGPL,
+    // read for semantics only). Same answer as ES, so there is nothing to
+    // fail loudly about.
+
     // bool_prefix: rewrite to a Bool::should over per-field match_bool_prefix
     // clauses. Tokens except the last become Match queries, the last becomes
     // a Prefix query — matching ES `match_bool_prefix` semantics across all
@@ -767,6 +832,8 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
         operator,
         analyzer,
         boost,
+        slop,
+        max_expansions,
     })
 }
 
@@ -2063,6 +2130,8 @@ fn make_simple_query_node(term: &str, fields: &[String]) -> QueryNode {
             operator: None,
             analyzer: None,
             boost: None,
+            slop: 0,
+            max_expansions: 50,
         }
     }
 }
@@ -4347,6 +4416,68 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// #230 — `slop` and `max_expansions` are phrase parameters of
+    /// `multi_match`. They used to be dropped here, so `{"type":"phrase",
+    /// "slop":2}` was accepted and silently answered as an exact phrase.
+    #[test]
+    fn test_multi_match_phrase_params_are_parsed() {
+        let node = q(json!({
+            "multi_match": {
+                "query": "quick fox", "fields": ["body"],
+                "type": "phrase", "slop": 3
+            }
+        }));
+        assert!(matches!(
+            node,
+            QueryNode::MultiMatch {
+                match_type: MultiMatchType::Phrase,
+                slop: 3,
+                max_expansions: 50,
+                ..
+            }
+        ));
+
+        let node = q(json!({
+            "multi_match": {
+                "query": "quick fo", "fields": ["body"],
+                "type": "phrase_prefix", "max_expansions": 7
+            }
+        }));
+        assert!(matches!(
+            node,
+            QueryNode::MultiMatch {
+                match_type: MultiMatchType::PhrasePrefix,
+                slop: 0,
+                max_expansions: 7,
+                ..
+            }
+        ));
+    }
+
+    /// Values ES rejects must be rejected here too, not silently coerced.
+    #[test]
+    fn test_multi_match_phrase_params_are_validated() {
+        for bad in [
+            json!({"multi_match": {"query": "a b", "fields": ["body"],
+                                   "type": "phrase", "slop": -1}}),
+            json!({"multi_match": {"query": "a b", "fields": ["body"],
+                                   "type": "phrase", "slop": 4294967296i64}}),
+            json!({"multi_match": {"query": "a b", "fields": ["body"],
+                                   "type": "phrase_prefix", "max_expansions": 0}}),
+            json!({"multi_match": {"query": "a b", "fields": ["body"],
+                                   "type": "bool_prefix", "slop": 2}}),
+            // Accepted-and-ignored is the defect class of #204: xerj cannot
+            // honour slop on a phrase_prefix, so it must refuse it.
+            json!({"multi_match": {"query": "a b", "fields": ["body"],
+                                   "type": "phrase_prefix", "slop": 2}}),
+        ] {
+            assert!(
+                parse_query(&bad).is_err(),
+                "expected a parse error for {bad}"
+            );
+        }
     }
 
     // ── term ──────────────────────────────────────────────────────────────────

--- a/engine/crates/xerj-query/src/planner.rs
+++ b/engine/crates/xerj-query/src/planner.rs
@@ -274,6 +274,7 @@ fn plan_node(query: QueryNode, schema: &Schema) -> ExecutionPlan {
             fields,
             query,
             match_type,
+            slop,
             ..
         } => {
             // Expand to a Bool(should=[ Match(field, query) for field in fields ])
@@ -286,6 +287,9 @@ fn plan_node(query: QueryNode, schema: &Schema) -> ExecutionPlan {
             );
             let cost = 5.0 * fields.len() as f64 * n as f64;
 
+            // `slop` only means anything for a phrase (issue #230); the
+            // field-centric types ignore it, as ES does.
+            let plan_slop = if phrase { slop } else { 0 };
             let sub_plans: Vec<ExecutionPlan> = fields
                 .into_iter()
                 .map(|field| ExecutionPlan::FtsSearch {
@@ -293,7 +297,7 @@ fn plan_node(query: QueryNode, schema: &Schema) -> ExecutionPlan {
                     tokens: tokens.clone(),
                     require_all: false,
                     phrase,
-                    slop: 0,
+                    slop: plan_slop,
                     cost: 5.0 * n as f64,
                 })
                 .collect();

--- a/engine/crates/xerj-query/src/planner.rs
+++ b/engine/crates/xerj-query/src/planner.rs
@@ -506,14 +506,16 @@ fn plan_node(query: QueryNode, schema: &Schema) -> ExecutionPlan {
         QueryNode::Intervals { field, .. } => ExecutionPlan::ExistsScan { field },
 
         // MatchPhrasePrefix: treat as a phrase search on the given field.
-        QueryNode::MatchPhrasePrefix { field, query, .. } => {
+        QueryNode::MatchPhrasePrefix {
+            field, query, slop, ..
+        } => {
             let tokens: Vec<String> = query.split_whitespace().map(str::to_string).collect();
             ExecutionPlan::FtsSearch {
                 field,
                 tokens,
                 require_all: true,
                 phrase: true,
-                slop: 0,
+                slop,
                 cost: 10.0,
             }
         }


### PR DESCRIPTION
Fixes #230

## What was wrong

`multi_match` with `type: phrase` / `phrase_prefix` never evaluated a phrase. Every arm tested whole-query lowercase **substring containment** on the raw field text:

| arm | pre-fix predicate |
|---|---|
| memtable membership (`doc_matches_query`) | `field_text.contains(query)` |
| memtable scoring (`score_query_against_doc`) | its own copy of the same test |
| segments (`query_node_to_fts`) | **declined the projection** → O(N) stored-doc scan running the same substring test |

Reproduced at `origin/main` (1ee31ec) before touching anything — all cases of the new test file fail:

```
phrase "merge policy"  -> {2}      expected {1,2}   # doc 1 is `merge, policy`
phrase "merge polic"   -> {2}      expected {}
phrase "log policy" slop:1 -> {}   expected {1}
phrase+operator:and reversed -> {1,2}  expected {}
negative slop, on the 3 phrase types -> accepted (200)   expected 400
```

Four distinct divergences:

- **under-match** — the standard analyzer strips punctuation, so ES matches `"merge policy"` against a doc reading `merge, policy` (adjacent terms). The raw text has no such substring, so xerj returned 0 hits.
- **over-match** — `"merge polic"` *is* a substring of `merge policy`; ES's analyzed terms never line up, xerj returned the doc.
- **`operator` overrode the phrase** — `{"type":"phrase","operator":"and"}` fell into the token-AND branch (tested *before* the phrase branch) and silently stopped being a phrase.
- **`slop` was parsed away** — `parse_multi_match` dropped `slop`/`max_expansions` entirely, so `{"type":"phrase","slop":2}` was accepted and answered as slop 0. Accept-and-ignore, the #204 defect class.

## Root cause

The phrase types were never lowered to a positional query. The FTS layer has had the machinery all along — `FtsQuery::Phrase`, `PhrasePrefix`, and `phrase_positions_match` over real term positions, which single-field `match_phrase` already uses. `multi_match` simply never reached it, and the memtable arm approximated instead of sharing the predicate.

## The fix

Lower `type: phrase` to **one positional clause per field, combined by dis_max** — the shape ES builds (`MultiMatchQueryParser.buildFieldQueries` + `combineGrouped` → `DisjunctionMaxQuery`; tie_breaker 0.0). ES is AGPL and **approach-only**: read for semantics, no code copied.

Memtable membership, memtable scoring and the stored-doc scan walk the same analyzed token stream through one shared helper (`phrase_walk`, reached via `phrase_positions_in_tokens` / `phrase_prefix_positions_in_tokens`), which mirrors `xerj_fts::search::phrase_positions_match` clause for clause — every-anchor start, greedy earliest-match walk, summed gaps ≤ slop. `MatchPhrase`'s and `MatchPhrasePrefix`'s stored-scan arms had the identical raw-substring bug and now share it too.

**Both sides tokenize with the standard analyzer.** `phrase_tokens()` runs `AnalyzerRegistry::default().standard()` — the same pipeline the indexing path and `query_node_to_fts` use — on the field text *and* on the query text of the phrase arms. This is the load-bearing detail: UAX#29 keeps intra-word `.`, `'` and `_` inside one word, so `3.14`, `don't` and `foo_bar` are ONE analyzed term each. Any hand-rolled split makes them two or three and the two evaluators start answering different questions.

On the phrase entry points, `slop` / `max_expansions` are parsed, range-checked and carried. **What xerj cannot honour there is refused, not ignored.** That is a claim about *plumbing*, and only about plumbing: the values ES accepts are now read and carried instead of dropped. It is **not** a claim that XERJ's sloppy phrase means the same thing as Lucene's — it does not, and the difference is measured and listed under Known limits. The exact perimeter, because "everywhere" was the claim that blocked this PR at the merge gate and it was not true:

- `slop` is accepted and honoured on `phrase` **and** `phrase_prefix`, at both entry points (`multi_match` and single-field `match_phrase` / `match_phrase_prefix`). ES does the same: `MultiMatchQueryBuilder` rejects `slop` for `bool_prefix` only (`.../index/query/MultiMatchQueryBuilder.java:673`), and `TextFieldMapper.createPhrasePrefixQuery` builds a `MultiPhrasePrefixQuery` with `setSlop(slop)` next to `setMaxExpansions` (`.../index/mapper/TextFieldMapper.java:2019`, the two setters at `:2028`-`:2029`, reached from the `phrasePrefixQuery` entry at `:1269`). Carrying it required a new `PhrasePrefixQuery.slop` in `xerj-fts` (applied to each expansion's phrase query) and a slop-aware prefix walk in the stored-doc scan.
- a negative slop → 400 from each of the **three phrase entry points — `match_phrase`, `match_phrase_prefix`, `multi_match`** — through one shared `parse_phrase_slop`. `match_phrase` / `match_phrase_prefix` previously coerced it to 0. A slop that does not fit a `u32` → 400 as well, rather than a wrapping cast that turns it into a small silently-honoured one.
- **`span_near` also accepts a `slop`, and this PR does NOT cover it.** It keeps `main`'s `obj.get("slop").and_then(as_u64).unwrap_or(0)` (`parser.rs`, `parse_span_near`), so `{"span_near": {…, "slop": -1}}` still returns 200 with the slop silently 0 — an accept-and-ignore, on a query type outside the phrase work. It is left alone on purpose rather than swept into the shared parse: ES applies no validation there either — `SpanNearQueryBuilder` stores the int unchecked (`.../index/query/SpanNearQueryBuilder.java:62`), unlike every phrase builder — so refusing it would be a new 400 on a query ES answers. Recorded as a known gap in the code, in the test's scope comment, and under Known limits below. Not claimed as fixed.
- `max_expansions` goes through one shared `parse_max_expansions`, and the floor differs by entry point because **ES's does**: `multi_match` rejects non-positive (`MultiMatchQueryBuilder.java:389` rejects `<= 0`), `match_phrase_prefix` rejects negative but accepts `0` (`MatchPhrasePrefixQueryBuilder.java:118` rejects only `< 0`, "No negative maxExpansions allowed"). Neither now falls back to the default on a value it cannot read: `parse_match_phrase_prefix` used to read `as_u64().unwrap_or(50)`, so `-1` and `"7"` were both accepted and silently answered as 50 — the same #204 defect class as the dropped `slop`, one line apart.
- floats and numeric strings are **coerced, not refused**: `slop: 2.0` → 2, `slop: "2"` → 2, `slop: 2.7` → 2, and the same for `max_expansions`. ES reads both with `XContentParser.intValue()` under its default coercing policy, which truncates a float token and narrows a numeric string (`AbstractXContentParser.java:171` `intValue(coerce)`, whose `VALUE_STRING` arm calls `:162` `parseInt` — itself a `Double.parseDouble` narrowed with `(int)` — while the float token falls through to `:74` `ensureNumberConversion`, which only raises when `coerce == false`; the "known to silently truncate fractions" note is the comment at `:70`). An earlier revision of this branch read them with `as_i64()` alone and so returned 400 for `2.0`, which `main` answered with 200: a new wire break on a query ES answers, caught by the merge gate and fixed here rather than shipped.
- `slop` + `type: bool_prefix` → 400 (ES's own wording; the YAML suite's `catch:` never verified it actually errored, so this arm passed while xerj silently ignored slop).
- `slop` on the field-centric types stays accepted-and-unused, because that is exactly what ES does with it (only PHRASE/PHRASE_PREFIX lower to a phrase query).

## Flush invariance — the exact claim

The `#218` invariant is that the hit set does not change at `_flush`. This PR holds it for `multi_match` phrase **and** phrase_prefix, and the test file asserts every case pre-flush and post-flush in one helper.

Holding it cost the `phrase_prefix` projection: `phrase_prefix` deliberately keeps the **declined / stored-scan** routing it has on `main`. The segment clause bounds the trailing prefix to `max_expansions` terms taken from the field's term dictionary; the stored-doc walk has no term dictionary and expands with an unbounded `starts_with`. Projecting it makes the hit set shrink at `_flush` — an earlier revision of this branch did exactly that. The honest consequence, stated rather than papered over: **`max_expansions` does not bind on `multi_match`** (it did not on `main` either — the parameter was dropped in the parser), and phrase_prefix keeps the O(N) stored scan. `phrase` — where the measured win is — still projects.

`max_expansions` *does* bind on single-field `match_phrase_prefix` segments and not on its memtable. That asymmetry is pre-existing on `main` and untouched here; it is not introduced by this PR and not fixed by it. (This PR changes how the value is *parsed* on that path — an unreadable one is now a 400 instead of a silent 50 — not whether or where it binds.)

## Perf — the disclosed residual in #230, quantified

Measured on this branch's build (before the review repairs; the `phrase` projection is unchanged since): one index, 50k docs, one segment, 20-word vocabulary, median of 9 **uncached** 3-term phrases. Clean A/B on identical fields — `analyzer: whitespace` declines the projection and forces the old path with the same predicate:

| path | median |
|---|---|
| positional postings clause (this PR) | **22.6 ms** |
| declined → stored-doc scan (old behaviour) | 128.0 ms |

**5.7× faster** for `type: phrase`. Not re-measured after the review repairs; the declined side now runs the standard analyzer instead of a hand-rolled split, which is not cheaper, so the ratio is if anything understated. `phrase_prefix` keeps the stored scan and gets no win.

The projection is still declined **whole** (stored-scan fallback) when any listed field is keyword/exact or a dotted multi-field path, or when a non-standard query `analyzer` is named — those cannot be reproduced by a positions intersection, and projecting them would make the hit set change at `_flush`.

## What the adversarial review found, and what changed

| finding | repair |
|---|---|
| memtable/stored-scan tokenized with `split(!is_alphanumeric)` while the segment clause used the `standard` analyzer → flush-variant hit set on `3.14`, `don't`, `foo_bar`, and ES-wrong pre-flush | `phrase_tokens()` now runs the standard analyzer (`index.rs`) |
| the *query*-side tokens fed to `multi_match_phrase_hit` were built by the same split | phrase arms of `doc_matches_query` and `score_query_against_doc` use analyzer tokens; the cross_fields / AND / OR arms keep their split unchanged |
| projecting `phrase_prefix` bound `max_expansions` on segments only → hit set shrank at `_flush` | `phrase_prefix` no longer projects; both states run the stored-doc walk. Flush-invariance claim above rewritten to say exactly what holds and what it cost |
| new 400 on `slop` + `type: phrase_prefix`, while the identical `match_phrase_prefix` form was accepted-and-ignored — a wire break *and* an accept-and-ignore at once | `slop` is honoured on `phrase_prefix` at both entry points (new `PhrasePrefixQuery.slop`, slop-aware stored-doc prefix walk, `parse_match_phrase_prefix` reads it). One shared `parse_phrase_slop` validates the value identically at all three phrase entry points |

## What the merge gate found after that, and what changed

The gate re-measured the claims against a server built from the reviewed head. All four review findings verified resolved; three things about the *claims* did not survive, and are fixed here:

| gate finding | what changed |
|---|---|
| the body claimed negative slop is a 400 "from **every** entry point", and `{"span_near": {…, "slop": -1}}` measured 200 with the slop silently 0 (`parse_span_near` was never in the shared parse) | claim narrowed to the three phrase entry points it actually covers; `span_near` promoted to an explicit, uncovered known gap in the body, in `parse_span_near`, and in the test's scope comment. Not "fixed" in code because ES does not validate it either — see the bullet above |
| the same overclaim was frozen into the test name `negative_slop_is_rejected_at_every_entry_point` | renamed `..._at_the_three_phrase_entry_points`, with the `span_near` exclusion written into its doc comment |
| **new, undisclosed wire break**: `{"match_phrase": {"body": {"query": "a b", "slop": 2.0}}}` returned 400 on this branch where `main` returned 200 and ES answers with slop 2 — `parse_phrase_slop` read the value with `as_i64()` | fixed, not disclosed-and-shipped: `coerce_es_int` reproduces `XContentParser.intValue()`'s coercion (float truncated, numeric string narrowed), so `2.0` / `"2"` / `2.7` all parse to 2. New test `float_and_string_encoded_slop_are_coerced_like_es` |

Fixing that last one exposed the same silent-default read one line away: `parse_match_phrase_prefix` took `max_expansions` as `as_u64().unwrap_or(50)`, so `-1` and `"7"` were accepted and answered as 50. Both entry points now share `parse_max_expansions`, which refuses what it cannot read and keeps ES's asymmetric floor (`<= 0` rejected on `multi_match`, `< 0` on `match_phrase_prefix`).

### And what a second pass over the claims found

Re-measuring the corrected body on a fresh server (table below) held for every row. Auditing the *rest* of the prose against the ES tree and the running binary turned up three more places where a sentence outran what is true; all three are corrected above rather than left for the gate:

| what was wrong | what it says now |
|---|---|
| "**and what ES honours, xerj now honours**" — true of the parameter plumbing, false of the semantics: XERJ's sloppy phrase is in-order only, so `{"query": "policy merge", "slop": 2}` over `merge policy` returns 0 hits where Lucene returns the doc (`SloppyPhraseMatcher` javadoc: `"b a"` at distance 2). Measured at slop 2 and 3, both states | the sentence is now scoped to plumbing in so many words, the divergence is a Known limit with the measurement, `phrase_walk`'s doc comment carries it, and the new test `sloppy_phrase_is_in_order_only_unlike_lucene` pins it (with an in-order control so it cannot pass vacuously) |
| two ES citations pointed at the wrong lines: `TextFieldMapper.java:1269` is the `phrasePrefixQuery` caller, not the `setSlop` call, and `AbstractXContentParser.java:74` is the `coerce == false` guard, not the coercing read | corrected to `TextFieldMapper.java:2019` (setters at `:2028`-`:2029`) and `AbstractXContentParser.java:171` → `:162`, in the body and in all four source comments that carried them. Every remaining file:line in this PR was re-opened in the ES tree and checked |
| the scope sentence "these three query types are the whole of it" was written against `slop`; `query_string` also takes a proximity input | `query_string`'s `phrase_slop` **and** its inline `"a b"~2` syntax measured as silently ignored (slop-0 hit set) and are listed under Known limits next to `span_near`, so the perimeter is stated by measurement rather than by assumption |

## Tests

`engine/crates/xerj-engine/tests/multi_match_phrase_positions.rs` — 12 tests, every semantic case asserted **both pre-flush (memtable) and post-flush (segment)** in one helper, cross-checked against single-field `match_phrase`/`match_phrase_prefix` as the in-repo oracle. Plus 4 new parser tests in `xerj-query` (`test_multi_match_phrase_params_are_parsed`, `..._are_validated`, `test_phrase_params_are_coerced_like_es`, `test_phrase_prefix_slop_is_carried_at_both_entry_points`).

Test names say only what they cover. `negative_slop_is_rejected_at_the_three_phrase_entry_points` names the three; its doc comment states in so many words that `span_near` is *not* one of them and still answers `slop: -1` with 200. (It was called `..._at_every_entry_point` until the merge gate measured `span_near` and found the name outran the code — renamed rather than left to read as coverage that does not exist.)

One test asserts a **divergence** rather than a fix: `sloppy_phrase_is_in_order_only_unlike_lucene` pins that a transposed phrase does not match at any slop, which is what XERJ does and not what ES does. It exists so the limit cannot be quietly re-claimed later, and it flips the day the walk learns transpositions.

**Negative control, actually run**: the new test file was checked out against the pre-repair head of this branch (a2447c5d) and executed there — **7 passed, 3 failed**, exactly the review's findings (the file held 10 tests at that run and holds 12 now; names as they stood then, and the third is the test renamed above):

```
phrase_tokenizer_matches_the_segment_analyzer
  PRE-flush hit set for mm{query:"release 3",type:phrase}: left {"n1"}  right {}
phrase_prefix_slop_is_honoured_at_both_entry_points
  parse_request: `multi_match.slop` is not supported for type [phrase_prefix]
negative_slop_is_rejected_at_every_entry_point
  match_phrase slop -1 parsed to MatchPhrase { slop: 0 } instead of erroring
```

`phrase_prefix_max_expansions_does_not_change_the_hit_set_at_flush` was **not** one of the three — it passes at the pre-repair head too, so it is an invariant assertion rather than a regression catcher, and its doc comment says so. The discriminating guard for the routing change is the unit test `index::fts_projection_tests::multi_match_phrase_projects_positional_dis_max`, which now asserts `query_node_to_fts` returns `None` for `phrase_prefix` (it asserted the opposite before).

## Gates

Re-run locally in this worktree on the **final** tree (the numbers below are this round's own run, not the previous round's carried forward):

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p xerj-fts -p xerj-query -p xerj-engine --all-targets -- -D warnings` | clean |
| `cargo test --release -p xerj-fts -p xerj-query -p xerj-engine --no-fail-fast` | **954 passed · 0 failed · 24 ignored**, 35 test binaries (`multi_match_phrase_positions` **12/12**, `xerj-engine` lib 429, `xerj-query` lib 175, `xerj-fts` lib 49) |
| ES-compat YAML conformance, local, private port + throwaway data dir, 200 files | see the run below |

One flake to disclose: on an earlier full run, under a load average of ~200 from sibling builds on the same box, `xerj-fts` `search::tests::bool_deadline_never_broadens_a_must` failed on its *precondition* assertion ("the budget must have been spent inside the clause list") — a wall-clock deadline test. It passed on three consecutive re-runs and in the clean full run above. This PR's only `xerj-fts` change is a new `slop` field on `PhrasePrefixQuery`, which that test does not touch.

The ES-YAML conformance suite **was** re-run locally for this round, because the PR changes query parsing: a server built from this exact head, on a private port (`9366`) with a throwaway data dir, 200 files — **1366 passed · 0 failed · 3 skipped · 1369 total**. Same numbers as the CI job.

A note on how that server was obtained, because it nearly produced a false "all green": the shared cargo target dir is used by several worktrees at once, and `release/xerj` was a *different* branch's binary (`--version` reported `rc.14`, this tree is `rc.13`) while this build's own artifact sat in `release/deps/`. Probed against the wrong binary, every rejection claim in the table below reads as 200 — i.e. the exact failure the first gate round found, but caused by the harness rather than the code. Every number here was taken from a binary whose `--version` was checked against this worktree first.

The claim-level fixes were re-measured on that same live server, since a body edit that is not measured is how this got blocked in the first place. Corpus: one index, field `body` (`text`), docs `1:"merge policy"`, `2:"merge, policy tuning"`, `3:"merge the policy"`, `4:"merge a b policy"`, `5:"merge nothing here"`. The phrase `"merge policy"` therefore matches `{1,2}` at slop 0, `{1,2,3}` at slop 1 and `{1,2,3,4}` at slop 2 — so a coerced slop is visible in the hit set, not just in the status code. Every hit set below was taken pre-flush **and** post-flush and was identical in both states.

| request | before (this branch) | now | ES |
|---|---|---|---|
| `span_near` `slop:-1` | 200, slop silently 0 | **200, slop silently 0 — unchanged, now disclosed** | 200 (no validation, `SpanNearQueryBuilder.java:62`) |
| `multi_match` / `match_phrase` / `match_phrase_prefix` `slop:-1` | 400 | 400 (`…slop` must not be negative) | 400 ("No negative slop allowed") |
| `match_phrase` `slop:2.0` | **400** | **200, and honoured** — `{1,2,3,4}`, byte-identical to integer `slop:2`, where `slop:0` gives `{1,2}` | 200, slop 2 |
| `match_phrase` `slop:2.7` | **400** | 200, truncated to 2 — `{1,2,3,4}` | 200, slop 2 (truncating) |
| `match_phrase` `slop:"2"` | 400 | 200, honoured — `{1,2,3,4}` | 200, slop 2 |
| `multi_match` `type:phrase` `slop:2.0` | **400** | 200, honoured — `{1,2,3,4}` | 200, slop 2 |
| `match_phrase` `slop:"two"` / `slop:true` | 400 | 400 (`must be a number`) | 400 |
| `match_phrase` `slop:1e12` | 400 | 400 (`is out of range`) | 400 |
| `match_phrase_prefix` `max_expansions:-1` | 200, silently 50 | **400** | 400 ("No negative maxExpansions allowed") |
| `match_phrase_prefix` `max_expansions:"7"` / `7.0` | 200, silently 50 | 200, read as 7 | 200, 7 |
| `match_phrase_prefix` `max_expansions:"many"` | 200, silently 50 | **400** | 400 |
| `match_phrase_prefix` `max_expansions:0` | 200 | 200 | 200 (ES rejects `<0` only here) |
| `multi_match` `max_expansions:0` | 400 | 400 (`must be positive`) | 400 (ES rejects `<=0` here) |
| `multi_match` `slop` + `type:bool_prefix` | 400 | 400 (`[slop] not allowed for type [bool_prefix]`) | 400 (`MultiMatchQueryBuilder.java:673`) |

Every ES file:line in this PR body and in the touched source comments was re-opened in the ES tree and checked to point at the code the sentence describes; two were off (`TextFieldMapper.java:1269` named the caller rather than the `setSlop` call, `AbstractXContentParser.java:74` named the guard rather than the coercing read) and are corrected above and in the comments.

## Known limits, stated plainly

- **No `position_increment_gap`.** An array-valued field is flattened to one space-joined string in the indexing path before the FTS layer sees it, so a phrase can span two array elements. ES prevents this with a gap. Fixing it belongs in the indexing path — doing it only in the stored-scan evaluator would fix the memtable, leave the segment, and reintroduce the flush-variant hit set this PR removes.
- **`max_expansions` does not bind on `multi_match`** (see the flush-invariance section). It binds on single-field `match_phrase_prefix` segments only — pre-existing, untouched.
- **Keyword fields keep the stored scan.** A keyword FST holds one case-preserved whole-value term, which the schema-blind stored-scan evaluator (it tokenizes every field) cannot model, so a phrase `multi_match` naming one is declined whole.
- **`span_near.slop` is still accept-and-ignore.** `{"span_near": {"clauses": […], "slop": -1}}` returns 200 with the slop read as 0, and so does `"slop": 2.0` and `"slop": "2"`. This PR does not touch it: it is pre-existing on `main`, it is a span query rather than a phrase one, and — unlike the phrase builders — ES applies no validation there (`SpanNearQueryBuilder.java:62`), so a 400 would break a query ES answers. Closing it means *honouring* the value, which needs a decision about what a negative span slop should match. The gap is written into `parse_span_near` so the next reader finds it.
- **`slop` is in-order only, and ES's is not.** Lucene's sloppy phrase admits a transposition at a distance cost — `SloppyPhraseMatcher`'s class javadoc, verbatim: «for query `"a b"~2`, a document `x a b a y` can be matched twice: once for `"a b"` (distance=0), and once for `"b a"` (distance=2)». XERJ's walk anchors and steps forward only, so `{"match_phrase": {"body": {"query": "policy merge", "slop": 2}}}` over a document reading `merge policy` returns **zero hits here and two in ES**. Measured on this build at slop 2 and 3, pre- and post-flush, alongside an in-order control that does match. This is pre-existing — `xerj_fts::search::phrase_positions_match` has always been in-order and single-field `match_phrase` has always used it — and it is not a regression, because the `multi_match` phrase arms tested raw-substring containment before this PR and matched no transposition either. This PR does not close it: matching Lucene means changing the segment matcher and the stored-scan walk *together*, or the hit set stops being flush-invariant, which is the defect class this PR exists to remove. Pinned by the test `sloppy_phrase_is_in_order_only_unlike_lucene` and written into `phrase_walk`'s doc comment so it cannot be quietly re-claimed.
- **`query_string` ignores proximity entirely — also out of scope.** Measured on this build: `{"query_string": {"query": "body:\"merge policy\"", "phrase_slop": 2}}` and the inline Lucene form `body:"merge policy"~2` both return the slop-0 hit set. `parse_query_string` reads only `query` / `default_field` / `default_operator` / `boost`, so `phrase_slop` is dropped in silence — the same #204 class as `span_near.slop`, in a query type this PR does not touch. Stated here so the "three phrase entry points" scope above is read as the exact perimeter it is, not as "every place a slop can appear".
- **`slop` above `u32::MAX` is a 400 here and above `i32::MAX` in ES.** XERJ's slop is a `u32`, ES's an `int`, so values in `(i32::MAX, u32::MAX]` are accepted here and rejected there. Untouched by this PR; noted because the 400-on-out-of-range claim above is a `u32` claim, not an ES-exact one.


