### PR TITLE
fix(search): tied scores get one total order — bounded pages are prefixes for match/term/match_all; constant_score on a mixed corpus still is not (refs #191)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -11792,6 +11792,50 @@ impl Index {
         self.query_cache_misses.load(Ordering::Relaxed)
     }
 
+    /// The last-ranking `(score, seq_no, _id)` page key held by `hits`, under
+    /// the exact comparator the final page sort uses (score DESC, `seq_no` ASC,
+    /// `_id` ASC).
+    ///
+    /// #191 — the bounded collector's admission bound has to be this WHOLE key,
+    /// not just the score.  Documents that tie on score are separated by
+    /// `seq_no`, and the collection walk visits segments in snapshot order and
+    /// documents in stored-layout order — neither is `seq_no`-ascending — so a
+    /// score-only bound silently rejected tied documents that outrank the kept
+    /// set, and a `size:5` page stopped agreeing with a `size:1000` one.
+    ///
+    /// The score minimum is found first with a lookup-free scan; the `seq_no`
+    /// (a `VersionMap` hash lookup) is resolved only for the hits that actually
+    /// tie that minimum, so the usual tie-free case costs one lookup.
+    fn worst_page_key(&self, hits: &[Hit]) -> Option<(f32, u64, String)> {
+        let min_score = hits
+            .iter()
+            .map(|h| h.score)
+            .fold(None, |acc: Option<f32>, s| {
+                Some(match acc {
+                    Some(a) if a <= s => a,
+                    _ => s,
+                })
+            })?;
+        let mut worst: Option<(f32, u64, String)> = None;
+        for h in hits.iter().filter(|h| h.score == min_score) {
+            let key = (
+                h.score,
+                self.lookup_seq_no(&h.id).unwrap_or(u64::MAX),
+                h.id.clone(),
+            );
+            let worse = match worst.as_ref() {
+                None => true,
+                // Ranks LATER than the incumbent = worse: same score, then
+                // larger seq_no, then larger `_id`.
+                Some(w) => (key.1, &key.2) > (w.1, &w.2),
+            };
+            if worse {
+                worst = Some(key);
+            }
+        }
+        worst
+    }
+
     /// Look up the latest `seq_no` for a document by id via the version
     /// map. Returns `None` when the doc is unknown or tombstoned.
     ///
@@ -14532,7 +14576,37 @@ impl Index {
                 false
             };
 
-            for meta in &snap.segments {
+            // #191 — worst `(score, seq_no, _id)` key currently kept by the
+            // stored-scan collector, maintained across segments so the skip
+            // below is O(1).  See `worst_page_key`.
+            let mut scan_page_worst: Option<(f32, u64, String)> = None;
+            // #191 — walk the segments in ARRIVAL order.  `IndexSnapshot`
+            // documents its list as "oldest first", but nothing enforces it:
+            // `with_new_segment` appends in flush-COMPLETION order (a flush
+            // drains each memtable shard into its own segment, so the shards
+            // race) and `replace_segments` appends a merge's output — the
+            // oldest data in the index — at the very end.  Documents inside a
+            // segment ARE `seq_no`-ordered (`drain_for_flush` and the merge
+            // both sort by `seq_no`), so ordering the segments by `min_seq_no`
+            // is what makes the whole walk approximate the page's own
+            // `(score DESC, seq_no ASC)` order — Lucene's "leaves in index
+            // order, docs ascending within a leaf" invariant, which is exactly
+            // what lets a bounded collector stop early
+            // (`TopScoreDocCollector.java:122-124`).  Correctness no longer
+            // depends on this — the bounds below are order-independent — but
+            // without it a reversed list would defeat every early-out.
+            // `id` breaks the remaining tie so the walk is deterministic.
+            let ordered_segments: Vec<&xerj_storage::segment::SegmentMeta> = {
+                let mut v: Vec<&xerj_storage::segment::SegmentMeta> =
+                    snap.segments.iter().collect();
+                v.sort_by(|a, b| {
+                    a.min_seq_no
+                        .cmp(&b.min_seq_no)
+                        .then_with(|| a.id.cmp(&b.id))
+                });
+                v
+            };
+            for meta in ordered_segments {
                 dbg_segs += 1;
                 // F1: once the exact total is authoritative AND the bounded
                 // collector is full, remaining segments can neither add a
@@ -14542,8 +14616,32 @@ impl Index {
                 // O(N) cost just moves from JSON-parsing to `decode_stored`
                 // over every segment.  This is what turns the whole query into
                 // O(from+size) rather than O(segments·docs_per_segment).
+                //
+                // #191 — this used to be an unconditional `break`, which made
+                // the page "the first `cap` matches in SEGMENT-LIST order".
+                // That list is flush/merge COMPLETION order, not `seq_no`
+                // order: a flush drains each memtable shard into its own
+                // segment, and a merge appends its output at the end.  The
+                // final page sort ties by `seq_no` ASC (ES `_doc`), so with
+                // tied scores a `size:5` page and a `size:1000` page named
+                // different documents.  A segment is now skipped only when it
+                // provably cannot displace a kept hit: every document in it
+                // arrived strictly after the worst kept hit
+                // (`min_seq_no > worst.seq_no`), so on a tie it loses.
+                // Segments that CAN compete are scanned, and the cross-segment
+                // merge at the bottom of the loop re-selects the best `cap` by
+                // the same comparator the final page sort uses.
                 if count_authoritative && all_hits.len() >= materialisation_limit {
-                    break;
+                    if scan_page_worst.is_none() {
+                        scan_page_worst = self.worst_page_key(&all_hits);
+                    }
+                    match scan_page_worst.as_ref() {
+                        Some(w) if meta.min_seq_no > w.1 => continue,
+                        // No key resolvable (empty collector) — keep the
+                        // historical behaviour and stop.
+                        None => break,
+                        Some(_) => {}
+                    }
                 }
                 // Cooperative deadline: stop fanning into further segments
                 // once the request timeout has elapsed — partial results
@@ -14555,6 +14653,23 @@ impl Index {
 
                 let seg_id = meta.id.clone();
                 let fts_dir = segments_dir.clone();
+
+                // #191 — on the count-authoritative stored-scan path each
+                // segment gets its OWN `materialisation_limit` of headroom:
+                // `scan_stored_section_into` stops at
+                // `all_hits.len() >= limit`, so a collector already filled by
+                // an earlier segment would let a genuinely competitive segment
+                // contribute nothing.  Positions inside a segment ARE `seq_no`
+                // order (`drain_for_flush` and the merge both sort by
+                // `seq_no`), so this segment's first `cap` matches are its own
+                // `cap` best; the merge below then re-selects the global best
+                // `cap`.  Peak is 2×cap, trimmed at the bottom of the loop.
+                let scan_limit = if count_authoritative && !count_only && sort_topk.is_none() {
+                    all_hits.len().saturating_add(materialisation_limit)
+                } else {
+                    materialisation_limit
+                };
+                let hits_before_segment = all_hits.len();
 
                 let field_refs: Vec<&str> = fts_open_fields.iter().map(|s| s.as_str()).collect();
                 // `QueryString` is steered by its own flag rather than added
@@ -14895,19 +15010,32 @@ impl Index {
                                 // O(matches) score-sort *inside* `search_bounded`
                                 // is a separate cost governed by `fts_cap`, not by
                                 // this admission walk, and is out of scope here.)
-                                let mut page_worst: Option<f32> = if sort_topk.is_none()
+                                //
+                                // #191 — `page_worst` is the FULL page key
+                                // `(score, seq_no, _id)` of the worst kept hit,
+                                // not just its score.  A score-only bound is
+                                // only sound when the walk visits documents in
+                                // tie-break order, which is what Lucene relies
+                                // on ("Since docs are returned in-order (i.e.,
+                                // increasing doc Id), a document with equal
+                                // score to pqTop.score cannot compete since
+                                // HitQueue favors documents with lower doc Ids"
+                                // — lucene/core/src/java/org/apache/lucene/
+                                // search/TopScoreDocCollector.java:122-124, over
+                                // the `(score, doc)` comparator in
+                                // HitQueue.java:76-82).  XERJ ties by `seq_no`
+                                // (arrival order = ES `_doc`) but walks segments
+                                // in snapshot order and documents in STORED
+                                // LAYOUT order — neither is seq-ascending — so
+                                // an equal-scoring hit met later in the walk can
+                                // still own a smaller `seq_no` and must be
+                                // allowed to compete.
+                                let mut page_worst: Option<(f32, u64, String)> = if sort_topk
+                                    .is_none()
                                     && !count_only
                                     && all_hits.len() >= materialisation_limit
                                 {
-                                    all_hits.iter().map(|h| h.score).fold(
-                                        None,
-                                        |acc: Option<f32>, s| {
-                                            Some(match acc {
-                                                Some(a) if a <= s => a,
-                                                _ => s,
-                                            })
-                                        },
-                                    )
+                                    self.worst_page_key(&all_hits)
                                 } else {
                                     None
                                 };
@@ -14928,12 +15056,31 @@ impl Index {
                                 // segments and drop global sort candidates.  The
                                 // bounded `SortTopK` heap — not this cap — bounds the
                                 // sorted path's memory.
+                                //
+                                // #191 — a segment whose best score BEATS the
+                                // worst kept hit can always contribute.  A
+                                // segment whose best score merely TIES it can
+                                // still contribute, but only through the
+                                // `seq_no` tie-break, and only if it holds a
+                                // document that arrived no later than the worst
+                                // kept hit.  `min_seq_no` decides that in O(1)
+                                // from the segment meta — the same
+                                // later-segment argument `scored_columnar`'s
+                                // `later_min_seq` break already makes — so an
+                                // all-tied corpus does not degrade into opening
+                                // every segment.  A segment written before
+                                // `min_seq_no` was recorded reads back 0, which
+                                // simply makes the gate admit it: correct, just
+                                // not shortcut.
                                 let seg_can_enter = sort_topk.is_some()
                                     || all_hits.len() < materialisation_limit
-                                    || seg_hits
-                                        .first()
-                                        .zip(page_worst)
-                                        .is_some_and(|(sh, worst)| sh.score > worst);
+                                    || seg_hits.first().zip(page_worst.as_ref()).is_some_and(
+                                        |(sh, worst)| {
+                                            sh.score > worst.0
+                                                || (sh.score == worst.0
+                                                    && meta.min_seq_no <= worst.1)
+                                        },
+                                    );
                                 if !fts_sorted_handled
                                     && !count_only
                                     && !seg_hits.is_empty()
@@ -15019,13 +15166,17 @@ impl Index {
                                         // `materialisation_limit` hits seen so far
                                         // by the SAME comparator the final page sort
                                         // uses (score DESC, seq_no ASC, `_id` ASC),
-                                        // and return the surviving worst score (the
-                                        // new cap-th score, = the min of the kept
-                                        // set).  Shared by the in-walk 2×cap eager
-                                        // trim and the end-of-run trim so admission
-                                        // and final ordering always agree.
-                                        let trim_to_cap =
-                                            |hits: Vec<Hit>| -> (Vec<Hit>, Option<f32>) {
+                                        // and return the surviving worst PAGE KEY
+                                        // (the new cap-th `(score, seq_no, _id)`,
+                                        // = the last of the kept set under that
+                                        // comparator).  Shared by the in-walk 2×cap
+                                        // eager trim and the end-of-run trim so
+                                        // admission and final ordering always agree.
+                                        #[allow(clippy::type_complexity)]
+                                        let trim_to_cap = |hits: Vec<Hit>| -> (
+                                            Vec<Hit>,
+                                            Option<(f32, u64, String)>,
+                                        ) {
                                                 let mut decorated: Vec<(u64, Hit)> = hits
                                                     .into_iter()
                                                     .map(|h| {
@@ -15044,7 +15195,9 @@ impl Index {
                                                         .then_with(|| a.1.id.cmp(&b.1.id))
                                                 });
                                                 decorated.truncate(materialisation_limit);
-                                                let worst = decorated.last().map(|(_, h)| h.score);
+                                                let worst = decorated
+                                                    .last()
+                                                    .map(|(seq, h)| (h.score, *seq, h.id.clone()));
                                                 let kept =
                                                     decorated.into_iter().map(|(_, h)| h).collect();
                                                 (kept, worst)
@@ -15077,7 +15230,9 @@ impl Index {
                                             // the sort key, not the highest-scoring
                                             // prefix.
                                             if sort_topk.is_none()
-                                                && page_worst.is_some_and(|worst| sh.score < worst)
+                                                && page_worst
+                                                    .as_ref()
+                                                    .is_some_and(|worst| sh.score < worst.0)
                                             {
                                                 break;
                                             }
@@ -15145,12 +15300,17 @@ impl Index {
                                                 // it exceeds 2×cap, trim back to the
                                                 // best cap by the final comparator
                                                 // and refresh `page_worst` to the new
-                                                // cap-th score.  Between cap and 2×cap
-                                                // no recompute is needed: every hit
-                                                // pushed since the last (re)establish
-                                                // scored `>= page_worst` (it did not
-                                                // break), so the running min — and
-                                                // hence `page_worst` — is unchanged.
+                                                // cap-th key.  Between cap and 2×cap
+                                                // no recompute is needed: `page_worst`
+                                                // is established the instant the
+                                                // collector holds exactly `cap` hits,
+                                                // so it IS the cap-th key at that
+                                                // moment, and every later push can only
+                                                // improve the true cap-th key.  A stale
+                                                // `page_worst` is therefore a WEAKER
+                                                // threshold than the truth — it admits
+                                                // more than strictly necessary, never
+                                                // less, which is the safe direction.
                                                 if all_hits.len() >= materialisation_limit {
                                                     if all_hits.len()
                                                         > materialisation_limit.saturating_mul(2)
@@ -15161,15 +15321,7 @@ impl Index {
                                                         all_hits = kept;
                                                         page_worst = worst;
                                                     } else if page_worst.is_none() {
-                                                        page_worst = all_hits
-                                                            .iter()
-                                                            .map(|h| h.score)
-                                                            .fold(None, |acc: Option<f32>, s| {
-                                                                Some(match acc {
-                                                                    Some(a) if a <= s => a,
-                                                                    _ => s,
-                                                                })
-                                                            });
+                                                        page_worst = self.worst_page_key(&all_hits);
                                                     }
                                                 }
                                             }
@@ -15526,7 +15678,7 @@ impl Index {
                             query,
                             is_match_all,
                             count_only,
-                            materialisation_limit,
+                            scan_limit,
                             count_authoritative,
                             &mut total_count,
                             &mut all_hits,
@@ -15578,7 +15730,7 @@ impl Index {
                                     query,
                                     is_match_all,
                                     count_only,
-                                    materialisation_limit,
+                                    scan_limit,
                                     count_authoritative,
                                     &mut total_count,
                                     &mut all_hits,
@@ -15592,7 +15744,7 @@ impl Index {
                                     query,
                                     is_match_all,
                                     count_only,
-                                    materialisation_limit,
+                                    scan_limit,
                                     count_authoritative,
                                     &mut total_count,
                                     &mut all_hits,
@@ -15675,7 +15827,7 @@ impl Index {
                                     query,
                                     is_match_all,
                                     count_only,
-                                    materialisation_limit,
+                                    scan_limit,
                                     count_authoritative,
                                     &mut total_count,
                                     &mut all_hits,
@@ -15735,6 +15887,42 @@ impl Index {
                             }
                         }
                     }
+                }
+
+                // #191 — cross-segment merge for the stored-scan path.  This
+                // segment was allowed its own `materialisation_limit` of
+                // headroom (see `scan_limit`), so reduce back to the global
+                // best `cap` by the SAME comparator the final page sort uses
+                // (score DESC, `seq_no` ASC, `_id` ASC) and refresh the skip
+                // bound.  Without it the collector kept whichever segment
+                // reached the cap first — segment-list order — rather than the
+                // documents the page sort would pick, so a bounded page and a
+                // full page named different documents whenever scores tied.
+                // Trimmed hits stay in `seen_ids`: the cap-th key only ever
+                // improves, so a document that lost the trim can never become
+                // competitive again.
+                if count_authoritative
+                    && !count_only
+                    && sort_topk.is_none()
+                    && all_hits.len() != hits_before_segment
+                    && all_hits.len() >= materialisation_limit
+                {
+                    let mut decorated: Vec<(u64, Hit)> = std::mem::take(&mut all_hits)
+                        .into_iter()
+                        .map(|h| (self.lookup_seq_no(&h.id).unwrap_or(u64::MAX), h))
+                        .collect();
+                    decorated.sort_by(|a, b| {
+                        b.1.score
+                            .partial_cmp(&a.1.score)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                            .then_with(|| a.0.cmp(&b.0))
+                            .then_with(|| a.1.id.cmp(&b.1.id))
+                    });
+                    decorated.truncate(materialisation_limit);
+                    scan_page_worst = decorated
+                        .last()
+                        .map(|(seq, h)| (h.score, *seq, h.id.clone()));
+                    all_hits = decorated.into_iter().map(|(_, h)| h).collect();
                 }
             }
         }

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -11836,6 +11836,39 @@ impl Index {
         worst
     }
 
+    /// Reduce `hits` to the best `cap` under the SAME comparator the final page
+    /// sort uses (`score DESC, seq_no ASC, _id ASC` — `index.rs:16222-16228`),
+    /// and return the surviving cap-th `(score, seq_no, _id)` page key.
+    ///
+    /// #191 — every bounded collector in `search` trims through here, so
+    /// admission and final ordering can never drift apart: a `size:5` page is
+    /// the first five of a `size:1000` one whatever order the walk visited the
+    /// documents in.
+    #[allow(clippy::type_complexity)]
+    fn trim_page_to_cap(
+        &self,
+        hits: Vec<Hit>,
+        cap: usize,
+    ) -> (Vec<Hit>, Option<(f32, u64, String)>) {
+        let mut decorated: Vec<(u64, Hit)> = hits
+            .into_iter()
+            .map(|h| (self.lookup_seq_no(&h.id).unwrap_or(u64::MAX), h))
+            .collect();
+        decorated.sort_by(|a, b| {
+            b.1.score
+                .partial_cmp(&a.1.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+                .then_with(|| a.1.id.cmp(&b.1.id))
+        });
+        decorated.truncate(cap);
+        let worst = decorated
+            .last()
+            .map(|(seq, h)| (h.score, *seq, h.id.clone()));
+        let kept = decorated.into_iter().map(|(_, h)| h).collect();
+        (kept, worst)
+    }
+
     /// Look up the latest `seq_no` for a document by id via the version
     /// map. Returns `None` when the doc is unknown or tombstoned.
     ///
@@ -13501,6 +13534,26 @@ impl Index {
         // memtable and a segment (possible during a flush race).  We prefer
         // the first appearance (which is usually the memtable, i.e. the
         // newest version).
+        //
+        // #191 — the `materialisation_limit` bound here is a plain FIFO cut,
+        // and it is only CORRECT because every arm that feeds it upholds one
+        // of two invariants:
+        //
+        //   * `AllDocIds` / `DocValuesHits` — the memtable already narrowed
+        //     its candidates to the globally best `limit` by `(seq_no, _id)`
+        //     (`ShardedFtsMemtable::narrow_to_page`), so the FIFO never
+        //     truncates at all; and
+        //   * `FtsHits` — the memtable returns its hits already sorted by the
+        //     full page key (`sort_hits_by_page_key`), so the first `limit`
+        //     ARE the page.  This matters on the ghost-window path, which asks
+        //     the memtable for every hit rather than a bounded prefix.
+        //
+        // The brute-scan arm upholds neither (it walks shards in index order),
+        // so it does NOT route post-cap admissions through here — see the
+        // `DocsForScan` arm.  Before #191 the FIFO was applied to unordered
+        // input and the surviving tied documents were decided by shard-walk
+        // order: `size:5` and `size:1000` disagreed on a 600-document
+        // all-tied memtable.
         macro_rules! admit_hit {
             ($hit:expr) => {{
                 total_count += 1;
@@ -13616,7 +13669,11 @@ impl Index {
             /// The `u64` is the UNCOLLECTED matching-doc remainder (bounded
             /// fused-bool path); it still counts toward `hits.total`.
             DocValuesHits(Vec<(String, usize)>, u64),
-            DocsForScan(Vec<(String, Arc<Value>)>), // doc_id + shared source for term-level scan
+            /// `(seq_no, doc_id, shared source)` for a term-level brute scan.
+            /// #191 — `seq_no` rides along so the bounded collector can rank a
+            /// document it reaches after filling the cap against the page it
+            /// already holds; shard-concatenation order is not arrival order.
+            DocsForScan(Vec<(u64, String, Arc<Value>)>),
         }
 
         // Search the memtable (unflushed docs only). Flushed docs are searched
@@ -13796,7 +13853,7 @@ impl Index {
                         // the heap is full (NOT the id-only snapshot,
                         // whose per-doc deep clone cost ~1 s/query at a
                         // 1 M-doc memtable).
-                        None => MemSnapshot::DocsForScan(mem.all_docs_with_sources_arc()),
+                        None => MemSnapshot::DocsForScan(mem.all_docs_with_seq_arc()),
                     }
                 } else {
                     let (ids, total) = mem.doc_ids_bounded(materialisation_limit);
@@ -13880,7 +13937,7 @@ impl Index {
                     } else {
                         // Brute per-doc scan — same authority the size>0
                         // path falls back to; `doc_matches_query` semantics.
-                        MemSnapshot::DocsForScan(mem.all_docs_with_sources_arc())
+                        MemSnapshot::DocsForScan(mem.all_docs_with_seq_arc())
                     }
                 } else if let Some((hits, total)) = (|| {
                     // Fused columnar term/range/bool: ONE position walk
@@ -13934,7 +13991,7 @@ impl Index {
                     // query (plus a second per-doc clone for `_id`
                     // injection below) was the single hottest search-side
                     // cost in the read-under-write thread dumps.
-                    let docs: Vec<(String, Arc<Value>)> = mem.all_docs_with_sources_arc();
+                    let docs: Vec<(u64, String, Arc<Value>)> = mem.all_docs_with_seq_arc();
                     MemSnapshot::DocsForScan(docs)
                 }
             } else {
@@ -14100,7 +14157,15 @@ impl Index {
                 let query_may_read_id: bool = serde_json::to_string(query)
                     .map(|s| s.contains("_id") || s.contains("Ids") || s.contains("ids"))
                     .unwrap_or(true);
-                for (doc_id, source) in docs {
+                // #191 — the cap-th page key the bounded collector currently
+                // holds, recomputed only when it can have changed (the moment
+                // the collector first fills, and after every trim).  A stale
+                // value is always a WEAKER threshold than the truth — it admits
+                // more than strictly necessary, never less — which is the safe
+                // direction, the same argument the segment walk's `page_worst`
+                // relies on.
+                let mut scan_worst: Option<(f32, u64, String)> = None;
+                for (seq_no, doc_id, source) in docs {
                     let matched = if let QueryNode::Ids { values } = query {
                         values.iter().any(|v| v == doc_id.as_str())
                     } else if !query_may_read_id || source.get("_id").is_some() {
@@ -14121,13 +14186,31 @@ impl Index {
                         // Materialise (score + owned source) ONLY when the
                         // hit can actually enter the bounded collector /
                         // top-N heap; everything else is a bare count.
-                        // Identical outcome to unconditionally building the
-                        // Hit: `admit_hit!` drops post-cap hits anyway.
+                        //
+                        // #191 — "can enter" is no longer "the collector still
+                        // has room".  This walk visits shards in index order
+                        // and each shard in arrival order, so it is NOT a
+                        // globally arrival-ordered walk: a document reached
+                        // after the cap is full can still hold a smaller
+                        // `seq_no` than the page's worst hit and therefore win
+                        // the tie-break against it.  Admit exactly those as
+                        // well — one `u64` compare against `scan_worst`, no
+                        // extra source clone for the ones that lose — and let
+                        // the trim below put the collector back at the cap by
+                        // the final comparator.  Documents that lose on
+                        // `seq_no` but would have won on SCORE are still
+                        // dropped here; that is pre-existing (they were dropped
+                        // outright before) and is recorded under Residual risk.
+                        let competitive = all_hits.len() < materialisation_limit || {
+                            if scan_worst.is_none() {
+                                scan_worst = self.worst_page_key(&all_hits);
+                            }
+                            scan_worst.as_ref().is_some_and(|w| seq_no < w.1)
+                        };
                         if count_only {
                             total_count += 1;
                         } else if sort_topk.is_some()
-                            || (all_hits.len() < materialisation_limit
-                                && !seen_ids.contains(&doc_id))
+                            || (competitive && !seen_ids.contains(&doc_id))
                         {
                             // Field-sorted: pre-clone primary-key rejection.
                             // Once the heap is full, a doc whose PRIMARY
@@ -14147,7 +14230,7 @@ impl Index {
                                 }
                             }
                             let score = score_doc(&source, &doc_id);
-                            admit_hit!(Hit {
+                            let hit = Hit {
                                 id: doc_id,
                                 score,
                                 source: (*source).clone(),
@@ -14156,13 +14239,48 @@ impl Index {
                                 highlight: None,
                                 matched_queries: Vec::new(),
                                 passage: None,
-                            });
+                            };
+                            if sort_topk.is_some() {
+                                admit_hit!(hit);
+                            } else {
+                                // `admit_hit!`'s FIFO bound would throw the
+                                // post-cap admissions above straight back
+                                // away, so this arm collects them itself and
+                                // trims by the page comparator once the
+                                // overflow reaches 2×cap — the same eager-trim
+                                // shape the segment walk uses.
+                                total_count += 1;
+                                if !seen_ids.contains(&hit.id) {
+                                    seen_ids.insert(hit.id.clone());
+                                    all_hits.push(hit);
+                                    if all_hits.len() > materialisation_limit.saturating_mul(2) {
+                                        let (kept, worst) = self.trim_page_to_cap(
+                                            std::mem::take(&mut all_hits),
+                                            materialisation_limit,
+                                        );
+                                        all_hits = kept;
+                                        scan_worst = worst;
+                                    }
+                                }
+                            }
                         } else {
                             total_count += 1;
                         }
                     }
                 }
             }
+        }
+
+        // #191 — normalise the memtable contribution back to exactly the cap
+        // before the segment walk starts, so every downstream stage sees the
+        // documented shape (`all_hits` holds the best `materialisation_limit`
+        // by the final comparator).  Only the brute-scan arm can overshoot —
+        // it admits post-cap documents that outrank the page it holds — and
+        // only up to 2×cap before its own eager trim fires.
+        if sort_topk.is_none() && all_hits.len() > materialisation_limit {
+            let (kept, _worst) =
+                self.trim_page_to_cap(std::mem::take(&mut all_hits), materialisation_limit);
+            all_hits = kept;
         }
 
         // --- Segment search ---
@@ -15177,31 +15295,8 @@ impl Index {
                                             Vec<Hit>,
                                             Option<(f32, u64, String)>,
                                         ) {
-                                                let mut decorated: Vec<(u64, Hit)> = hits
-                                                    .into_iter()
-                                                    .map(|h| {
-                                                        (
-                                                            self.lookup_seq_no(&h.id)
-                                                                .unwrap_or(u64::MAX),
-                                                            h,
-                                                        )
-                                                    })
-                                                    .collect();
-                                                decorated.sort_by(|a, b| {
-                                                    b.1.score
-                                                        .partial_cmp(&a.1.score)
-                                                        .unwrap_or(std::cmp::Ordering::Equal)
-                                                        .then_with(|| a.0.cmp(&b.0))
-                                                        .then_with(|| a.1.id.cmp(&b.1.id))
-                                                });
-                                                decorated.truncate(materialisation_limit);
-                                                let worst = decorated
-                                                    .last()
-                                                    .map(|(seq, h)| (h.score, *seq, h.id.clone()));
-                                                let kept =
-                                                    decorated.into_iter().map(|(_, h)| h).collect();
-                                                (kept, worst)
-                                            };
+                                            self.trim_page_to_cap(hits, materialisation_limit)
+                                        };
                                         for sh in &seg_hits {
                                             // `seg_hits` descends by score, so once
                                             // a hit's score is STRICTLY below the

--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -23,6 +23,33 @@ use xerj_fts::bm25::Bm25Scorer;
 pub struct MemtableHit {
     pub doc_id: String,
     pub score: f32,
+    /// WAL `seq_no` of the buffered document (`u64::MAX` when it can't be
+    /// resolved).  #191 — the memtable's bounded FTS materialisation has to
+    /// truncate under the SAME total order the final page sort uses
+    /// (`score DESC, seq_no ASC, _id ASC`); score alone leaves the survivors
+    /// of a tie decided by shard-walk order, which is not arrival order.
+    pub seq_no: u64,
+}
+
+/// Order `hits` by the page key XERJ's final sort uses: `score DESC`, then
+/// `seq_no ASC` (arrival order — the `_doc` analogue), then `_id ASC`
+/// (`index.rs:16222-16228`).
+///
+/// #191 — any bounded materialisation must truncate under the SAME total order
+/// the page is finally sorted by, otherwise the documents that survive a tie
+/// are decided by whatever order the walk happened to visit them in.  Lucene
+/// makes the same comparator total for the same reason
+/// (`HitQueue.lessThan` breaks an equal score by the smaller doc id,
+/// `lucene/core/src/java/org/apache/lucene/search/HitQueue.java:76-82`);
+/// approach only, no code taken.
+fn sort_hits_by_page_key(hits: &mut [MemtableHit]) {
+    hits.sort_unstable_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.seq_no.cmp(&b.seq_no))
+            .then_with(|| a.doc_id.cmp(&b.doc_id))
+    });
 }
 
 #[cfg(test)]
@@ -829,17 +856,49 @@ impl ShardedFtsMemtable {
     /// on every request — ~1 s per query at a 300 k-doc memtable under
     /// sustained bulk load (the `mem_admit` phase of the read-under-write
     /// breakdown).
+    /// #191 — reduce per-shard bounded candidates to the globally best `limit`
+    /// under the order the final page sort uses.
+    ///
+    /// Every hit these paths produce carries the SAME score (`1.0` for the
+    /// id-only and doc-values collectors; a top-level `constant_score` rewrites
+    /// them all to the wrapper's boost), so the page order reduces to
+    /// `(seq_no ASC, _id ASC)` — the tail of `(score DESC, seq_no ASC, _id ASC)`
+    /// at `index.rs:16222-16228`.
+    ///
+    /// Returns the surviving cap-th `seq_no` as the next shard's cutoff, so the
+    /// walk can stop cloning ids that can no longer reach the page.
+    fn narrow_to_page<T>(cands: &mut Vec<(u64, String, T)>, limit: usize) -> u64 {
+        if cands.len() <= limit {
+            return u64::MAX;
+        }
+        cands.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        cands.truncate(limit);
+        cands.last().map_or(u64::MAX, |c| c.0)
+    }
+
     pub fn doc_ids_bounded(&self, limit: usize) -> (Vec<String>, u64) {
-        let mut out: Vec<String> = Vec::with_capacity(limit.min(4096));
+        // #191 — this used to fill greedily from shard 0 (`limit - out.len()`
+        // of room for each later shard), so an index whose memtable held more
+        // than `limit` documents returned "shard 0's first `limit` ids", not
+        // "the `limit` earliest-arriving ids".  Shard assignment is by doc-id
+        // hash (and by BATCH for bulk), so that set is neither arrival order
+        // nor stable, and `size:5` stopped being a prefix of `size:1000` on an
+        // all-tied corpus.  Bound each shard independently and keep the global
+        // best `limit` by `(seq_no, _id)` instead.
+        let mut cands: Vec<(u64, String, ())> = Vec::with_capacity(limit.min(4096));
         let mut total: u64 = 0;
+        let mut cutoff = u64::MAX;
         for s in &self.shards {
             let g = s.read();
             total += g.doc_count() as u64;
-            if out.len() < limit {
-                out.extend(g.doc_ids_up_to(limit - out.len()));
-            }
+            cands.extend(
+                g.ranked_ids_up_to(limit, cutoff)
+                    .into_iter()
+                    .map(|(q, id)| (q, id, ())),
+            );
+            cutoff = Self::narrow_to_page(&mut cands, limit);
         }
-        (out, total)
+        (cands.into_iter().map(|(_, id, ())| id).collect(), total)
     }
 
     /// Return every (doc_id, source) pair.  Aggregates across all
@@ -859,6 +918,22 @@ impl ShardedFtsMemtable {
         let mut out = Vec::new();
         for s in &self.shards {
             out.extend(s.read().all_docs_with_sources_arc());
+        }
+        out
+    }
+
+    /// `(seq_no, doc_id, source_arc)` for every buffered document.
+    ///
+    /// #191 — the brute per-doc scan's bounded collector has to decide whether
+    /// a document it reaches AFTER filling the cap still belongs on the page.
+    /// Shards are concatenated in index order, which is not arrival order, so
+    /// that decision needs the document's arrival `seq_no`.  Carrying it in the
+    /// snapshot costs 8 bytes per entry and saves a `VersionMap` hash lookup
+    /// per match on the hottest memtable read path.
+    pub fn all_docs_with_seq_arc(&self) -> Vec<(u64, String, Arc<Value>)> {
+        let mut out = Vec::new();
+        for s in &self.shards {
+            out.extend(s.read().all_docs_with_seq_arc());
         }
         out
     }
@@ -1294,11 +1369,12 @@ impl ShardedFtsMemtable {
                 field_boosts,
             ));
         }
-        all.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        // #191 — the cross-shard merge sorts by the FULL page key, not by score
+        // alone.  Score alone leaves ties in shard-concatenation order, so
+        // `truncate(limit)` kept "the tied documents that happen to live in the
+        // lowest-numbered shards" rather than the earliest-arriving ones, and a
+        // `size:5` page stopped being a prefix of a `size:1000` one.
+        sort_hits_by_page_key(&mut all);
         // A doc_id lives in exactly ONE shard, so `all` has no duplicates:
         // its pre-truncation length IS the exact global match count when
         // `shard_limit == usize::MAX` (a lower bound otherwise).
@@ -1482,19 +1558,28 @@ impl ShardedFtsMemtable {
         if preds.is_empty() {
             return None;
         }
-        let mut out: Vec<(String, usize)> = Vec::new();
+        // #191 — bound each shard independently and keep the global best
+        // `limit` by `(seq_no, _id)`; `limit - out.len()` starved every shard
+        // after the first, so the page was "shard 0's first `limit` matches".
+        let mut cands: Vec<(u64, String, usize)> = Vec::new();
         let mut total: u64 = 0;
         for s in &self.shards {
             let g = s.read();
             if g.doc_count() == 0 {
                 continue;
             }
-            let room = limit.saturating_sub(out.len());
-            let (mut hits, t) = g.doc_values_bool_hits(preds, room)?;
-            out.append(&mut hits);
+            let (hits, t) = g.doc_values_bool_hits(preds, limit)?;
+            cands.extend(
+                hits.into_iter()
+                    .map(|(id, pos)| (g.seq_no_at(pos), id, pos)),
+            );
             total += t;
+            Self::narrow_to_page(&mut cands, limit);
         }
-        Some((out, total))
+        Some((
+            cands.into_iter().map(|(_, id, pos)| (id, pos)).collect(),
+            total,
+        ))
     }
 
     /// Columnar per-value counts for one field across all shards, for the
@@ -1597,23 +1682,30 @@ impl ShardedFtsMemtable {
         value: &str,
         limit: usize,
     ) -> Option<(Vec<(String, usize)>, u64)> {
-        let mut out: Vec<(String, usize)> = Vec::new();
+        let mut cands: Vec<(u64, String, usize)> = Vec::new();
         let mut total: u64 = 0;
         let mut any_hit = false;
         for s in &self.shards {
             let g = s.read();
-            // Step 1: bound the id clone to the remaining global window;
-            // the total is still exact per shard.  Mirrors
-            // `doc_values_bool_query`.
-            let room = limit.saturating_sub(out.len());
-            if let Some((mut hits, t)) = g.doc_values_term_query(field, value, room) {
+            // Step 1: bound the id clone per shard; the total is still exact
+            // per shard.  Mirrors `doc_values_bool_query`.  #191 — the bound
+            // used to be the REMAINING global window, which handed the whole
+            // page to shard 0.
+            if let Some((hits, t)) = g.doc_values_term_query(field, value, limit) {
                 any_hit = true;
-                out.append(&mut hits);
+                cands.extend(
+                    hits.into_iter()
+                        .map(|(id, pos)| (g.seq_no_at(pos), id, pos)),
+                );
                 total += t;
+                Self::narrow_to_page(&mut cands, limit);
             }
         }
         if any_hit {
-            Some((out, total))
+            Some((
+                cands.into_iter().map(|(_, id, pos)| (id, pos)).collect(),
+                total,
+            ))
         } else {
             None
         }
@@ -1625,20 +1717,28 @@ impl ShardedFtsMemtable {
         values: &[String],
         limit: usize,
     ) -> Option<(Vec<(String, usize)>, u64)> {
-        let mut out: Vec<(String, usize)> = Vec::new();
+        // #191 — per-shard bound + global `(seq_no, _id)` narrowing, as in
+        // `doc_values_term_query`.
+        let mut cands: Vec<(u64, String, usize)> = Vec::new();
         let mut total: u64 = 0;
         let mut any_hit = false;
         for s in &self.shards {
             let g = s.read();
-            let room = limit.saturating_sub(out.len());
-            if let Some((mut hits, t)) = g.doc_values_terms_query(field, values, room) {
+            if let Some((hits, t)) = g.doc_values_terms_query(field, values, limit) {
                 any_hit = true;
-                out.append(&mut hits);
+                cands.extend(
+                    hits.into_iter()
+                        .map(|(id, pos)| (g.seq_no_at(pos), id, pos)),
+                );
                 total += t;
+                Self::narrow_to_page(&mut cands, limit);
             }
         }
         if any_hit {
-            Some((out, total))
+            Some((
+                cands.into_iter().map(|(_, id, pos)| (id, pos)).collect(),
+                total,
+            ))
         } else {
             None
         }
@@ -1709,20 +1809,28 @@ impl ShardedFtsMemtable {
         lt: Option<f64>,
         limit: usize,
     ) -> Option<(Vec<(String, usize)>, u64)> {
-        let mut out: Vec<(String, usize)> = Vec::new();
+        // #191 — per-shard bound + global `(seq_no, _id)` narrowing, as in
+        // `doc_values_term_query`.
+        let mut cands: Vec<(u64, String, usize)> = Vec::new();
         let mut total: u64 = 0;
         let mut any_hit = false;
         for s in &self.shards {
             let g = s.read();
-            let room = limit.saturating_sub(out.len());
-            if let Some((mut hits, t)) = g.doc_values_range_query(field, gte, gt, lte, lt, room) {
+            if let Some((hits, t)) = g.doc_values_range_query(field, gte, gt, lte, lt, limit) {
                 any_hit = true;
-                out.append(&mut hits);
+                cands.extend(
+                    hits.into_iter()
+                        .map(|(id, pos)| (g.seq_no_at(pos), id, pos)),
+                );
                 total += t;
+                Self::narrow_to_page(&mut cands, limit);
             }
         }
         if any_hit {
-            Some((out, total))
+            Some((
+                cands.into_iter().map(|(_, id, pos)| (id, pos)).collect(),
+                total,
+            ))
         } else {
             None
         }
@@ -2623,18 +2731,27 @@ impl FtsMemtable {
 
         let mut hits: Vec<MemtableHit> = scores
             .into_iter()
-            .map(|(doc_id, score)| MemtableHit {
-                doc_id: doc_id.to_string(),
-                score,
+            .map(|(doc_id, score)| {
+                // #191 — carry the arrival order with the hit.  `scores` is a
+                // HashMap, so without it the pre-truncation order of an
+                // all-tied hit set is the hash iteration order: the surviving
+                // documents changed from run to run.
+                let seq_no = self
+                    .doc_id_index
+                    .get(&doc_id)
+                    .map_or(u64::MAX, |&pos| self.seq_no_at(pos));
+                MemtableHit {
+                    doc_id: doc_id.to_string(),
+                    score,
+                    seq_no,
+                }
             })
             .collect();
 
-        // Sort by score descending.
-        hits.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        // Sort by the FULL page key (score DESC, seq_no ASC, `_id` ASC) — the
+        // comparator `index.rs:16222-16228` applies to the final page — so a
+        // truncation at `limit` keeps exactly the documents that page would.
+        sort_hits_by_page_key(&mut hits);
         hits.truncate(limit);
         hits
     }
@@ -2662,6 +2779,37 @@ impl FtsMemtable {
     /// `ShardedFtsMemtable::doc_ids_bounded`.
     pub fn doc_ids_up_to(&self, n: usize) -> Vec<String> {
         self.docs.iter().take(n).map(|e| e.doc_id.clone()).collect()
+    }
+
+    /// The WAL `seq_no` of the document at shard-local position `pos`
+    /// (`u64::MAX` when the position is out of range).
+    ///
+    /// #191 — the bounded memtable paths must rank candidates ACROSS shards
+    /// by the same key the final page sort uses, and `seq_no` is that key's
+    /// tie-break.  Positions are only comparable within a shard; `seq_no` is
+    /// global.
+    pub fn seq_no_at(&self, pos: usize) -> u64 {
+        self.docs.get(pos).map_or(u64::MAX, |e| e.seq_no)
+    }
+
+    /// `(seq_no, doc_id)` for the first `n` buffered documents, stopping early
+    /// once an entry's `seq_no` exceeds `cutoff`.
+    ///
+    /// #191 — `docs` is append-ordered and `remove` preserves that order, so a
+    /// shard's entries ascend by `seq_no`: once one entry is past the caller's
+    /// running cap-th key, so is every entry after it, and neither needs its
+    /// `doc_id` cloned.  That early break is what keeps the per-shard bound
+    /// (which replaced a greedy "fill from shard 0" walk) from multiplying the
+    /// id clones by the shard count.
+    pub fn ranked_ids_up_to(&self, n: usize, cutoff: u64) -> Vec<(u64, String)> {
+        let mut out = Vec::new();
+        for e in self.docs.iter().take(n) {
+            if e.seq_no > cutoff {
+                break;
+            }
+            out.push((e.seq_no, e.doc_id.clone()));
+        }
+        out
     }
 
     /// Resolve a MemEntry's source Value — if `source` is Null but
@@ -2706,6 +2854,14 @@ impl FtsMemtable {
         self.docs
             .iter()
             .map(|e| (e.doc_id.clone(), Self::resolve_source_arc(e)))
+            .collect()
+    }
+
+    /// `seq_no`-carrying twin of [`Self::all_docs_with_sources_arc`] (#191).
+    pub fn all_docs_with_seq_arc(&self) -> Vec<(u64, String, Arc<Value>)> {
+        self.docs
+            .iter()
+            .map(|e| (e.seq_no, e.doc_id.clone(), Self::resolve_source_arc(e)))
             .collect()
     }
 

--- a/engine/crates/xerj-engine/tests/tied_score_page_order.rs
+++ b/engine/crates/xerj-engine/tests/tied_score_page_order.rs
@@ -214,21 +214,35 @@ async fn tie_straddling_a_page_boundary_resolves_the_same_way_at_every_size() {
 /// The same property with an UNFLUSHED tail — the shape a live index is in
 /// between flushes, and the one a paginating client hits most often.
 ///
-/// The corpus is deliberately larger than the collector's 256-hit floor
-/// (`materialisation_limit = (from + size + 100).max(256)`; the `from + size`
-/// narrowing applies only to an EMPTY memtable, so a mixed fixture always
-/// pays the floor plus 100 hits of slack).  A smaller mixed fixture proves
-/// nothing at all: the whole corpus fits under the cap, the bounded collector
-/// never truncates, and every page agrees trivially.
+/// Sizing this fixture takes two conditions at once, and an earlier revision
+/// of this test met neither.  With `materialisation_limit = (from + size +
+/// 100).max(256)` and the flushed documents arriving FIRST (so they own the
+/// low `seq_no`s and the head of every page):
 ///
-/// Honest scope: unlike the two tests above, this one PASSED on the pre-fix
-/// engine in the runs we measured — the 100-hit slack means truncation only
-/// ever reached documents past the prefixes asserted here, so the pre-fix
-/// walk got away with dropping whichever segment it reached last.  It earns
-/// its place as a REGRESSION guard, not a reproducer: the fix changes both
-/// the segment walk order and the per-segment headroom, and the memtable
-/// (which seeds the collector past its cap before the first segment is even
-/// opened) is where a mistake in either would surface first.
+///   1. the UNFLUSHED batch must be larger than the cap, or the memtable hands
+///      up every buffered hit and its bound is never exercised; and
+///   2. some asserted page position must actually LAND on a memtable
+///      document — i.e. `size` must exceed the flushed count — while (1) still
+///      holds, which bounds `flushed < size < unflushed - 100`.
+///
+/// 40 flushed + 300 unflushed satisfies both across `size` 41…199.  The
+/// original 320 flushed + 40 unflushed satisfied neither: 40 buffered hits
+/// never reached a 256-hit cap, so the memtable collector could not truncate,
+/// and every page position asserted (`size` ≤ 359, against 320 flushed
+/// documents) was answered from segments.  That test passed before the fix and
+/// after it, and would have kept passing however broken the memtable path
+/// became.  Measured on this fixture at the pre-repair commit, `size` 60, 100
+/// and 150 each returned a non-prefix page for all three shapes below.
+///
+/// `constant_score` is deliberately NOT one of the shapes here, and that is a
+/// known gap rather than an oversight: on a MIXED corpus its bounded page
+/// contains only memtable documents (`size:1` returns `mem0000` where the full
+/// page starts `seg0000`) because the segment walk is skipped once the
+/// collector is already full.  That reproduces identically before and after
+/// this change — it is a separate, pre-existing defect in the segment-side
+/// early-out, not the memtable bound under test here — and it is why this PR
+/// says `Refs #191` rather than `Fixes #191`.  The memtable-only test below
+/// does cover `constant_score`, which is the path this change fixes.
 #[tokio::test]
 async fn tied_scores_page_the_same_way_with_an_unflushed_memtable() {
     let dir = TempDir::new().unwrap();
@@ -237,8 +251,8 @@ async fn tied_scores_page_the_same_way_with_an_unflushed_memtable() {
     let idx = engine.get_index("mixed").unwrap();
 
     let mut inserted = Vec::new();
-    for batch in 0..4 {
-        for i in 0..80 {
+    for batch in 0..2 {
+        for i in 0..20u32 {
             let id = format!("seg{batch}{i:03}");
             idx.index_document(
                 Some(id.clone()),
@@ -250,8 +264,10 @@ async fn tied_scores_page_the_same_way_with_an_unflushed_memtable() {
         }
         idx.flush().await.unwrap();
     }
-    // Deliberately NOT flushed — these stay in the memtable.
-    for i in 0..40 {
+    // Deliberately NOT flushed — these stay in the memtable, and there are
+    // more of them than any cap the sizes below imply, so the memtable-side
+    // bound is the thing under test.
+    for i in 0..300 {
         let id = format!("mem{i:03}");
         idx.index_document(
             Some(id.clone()),
@@ -261,7 +277,7 @@ async fn tied_scores_page_the_same_way_with_an_unflushed_memtable() {
         .unwrap();
         inserted.push(id);
     }
-    let total = inserted.len() as u64; // 360 > the 256 floor
+    let total = inserted.len() as u64; // 340: 40 flushed + 300 unflushed
 
     for (label, q) in [
         ("match", json!({"match": {"body": "listpack"}})),
@@ -276,13 +292,119 @@ async fn tied_scores_page_the_same_way_with_an_unflushed_memtable() {
             "{label}: an all-tied page must come back in arrival order, \
              segment documents before memtable ones"
         );
-        // Sizes on both sides of the 256 floor.
-        for size in [1usize, 5, 50, 255, 256, 257, 300, 359] {
+        // Every one of these implies a cap below 300, so the memtable is
+        // always truncating; the ones past 40 are the ones whose page actually
+        // contains buffered documents.
+        for size in [1usize, 5, 41, 60, 100, 150, 199] {
             let p = idx.search(&req(0, size, &q)).await.unwrap();
             assert_eq!(
                 page_ids(&p.hits),
                 full_ids[..size],
                 "{label}: size:{size} page disagrees with the full materialisation"
+            );
+        }
+    }
+}
+
+/// #191's most natural reproduction, and the one the PR originally shipped
+/// without: index N identical documents and page them BEFORE the flush.
+///
+/// Nothing here has been written to a segment, so every collector decision is
+/// made on the memtable side.  That side bounds its materialisation twice over
+/// — the sharded memtable caps each shard's contribution, and `admit_hit!`
+/// caps the merged result — and neither bound used to rank candidates by the
+/// page key.  A `ShardedFtsMemtable` holds 16 independent shards, a document
+/// lands in one by id hash (a whole bulk batch by its FIRST id's hash), and
+/// the query path walks them in INDEX order while filling a global budget.
+/// So the page was "the tied documents that happen to live in the
+/// lowest-numbered shards", which is neither arrival order nor stable.
+///
+/// Measured pre-fix, release, 600 byte-identical documents (every score bit
+/// pattern `1065353216`, an exact tie), for `match`, `term`, `match_all` AND
+/// `constant_score` alike:
+///
+/// ```text
+/// size:5    → ["m0000", "m0001", "m0004", "m0005", "m0008"]
+/// size:1000 → ["m0000", "m0001", "m0002", "m0003", "m0004"], …
+/// ```
+///
+/// Each shape reaches a different memtable collector, which is why all four
+/// are asserted: `match` takes the scored FTS merge, `term` the columnar
+/// doc-values walk, `match_all` the bounded id list, and `constant_score` the
+/// brute per-document scan.
+#[tokio::test]
+async fn tied_scores_page_the_same_way_with_no_flush_at_all() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("memonly", Schema::empty()).unwrap();
+    let idx = engine.get_index("memonly").unwrap();
+
+    // Comfortably past the 256-hit floor.  `size:300` implies a 400-hit cap
+    // and so still truncates; `size:599` implies 699 and does not, which is
+    // why the full page below is a complete materialisation to compare
+    // against.
+    let mut inserted = Vec::new();
+    for i in 0..600 {
+        let id = format!("m{i:04}");
+        idx.index_document(
+            Some(id.clone()),
+            json!({"body": "listpack encoding", "kind": "same"}),
+        )
+        .await
+        .unwrap();
+        inserted.push(id);
+    }
+
+    for (label, q) in [
+        ("match", json!({"match": {"body": "listpack"}})),
+        ("term", json!({"term": {"kind": "same"}})),
+        ("match_all", json!({"match_all": {}})),
+        (
+            "constant_score",
+            json!({"constant_score": {"filter": {"match_all": {}}}}),
+        ),
+    ] {
+        let full = idx.search(&req(0, 1000, &q)).await.unwrap();
+        let full_ids = page_ids(&full.hits);
+        assert_eq!(full.total.value, 600, "{label}: every doc matches");
+
+        // The tie really is exact — otherwise the test proves nothing.
+        let scores: Vec<f32> = full.hits.iter().map(|h| h.score).collect();
+        assert!(
+            scores.windows(2).all(|w| w[0].to_bits() == w[1].to_bits()),
+            "{label}: fixture must produce an EXACT tie, got {:?}",
+            &scores[..5]
+        );
+        assert_eq!(
+            full_ids, inserted,
+            "{label}: an all-tied memtable page must come back in arrival order"
+        );
+
+        // Sizes on both sides of the 256 floor.  Measured pre-fix, `size` 5,
+        // 50 and 300 each returned a page drawn from the low-numbered shards
+        // for all four shapes; `size:1` happened to survive, because the
+        // globally-first document also lived in a shard the truncated walk
+        // reached.
+        for size in [1usize, 2, 5, 50, 255, 256, 257, 300, 599] {
+            let p = idx.search(&req(0, size, &q)).await.unwrap();
+            assert_eq!(
+                page_ids(&p.hits),
+                full_ids[..size],
+                "{label}: size:{size} page disagrees with the full materialisation"
+            );
+            assert_eq!(
+                p.total.value, 600,
+                "{label}: size:{size} total must stay exact"
+            );
+        }
+
+        // Paging one hit at a time reproduces the same order.
+        for from in [0usize, 1, 254, 255, 256, 300] {
+            let p = idx.search(&req(from, 1, &q)).await.unwrap();
+            assert_eq!(
+                page_ids(&p.hits),
+                full_ids[from..from + 1],
+                "{label}: from:{from} size:1 disagrees with the full materialisation"
             );
         }
     }

--- a/engine/crates/xerj-engine/tests/tied_score_page_order.rs
+++ b/engine/crates/xerj-engine/tests/tied_score_page_order.rs
@@ -1,0 +1,289 @@
+//! Regression test for #191 — tied `_score`s must resolve to ONE total order,
+//! and every bounded page must be a prefix of the full materialisation.
+//!
+//! ES/Lucene make the top-k comparator total: `HitQueue.lessThan` breaks an
+//! equal-score tie by the smaller `doc` id, and leaves are visited in
+//! ascending global doc-id order, so the same document wins the tie no matter
+//! how many hits were collected
+//! (`lucene/core/src/java/org/apache/lucene/search/HitQueue.java:76-82` and
+//! `TopScoreDocCollector.java:122-124`).
+//!
+//! XERJ ties by `seq_no` (arrival order — its `_doc` analogue) but does NOT
+//! walk documents in `seq_no` order: `IndexSnapshot::segments` is in
+//! flush/merge COMPLETION order (a flush drains each memtable shard into its
+//! own segment; a merge appends its output at the end), and an FTS segment
+//! returns its hits in stored-layout order.  Both bounded collectors therefore
+//! used to resolve ties by *where the walk happened to reach the cap*:
+//!
+//!   * the scored FTS collector rejected a later segment whose best score only
+//!     TIED the worst kept hit (`>` instead of a full-key comparison), and
+//!   * the count-authoritative stored scan simply `break`ed once the collector
+//!     was full, keeping the first `cap` matches in segment-list order.
+//!
+//! Measured pre-fix on the corpus below (12 byte-identical documents, one
+//! exact score): `size:1000` returns doc00…doc23 in arrival order, while
+//! `size:1` returned `doc02` on one release run and `doc01` on the next —
+//! the answer is not merely wrong, it is not even STABLE, because the losing
+//! tie-break is the racy segment-list order.  The partial-tie fixture below
+//! returned `[top0, top1, tie03]` at `size:3` against `[top0, top1, tie00]`
+//! at `size:500`.
+//!
+//! The properties asserted here are the ones a paginating client relies on:
+//!   1. every `size:k` page equals the first `k` of the full page,
+//!   2. walking the corpus one hit at a time with `from` reproduces it, and
+//!   3. the answer does not depend on how many hits were requested.
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+fn make_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    Engine::new(config).expect("engine::new")
+}
+
+fn req(from: usize, size: usize, q: &Value) -> xerj_query::ast::SearchRequest {
+    parse_request(&json!({"from": from, "size": size, "query": q})).expect("parse_request")
+}
+
+/// 12 byte-identical documents over three flushes.  Identical text means an
+/// exact BM25 tie on every scored path and an exact constant on every
+/// filter path — the shape #191 is about.
+async fn tied_corpus(idx: &std::sync::Arc<xerj_engine::index::Index>) -> Vec<String> {
+    let mut ids = Vec::new();
+    for batch in 0..3 {
+        for i in 0..4 {
+            let id = format!("doc{batch}{i}");
+            idx.index_document(
+                Some(id.clone()),
+                json!({
+                    "body": "listpack encoding for small collections",
+                    "kind": "same",
+                }),
+            )
+            .await
+            .unwrap();
+            ids.push(id);
+        }
+        idx.flush().await.unwrap();
+    }
+    ids
+}
+
+fn page_ids(hits: &[xerj_query::Hit]) -> Vec<String> {
+    hits.iter().map(|h| h.id.clone()).collect()
+}
+
+#[tokio::test]
+async fn tied_scores_bounded_pages_are_prefixes_of_the_full_page() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("tie", Schema::empty()).unwrap();
+    let idx = engine.get_index("tie").unwrap();
+    let inserted = tied_corpus(&idx).await;
+
+    // Each shape exercises a different collector:
+    //   match           → scored FTS admission walk (`page_worst`)
+    //   term            → count-authoritative stored scan (`scan_page_worst`)
+    //   match_all       → columnar top-k
+    //   constant_score  → columnar top-k with the wrapper's constant score
+    for (label, q) in [
+        ("match", json!({"match": {"body": "listpack"}})),
+        ("term", json!({"term": {"kind": "same"}})),
+        ("match_all", json!({"match_all": {}})),
+        (
+            "constant_score",
+            json!({"constant_score": {"filter": {"match_all": {}}}}),
+        ),
+    ] {
+        let full = idx.search(&req(0, 1000, &q)).await.unwrap();
+        assert_eq!(full.total.value, 12, "{label}: every doc matches");
+        let full_ids = page_ids(&full.hits);
+        assert_eq!(
+            full_ids.len(),
+            12,
+            "{label}: full materialisation returns all 12"
+        );
+
+        // The tie really is exact — otherwise the test proves nothing.
+        let scores: Vec<f32> = full.hits.iter().map(|h| h.score).collect();
+        assert!(
+            scores.windows(2).all(|w| w[0].to_bits() == w[1].to_bits()),
+            "{label}: fixture must produce an EXACT tie, got {scores:?}"
+        );
+
+        // Property 1 — the tie-break is arrival order (`_doc`), matching the
+        // `(score DESC, seq_no ASC, _id ASC)` order the final page sort uses.
+        assert_eq!(
+            full_ids, inserted,
+            "{label}: an all-tied page must come back in arrival order"
+        );
+
+        // Property 2 — every bounded page is a prefix of the full page.
+        for size in 1..=12usize {
+            let p = idx.search(&req(0, size, &q)).await.unwrap();
+            assert_eq!(
+                page_ids(&p.hits),
+                full_ids[..size],
+                "{label}: size:{size} page disagrees with the full materialisation"
+            );
+            assert_eq!(
+                p.total.value, 12,
+                "{label}: size:{size} total must stay exact"
+            );
+        }
+
+        // Property 3 — paging one hit at a time reproduces the same order.
+        let walked: Vec<String> = {
+            let mut acc = Vec::new();
+            for from in 0..12usize {
+                let p = idx.search(&req(from, 1, &q)).await.unwrap();
+                acc.extend(page_ids(&p.hits));
+            }
+            acc
+        };
+        assert_eq!(
+            walked, full_ids,
+            "{label}: from/size walk disagrees with the full materialisation"
+        );
+    }
+}
+
+/// The same property when the tie is only PARTIAL: a handful of documents
+/// outscore the rest, and the tied block straddles the page boundary.  This is
+/// the `multi_match` / `best_fields` shape from the issue report, where four
+/// documents landed on exactly 2.859662 across a `size:3` boundary.
+#[tokio::test]
+async fn tie_straddling_a_page_boundary_resolves_the_same_way_at_every_size() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("straddle", Schema::empty()).unwrap();
+    let idx = engine.get_index("straddle").unwrap();
+
+    // Two clear winners (the term twice in a short body), then eight
+    // documents that tie each other exactly.
+    for i in 0..2 {
+        idx.index_document(
+            Some(format!("top{i}")),
+            json!({"body": "quicklist quicklist"}),
+        )
+        .await
+        .unwrap();
+    }
+    idx.flush().await.unwrap();
+    for batch in 0..2 {
+        for i in 0..4 {
+            idx.index_document(
+                Some(format!("tie{batch}{i}")),
+                json!({"body": "quicklist entry"}),
+            )
+            .await
+            .unwrap();
+        }
+        idx.flush().await.unwrap();
+    }
+
+    let q = json!({"match": {"body": "quicklist"}});
+    let full = idx.search(&req(0, 500, &q)).await.unwrap();
+    let full_ids = page_ids(&full.hits);
+    assert_eq!(full.total.value, 10);
+
+    // The tied block is real: the last eight hits share one score.
+    let scores: Vec<f32> = full.hits.iter().map(|h| h.score).collect();
+    assert!(
+        scores[2..]
+            .windows(2)
+            .all(|w| w[0].to_bits() == w[1].to_bits()),
+        "fixture must tie the trailing block, got {scores:?}"
+    );
+
+    for size in 1..=10usize {
+        let p = idx.search(&req(0, size, &q)).await.unwrap();
+        assert_eq!(
+            page_ids(&p.hits),
+            full_ids[..size],
+            "size:{size} page disagrees with the full materialisation"
+        );
+    }
+}
+
+/// The same property with an UNFLUSHED tail — the shape a live index is in
+/// between flushes, and the one a paginating client hits most often.
+///
+/// The corpus is deliberately larger than the collector's 256-hit floor
+/// (`materialisation_limit = (from + size + 100).max(256)`; the `from + size`
+/// narrowing applies only to an EMPTY memtable, so a mixed fixture always
+/// pays the floor plus 100 hits of slack).  A smaller mixed fixture proves
+/// nothing at all: the whole corpus fits under the cap, the bounded collector
+/// never truncates, and every page agrees trivially.
+///
+/// Honest scope: unlike the two tests above, this one PASSED on the pre-fix
+/// engine in the runs we measured — the 100-hit slack means truncation only
+/// ever reached documents past the prefixes asserted here, so the pre-fix
+/// walk got away with dropping whichever segment it reached last.  It earns
+/// its place as a REGRESSION guard, not a reproducer: the fix changes both
+/// the segment walk order and the per-segment headroom, and the memtable
+/// (which seeds the collector past its cap before the first segment is even
+/// opened) is where a mistake in either would surface first.
+#[tokio::test]
+async fn tied_scores_page_the_same_way_with_an_unflushed_memtable() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    engine.create_index("mixed", Schema::empty()).unwrap();
+    let idx = engine.get_index("mixed").unwrap();
+
+    let mut inserted = Vec::new();
+    for batch in 0..4 {
+        for i in 0..80 {
+            let id = format!("seg{batch}{i:03}");
+            idx.index_document(
+                Some(id.clone()),
+                json!({"body": "listpack encoding", "kind": "same"}),
+            )
+            .await
+            .unwrap();
+            inserted.push(id);
+        }
+        idx.flush().await.unwrap();
+    }
+    // Deliberately NOT flushed — these stay in the memtable.
+    for i in 0..40 {
+        let id = format!("mem{i:03}");
+        idx.index_document(
+            Some(id.clone()),
+            json!({"body": "listpack encoding", "kind": "same"}),
+        )
+        .await
+        .unwrap();
+        inserted.push(id);
+    }
+    let total = inserted.len() as u64; // 360 > the 256 floor
+
+    for (label, q) in [
+        ("match", json!({"match": {"body": "listpack"}})),
+        ("term", json!({"term": {"kind": "same"}})),
+        ("match_all", json!({"match_all": {}})),
+    ] {
+        let full = idx.search(&req(0, 1000, &q)).await.unwrap();
+        let full_ids = page_ids(&full.hits);
+        assert_eq!(full.total.value, total, "{label}: every doc matches");
+        assert_eq!(
+            full_ids, inserted,
+            "{label}: an all-tied page must come back in arrival order, \
+             segment documents before memtable ones"
+        );
+        // Sizes on both sides of the 256 floor.
+        for size in [1usize, 5, 50, 255, 256, 257, 300, 359] {
+            let p = idx.search(&req(0, size, &q)).await.unwrap();
+            assert_eq!(
+                page_ids(&p.hits),
+                full_ids[..size],
+                "{label}: size:{size} page disagrees with the full materialisation"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Refs #191 (deliberately NOT `Fixes` — see Residual risk; the remainder is tracked in #270).
Both commit messages on this branch carry an explicit `Refs #191` line and no
closing keyword — verified on the pushed commits, not asserted: a
case-insensitive scan of both messages for `(close|fix|resolve)[sd]?[ :]*#<n>`
returns nothing. No merge method can auto-close the issue.

(This paragraph deliberately never puts a closing keyword immediately before the
issue number. An earlier draft of it did — inside a sentence promising the issue
could not be auto-closed — and GitHub's parser duly listed the issue under
`closingIssuesReferences`. Re-verified after removing it: the API reports
`closingIssuesReferences: []` for this PR.)

## Scope of the claim, up front

Precisely what is and is not fixed, so the headline is not read wider than the
measurement:

| corpus | `match` | `term` | `match_all` | `constant_score` |
|---|---|---|---|---|
| fully flushed | fixed | fixed | fixed | fixed |
| entirely unflushed | fixed | fixed | fixed | fixed |
| **mixed** (flushed + unflushed) | fixed | fixed | fixed | **NOT fixed** |

`constant_score` on a **mixed** corpus violates the prefix property at every
size tested, and separately a scored `match` over a large all-tied corpus still
loses the arrival-order tie-break after the main sort. Both are measured, both
reproduce identically before and after this PR (so neither is a regression from
it), and both are filed as #270 — details under
[Residual risk](#residual-risk). A mixed corpus is the normal state of a live
index between flushes, so gap 1 is routinely reachable, not a corner case.

> **Correction (2026-08-10).** An earlier revision of this description, and of
> #270, justified deferring the second gap with "the ES-YAML conformance suite
> could not be run in this sandbox (it wants port 9200, which is occupied)".
> **That was false and has been removed.** The runner takes `--url`
> (`engine/tests/es-compat-yaml/src/main.rs:27`) and the server takes a config
> with any `es_compat_port`. Disproved by direct measurement, not by argument:
> the suite was re-run for this revision on **port 9617 with a throwaway data
> dir, while a separate instance held :9200** (green, 9382 shards, at the moment
> the run started), at **1366 passed / 0 failed / 3 skipped / 1369 total**. Two
> earlier runs agree: this branch's own first commit reported the same 1366/0/3
> on port 9391, and the previous revision on port 9473. The deferral of the
> tie-break work was a scope call, not a blocked gate; it is now written as one.

> **Revision note (2026-08-10, comments only).** Four doc comments the second
> commit added cited `index.rs:16127-16133` as "the final page sort". That range
> was right when the FIRST commit wrote it (at 5bd361b8 those lines are exactly
> the decorate-then-`sort_by`) and went stale when the second commit inserted
> ~370 lines above it: at this head 16127-16133 lands inside the `function_score`
> `max_boost` composition, and on `main` it lands on the post-rescore re-sort
> that ties by `_id` ALONE — one of the five re-sorts #270 tracks as a defect.
> Corrected at all four sites (`index.rs:11840`, `memtable.rs:36`, `:866`,
> `:2752`) and in this description to `index.rs:16222-16228`, which is that sort
> in this tree. Comments only, no behaviour change; the gates below were re-run
> on the corrected tree.

## The defect, reproduced first

At `origin/main` (12d5cc32 / 1ee31ecd), release build, new test
`engine/crates/xerj-engine/tests/tied_score_page_order.rs`:

```
match, size:1     → ["doc02"]          ← ["doc01"] on the very next run
match, size:1000  → doc00, doc01, …    ← pages disagree

partial tie, size:3   → ["top0", "top1", "tie03"]
partial tie, size:500 → ["top0", "top1", "tie00"]
```

Not merely wrong — **not stable**. The same binary on the same 12-document
fixture named a different winner run to run, because the losing tie-break was
the racy segment-list order.

## Root cause

The final page sort is a total order — `(score DESC, seq_no ASC, _id ASC)`,
`seq_no` being arrival order, XERJ's `_doc` analogue (`index.rs:16222-16228`).
Both bounded collectors admitted on **score alone**, so which of a set of tied
documents survived was decided by wherever the walk happened to reach the cap:

* the scored FTS collector admitted a later segment only when its best score
  was *strictly* greater than the worst kept score (`sh.score > worst`), so a
  segment that merely **tied** was dropped whole — including the tie-winner
  holding the smaller `seq_no`;
* the count-authoritative stored scan simply `break`ed out of the segment loop
  once the collector was full, making the page "the first `cap` matches in
  segment-**list** order".

Neither order is `seq_no` order. `IndexSnapshot::segments` is flush/merge
*completion* order: a flush drains each memtable shard into its own segment
(`index.rs:23329`) and the shards race, while `replace_segments` appends a
merge's output — the oldest data in the index — at the very end of the list
(`xerj-storage/src/index_store.rs:115-125`).

**Prior art (retrieved, approach only — no code copied).** Lucene's comparator
is total: `HitQueue.lessThan` breaks an equal-score tie by the smaller `doc`
id (`lucene/core/src/java/org/apache/lucene/search/HitQueue.java:76-82`).
Crucially, `TopScoreDocCollector` is *allowed* to reject an equal-scoring hit
only because the walk is in ascending doc-id order — *"Since docs are returned
in-order (i.e., increasing doc Id), a document with equal score to
pqTop.score cannot compete since HitQueue favors documents with lower doc
Ids"* (`TopScoreDocCollector.java:122-124`). XERJ had the comparator but not
the walk invariant, so it could not borrow the shortcut. That is the whole bug
in one sentence.

#188 makes it matter more, not less: index-wide BM25 statistics remove the
per-segment normalisation artefacts that used to separate identical documents
by accident, so genuinely-identical documents now genuinely tie.

## The fix

Make the admission bound the **whole page key**, not the score.

* `Index::worst_page_key` returns the last-ranking `(score, seq_no, _id)` the
  collector holds, under the same comparator the final sort uses. The score
  minimum is found with a lookup-free scan; the `seq_no` (a `VersionMap` hash
  get) is resolved only for hits that tie it, so the ordinary tie-free case
  still costs one lookup.
* **FTS path** — a segment enters when its best score beats the worst kept
  hit, *or* ties it while `meta.min_seq_no <= worst.seq_no` (it could still
  hold an earlier-arriving document that wins the tie-break). O(1) from
  segment metadata, so an all-tied corpus does not degrade into opening every
  segment. The in-walk `page_worst` and `trim_to_cap` carry the full key too.
* **Stored-scan path** — the unconditional `break` becomes a per-segment skip
  on the same argument (`meta.min_seq_no > worst.seq_no` ⇒ every document in
  it arrived later, so on a tie it loses). Competing segments are scanned with
  their own `materialisation_limit` of headroom, and a cross-segment merge at
  the bottom of the loop re-selects the global best `cap` by the final
  comparator. Peak 2×cap, trimmed every iteration.
* The segment walk is ordered by `min_seq_no` (then `id`). Documents inside a
  segment are already `seq_no`-ascending — both `drain_shard_inner`
  (`memtable.rs:1978`) and the merge (`index.rs:8419`) sort by `seq_no` — so
  this makes the whole walk approximate the page's own order, which is what
  keeps the early-outs firing. Correctness no longer depends on it: the bounds
  above are order-independent.

Trimmed hits deliberately stay in `seen_ids` — the cap-th key only ever
improves, so a document that lost a trim can never become competitive again.


## Review round 2 — the memtable half, which the first round missed

An adversarial review found the headline property still FALSE on a first-class
path, and it was right. Reproduced at the previous PR head (release, 600
byte-identical documents, **never flushed**, every score bit `1065353216`):

```
size:5    → ["m0000","m0001","m0004","m0005","m0008"]
size:1000 → ["m0000","m0001","m0002","m0003","m0004"], …
```

Identical for `match`, `term`, `match_all` and `constant_score`.

**Where the defect actually was.** The review pinned `admit_hit!`
(`index.rs:13525`/`:13575`) as a pure FIFO. The FIFO is real, but it is not
where these documents were lost — by the time `admit_hit!` runs the memtable
has *already* truncated. `ShardedFtsMemtable` holds 16 independent shards, a
document lands in one by id hash (a whole bulk batch by its FIRST id's hash),
and every bounded read walked the shards in INDEX order against a single global
budget (`limit - out.len()`). Shard 0 therefore consumed the entire budget and
the later shards were starved, so the page was "the tied documents that happen
to live in the lowest-numbered shards" — neither arrival order nor stable.
Bounding `admit_hit!` alone would have changed nothing: it never sees the
documents it is accused of dropping.

**The fix, in three places.**

* `doc_ids_bounded`, `doc_values_bool_query`, `doc_values_term_query`,
  `doc_values_terms_query`, `doc_values_range_query` — each shard is now bounded
  independently and the candidates are narrowed to the globally best `limit` by
  `(seq_no ASC, _id ASC)` (`ShardedFtsMemtable::narrow_to_page`). Every hit on
  these paths carries the same score, so that IS the page order. `docs` is
  append-ordered and `remove` preserves order, so a shard's entries ascend by
  `seq_no`.
  **Only `doc_ids_bounded` feeds the running cap-th key back as a cutoff**
  (`ranked_ids_up_to`, `memtable.rs:899`), so only there does the per-shard
  bound avoid multiplying the id clones by the shard count. The four
  `doc_values_*` wrappers discard `narrow_to_page`'s returned cutoff
  (`memtable.rs:1577`, `:1701`, `:1734`, `:1826`) because their per-shard
  callee takes no cutoff argument — see [Known cost](#known-cost) for what that
  costs and why it was not fixed here.
* `search_text_boosted_inner` — the cross-shard merge sorted by score alone, so
  `truncate(limit)` kept whichever tied documents the shard concatenation
  happened to put first; worse, each shard's hits come out of a `HashMap`, so
  the surviving set moved run to run. `MemtableHit` now carries `seq_no` and
  both merges sort by the full page key (`sort_hits_by_page_key`).
* The brute per-document scan (`MemSnapshot::DocsForScan`, which is what
  `constant_score` takes) walks shards in index order, so it cannot rely on a
  FIFO bound either. Its snapshot now carries `seq_no`, and once the collector
  is full a document is still admitted when its `seq_no` beats the page's worst
  hit — one `u64` compare, no extra source clone for the ones that lose —
  with a 2×cap eager trim through the shared `Index::trim_page_to_cap`.

`admit_hit!`'s FIFO is left in place and is now documented as correct *given*
the invariant each arm upholds: `AllDocIds`/`DocValuesHits` are pre-narrowed to
the cap, and `FtsHits` arrives already sorted by the page key (which matters on
the ghost-window path, where the memtable is asked for every hit).
`index.rs`'s duplicated trim closure now delegates to `Index::trim_page_to_cap`
so admission and final ordering cannot drift apart again.

## Tests

`engine/crates/xerj-engine/tests/tied_score_page_order.rs`, 4 tests:

1. `tied_scores_bounded_pages_are_prefixes_of_the_full_page` — 12
   byte-identical documents over 3 flushes, asserted for `match`, `term`,
   `match_all` and `constant_score`. Asserts the fixture ties **exactly**
   (`to_bits()` equality) before asserting anything else. **Fails pre-fix.**
2. `tie_straddling_a_page_boundary_resolves_the_same_way_at_every_size` — the
   partial-tie shape from the issue report. **Fails pre-fix.**
3. `tied_scores_page_the_same_way_with_no_flush_at_all` — **new**, and the
   reproduction #191 describes most directly: 600 identical documents, nothing
   flushed, all four shapes, `size` 1…599 plus a one-hit-at-a-time `from` walk.
   Measured failing at the previous PR head with exactly the output quoted
   above; passes now.
4. `tied_scores_page_the_same_way_with_an_unflushed_memtable` — **re-sized**,
   because as written it could not exercise the collector it was named for. 320
   flushed + 40 unflushed against a 256-hit cap meant `all_hits` never truncated
   on the memtable path, so it passed before and after and would have kept
   passing however broken that path became. It is now 40 flushed + 300
   unflushed with `size` 41…199, which is the window where the memtable is
   truncating AND the asserted page positions actually land on buffered
   documents. Measured at the previous PR head, `size` 60, 100 and 150 each
   returned a non-prefix page for all three shapes.

## Gates (run locally, this tree)

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --release -p xerj-engine --all-targets -- -D warnings` | clean |
| `cargo test --release -p xerj-engine` | 30 binaries, 710 passed, **0 failed**, 23 ignored |
| ES-YAML conformance (live, private port 9617) | **1366 passed / 0 failed / 3 skipped / 1369 total** |

Every row above was re-run on the pushed head, not carried over. The conformance
run used `--config` with `es_compat_port = 9617`, `bind_address = "127.0.0.1"`
and a throwaway `data_dir`, and the runner was pointed at
`--url http://127.0.0.1:9617`, so it never addressed :9200 — which was serving
another instance (green, 9382 shards) when the run began. Occupied `:9200` has
never been a reason not to run this suite.

Before/after on the mixed 40-flushed + 300/600-unflushed probe, same binary,
prefix violations among `size` ∈ {1, 5, 41, 60, 100, 150, 199}:

| shape | previous PR head | this branch |
|---|---|---|
| `match` (u=300 / u=600) | 60, 100, 150 / 5, 41, 60, 100, 150, 199 | none / none |
| `term` (u=300 / u=600) | 60, 100, 150 / 60, 100, 150, 199 | none / none |
| `match_all` (u=300 / u=600) | 60, 100, 150 / 60, 100, 150, 199 | none / none |
| `constant_score` (u=300 / u=600) | all / all | **all / all — NOT fixed**, see Residual risk 1 |

## Residual risk

<a name="residual-risk"></a>

Two measured gaps remain — **known gaps, not speculation**. Both reproduce
**identically before and after this change**, so neither is a regression, but
both are part of what #191 reports. That is why this PR references #191 with
`Refs` and no closing keyword, why both commit messages on this branch do the
same, and why merging must not auto-close the issue. Verified rather than
asserted: GitHub reports `closingIssuesReferences: []` for this PR, and a
case-insensitive scan of both commit messages for `close/fix/resolve #<n>`
returns nothing. #191 stays open until #270 closes.

1. **`constant_score` on a MIXED corpus still returns a non-prefix page.** With
   40 flushed + 300 unflushed identical documents, `size:1` returns `mem0000`
   where the full page starts `seg0000`; every size in {1, 5, 41, 60, 100, 150,
   199} violates the prefix property. `hits.total` is correct (340), so this is
   materialisation, not counting. Mechanism, established by reading rather than
   by instrumentation: `hydrate_prefiltered_unsorted` leaves the segment
   hydration unconditionally once the collector is full
   (`index.rs:22479` and `index.rs:22530`), so segment documents — which hold
   the LOWEST `seq_no` and therefore own the head of the page — never enter
   `all_hits` at all. That early-out is untouched by this change, and this is
   the one shape the re-sized mixed test above deliberately excludes and says
   so. A mixed corpus is the normal state of a live index between flushes, so
   this is routinely reachable, not a corner case.
2. **A scored `match` over an all-tied corpus loses the `_doc` tie-break at
   scale.** At 40 flushed + 600 unflushed, every hit comes back with score
   exactly `1.0` and the page is ordered by `_id` ASC (`mem…` before `seg…`)
   instead of arrival order. Bounded and full pages still AGREE, so #191's
   prefix property holds — but the arrival-order tie-break the final sort
   establishes is being discarded afterwards. There are five post-sort re-sorts
   in `search` (`index.rs` — the IDF rescore, the TF-IDF fallback, and three in
   the explicit `rescore` path) that tie by `_id` alone.

   **Why it is not fixed here — a scope call, not a blocked gate.** Changing
   those five tie-breaks is a search-semantics change at five call sites, and
   several ES-YAML conformance cases pin document order through `rescore` and
   `collapse`, so any of them whose expectation encoded the old `_id` order has
   to be reconciled deliberately. That belongs in its own PR with its own
   before/after evidence, not bundled into a tie-break repair. (An earlier
   revision of this section claimed the conformance suite "could not be run in
   this sandbox (it wants port 9200, which is occupied)". That was false — see
   the Correction at the top — and it is not the reason.)

   Both gaps are filed as #270.
3. Pre-existing and unchanged: the count-authoritative stored scan still admits
   a segment's *first* `cap` matches in positional order, which is that
   segment's `cap` best by `seq_no` but not by score if a `function_score`
   varies the score on that path.

## Known cost this PR adds

<a name="known-cost"></a>

Two allocation costs the fix introduces. Both are bounded and correct — neither
can drop or duplicate a hit — but neither is covered by a test here, and saying
so is cheaper than letting someone discover it in a profile.

1. **The four `doc_values_*` memtable wrappers now clone up to `16 × limit`
   candidate ids over a whole query, where they used to clone `limit`.** (16 =
   `DEFAULT_ENGINE_MEMTABLE_SHARDS`, `memtable.rs:648`.) Each shard is handed the
   FULL `limit` rather than the remaining global budget — that is exactly what
   makes the page a prefix instead of "whatever shard 0 held". The *live* set
   stays ≤ `2 × limit`, because `narrow_to_page` runs after every shard; it is
   the total number of id clones that scales with the shard count.
   `doc_ids_bounded` avoids that by feeding the surviving cap-th `seq_no` back as
   a cutoff (`memtable.rs:899` → `ranked_ids_up_to`); the other four discard the
   cutoff `narrow_to_page` returns (`memtable.rs:1577`, `:1701`, `:1734`,
   `:1826`) because their per-shard callee has no cutoff parameter. Threading one
   through those four is a wider change than a tie-break repair should carry, so
   it is deliberately left. Reasoned from the code, **not measured** — no
   benchmark here quantifies it.
2. **The count-authoritative stored-scan path peaks at 2×cap instead of 1×cap.**
   Each competing segment is granted its own `materialisation_limit` of headroom
   (`scan_limit = all_hits.len() + materialisation_limit`) so a later segment can
   still win a tie, and the cross-segment merge trims back to `cap` on every
   iteration. Peak page-collector memory on that path therefore doubles.

**Behaviour note, for the record.** Ordering the segment walk by `min_seq_no`
also changes which copy `seen_ids` meets first when one `_id` exists in more
than one segment (an update whose old copy has not been merged away). Superseded
positions are excluded before that point by the per-segment ghost bitmap —
`ghost_positions_cache`, "bit `pos` set ⇔ the stored doc at `pos` is tombstoned
**or superseded** per the version map", consulted whenever `deletes_present`
(`index.rs:5137-5145`) — and the full `xerj-engine` suite plus the ES-YAML
conformance suite pass on this head. No dedicated update/delete stress case was
written for this PR, so that is coverage-by-existing-suite, not a targeted
proof.


