### PR TITLE
autoindex: recognise .mts/.cts as TypeScript

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -66,9 +66,15 @@ fn registry() -> &'static [LangDef] {
                 tree_sitter_javascript::LANGUAGE.into(),
                 JS_Q,
             ),
+            // `.mts`/`.cts` are TypeScript's ESM/CJS extensions — the exact
+            // counterparts of the `.mjs`/`.cjs` that javascript already claims
+            // below. Omitting them did not merely skip the AST pass: an
+            // unclaimed extension is not code to the sniffer at all, so those
+            // files fell through to the prose extractor and were chunked into
+            // several body-only records with no `language`, `defs` or `symbols`.
             def(
                 "typescript",
-                &["ts"],
+                &["ts", "mts", "cts"],
                 tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
                 TS_Q,
             ),
@@ -583,6 +589,26 @@ mod tests {
         let s = syms("typescript", "export const Button = () => 1;\n");
         assert!(has(&s, "Button", "function"), "got {s:?}");
         assert!(has(&s, "Button", "const"), "got {s:?}");
+    }
+
+    /// `.mts`/`.cts` are TypeScript's ESM/CJS file extensions, the exact
+    /// counterparts of `.mjs`/`.cjs` which javascript already claims. Without
+    /// them a Node-ESM TypeScript file is not code to the sniffer at all: it
+    /// falls through to the prose extractor, so it yields no `language`, no
+    /// `defs`, no `symbols`, and gets chunked into several records instead of
+    /// one.
+    #[test]
+    fn typescript_module_extensions() {
+        assert!(is_code_ext("mts"), "mts must be recognised as code");
+        assert!(is_code_ext("cts"), "cts must be recognised as code");
+        for ext in ["mts", "cts"] {
+            let d = registry().iter().find(|d| d.exts.contains(&ext));
+            assert_eq!(
+                d.map(|d| d.name),
+                Some("typescript"),
+                "{ext} must route to the typescript grammar"
+            );
+        }
     }
     #[test]
     fn rust() {


### PR DESCRIPTION
Written by an AI coding agent (Claude Opus 5 via Claude Code), run by @pradaev.
@pradaev has signed the CLA (#289) and approved this for review.

## Defect

`registry()` claims `ts` for TypeScript and `js`/`jsx`/`mjs`/`cjs` for JavaScript.
TypeScript's own ESM/CJS extensions, `.mts` and `.cts`, are absent — even though
they are the exact counterparts of the `.mjs`/`.cjs` already claimed.

The consequence is larger than a skipped AST pass. `is_code_ext` is what tells the
sniffer a file is code at all, so an unclaimed extension does not degrade to
"code without symbols" — it falls through to the prose extractor. A `.mts` file is
indexed with no `language`, no `defs`, no `symbols`, and is split into several
body-only records instead of one document. It is invisible to symbol search, and
anything that treats one hit as one file counts it several times.

Node-ESM TypeScript projects use `.mts` for entry points and test suites — the
modules most likely to be looked up by name.

## Fix

One registry row: `&["ts"]` → `&["ts", "mts", "cts"]`, plus a comment recording
why the omission was not harmless.

## Failing test first

`typescript_module_extensions`, run against unfixed `main`:

```
---- extract::code::tests::typescript_module_extensions stdout ----
thread 'extract::code::tests::typescript_module_extensions' panicked at
crates/xerj-autoindex/src/extract/code.rs:458:9:
mts must be recognised as code

test result: FAILED. 24 passed; 3 failed
```

(That run also contained the two failures fixed by the sibling PRs; this branch
carries only the extension test.)

## Verified — commands run in this environment, output observed

- `cargo test -p xerj-autoindex --lib extract::code` on unfixed main → the failure above
- `cargo test -p xerj-autoindex --lib extract::code` on this branch → `ok. 25 passed; 0 failed`
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- ES-YAML conformance suite -> `1366 passed · 0 failed · 3 skipped · 1369 total`,
  runner exit 0. Disclosure: I ran the gate once, on the `fix/php-enum-and-const`
  branch's tree, not separately on this one. All three branches change the same
  crate (`xerj-autoindex`) and touch no ES wire surface — this one is
  a single registry row.

## Assumed — NOT tested

- That `.cts` appears in real corpora at a rate worth claiming. I added it for
  symmetry with `.cjs` and because the grammar handles it identically; I measured
  `.mts` only. Falsified by a corpus where `.cts` parses differently under
  `LANGUAGE_TYPESCRIPT`.

## Evidence boundary

The behaviour was first observed while indexing a private TypeScript monorepo
(~1,600 first-party TS-family files), where 279 `.mts` files carried no
`language`, `defs` or `symbols`. That corpus is not shareable, so the committed
test — not the number — is the reproducible evidence here.

## Not run

- The crate's wider suite has a pre-existing, platform-specific failure on macOS,
  `content::tests::lossy_display_collisions_keep_distinct_alias_identities`
  (`Os { code: 92, "Illegal byte sequence" }` — APFS rejects the non-UTF-8
  filename the test creates). It reproduces on unmodified `main` in this
  environment and is unrelated to this change.
