### PR TITLE
autoindex: capture exported module const in TypeScript

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -237,6 +237,42 @@ const JS_Q: &str = r#"
 (export_statement declaration: (lexical_declaration (variable_declarator name: (identifier) @function value: (arrow_function))))
 "#;
 
+// The last pattern is #170's failure mode in the language where it is most
+// common. Modern TypeScript declares most of a module's public surface as
+// `export const x = someBuilder(...)` — schema/table definitions, routers,
+// config objects. That is not an `arrow_function`, so the arrow-valued pattern
+// above missed it, and a module made entirely of such declarations extracted
+// ZERO symbols.
+//
+// Scoped to EXPORTED module constants, deliberately, and narrower than the
+// obvious fix:
+//
+//   * `program > export_statement` only. A bare `program > lexical_declaration`
+//     would also pick up module-private constants. That was measured and
+//     dropped — see the note below — because `defs` is a cross-file retrieval
+//     surface: what another module can name is what another module can search
+//     for. A private constant is found by `body` search, by a caller who is
+//     already in the right file.
+//   * Anchored, not free-floating: `lexical_declaration` is the same node
+//     inside a function body, so an unanchored pattern would fill `defs` with
+//     every function-local `const` — the 90%-locals trap measured for C in #170.
+//   * `"const"` token matched, so `let` stays out: `lexical_declaration` covers
+//     both, and a mutable module binding is state, not a constant.
+//
+// Measured, and the reason for the narrower scope: on a private TypeScript
+// monorepo (~1,600 TS-family files) the broad form was benchmarked against the
+// unpatched engine across 8 retrieval tasks and produced no token improvement
+// (+1.8%, inside a per-task spread of -11%..+12%), at unchanged answer accuracy.
+// It did cut search round-trips by 19%, but every extra symbol is paid for on
+// every response that carries the array. With no demonstrated retrieval gain,
+// the private half of the capture was not worth its weight; the exported half
+// is what closes the zero-symbol hole.
+//
+// An arrow-valued exported const is captured twice on purpose — `@function` by
+// the pattern above and `@const` here. `defs` dedups on (kind, name), so the
+// file becomes reachable by both `function Button` and `const Button`, which is
+// what a caller searching for either would expect; suppressing one would mean
+// choosing which of the two true statements to hide.
 const TS_Q: &str = r#"
 (function_declaration name: (identifier) @function)
 (class_declaration name: (type_identifier) @class)
@@ -245,6 +281,7 @@ const TS_Q: &str = r#"
 (type_alias_declaration name: (type_identifier) @type)
 (enum_declaration name: (identifier) @enum)
 (variable_declarator name: (identifier) @function value: (arrow_function))
+(program (export_statement declaration: (lexical_declaration "const" (variable_declarator name: (identifier) @const))))
 "#;
 
 // `const_item` / `static_item` are captured because a file whose whole content
@@ -485,6 +522,51 @@ mod tests {
         assert!(has(&s, "C", "class"));
         assert!(has(&s, "m", "method"));
         assert!(has(&s, "f", "function"));
+    }
+
+    /// Exported module constants. `export const x = someBuilder(...)` is the
+    /// dominant way modern TypeScript declares a module's public surface
+    /// (schema/table/router builders, config objects). It is not an
+    /// `arrow_function`, so before this the only const pattern (arrow-valued)
+    /// missed it and a module consisting of such declarations extracted ZERO
+    /// symbols — #170's failure mode, in the language where it is most common.
+    /// The negative assertions below are the scope boundary, not omissions.
+    #[test]
+    fn typescript_module_const() {
+        let s = syms(
+            "typescript",
+            "export const users = pgTable(\"users\", {});\n\
+             export const ROUTES = [\"a\", \"b\"];\n\
+             const MAX_BODY_CHARS = 30_000;\n\
+             export let mutableState = 2;\n\
+             function f(){ const local = 1; return local; }\n",
+        );
+        assert!(has(&s, "users", "const"), "got {s:?}");
+        assert!(has(&s, "ROUTES", "const"), "got {s:?}");
+        // Module-PRIVATE const stays out. Not an oversight: `defs` is the
+        // cross-file retrieval surface, and the broad form that also captured
+        // these showed no retrieval gain while adding weight to every response
+        // that carries the array — see the note on TS_Q.
+        assert!(
+            !has(&s, "MAX_BODY_CHARS", "const"),
+            "captured a module-private const: {s:?}"
+        );
+        // Function-local `const` must NOT be captured, or `defs` fills with
+        // locals — the same trap measured at 90% noise for C in #170.
+        assert!(!has(&s, "local", "const"), "captured a local: {s:?}");
+        // `let` is mutable module state, not a constant, even when exported.
+        assert!(!has(&s, "mutableState", "const"), "captured a let: {s:?}");
+    }
+
+    /// Pins the deliberate overlap documented on TS_Q: an arrow-valued module
+    /// const is both a function and a const, and is captured as both so either
+    /// search term reaches the file. If a future edit suppresses one, this
+    /// fails and the reader is sent to the comment explaining the choice.
+    #[test]
+    fn typescript_arrow_const_is_both_kinds() {
+        let s = syms("typescript", "export const Button = () => 1;\n");
+        assert!(has(&s, "Button", "function"), "got {s:?}");
+        assert!(has(&s, "Button", "const"), "got {s:?}");
     }
     #[test]
     fn rust() {


### PR DESCRIPTION
Written by an AI coding agent (Claude Opus 5 via Claude Code), run by @pradaev.
@pradaev has signed the CLA (#289) and approved this for review.

**Rescoped after benchmarking.** The first revision of this branch also captured
module-private `const`. I measured it, found no retrieval gain, and narrowed the
change. Details and numbers below — the negative result is the reason for the
current scope.

## Defect

`TS_Q` captured a `const` only when its value was an `arrow_function`. That covers a
component or a handler and misses how modern TypeScript declares a module's public
surface:

```ts
export const users  = pgTable("users", { ... });   // schema / table
export const router = createRouter({ ... });       // router
```

Neither is an arrow function, so neither reached `defs`. A module whose whole public
surface is built by factory calls — a database schema, a route table, a config object —
extracted **zero** symbols and could not be found by symbol search at all. That is
#170's failure mode in the language where the idiom is most common.

## Fix

```
(program (export_statement declaration: (lexical_declaration "const" (variable_declarator name: (identifier) @const))))
```

Three boundaries, each pinned by an assertion:

- **Exported only.** `defs` is the cross-file retrieval surface: what another module can
  name is what another module can search for. A module-private constant is reachable by
  `body` search, by a caller already in the right file.
- **Anchored** to `program` through `export_statement`. `lexical_declaration` is the same
  node inside a function body, so an unanchored pattern would fill `defs` with every
  function-local `const` — the 90%-locals trap measured for C in #170.
- **`"const"` token matched**, so `let` stays out even when exported: a mutable module
  binding is state, not a constant.

An arrow-valued exported const is captured twice on purpose, `@function` and `@const`.
`defs` dedups on (kind, name), so the file answers both `function Button` and
`const Button`; `typescript_arrow_const_is_both_kinds` pins it.

## Why not the broader scope — the measurement that changed this PR

The first revision also captured module-private `const`. I benchmarked it end to end
against the unpatched engine: same 8 retrieval tasks, same corpus, same prompts, same
model, index rebuilt with the patched binary, one run per task.

| metric | unpatched index | patched (broad scope) |
|---|---|---|
| tokens | 347,221 | 353,521 (**+1.8%**) |
| tool calls | 69 | 74 (+7.2%) |
| wall time | 481 s | 510 s (+6.0%) |
| search round-trips | 53 | **43 (−18.9%)** |
| answer accuracy | 31.5 / 32 | 31.5 / 32 (unchanged) |

**No token improvement.** Per-task deltas ran −11.2% to +11.6%, so +1.8% is inside the
noise of a single run per task — the honest reading is "no effect detected", not
"regression". The one metric outside that spread favours the change (19% fewer search
round-trips at equal accuracy), which is consistent with symbols letting a caller land in
one hop; but each response now carries a larger `symbols` array, and that appears to eat
the saving.

The task I expected to benefit most — "list all 32 tables in the schema module", whose
target file went from zero symbols to 32 — got **7.9% more expensive**: the agent
received the symbols and still re-verified with grep.

Given no demonstrated retrieval gain, I cut the half of the capture that costs the most
and buys the least. Measured on the same corpus (1,634 TS-family files):

| scope | files gaining const symbols | const symbols added |
|---|---|---|
| private + exported | 918 | 2,382 |
| **exported only (this PR)** | **238** | **518** |

**78% less added weight, and the motivating case is untouched** — the schema module still
yields all 32 tables with exact line numbers.

## Failing test first

`typescript_module_const`, run against unfixed `main` — the extractor found only the
function and none of the module constants:

```
---- extract::code::tests::typescript_module_const stdout ----
thread 'extract::code::tests::typescript_module_const' panicked at
crates/xerj-autoindex/src/extract/code.rs:487:9:
got [("f", "function", 4)]

test result: FAILED. 24 passed; 3 failed
```

## Verified — commands run in this environment, output observed

- `cargo test -p xerj-autoindex --lib extract::code` on unfixed main → the failure above
- `cargo test -p xerj-autoindex --lib extract::code` on this revision → `ok. 26 passed; 0 failed`
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- ES-YAML conformance suite on this revision's tree:
  `./target/release/es-yaml-runner --dir tests/es-compat-yaml/yaml`
  → `1366 passed · 0 failed · 3 skipped · 1369 total`, runner exit 0
- Scope comparison (918/2,382 vs 238/518) produced by running `parse_symbols` over every
  `.ts`/`.tsx`/`.mts` file of the corpus under each query, in a throwaway test.
- Node shapes confirmed via `to_sexp()` before writing the pattern: an exported module
  const is `(program (export_statement declaration: (lexical_declaration (variable_declarator …))))`,
  a function-local one sits under `(statement_block …)`.

## Assumed — NOT tested

- That module-private constants are not worth capturing **in general**. I measured one
  corpus and 8 tasks; a codebase that keeps its tuning knobs private and greps for them by
  name would want the broader scope. Falsified by a corpus where private constants are the
  thing callers search for.
- Namespace/ambient blocks (`declare module { export const X = 1 }`) are not captured —
  not direct children of `program`. Frequency not measured.
- `var` at module scope is not captured (different node). Treated as legacy.

## Evidence boundary

The benchmark and the scope comparison ran against a private TypeScript monorepo that is
not shareable; the committed tests are the reproducible evidence, and the percentages are
context for the scoping decision rather than something you can re-run here.

## Not run

- Pre-existing macOS-only failure in the crate's wider suite
  (`content::tests::lossy_display_collisions_keep_distinct_alias_identities`,
  `Os { code: 92, "Illegal byte sequence" }`), reproduced on unmodified `main` in this
  environment and unrelated to this change.
