### PR TITLE
autoindex: capture PHP enums and class constants

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -409,12 +409,28 @@ const RUBY_Q: &str = r#"
 (module name: (constant) @module)
 "#;
 
+// `enum_declaration` was missing entirely, which is worse than a missing kind:
+// a PHP 8.1 enum file declares no class, interface or trait, so it extracted
+// ZERO symbols and could not be reached by symbol search at all (#170).
+//
+// `const_declaration` covers both a class/interface/enum constant and a
+// file-scope `const`, in one pattern — the grammar uses the same node for
+// both, with `const_element` holding the name. This is the only way to write a
+// named constant inside a PHP type, so without it a class of nothing but
+// constants was invisible.
+//
+// No anchoring here, unlike C/Go/Rust: PHP has no function-local `const`
+// statement, so there is no locals trap to guard against. (`define()` is a
+// function call, a different node, and is deliberately not captured.)
 const PHP_Q: &str = r#"
 (function_definition name: (name) @function)
 (method_declaration name: (name) @method)
 (class_declaration name: (name) @class)
 (interface_declaration name: (name) @interface)
 (trait_declaration name: (name) @trait)
+(enum_declaration name: (name) @enum)
+(enum_case name: (name) @const)
+(const_declaration (const_element (name) @const))
 "#;
 
 // Also no constant capture, for a blunter reason than Java: there were 4 C#
@@ -720,6 +736,31 @@ mod tests {
         assert!(has(&s, "C", "class"));
         assert!(has(&s, "m", "method"));
         assert!(has(&s, "I", "interface"));
+    }
+
+    /// PHP 8.1 enums and class constants. `enum_declaration` was absent from
+    /// PHP_Q entirely, so an enum file extracted zero symbols and was
+    /// unreachable by symbol search; class constants — PHP's only way to write
+    /// a named constant inside a type — were invisible for the same reason.
+    /// PHP has no function-local `const` statement, so unlike C/Go/Rust these
+    /// patterns need no anchoring.
+    #[test]
+    fn php_enum_and_const() {
+        let s = syms(
+            "php",
+            "<?php\n\
+             enum Suit: string { case Hearts = 'H'; case Spades = 'S'; }\n\
+             class C { const LIMIT = 5; public const int TYPED = 1; }\n\
+             interface I { const IFACE_CONST = 2; }\n\
+             const TOP_LEVEL = 3;\n",
+        );
+        assert!(has(&s, "Suit", "enum"), "got {s:?}");
+        assert!(has(&s, "Hearts", "const"), "got {s:?}");
+        assert!(has(&s, "Spades", "const"), "got {s:?}");
+        assert!(has(&s, "LIMIT", "const"), "got {s:?}");
+        assert!(has(&s, "TYPED", "const"), "got {s:?}");
+        assert!(has(&s, "IFACE_CONST", "const"), "got {s:?}");
+        assert!(has(&s, "TOP_LEVEL", "const"), "got {s:?}");
     }
     #[test]
     fn csharp() {


### PR DESCRIPTION
Written by an AI coding agent (Claude Opus 5 via Claude Code), run by @pradaev.
@pradaev has signed the CLA (#289) and approved this for review.

## Defect

`PHP_Q` matched functions, methods, classes, interfaces and traits.
`enum_declaration` was absent, and so was every form of named constant.

**The enum gap is the severe one**, because it is not a missing kind on an
otherwise-indexed file. A PHP 8.1 enum declares no class, no interface and no
trait, so a file holding one extracted **zero** symbols — the type could not be
found by its own name through symbol search at all. That is #170's failure mode.
Backed enums are the idiomatic way to express a closed set of values in modern
PHP, and they are exactly what a caller looks up by name.

**Class constants** are PHP's only way to write a named constant inside a type.
Without them, a class made mostly of constants — a limits table, a status
registry — carried only its own name into `defs`, and the constant the caller was
searching for was not there.

## Fix

```
(enum_declaration name: (name) @enum)
(enum_case name: (name) @const)
(const_declaration (const_element (name) @const))
```

- One `const_declaration` pattern serves both a class/interface/enum constant and
  a file-scope `const` — the grammar uses the same node for both, with
  `const_element` holding the name. Verified against `to_sexp()` output, including
  the modifier-and-type form `public const int X = 1`, where the name still sits
  in `const_element`.
- **Deliberately not anchored**, unlike the C, Go and Rust queries. PHP has no
  function-local `const` statement, so there is no locals trap to guard against,
  and anchoring would only cost recall on constants declared inside a namespace
  block. `define()` is a function call — a different node — and stays uncaptured.
- Enum cases are `@const`, matching how Go's `const_spec` members are treated: a
  case is a named constant of the enum type, and it is what a caller greps for
  when they know the value but not the type.

## Failing test first

`php_enum_and_const`, run against unfixed `main`. Note what is in the output: the
class and the interface, and nothing else — the enum `Suit` is absent entirely,
along with all five constants:

```
---- extract::code::tests::php_enum_and_const stdout ----
thread 'extract::code::tests::php_enum_and_const' panicked at
crates/xerj-autoindex/src/extract/code.rs:513:9:
got [("C", "class", 3), ("I", "interface", 4)]

test result: FAILED. 24 passed; 3 failed
```

## Verified — commands run in this environment, output observed

- `cargo test -p xerj-autoindex --lib extract::code` on unfixed main → the failure above
- `cargo test -p xerj-autoindex --lib extract::code` on this branch → `ok. 25 passed; 0 failed`
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- ES-YAML conformance suite, on this branch's tree:
  `./target/release/es-yaml-runner --dir tests/es-compat-yaml/yaml`
  -> `1366 passed · 0 failed · 3 skipped · 1369 total`, runner exit 0
  (release binary built from this branch, node started on a fresh `mktemp -d`)
- Node shapes confirmed by dumping `to_sexp()` before writing the patterns:
  `(enum_declaration name: (name) … body: (enum_declaration_list (enum_case name: (name) …)))`
  and `(const_declaration (visibility_modifier) type: (primitive_type) (const_element (name) …))`.

## Assumed — NOT tested

- Enum cases of a *pure* enum (no backing type) are assumed to use the same
  `enum_case` node as a backed enum. The test covers the backed form only.
  Falsified by a grammar that gives pure cases a different node.
- Capturing every enum case is assumed to be net-positive rather than noise. A
  very large enum will now contribute many `@const` entries. Go's grouped
  `const (…)` sets the precedent, but I did not measure the distribution of PHP
  enum sizes.

## Evidence boundary

First observed while indexing a private PHP monolith: 571 files whose top-level
declaration is an `enum` produced no `defs`/`symbols`, confirmed by fetching one
such document from a running node and finding `language: php` with both fields
absent. That corpus is not shareable, so the committed test is the reproducible
evidence.

## Not run

- Pre-existing macOS-only failure in the crate's wider suite
  (`content::tests::lossy_display_collisions_keep_distinct_alias_identities`,
  `Os { code: 92, "Illegal byte sequence" }`), reproduced on unmodified `main`
  in this environment and unrelated to this change.
