### PR TITLE
Add pradaev to .contributors (CLA)

### DIFF
--- a/.contributors
+++ b/.contributors
@@ -2,5 +2,6 @@
   "xerj-org",
   "dependabot[bot]",
   "Vinz2168",
-  "buger"
+  "buger",
+  "pradaev"
 ]


### PR DESCRIPTION
Signing the CLA.

I have read [CLA.md](../blob/main/CLA.md), including section 5 on generative AI,
and I agree to it for my contributions to this project.

This branch adds only my username to `.contributors`, as the signing
instructions ask.

Context for the reviewer, in the spirit of `.github/AI_CONTRIBUTIONS.md`: the
commit itself was produced by an AI coding agent (Claude Opus 5 via Claude Code)
running under my account and at my explicit instruction. The agreement is mine —
I am the party making the section 4 representations and the account is the
signature.

Signed in support of #284, #285 and #286.
