### PR TITLE
fix(engine,api): dynamic mapping opacity for nested objects (mapping never recurses, then _mapping/_field_caps never merge it in)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -13,7 +13,7 @@ use axum::{
 use chrono::{Datelike, TimeZone, Timelike, Utc};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 use xerj_common::types::{FieldConfig, FieldType, Schema};
 use xerj_query::parse_request;
@@ -2430,6 +2430,85 @@ fn merge_dotted_property(
     merge_dotted_property(sub_obj, &rest, leaf_value);
 }
 
+/// Merge a stored (explicit, cached-at-index-creation) mapping's
+/// `properties` with the live schema-derived `properties`
+/// (`schema_to_es_properties`).
+///
+/// The stored declaration wins for any field it names -- it may carry
+/// explicit settings (`ignore_above`, `analyzer`, `dense_vector` options,
+/// ...) the schema's own type inference wouldn't reconstruct identically.
+/// But a field the live schema knows about and the stored blob doesn't is
+/// still included, instead of being permanently invisible: without this,
+/// GET _mapping/_field_caps serve the ORIGINAL index-creation-time blob
+/// forever, and any field discovered dynamically since -- flat or nested,
+/// at any depth -- never appears in either, no matter how long the index
+/// has been receiving new documents.
+///
+/// Recurses into whichever nested-children key each side actually uses
+/// (`properties` for Object/Nested, `fields` for a leaf's multi-fields),
+/// so a field explicitly declared without its own nested declaration
+/// (e.g. a bare `{"type": "object"}`) still picks up children discovered
+/// dynamically since, rather than only ever getting top-level treatment.
+fn merge_mapping_properties(
+    stored_properties: &serde_json::Map<String, Value>,
+    live_properties: &serde_json::Map<String, Value>,
+) -> serde_json::Map<String, Value> {
+    let mut merged = stored_properties.clone();
+    for (key, live_val) in live_properties {
+        match merged.get_mut(key) {
+            None => {
+                merged.insert(key.clone(), live_val.clone());
+            }
+            Some(stored_val) => {
+                for children_key in ["properties", "fields"] {
+                    let Some(live_children) =
+                        live_val.get(children_key).and_then(|v| v.as_object())
+                    else {
+                        continue;
+                    };
+                    let stored_children = stored_val
+                        .get(children_key)
+                        .and_then(|v| v.as_object())
+                        .cloned()
+                        .unwrap_or_default();
+                    let merged_children = merge_mapping_properties(&stored_children, live_children);
+                    if let Some(obj) = stored_val.as_object_mut() {
+                        obj.insert(children_key.to_string(), Value::Object(merged_children));
+                    }
+                }
+            }
+        }
+    }
+    merged
+}
+
+/// Companion `dense_vector` fields the engine auto-creates for each
+/// `semantic_text` field (e.g. `body` -> `body_vector`, or `target_field`
+/// if the caller declared one) are an implementation detail, never meant
+/// to be user-visible -- nothing in the caller's own mapping ever names
+/// them. Once a document makes the live schema aware of a companion field,
+/// `merge_mapping_properties` above would otherwise happily surface it in
+/// `GET _mapping`/`_field_caps`, even though it was never declared under
+/// that name by anyone. Scans `stored_properties` (the only place a
+/// `semantic_text` field can legitimately be declared -- dynamic mapping
+/// never infers that type) for each one and returns the companion name
+/// `semantic_mapping_contract` computes for it, so callers can filter
+/// those out of what they feed into `merge_mapping_properties`.
+fn semantic_companion_field_names(
+    stored_properties: &serde_json::Map<String, Value>,
+) -> HashSet<String> {
+    stored_properties
+        .iter()
+        .filter_map(|(name, def)| {
+            let obj = def.as_object()?;
+            (obj.get("type").and_then(Value::as_str) == Some("semantic_text")).then(|| {
+                let (target, _dimensions, _similarity) = semantic_mapping_contract(name, obj);
+                target
+            })
+        })
+        .collect()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // GET /{index}/_mapping
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2476,17 +2555,43 @@ pub async fn get_mapping(
             .get(name)
             .map(|v| v.clone())
             .unwrap_or(Value::Null);
-        let mut mappings = if stored.is_null() {
-            match &idx {
-                Some(i) => {
-                    let schema = i.schema().await;
-                    let properties = schema_to_es_properties(&schema);
-                    json!({ "properties": properties })
-                }
-                None => json!({ "properties": {} }),
+        let mut mappings = match (&idx, stored.is_null()) {
+            (Some(i), true) => {
+                let schema = i.schema().await;
+                let properties = schema_to_es_properties(&schema);
+                json!({ "properties": properties })
             }
-        } else {
-            stored
+            // A live index with a stored (explicit-at-creation) mapping:
+            // merge in anything the live schema has picked up dynamically
+            // since -- otherwise a field discovered after index creation
+            // (flat or nested, at any depth) is permanently invisible here,
+            // forever serving the exact blob index creation started with.
+            (Some(i), false) => {
+                let schema = i.schema().await;
+                let mut live_properties = schema_to_es_properties(&schema);
+                let stored_properties = stored
+                    .get("properties")
+                    .and_then(|p| p.as_object())
+                    .cloned()
+                    .unwrap_or_default();
+                // semantic_text's own companion dense_vector fields are an
+                // engine-internal implementation detail, never declared by
+                // the caller under that name -- exclude them from what the
+                // live schema contributes, same as they were never visible
+                // before this merge existed (see semantic_companion_field_names).
+                let companions = semantic_companion_field_names(&stored_properties);
+                live_properties.retain(|k, _| !companions.contains(k));
+                let merged = merge_mapping_properties(&stored_properties, &live_properties);
+                let mut m = stored.clone();
+                if let Some(obj) = m.as_object_mut() {
+                    obj.insert("properties".to_string(), Value::Object(merged));
+                }
+                m
+            }
+            // No live index (failed index, #206) -- nothing to merge with,
+            // serve whatever's recoverable as-is.
+            (None, false) => stored,
+            (None, true) => json!({ "properties": {} }),
         };
         // ES injects default `rescore_vector.oversample: 3.0` on any
         // dense_vector whose `index_options.type` is BBQ-quantised
@@ -18818,6 +18923,77 @@ pub struct FieldCapsParams {
     pub fields: Option<String>,
 }
 
+/// Register one `_field_caps` entry for `field`, dotted-path-qualified by
+/// `dotted_prefix`, then recurse into its own nested `properties` children
+/// (Object/Nested only) so those get their own dotted-path entries too --
+/// e.g. a `metadata` object field with a `kind` child registers both
+/// `metadata` AND `metadata.kind`, not just the former.
+///
+/// Deliberately does NOT recurse into a leaf field's `fields` (multi-field
+/// siblings like `.keyword`) -- that's a different concept (the same value
+/// indexed a second way, not a distinct child field) and stays the job of
+/// `collect_multi_fields`, called separately with the same merged
+/// `properties` this function is given. Before this function existed, the
+/// per-field loop only ever looked at the top-level `schema.fields`, so a
+/// nested object's own children (`metadata.kind` itself, not just further
+/// multi-fields under it like `metadata.kind.keyword`) were never their
+/// own `_field_caps` entry, even once the mapping/properties correctly
+/// described them.
+#[allow(clippy::too_many_arguments)]
+fn register_field_cap_entry(
+    field: &FieldConfig,
+    dotted_prefix: &str,
+    properties: &Value,
+    fields_filter: &str,
+    idx_name: &str,
+    fields_map: &mut HashMap<String, serde_json::Map<String, Value>>,
+) {
+    let dotted_name = if dotted_prefix.is_empty() {
+        field.name.clone()
+    } else {
+        format!("{dotted_prefix}.{}", field.name)
+    };
+
+    let matches = fields_filter == "*"
+        || fields_filter
+            .split(',')
+            .any(|f| source_field_matches(&dotted_name, f.trim()));
+    if matches {
+        let native_es_type = native_type_to_es_str(&field.field_type);
+        let es_type = declared_flattened_type(properties, &dotted_name)
+            .or_else(|| declared_numeric_type(properties, &dotted_name))
+            .unwrap_or(native_es_type);
+        let searchable = field.is_searchable();
+        let aggregatable = field.is_aggregatable();
+
+        let type_map = fields_map.entry(dotted_name.clone()).or_default();
+        let type_entry = type_map.entry(es_type.to_string()).or_insert_with(|| {
+            json!({
+                "type": es_type,
+                "searchable": searchable,
+                "aggregatable": aggregatable,
+                "indices": []
+            })
+        });
+        if let Some(arr) = type_entry["indices"].as_array_mut() {
+            arr.push(Value::String(idx_name.to_string()));
+        }
+    }
+
+    if matches!(field.field_type, FieldType::Object | FieldType::Nested) {
+        for child in &field.fields {
+            register_field_cap_entry(
+                child,
+                &dotted_name,
+                properties,
+                fields_filter,
+                idx_name,
+                fields_map,
+            );
+        }
+    }
+}
+
 pub async fn field_caps(
     State(state): State<AppState>,
     Path(index): Path<String>,
@@ -18867,45 +19043,42 @@ pub async fn field_caps(
             .get(idx_name.as_str())
             .map(|v| v.clone())
             .unwrap_or(Value::Null);
+        let mut live_properties = schema_to_es_properties(&schema);
         let properties = if stored_mapping.is_null() {
-            Value::Object(schema_to_es_properties(&schema))
+            Value::Object(live_properties)
         } else {
-            stored_mapping
+            // Merge, don't just fall back to the cached blob: a field the
+            // live schema has discovered since index creation (flat or
+            // nested, at any depth) must still surface here, not only ever
+            // the fields the index started with (see get_mapping, same
+            // fix). `declared_flattened_type`/`declared_numeric_type`
+            // below need the stored declaration where there is one, hence
+            // merging rather than switching to `live_properties` outright.
+            let stored_properties = stored_mapping
                 .get("properties")
+                .and_then(|p| p.as_object())
                 .cloned()
-                .unwrap_or_else(|| json!({}))
+                .unwrap_or_default();
+            // Exclude semantic_text's own companion dense_vector fields --
+            // never declared by the caller under that name, see
+            // semantic_companion_field_names (same exclusion as get_mapping).
+            let companions = semantic_companion_field_names(&stored_properties);
+            live_properties.retain(|k, _| !companions.contains(k));
+            Value::Object(merge_mapping_properties(
+                &stored_properties,
+                &live_properties,
+            ))
         };
 
         for field in &schema.fields {
-            // Support comma-separated field list and wildcard suffix.
-            if fields_filter != "*" {
-                let matches = fields_filter
-                    .split(',')
-                    .any(|f| source_field_matches(&field.name, f.trim()));
-                if !matches {
-                    continue;
-                }
-            }
-
-            let native_es_type = native_type_to_es_str(&field.field_type);
-            let es_type = declared_flattened_type(&properties, &field.name)
-                .or_else(|| declared_numeric_type(&properties, &field.name))
-                .unwrap_or(native_es_type);
-            let searchable = field.is_searchable();
-            let aggregatable = field.is_aggregatable();
-
-            let type_map = fields_map.entry(field.name.clone()).or_default();
-            let type_entry = type_map.entry(es_type.to_string()).or_insert_with(|| {
-                json!({
-                    "type": es_type,
-                    "searchable": searchable,
-                    "aggregatable": aggregatable,
-                    "indices": []
-                })
-            });
-            if let Some(arr) = type_entry["indices"].as_array_mut() {
-                arr.push(Value::String(idx_name.clone()));
-            }
+            register_field_cap_entry(
+                field,
+                "",
+                &properties,
+                fields_filter,
+                idx_name,
+                &mut fields_map,
+            );
         }
 
         // Multi-fields (`"fields": {"keyword": {"type": "keyword"}}`) are

--- a/engine/crates/xerj-api/src/memory_api.rs
+++ b/engine/crates/xerj-api/src/memory_api.rs
@@ -183,10 +183,22 @@ async fn ensure_backing_index(
     // similarity. 384 mirrors the built-in embedder width (xerj_ai DEFAULT_DIMS);
     // kept as a literal to avoid a build-graph edge from xerj-api onto xerj-ai
     // (same convention as es_compat's semantic_text mapper).
+    //
+    // `metadata` is deliberately NOT pre-declared here (unlike `text`/
+    // `stored_at`, which are always present and same-shaped). Its own shape
+    // is caller-defined and varies per memory, so pinning it to a bare
+    // `{"type": "object"}` up front would permanently prevent its keys from
+    // ever being dynamically mapped -- once a field has ANY explicit
+    // mapping entry, later documents no longer go through dynamic
+    // discovery for it, even a shallow one with no `properties`. Leaving it
+    // out lets the first stored memory's `metadata` keys flow through the
+    // engine's normal dynamic-mapping path instead, which now recurses
+    // into nested objects (see xerj-engine's `dynamic_field_config`), so
+    // `metadata.kind`/`metadata.topic`/etc. become real, `_mapping`-visible
+    // fields instead of being permanently opaque.
     let mut properties = json!({
         "text": { "type": "semantic_text", "dimensions": 384 },
-        "stored_at": { "type": "long" },
-        "metadata": { "type": "object" }
+        "stored_at": { "type": "long" }
     });
     if let Some(dims) = vector_dims {
         if dims == 0 {

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -36440,11 +36440,7 @@ mod date_detection_tests {
         assert!(matches!(kind.fields[0].field_type, FieldType::Keyword));
 
         // Multi-level nesting: object -> object -> leaf.
-        let fc = dynamic_field_config(
-            "a",
-            &serde_json::json!({"b": {"c": 1}}),
-            true,
-        );
+        let fc = dynamic_field_config("a", &serde_json::json!({"b": {"c": 1}}), true);
         let b = &fc.fields[0];
         assert_eq!(b.name, "b");
         assert!(matches!(b.field_type, FieldType::Object));
@@ -36493,7 +36489,11 @@ mod date_detection_tests {
             true,
         );
         assert!(matches!(fc.field_type, FieldType::Object));
-        assert_eq!(fc.fields.len(), 1, "only the first element's keys are discovered");
+        assert_eq!(
+            fc.fields.len(),
+            1,
+            "only the first element's keys are discovered"
+        );
         assert_eq!(fc.fields[0].name, "kind");
     }
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -28088,6 +28088,12 @@ fn infer_field_type(val: &Value, date_detection: bool) -> FieldType {
 /// `KeywordFieldMapper("keyword").ignoreAbove(256)`).
 const DYNAMIC_KEYWORD_IGNORE_ABOVE: u32 = 256;
 
+/// ES default `index.mapping.depth.limit` — how many `properties` levels a
+/// dynamically discovered document may nest before recursion stops. Applies
+/// only to the nested-object walk below; it does not change how deep an
+/// *explicit* `_mapping` PUT may nest (that path is unaffected by this cap).
+const DYNAMIC_MAPPING_DEPTH_LIMIT: usize = 20;
+
 /// Build the [`FieldConfig`] for a dynamically discovered field.
 ///
 /// Wraps [`infer_field_type`] and mirrors the ES default dynamic mapping for
@@ -28101,13 +28107,62 @@ const DYNAMIC_KEYWORD_IGNORE_ABOVE: u32 = 256;
 /// this records that contract in the schema rather than leaving it implicit.
 /// Sub-fields of a leaf parent are NOT top-level `schema.fields` entries, so
 /// the search path's text/keyword field sets are unaffected.
+///
+/// A nested JSON object gets the same treatment one level deeper: its own
+/// keys are recursively dynamic-mapped into child `FieldConfig`s under
+/// `fields`, the same way `Text` gets its `keyword` sibling -- `FieldConfig`
+/// and the ES-compat mapping renderer already both understand this dual
+/// meaning of `fields` (real `properties` on `Object`/`Nested`, multi-fields
+/// on a leaf type, see the doc comment on `FieldConfig::fields`); only the
+/// *dynamic-discovery* path was never populating it for `Object`, so a
+/// subfield like `metadata.kind` was genuinely queryable (the query path
+/// resolves dotted paths against `_source` regardless of the mapping) but
+/// invisible to `GET _mapping`/`_field_caps` -- indistinguishable from not
+/// existing to any client that discovers fields that way instead of already
+/// knowing the field name in advance (Kibana/OSD's own field list included).
+/// Array-of-objects is intentionally out of scope here: `infer_field_type`
+/// already only inspects an array's first element for its *type*, so this
+/// recurses into that same first element for consistency rather than
+/// attempting to reconcile a heterogeneous shape across array entries --
+/// no behavior change for arrays beyond what recursing into their inferred
+/// Object element already implies.
 fn dynamic_field_config(key: &str, val: &Value, date_detection: bool) -> FieldConfig {
+    dynamic_field_config_at_depth(key, val, date_detection, 1)
+}
+
+fn dynamic_field_config_at_depth(
+    key: &str,
+    val: &Value,
+    date_detection: bool,
+    depth: usize,
+) -> FieldConfig {
     let ft = infer_field_type(val, date_detection);
     let mut fc = FieldConfig::new(key.to_string(), ft);
-    if matches!(fc.field_type, FieldType::Text) {
-        let mut kw = FieldConfig::new("keyword".to_string(), FieldType::Keyword);
-        kw.options.ignore_above = Some(DYNAMIC_KEYWORD_IGNORE_ABOVE);
-        fc.fields.push(kw);
+    match fc.field_type {
+        FieldType::Text => {
+            let mut kw = FieldConfig::new("keyword".to_string(), FieldType::Keyword);
+            kw.options.ignore_above = Some(DYNAMIC_KEYWORD_IGNORE_ABOVE);
+            fc.fields.push(kw);
+        }
+        FieldType::Object if depth < DYNAMIC_MAPPING_DEPTH_LIMIT => {
+            // `val` itself may be the Array whose first element inferred
+            // Object (see doc comment) -- unwrap to whichever object is the
+            // real source of the nested keys.
+            let obj = val
+                .as_object()
+                .or_else(|| val.as_array()?.iter().find(|v| !v.is_null())?.as_object());
+            if let Some(obj) = obj {
+                for (sub_key, sub_val) in obj {
+                    fc.fields.push(dynamic_field_config_at_depth(
+                        sub_key,
+                        sub_val,
+                        date_detection,
+                        depth + 1,
+                    ));
+                }
+            }
+        }
+        _ => {}
     }
     fc
 }
@@ -36340,13 +36395,14 @@ mod date_detection_tests {
         assert!(matches!(fc.field_type, FieldType::Text));
         assert_eq!(fc.fields.len(), 1);
 
-        // Non-string inferences carry NO multi-field.
+        // Non-string leaf inferences carry NO multi-field. Object is
+        // exercised separately below (dynamic_object_recurses_into_nested_properties)
+        // since it now gets real child sub-fields, not zero.
         for (val, want_sub) in [
             (serde_json::json!(42), 0usize),
             (serde_json::json!(2.5), 0),
             (serde_json::json!(true), 0),
             (serde_json::json!("2026-07-25T10:30:00Z"), 0), // date-detected
-            (serde_json::json!({"a": 1}), 0),
         ] {
             let fc = dynamic_field_config("f", &val, true);
             assert_eq!(fc.fields.len(), want_sub, "value {val} sub-field count");
@@ -36356,6 +36412,89 @@ mod date_detection_tests {
         let fc = dynamic_field_config("ts", &serde_json::json!("2026-07-25T10:30:00Z"), false);
         assert!(matches!(fc.field_type, FieldType::Text));
         assert_eq!(fc.fields.len(), 1);
+    }
+
+    /// A dynamically discovered nested object must recurse into its own
+    /// keys instead of staying an opaque `{"type": "object"}` -- otherwise
+    /// a subfield like `metadata.kind` is genuinely queryable (the query
+    /// path resolves dotted paths against `_source` regardless of the
+    /// mapping) but invisible to `GET _mapping`/`_field_caps`, indistinguishable
+    /// from not existing to any client that discovers fields that way. Found
+    /// via `/_memory`'s `metadata` field, which is exactly this shape.
+    #[test]
+    fn dynamic_object_recurses_into_nested_properties() {
+        let fc = dynamic_field_config(
+            "metadata",
+            &serde_json::json!({"kind": "preference", "topic": "language"}),
+            true,
+        );
+        assert!(matches!(fc.field_type, FieldType::Object));
+        assert_eq!(fc.fields.len(), 2, "both nested keys should be discovered");
+
+        let kind = fc.fields.iter().find(|f| f.name == "kind").expect("kind");
+        assert!(matches!(kind.field_type, FieldType::Text));
+        // Recursion composes with #209: a nested Text field gets its own
+        // .keyword multi-field too, same as a top-level one would.
+        assert_eq!(kind.fields.len(), 1);
+        assert_eq!(kind.fields[0].name, "keyword");
+        assert!(matches!(kind.fields[0].field_type, FieldType::Keyword));
+
+        // Multi-level nesting: object -> object -> leaf.
+        let fc = dynamic_field_config(
+            "a",
+            &serde_json::json!({"b": {"c": 1}}),
+            true,
+        );
+        let b = &fc.fields[0];
+        assert_eq!(b.name, "b");
+        assert!(matches!(b.field_type, FieldType::Object));
+        let c = &b.fields[0];
+        assert_eq!(c.name, "c");
+        assert!(matches!(c.field_type, FieldType::Long));
+
+        // Mixed-type nested keys are inferred independently, like top-level
+        // dynamic mapping already does.
+        let fc = dynamic_field_config(
+            "metadata",
+            &serde_json::json!({"count": 3, "active": true, "label": "x"}),
+            true,
+        );
+        let by_name = |n: &str| fc.fields.iter().find(|f| f.name == n).unwrap();
+        assert!(matches!(by_name("count").field_type, FieldType::Long));
+        assert!(matches!(by_name("active").field_type, FieldType::Boolean));
+        assert!(matches!(by_name("label").field_type, FieldType::Text));
+
+        // Depth limit: recursion stops at DYNAMIC_MAPPING_DEPTH_LIMIT rather
+        // than walking an adversarially deep document forever (ES has the
+        // same guard via index.mapping.depth.limit, default 20).
+        let mut deep = serde_json::json!(1);
+        for _ in 0..DYNAMIC_MAPPING_DEPTH_LIMIT + 5 {
+            deep = serde_json::json!({"n": deep});
+        }
+        let fc = dynamic_field_config("root", &deep, true);
+        let mut cur = &fc;
+        let mut levels = 0;
+        while let Some(next) = cur.fields.first() {
+            cur = next;
+            levels += 1;
+        }
+        assert!(
+            levels < DYNAMIC_MAPPING_DEPTH_LIMIT + 5,
+            "recursion must stop before reaching the artificially deep bottom, got {levels} levels"
+        );
+
+        // Array of objects: infer_field_type already only looks at the
+        // first non-null element to decide the *type* (Object); the
+        // dynamic-mapping walk mirrors that by recursing into the same
+        // element rather than reconciling every array entry's shape.
+        let fc = dynamic_field_config(
+            "tags",
+            &serde_json::json!([{"kind": "x"}, {"kind": "y", "extra": true}]),
+            true,
+        );
+        assert!(matches!(fc.field_type, FieldType::Object));
+        assert_eq!(fc.fields.len(), 1, "only the first element's keys are discovered");
+        assert_eq!(fc.fields[0].name, "kind");
     }
 
     /// Ingest-time acceptance for default-format date fields: lenient on


### PR DESCRIPTION
## Summary

A dynamically-discovered nested object field (e.g. `{"metadata": {"kind": "preference"}}`) is genuinely queryable (`{"term": {"metadata.kind": "..."}}` works — the query path resolves dotted paths against `_source` regardless of the mapping) but permanently invisible to `GET _mapping`/`_field_caps` — indistinguishable from not existing to any client that discovers fields that way instead of already knowing the field name in advance (Kibana/OSD's own field list included).

Three related, separately-fixable bugs turned out to be involved, all in `xerj-engine`/`xerj-api`'s dynamic-mapping path. This PR fixes all three.

## How this was found

Building an external MCP tool (an OpenSearch-Dashboards dashboard-authoring agent skill) that discovers a data index's fields purely through `_mapping`/`_field_caps` — the same way Kibana/OSD itself does — to build a visualization over a `/_memory` namespace's own backing index. `metadata.kind`/`metadata.topic` never appeared as discoverable fields, despite being real, queryable data.

## Root causes (traced in source, reproduced live at each step — not guessed)

**1. `infer_field_type`/`dynamic_field_config` (`xerj-engine/src/index.rs`) never recursed into `Value::Object`.** A nested object was always recorded as an opaque `{"type": "object"}` terminal during dynamic-mapping discovery, unlike real ES/OS default dynamic mapping, which recursively maps nested object properties (same `Text`→`.keyword` multi-field treatment as #209, one level deeper).

**2. `get_mapping`/`field_caps` (`xerj-api/src/es_compat.rs`) served the cached explicit-mapping blob (`state.engine.index_mappings`) verbatim, forever, whenever an index was created with *any* explicit mapping — even a partial one.** Not specific to nesting at all: isolated with a flat repro — `PUT idx {"mappings":{"properties":{"a":{"type":"text"}}}}`, then index a doc with an extra undeclared flat field `"b"` — `"b"` is permanently absent from `GET _mapping`, no matter how many more documents arrive. `field_caps`'s multi-field expansion (the `#209` mechanism, `collect_multi_fields`) inherited the same staleness since it walks the same cached `properties`.

**3. `field_caps`'s per-field loop only ever registered top-level field names.** Even with (1) and (2) fixed, a nested object's own children were still invisible: `collect_multi_fields` finds `metadata.kind.keyword` (a real multi-field, its designed job) but never `metadata.kind` itself (a `properties` child, a different concept the loop never walked into).

## Fix

- `dynamic_field_config` recurses into `Value::Object` via a depth-capped `dynamic_field_config_at_depth` helper (`DYNAMIC_MAPPING_DEPTH_LIMIT = 20`, mirrors ES's own default `index.mapping.depth.limit`), populating `FieldConfig.fields` with nested children. **No renderer changes needed** — `schema_to_es_properties` already branched correctly on `field.field_type` to emit `properties` vs `fields`; only the *discovery* path had never populated it for `Object`.
- New `merge_mapping_properties` recursively merges the stored explicit `properties` with the live schema-derived ones — the stored declaration wins for any field it names (preserves explicit settings type inference wouldn't reconstruct identically: `ignore_above`, analyzer, `dense_vector` options, ...), but a field only the live schema knows about is still included, at any depth. Wired into both `get_mapping` and `field_caps`.
- New `register_field_cap_entry` replaces `field_caps`'s top-level-only loop: registers each field dotted-path-qualified, then recurses into `Object`/`Nested`'s own `properties` children (leaving `.keyword`-style multi-field siblings to `collect_multi_fields`, avoiding double registration).
- `xerj-api/src/memory_api.rs`'s `ensure_backing_index`: `/_memory`'s own `metadata` field is no longer pre-declared as a bare `{"type": "object"}` — any explicit declaration, even a shallow one, permanently blocks a field from going through dynamic discovery again, so leaving it undeclared lets it flow through the (now-fixed) dynamic path on first write.

**Regression found and fixed before this was ready**: the live-schema merge above started leaking `semantic_text`'s own companion `dense_vector` field (e.g. `body` → `body_vector`, an engine-only implementation detail never declared by the caller under that name) into `_mapping` — caught by `api_semantic_bulk_builds_complete_hnsw_and_survives_restart`, which explicitly asserts the companion stays hidden. New `semantic_companion_field_names` scans the stored mapping for `semantic_text` declarations (the only place that type can legitimately appear — dynamic mapping never infers it) and excludes each one's companion name (via the existing `semantic_mapping_contract`) from what the live schema contributes to the merge.

## Verified

End-to-end against a live build, on the motivating real case (not just synthetic repros):

```
POST /_memory/repro {"text": "example", "metadata": {"kind": "preference", "topic": "language"}}

GET .xerj-memory-repro/_mapping
  -> metadata.properties.{kind,topic}, each with its own #209 .keyword multi-field

GET .xerj-memory-repro/_field_caps?fields=metadata.kind
  -> {"fields": {"metadata.kind": {"text": {...}}}}   (was: {"fields": {}})

GET .xerj-memory-repro/_field_caps?fields=*
  -> the complete correct set: metadata, metadata.kind, metadata.kind.keyword,
     metadata.topic, metadata.topic.keyword, text, text_vector, stored_at
```

- `cargo test -p xerj-api --lib`: 174/174 (includes 3 new/updated tests: `dynamic_object_recurses_into_nested_properties`, an updated `dynamic_string_gets_keyword_multi_field` — its non-string-leaf table was asserting the bug as expected behavior, `(json!({"a": 1}), 0)` — and the pre-existing `api_semantic_bulk_builds_complete_hnsw_and_survives_restart`, which is what caught the companion-field regression above).
- `cargo test -p xerj-engine --lib`: 463/465 (2 pre-existing, macOS-only `snapshot_path_security_tests` failures, unrelated — same ones called out as pre-existing in #290).
- `cargo clippy -p xerj-api -p xerj-engine --lib -- -D warnings`: clean.
- `cargo fmt -p xerj-api -p xerj-engine`: clean.
- Rebased onto `upstream/main` (rc.15) immediately before opening this PR — 0 commits behind, no conflicts on the dynamic-mapping-recursion commit; the mapping-merge commit auto-merged clean against the intervening `#202`/`#206` failed-index-recovery work in the same functions, verified by re-reading the merged `get_mapping`/`field_caps` bodies line by line rather than trusting a clean auto-merge.

## Scope

Two commits, independently reviewable:
1. `fix(engine): recurse dynamic mapping into nested object properties` — stands alone, correct and tested on its own merits, but **not sufficient by itself** to fix the real-world `/_memory` scenario (masked by bug 2 below) — flagging this so it doesn't read as "why doesn't this change anything I can observe" in isolation.
2. `fix(api): GET _mapping/_field_caps merge live schema instead of serving a stale index-creation blob` — the actual unblock for the motivating case, plus the field_caps nested-children fix and the companion-field regression fix.

**Deliberately left alone**: `field_caps` still exposes `text_vector`/`body_vector` via the separate top-level `schema.fields` loop (which reads the live schema directly and already showed it before this PR, confirmed against a pre-PR build — not a regression introduced here). No existing test requires `field_caps` to hide it (only the `_mapping` test does, and that one passes). Changing that would be scope creep beyond what this PR's repro and tests establish.

## Test plan

- [x] `cargo test -p xerj-api --lib` (174/174)
- [x] `cargo test -p xerj-engine --lib -- dynamic_` (2/2, new/updated tests)
- [x] `cargo test -p xerj-engine --lib` full suite (463/465, 2 pre-existing unrelated)
- [x] Reproduced each of the 3 bugs live before writing any fix, confirmed each is gone after
- [x] Reproduced the companion-field regression live, confirmed the fix closes it without reintroducing bug 2
- [x] `cargo clippy -p xerj-api -p xerj-engine --lib -- -D warnings`
- [x] `cargo fmt -p xerj-api -p xerj-engine -- --check`
- [x] Rebased clean against `upstream/main` immediately before opening
