### PR TITLE
test(api): make cluster-state read failure privilege-independent

### DIFF
--- a/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
+++ b/engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs
@@ -429,11 +429,11 @@ async fn a_corrupt_cluster_state_is_preserved_before_it_is_overwritten() {
 /// This is the worse half of the corrupt case and it was missed on the first
 /// pass: the bytes are perfectly good, only the `read(2)` failed — a uid
 /// change on a container volume, a backup tool's chmod, `EIO`, `EMFILE` at
-/// boot. The maps come up empty, and `write_file_atomic` renames
-/// `cluster_state.tmp` over the target; `rename(2)` needs write permission on
-/// the *directory*, not on the file, so a `PUT` answering
+/// boot. The maps come up empty, and `write_file_atomic` renames its staged
+/// file over the target; `rename(2)` needs write permission on the *directory*,
+/// not on the file, so a `PUT` answering
 /// `{"acknowledged": true}` unlinked a fully recoverable document. Measured
-/// on this test before the fix, with `chmod 000` for the boot only:
+/// before the fix with a read-error target that the atomic writer could replace:
 ///
 /// ```text
 /// PUT /_index_template/fresh -> 200 {"acknowledged":true}
@@ -443,7 +443,7 @@ async fn a_corrupt_cluster_state_is_preserved_before_it_is_overwritten() {
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn an_unreadable_cluster_state_is_never_overwritten() {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::symlink;
 
     let dir = tempfile::tempdir().expect("tempdir");
     {
@@ -452,17 +452,46 @@ async fn an_unreadable_cluster_state_is_never_overwritten() {
     }
 
     let state_path = dir.path().join("cluster_state.json");
+    let saved_path = dir.path().join("cluster_state.saved.json");
     let original = std::fs::read_to_string(&state_path).expect("read state");
     assert!(original.contains("logs-*"), "fixture must be on disk");
 
-    // Unreadable for the boot only; restored immediately afterwards so the
-    // assertions below read the file the node was left holding, and so a
-    // failure cannot be blamed on the test's own permissions.
-    std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o000))
-        .expect("chmod 000");
+    // Prove that this filesystem permits the destructive operation the latch
+    // prevents. A directory at the target would be a bad oracle because rename
+    // fails independently; a regular file can replace a symlink atomically.
+    let control_path = dir.path().join("replaceability-control");
+    let control_staged = dir.path().join("replaceability-staged");
+    symlink("replaceability-control", &control_path).expect("create control self-loop");
+    std::fs::write(&control_staged, b"replacement").expect("write control staging file");
+    std::fs::rename(&control_staged, &control_path)
+        .expect("a regular staged file must be able to replace the self-loop");
+    assert_eq!(
+        std::fs::read(&control_path).expect("read replacement control"),
+        b"replacement"
+    );
+    std::fs::remove_file(&control_path).expect("remove replacement control");
+
+    // A self-referential symlink makes read(2) fail with ELOOP even under root,
+    // while remaining replaceable by the atomic writer. Keep the valid bytes
+    // beside it so we can prove that the failed boot and refused writes did not
+    // alter the operator's configuration.
+    std::fs::rename(&state_path, &saved_path).expect("save valid cluster state");
+    symlink("cluster_state.json", &state_path).expect("create cluster-state self-loop");
+    let read_error = std::fs::read(&state_path).expect_err("self-loop must fail to read");
+    assert_ne!(
+        read_error.kind(),
+        std::io::ErrorKind::NotFound,
+        "the fixture must exercise the non-NotFound read-error branch"
+    );
+    assert!(
+        std::fs::symlink_metadata(&state_path)
+            .expect("inspect cluster-state self-loop")
+            .file_type()
+            .is_symlink(),
+        "the failing target must be a symlink, not a directory"
+    );
+
     let app = app_over(dir.path());
-    std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o644))
-        .expect("chmod 644");
 
     let (st, _) = get(&app, "/_index_template/logs").await;
     assert_eq!(
@@ -494,13 +523,28 @@ async fn an_unreadable_cluster_state_is_never_overwritten() {
     );
 
     assert_eq!(
-        std::fs::read_to_string(&state_path).expect("read state"),
+        std::fs::read_link(&state_path).expect("read cluster-state self-loop"),
+        std::path::PathBuf::from("cluster_state.json"),
+        "the refused write must not replace the unreadable target"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&saved_path).expect("read saved state"),
         original,
-        "the intact document must still be on disk, byte for byte"
+        "the intact document must remain recoverable, byte for byte"
     );
     assert!(
-        !dir.path().join("cluster_state.tmp").exists(),
-        "a refused write must not even stage a temp file"
+        !dir.path().join("cluster_state.corrupt.json").exists(),
+        "a read error must not be mislabeled as parse corruption"
+    );
+    assert!(
+        std::fs::read_dir(dir.path())
+            .expect("list data directory")
+            .all(|entry| !entry
+                .expect("read data-directory entry")
+                .file_name()
+                .to_string_lossy()
+                .starts_with("cluster_state.json.tmp.")),
+        "a refused write must not even stage a uniquely named temp file"
     );
 
     // And the refusal is not a one-off: the in-memory map must not be left
@@ -518,9 +562,11 @@ async fn an_unreadable_cluster_state_is_never_overwritten() {
         "deletes are writes too — they must be refused as well"
     );
 
-    // Recovery path: the file was readable all along, so a plain restart is
-    // the whole fix.
+    // Recovery path: remove the bad directory entry, put the saved bytes back,
+    // and restart. The latch belongs to the failed engine lifetime only.
     drop(app);
+    std::fs::remove_file(&state_path).expect("remove cluster-state self-loop");
+    std::fs::rename(&saved_path, &state_path).expect("restore valid cluster state");
     let app = app_over(dir.path());
     let (st, body) = get(&app, "/_index_template/logs").await;
     assert_eq!(


### PR DESCRIPTION
## Summary

The existing unreadable-cluster-state regression uses `chmod 000` to force `cluster_state.json` reads to fail. That oracle is privilege-dependent: root and processes with `CAP_DAC_OVERRIDE` can still read the file, so the test observes a successful restore and fails at GET with HTTP 200 instead of exercising the product's fail-closed branch.

This PR replaces that stimulus with a relative self-referential symlink. Reading the path fails with `ELOOP` regardless of uid, while the normal same-directory atomic rename can still replace it. A separate rename control proves the replacement is permitted on the test filesystem, so the test cannot pass merely because the target is intrinsically unreplaceable.

This is a test-oracle correction only. It changes no product code, graph code, graph lifecycle behavior, or publication authority. It should not be cited as evidence that graph generation, replay, cutover, or recovery works.

## What the regression proves

The corrected Unix-only test verifies that a non-`NotFound` read error leaves the cluster-state load latch closed and that management writes fail rather than overwrite state that could not be loaded. It additionally verifies:

- The cluster-state self-loop remains in place after refused writes.
- The saved valid state bytes remain exact.
- No corrupt-state salvage file is created for a read error.
- No unique atomic-write staging file is emitted.
- A failed PUT is rolled back in memory.
- Deletes remain guarded by the same latch.
- Restoring the valid path and restarting restores normal behavior.

The same-directory negative control first replaces another self-loop symlink with a staged regular file and reads the replacement back. A directory target was deliberately rejected as an oracle because file-over-directory rename would fail independently of the product latch.

## Causal controls

Current-main qualification ran under uid 0. In a disposable worktree at the exact parent commit, the inherited `chmod 000` regression failed as expected because root still read the state: the assertion observed HTTP 200 rather than the expected 404. The control exited 101 with 0 passed and 1 failed. The corrected self-loop oracle passed under the same uid.

An earlier temporary uncommitted causal mutation bypassed `ensure_cluster_state_writable`; the corrected test then failed at the management PUT with actual HTTP 200/acknowledged instead of expected HTTP 500. Removing that mutation returned the exact test to green. The mutation is absent from this commit and is retained only as historical supporting evidence.

## Public scope

The public diff changes exactly one file:

`engine/crates/xerj-api/tests/cluster_metadata_survives_restart.rs`

There are no product, dependency, workflow, or fixture files in the commit.

## Current branch identity and source audit

The prepared commit is `040d8710c4cc02bb12f240c784ec6cc70550a0fd`, exactly one commit over current upstream and fork main `ee29361bccce77de527baac3fe6ed387cd1f6dff`. Its tree is `196ae9a868a4cc2db7112b6b49b57e4e94586f27`.

The current commit's stable patch ID is `e009671330bd892f767367dc6eabca83877372c4`, and the changed test source SHA-256 is `e861e3c3cc8664665c1c5306a6846f0131c9977c7fe07bc785cbb2ff8c6f7304`. The commit author and committer are `buger <leonsbox@gmail.com>`.

The upstream delta inspected during source preparation does not modify this test, the API router/state wiring, or `xerj-engine/src/engine.rs`, where the cluster-state load latch and guarded flush live. #292 changes mapping and field-caps behavior in other API/engine regions; it does not touch this test or the relevant atomic-write helper.

Current-head source-only checks passed:

```bash
git diff --check HEAD^ HEAD
cargo fmt --all -- --check
git diff-tree --no-commit-id --name-status -r HEAD
git show --format= --binary HEAD | git patch-id --stable
```

Public commit scope checks also confirmed that the one-file diff contains no workflow, manifest, product, or generated-evidence files.

## Current-main qualification

All runtime, build, and conformance commands below ran while this exact source tree was named by commit `8c47179a534ee9c44c349747283a569ed0534a01`. The publication-only amended head `040d8710c4cc02bb12f240c784ec6cc70550a0fd` adds the required AI-accountability prose and has the same parent, tree, stable patch ID, full diff, and test bytes. The parent remained the current upstream and fork `main` after the gates completed and through the publication reseal:

- Corrected focused regression under uid 0: 1 passed, 0 failed.
- Exact inherited-oracle control at the parent commit under uid 0: expected failure, exit 101, observing HTTP 200 instead of expected 404.
- Full `xerj-api` package with serial libtest execution: 303 passed, 0 failed, 2 ignored.
- Default-threaded combined package coverage: 302 passed, 0 failed, 2 ignored with one unchanged script-limit case filtered, plus that exact case passing separately and in the complete serial run.
- `cargo clippy --locked -j 32 -p xerj-api --all-targets -- -D warnings`: passed.
- Scoped `xerj-server` and `es-yaml-runner` profiling builds: passed. The profiling profile uses thin LTO and 16 codegen units; no release or fat-LTO build was run.
- ES-YAML conformance against the resulting profiling binaries: 1,366 passed, 0 failed, 3 skipped (1,369 total). The runner and server both exited cleanly.

The combined default-threaded result is reported rather than an uninterrupted default-package pass because the unchanged `script_bucketed_agg_past_the_call_depth_limit_is_an_error_not_empty_buckets` case stalled once after its five sibling tests had passed. At the explicit bound its threads were asleep with no CPU use. Its source and all 218 production build inputs were byte-identical between the parent and candidate; the case passed when run alone and in the complete serial package run. No candidate-only product failure is being waived. A shared-target cross-worktree diagnostic was excluded from the causal evidence because artifact reuse would be ambiguous.

## Historical evidence boundary

Historical mutation-control logs are retained as non-public evidence. They are not linked from this PR and are not a public reproducibility artifact. The current-main results above come from a separate qualification of the exact prepared source tree while it was named by the pre-disclosure commit identified above; the current head changes commit prose only. No historical Cargo, Clippy, runtime, build, or conformance result has been relabeled as current evidence.

## Reproduction commands

Run the exact regression with development LTO disabled:

```bash
cd engine
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo test --locked -j 32 -p xerj-api --test cluster_metadata_survives_restart an_unreadable_cluster_state_is_never_overwritten -- --exact --nocapture --test-threads=1
```

Run the full changed integration target with:

```bash
cd engine
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo test --locked -j 32 -p xerj-api --test cluster_metadata_survives_restart -- --nocapture --test-threads=1
```

## Limitations

- The corrected oracle is guarded by `#[cfg(unix)]`; it does not claim Windows coverage.
- It tests a deterministic `ELOOP` read error, not every possible filesystem error such as `EIO` or `EMFILE`.
- It validates existing cluster-state fail-closed behavior; it does not implement or alter that behavior.
- The unchanged default-threaded script-test stall means package coverage is a combined serial/default/exact result, not an uninterrupted green default-package invocation.
- This prerequisite improves the reliability of one API test used during graph integration work. It provides no graph lifecycle or product-behavior evidence by itself.