### PR TITLE
fix(api): report refresh publication failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tolerance made the enforced floor `interval/2` shorter — 12.5 s at the
   shipped defaults. Measured at `--progress-interval 10`: 11 of 11 same-phase
   gaps under 15 s (min 10.0 s) before, none after (min 19.3 s).
+- **`/{index}/_refresh` reports segment-publication failures instead of
+  claiming every shard succeeded.** The endpoint previously discarded every
+  error returned by the synchronous engine flush and always answered HTTP 200
+  with `successful == total`. It now includes the index, status, and underlying
+  reason in `_shards.failures`, attempts every resolved index, and returns the
+  first failed shard's HTTP status as Elasticsearch 8.13.4 does for refresh.
 
 ## [1.0.0-rc.15] - 2026-08-10
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -15879,14 +15879,61 @@ pub async fn refresh_index(
         Ok(h) => h,
         Err(e) => return ApiError::new(e).into_response(),
     };
-    for (_, idx) in &handles {
-        let _ = idx.flush().await;
+    let total = handles.len() as u64;
+    let mut successful = 0u64;
+    let mut failures = Vec::new();
+    let mut response_status = StatusCode::OK;
+    for (name, idx) in &handles {
+        match idx.flush().await {
+            Ok(()) => successful += 1,
+            Err(error) => {
+                let rendered = ApiError::new(xerj_common::XerjError::from(error)).into_value();
+                let status = rendered
+                    .get("status")
+                    .and_then(Value::as_u64)
+                    .and_then(|code| StatusCode::from_u16(code as u16).ok())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                if failures.is_empty() {
+                    response_status = status;
+                }
+                let reason = rendered
+                    .pointer("/error/root_cause/0")
+                    .or_else(|| rendered.pointer("/error"))
+                    .cloned()
+                    .unwrap_or_else(|| json!({ "type": "exception", "reason": "refresh failed" }));
+                let status_name = status
+                    .canonical_reason()
+                    .unwrap_or("Internal Server Error")
+                    .to_ascii_uppercase()
+                    .replace([' ', '-'], "_");
+                failures.push(json!({
+                    "shard": 0,
+                    "index": name,
+                    "status": status_name,
+                    "reason": reason,
+                }));
+            }
+        }
     }
-    let n = handles.len() as u32;
-    Json(json!({
-        "_shards": { "total": n, "successful": n, "failed": 0 }
-    }))
-    .into_response()
+    let failed = failures.len() as u64;
+    let mut body = json!({
+        "_shards": { "total": total, "successful": successful, "failed": failed }
+    });
+    if failed > 0 {
+        body["_shards"]["failures"] = Value::Array(failures);
+    }
+
+    // Refresh is a synchronous publication barrier. Tantivy's analogous
+    // blocking commit contract returns its publication error to the caller
+    // (`tantivy/src/indexer/index_writer.rs:651-666`, MIT); dropping it here
+    // would turn "not published" into an affirmative success response.
+    // Match the refresh-specific ES 8.13.4 wire contract, whose REST handler
+    // uses `BaseBroadcastResponse::getStatus`: any failed shard makes the HTTP
+    // response use the first shard's status, even if another shard succeeded
+    // (`RestRefreshAction.java:47-52`, `BaseBroadcastResponse.java:114-122`;
+    // semantics only, no ES code). The body still reports every attempted
+    // shard (`RestActions.java:79-103`).
+    (response_status, Json(body)).into_response()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/engine/crates/xerj-api/tests/refresh_reports_flush_failure.rs
+++ b/engine/crates/xerj-api/tests/refresh_reports_flush_failure.rs
@@ -1,0 +1,162 @@
+//! A refresh is a synchronous visibility barrier: its HTTP response must not
+//! claim success when the engine could not publish the requested segment.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn request(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    let body = serde_json::from_slice(&bytes).expect("JSON response");
+    (status, body)
+}
+
+fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("data dir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let app = xerj_api::router::build_es_compat_router(xerj_api::state::AppState::new(
+        config, engine, metrics,
+    ));
+    (app, dir)
+}
+
+async fn create_text_index_with_document(app: &axum::Router, name: &str) {
+    let (status, body) = request(
+        app,
+        "PUT",
+        &format!("/{name}"),
+        json!({"mappings": {"properties": {"body": {"type": "text"}}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create {name}: {body}");
+
+    let (status, body) = request(
+        app,
+        "PUT",
+        &format!("/{name}/_doc/1"),
+        json!({"body": "must remain searchable after a successful refresh"}),
+    )
+    .await;
+    assert!(status.is_success(), "index document: {status} {body}");
+}
+
+fn block_segment_publication(dir: &std::path::Path, name: &str) {
+    let segments = dir.join(name).join("segments");
+    std::fs::remove_dir(&segments).expect("empty segments directory");
+    std::fs::write(&segments, b"not a directory").expect("segments blocker");
+}
+
+#[tokio::test]
+async fn refresh_reports_a_segment_publication_failure() {
+    let (app, dir) = app();
+    create_text_index_with_document(&app, "refresh-failure").await;
+
+    // Make segment publication fail independently of any particular encoder:
+    // replacing the still-empty segments directory with a regular file makes
+    // the real storage/FTS finalizer return an I/O error. This is deterministic
+    // even as individual side-car filename bugs are fixed.
+    block_segment_publication(dir.path(), "refresh-failure");
+
+    let (status, body) = request(&app, "POST", "/refresh-failure/_refresh", json!({})).await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "an all-shards refresh failure must not be HTTP 200: {body}"
+    );
+    assert_eq!(body.pointer("/_shards/total"), Some(&json!(1)), "{body}");
+    assert_eq!(
+        body.pointer("/_shards/successful"),
+        Some(&json!(0)),
+        "{body}"
+    );
+    assert_eq!(body.pointer("/_shards/failed"), Some(&json!(1)), "{body}");
+    assert_eq!(
+        body.pointer("/_shards/failures/0/index"),
+        Some(&json!("refresh-failure")),
+        "{body}"
+    );
+    assert_eq!(
+        body.pointer("/_shards/failures/0/status"),
+        Some(&json!("INTERNAL_SERVER_ERROR")),
+        "{body}"
+    );
+    let failure = body
+        .pointer("/_shards/failures/0")
+        .and_then(Value::as_object)
+        .expect("failure object");
+    let mut failure_fields: Vec<&str> = failure.keys().map(String::as_str).collect();
+    failure_fields.sort_unstable();
+    assert_eq!(
+        failure_fields,
+        ["index", "reason", "shard", "status"],
+        "ES 8.13.4 DefaultShardOperationFailedException shape: {body}"
+    );
+    assert_eq!(
+        body.pointer("/_shards/failures/0/reason/type"),
+        Some(&json!("store_exception")),
+        "{body}"
+    );
+    let reason = body
+        .pointer("/_shards/failures/0/reason/reason")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        !reason.is_empty() && reason != "refresh failed" && reason.contains("I/O error:"),
+        "segment publication must preserve the real storage I/O reason: {body}"
+    );
+}
+
+#[tokio::test]
+async fn multi_index_refresh_attempts_every_index_after_a_failure() {
+    let (app, dir) = app();
+    create_text_index_with_document(&app, "refresh-good").await;
+    create_text_index_with_document(&app, "refresh-bad").await;
+    block_segment_publication(dir.path(), "refresh-bad");
+
+    // The broken index is explicitly first: `successful == 1` proves the
+    // handler did not abort before attempting the second resolved index.
+    let (status, body) = request(
+        &app,
+        "POST",
+        "/refresh-bad,refresh-good/_refresh",
+        json!({}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "ES 8.13.4 refresh uses the first failed shard's status: {body}"
+    );
+    assert_eq!(body.pointer("/_shards/total"), Some(&json!(2)), "{body}");
+    assert_eq!(
+        body.pointer("/_shards/successful"),
+        Some(&json!(1)),
+        "{body}"
+    );
+    assert_eq!(body.pointer("/_shards/failed"), Some(&json!(1)), "{body}");
+    assert_eq!(
+        body.pointer("/_shards/failures/0/index"),
+        Some(&json!("refresh-bad")),
+        "{body}"
+    );
+}


### PR DESCRIPTION
## Summary

`POST /{index}/_refresh` currently awaits `Index::flush()` but discards every result, then always returns HTTP 200 with every resolved shard reported as successful. A storage publication failure is therefore translated into an affirmative success response.

This PR makes that response truthful. It attempts every resolved index, counts successful and failed publications, includes the existing XERJ error type and reason in `_shards.failures`, and returns the first failed shard's HTTP status when any publication fails.

The engine recovery behavior is unchanged. `Index::flush()` already returns publication failures, and the flush finalizer restores drained documents when publication fails. The defect is the API handler's `let _ = idx.flush().await` result translation.

## User-visible behavior

Before, a failed publication returned false success:

```http
HTTP/1.1 200 OK

{"_shards":{"total":1,"successful":1,"failed":0}}
```

After, the same failure is visible to the caller:

```http
HTTP/1.1 500 Internal Server Error

{"_shards":{"total":1,"successful":0,"failed":1,"failures":[{"shard":0,"index":"refresh-failure","status":"INTERNAL_SERVER_ERROR","reason":{"type":"store_exception","reason":"storage error: I/O error: File exists (os error 17)"}}]}}
```

For a multi-index refresh, failure does not short-circuit later indices. A broken-first, healthy-second request reports `total: 2`, `successful: 1`, and `failed: 1` after attempting both.

## Implementation

The handler keeps the existing index-resolution path and sequential flush behavior. For each returned XERJ index handle it:

1. Awaits the real `Index::flush()` result.
2. Increments `successful` only on `Ok(())`.
3. Converts an error through the existing `ApiError` mapping, preserving its status, exception type, and underlying reason.
4. Appends one shard failure containing `shard`, `index`, `status`, and `reason`.
5. Continues with the remaining resolved indices.

XERJ currently reports one shard per resolved local index on this endpoint, so `total`, `successful`, and `failed` count index handles. The patch does not change wildcard, comma-list, hidden-index, alias, closed-index, or missing-index resolution.

## Elasticsearch wire contract

The response matches Elasticsearch 8.13.4 at tag `v8.13.4`:

- `RestRefreshAction` selects `BaseBroadcastResponse::getStatus` for refresh responses.
- `BaseBroadcastResponse::getStatus` returns the first shard failure's status whenever `failedShards > 0`.
- `RestActions::buildBroadcastShardsHeader` renders `total`, `successful`, `failed`, and non-empty `failures`.
- `DefaultShardOperationFailedException::innerToXContent` renders `shard`, `index`, `status`, and `reason`.

Elasticsearch source was inspected only to verify wire behavior; no Elasticsearch code was copied. The implementation uses XERJ's existing error conversion and response construction.

## Checked-in regression tests

`engine/crates/xerj-api/tests/refresh_reports_flush_failure.rs` drives the real Axum router and engine. It replaces an empty per-index `segments/` directory with a regular file, causing the real storage finalizer to return a deterministic I/O error without depending on the separate FTS filename bug.

- The single-index case requires HTTP 500, `total: 1`, `successful: 0`, `failed: 1`, the exact four failure fields, `store_exception`, and a non-placeholder underlying I/O reason.
- The broken-first, healthy-second case requires HTTP 500 with one success and one failure, proving the handler does not stop after the first error.

Run the focused reproduction with:

```bash
cd engine
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo test --locked -j 32 -p xerj-api --test refresh_reports_flush_failure -- --nocapture
```

To reproduce the product failure manually, start XERJ with a fresh data directory, create a text index and one document, replace `<data-dir>/<index>/segments/` with a regular file while it is still empty, and call `POST /<index>/_refresh`. On upstream `main`, the endpoint falsely returns HTTP 200/all successful. With this patch it returns the storage error as a failed shard. This injection intentionally corrupts a disposable test index directory and must not be used against real data.

## Current branch state

The source prepared for this PR is commit `b52c20b9c3570fef33cc019fc9939b11c7b38da0`, exactly one commit over current upstream `ee29361bccce77de527baac3fe6ed387cd1f6dff`. Its tree is `1bce6094413a0a742a935590bec64ccf94101903`.

The upstream delta has a path-level overlap in `engine/crates/xerj-api/src/es_compat.rs` through #292, but no hunk-level overlap with the refresh handler. The composition was therefore reviewed semantically; #292's mapping merge, semantic-companion filtering, and recursive field-caps registration remain present and unchanged. This contribution still changes only the distant refresh handler and its dedicated test. The #292 changes in `xerj-api/src/memory_api.rs` and `xerj-engine/src/index.rs` are untouched.

The current commit's stable patch ID is `2dd2f4b2b534051442662f1d3fed1dd994439581`, and the regression-test file SHA-256 is `42442fc7eef07c1ba8a4f0ac2bbe9a1c74cc7be42b22abd24a0850fe04b543af`. The commit author and committer are `buger <leonsbox@gmail.com>`.

Current-head source checks passed: exact three-path scope, `git diff --check`, `cargo fmt --all -- --check`, workflow/scope checks, symbol-level preservation of #292's mapping paths, and source review of both refresh failure tests.

## Current-main qualification

All evidence-producing commands below ran on pre-amendment commit `0f9c6a53`, after fetching both upstream and fork `main` at `ee29361` before and after the gates. The publication commit `b52c20b9` changes only the engineering-log message and preserves the exact qualified tree `1bce6094413a0a742a935590bec64ccf94101903`:

- Focused real-router target: 2 passed, 0 failed.
- Causal control at the same candidate source, with only the refresh-handler change reversed and the exact tests retained: expected failure, 0 passed and 2 failed. Both assertions observed HTTP 200 where HTTP 500 is required.
- Full `xerj-api` package under uid 0 with only the inherited privilege-dependent chmod oracle filtered: 304 passed, 0 failed, 2 ignored, 1 filtered, in both serial and default-threaded runs.
- The exact filtered oracle under uid/gid 65534: 1 passed, 0 failed. Together, the split covers the complete package without relabeling a root-invalid oracle as skipped coverage.
- `cargo clippy --locked -j 32 -p xerj-api --all-targets -- -D warnings`: passed.
- Scoped profiling builds of `xerj-server` and `es-yaml-runner`: passed. The profiling profile uses thin LTO and 16 codegen units; no release or fat-LTO build was run.
- Live immutable-server proof: the single-index failure returned HTTP 500 with `total: 1`, `successful: 0`, and `failed: 1`; the mixed refresh returned HTTP 500 with `total: 2`, `successful: 1`, and `failed: 1`, naming only the broken index. The failed-refresh document remained searchable, and the healthy index remained searchable with durable publication artifacts. The server exited cleanly and all owned ports closed.
- ES-YAML conformance against the same immutable server binary: 1,366 passed, 0 failed, 3 skipped (1,369 total). The runner and server exited cleanly, their hashes remained unchanged, and all owned ports closed.

The dedicated candidate and causal-control build directories were source-isolated. Their sizes were recorded and both were deleted after the evidence was complete; the shared compiler cache was retained.

## Historical evidence boundary

Historical focused, causal-control, build, live-product, and conformance logs are retained as non-public evidence. They are not linked from this PR and are not a public reproducibility artifact. The current-main results above come from a separate qualification of pre-amendment commit `0f9c6a53`; publication commit `b52c20b9` has the identical source tree. No historical result has been relabeled as current evidence.

The checked-in multi-index test proves result accounting and no short-circuit. The post-failure-search and durable-publication claims above come from the separate current-head live-product run, not from that checked-in test alone.

## Scope and limitations

- This is a correctness and error-reporting fix; it makes no performance claim.
- It does not change flush recovery, retry, durability, index resolution, or selector behavior.
- It does not add concurrent multi-index flushes; indices remain attempted sequentially.
- It does not add a synthetic wire-only failure-injection endpoint. The deterministic filesystem injection is confined to the Rust integration test and disposable manual reproductions.
- The separate FTS sidecar filename fix is not a dependency. This test forces a generic segment-path publication failure.
- The full package result is deliberately split by effective privilege: the inherited chmod oracle is invalid under uid 0 and is reported separately under uid/gid 65534.
- Not run locally: the release/fat-LTO build and GitHub's Linux, macOS, and Windows platform matrix. This PR must not merge until the GitHub release/workspace and platform CI jobs are green.
- Not run: a live Elasticsearch failure injection. The compatibility contract was verified from the tagged Elasticsearch 8.13.4 sources cited above; XERJ's response was exercised by the checked-in regression tests and the live immutable-server reproduction.

## Dependency and review boundary

This is an independent one-commit contribution with no prerequisite or stacked dependency. The public diff contains only `CHANGELOG.md`, `engine/crates/xerj-api/src/es_compat.rs`, and `engine/crates/xerj-api/tests/refresh_reports_flush_failure.rs`.