### PR TITLE
autoindex: capture exported module const in JavaScript

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -234,6 +234,25 @@ const PYTHON_Q: &str = r#"
 (class_definition name: (identifier) @class)
 "#;
 
+// The last pattern is the JavaScript half of #170, and it is the same hole
+// #285 closed for TypeScript: an ESM module whose public surface is
+// `export const x = someBuilder(...)` — a schema, a route table, a config
+// object — is not a function value, so the two function-valued patterns above
+// miss it and the module extracts ZERO symbols.
+//
+// Deliberately identical in shape to the TS_Q pattern, and for the same three
+// reasons: exported-only because `defs` is the cross-file retrieval surface
+// (the broader scope was measured in #285 as weight without retrieval gain);
+// anchored to `program` because `lexical_declaration` is the same node inside a
+// function body, so an unanchored form would fill `defs` with function-local
+// `const` (the 90%-locals trap measured for C in #170); and the `"const"` token
+// matched so `export let` — mutable module state — stays out.
+//
+// The kind overlap is WIDER here than in TypeScript and is asserted, not
+// assumed: JS_Q's function-valued pattern admits `function_expression` as well
+// as `arrow_function`, so `export const f = function () {}` carries both
+// `@function` and `@const`, where the TS equivalent only does so for arrows.
+// `defs` dedups on (kind, name), so each spelling still answers its own search.
 const JS_Q: &str = r#"
 (function_declaration name: (identifier) @function)
 (generator_function_declaration name: (identifier) @function)
@@ -241,6 +260,7 @@ const JS_Q: &str = r#"
 (method_definition name: (property_identifier) @method)
 (variable_declarator name: (identifier) @function value: [(arrow_function) (function_expression)])
 (export_statement declaration: (lexical_declaration (variable_declarator name: (identifier) @function value: (arrow_function))))
+(program (export_statement declaration: (lexical_declaration "const" (variable_declarator name: (identifier) @const))))
 "#;
 
 // The last pattern is #170's failure mode in the language where it is most
@@ -533,6 +553,55 @@ mod tests {
         assert!(has(&s, "m", "method"));
         assert!(has(&s, "g", "function"));
     }
+
+    /// The JavaScript half of #293. `TS_Q` gained exported-module-`const`
+    /// capture in #285; `JS_Q` did not, so an ESM JavaScript module whose whole
+    /// public surface is `export const x = someBuilder(...)` still extracted
+    /// ZERO symbols — #170's failure mode, unchanged, in `.js`/`.jsx`/`.mjs`/
+    /// `.cjs`. The scope boundaries are the ones #285 established and are
+    /// re-asserted here rather than assumed to carry over: the grammar differs.
+    #[test]
+    fn javascript_exported_module_const() {
+        let s = syms(
+            "javascript",
+            "export const users = pgTable(\"users\", {});\n\
+             export const ROUTES = [\"a\", \"b\"];\n\
+             const MAX_BODY_CHARS = 30000;\n\
+             export let mutableState = 2;\n\
+             function f(){ const local = 1; return local; }\n",
+        );
+        assert!(has(&s, "users", "const"), "got {s:?}");
+        assert!(has(&s, "ROUTES", "const"), "got {s:?}");
+        // Module-private const stays out: `defs` is the cross-file retrieval
+        // surface, and #285 measured the broader scope as weight without gain.
+        assert!(
+            !has(&s, "MAX_BODY_CHARS", "const"),
+            "captured a module-private const: {s:?}"
+        );
+        // Function-local `const` must NOT be captured — the 90%-locals trap.
+        assert!(!has(&s, "local", "const"), "captured a local: {s:?}");
+        // `let` is mutable module state, not a constant, even when exported.
+        assert!(!has(&s, "mutableState", "const"), "captured a let: {s:?}");
+    }
+
+    /// The overlap is wider in JavaScript than in TypeScript, and that is worth
+    /// pinning rather than discovering later: `JS_Q`'s function-valued pattern
+    /// admits `function_expression` as well as `arrow_function`, so BOTH forms
+    /// of an exported function-valued const carry two kinds. `defs` dedups on
+    /// (kind, name), so each answers searches for either spelling.
+    #[test]
+    fn javascript_exported_function_valued_const_is_both_kinds() {
+        let s = syms(
+            "javascript",
+            "export const arrowFn = () => 1;\n\
+             export const exprFn = function () { return 1; };\n",
+        );
+        assert!(has(&s, "arrowFn", "function"), "got {s:?}");
+        assert!(has(&s, "arrowFn", "const"), "got {s:?}");
+        assert!(has(&s, "exprFn", "function"), "got {s:?}");
+        assert!(has(&s, "exprFn", "const"), "got {s:?}");
+    }
+
     #[test]
     fn typescript() {
         let s = syms(


### PR DESCRIPTION
Written by an AI coding agent (Claude Opus 5 via Claude Code), run by @pradaev, who has
signed the CLA (#289).

Closes #293 — thanks for the repro and the suggested pattern, both were exactly right.

## Defect

#285 added exported-module-`const` capture to `TS_Q`. `JS_Q` did not get the equivalent,
so the identical failure mode stayed live for ESM JavaScript:

```js
export const users = pgTable("users", {});
export const ROUTES = ["a", "b"];
```

Neither is a function value, so the two function-valued patterns in `JS_Q` missed both and
the document carried **no `defs`, no `symbols`, no `symbol_count`** — not "fewer symbols",
unreachable by symbol search entirely. #170's failure mode, across every extension the
javascript row claims: `.js`, `.jsx`, `.mjs`, `.cjs`.

## Fix

```
(program (export_statement declaration: (lexical_declaration "const" (variable_declarator name: (identifier) @const))))
```

Identical in shape to the TypeScript pattern, and for the same three reasons — exported-only
(`defs` is the cross-file surface; the broader scope was measured in #285 as weight without
retrieval gain), anchored to `program` (the 90%-locals trap), `"const"` token matched
(exported `let` is mutable state, not a constant). All three re-asserted for JS rather than
assumed to carry over, since the grammar differs.

**The one real difference, asserted not assumed** — you flagged it in the issue and you were
right: `JS_Q`'s function-valued pattern admits `function_expression` as well as
`arrow_function`, so in JavaScript **both** `export const f = () => {}` and
`export const f = function () {}` now carry two kinds, where TS only does so for arrows.
`defs` dedups on (kind, name), so each spelling answers its own search.
`javascript_exported_function_valued_const_is_both_kinds` pins it.

## Failing tests first

Both new tests, run against unfixed `main` (`ee29361`):

```
---- extract::code::tests::javascript_exported_module_const stdout ----
panicked at crates/xerj-autoindex/src/extract/code.rs:553:9:
got [("f", "function", 5)]

---- extract::code::tests::javascript_exported_function_valued_const_is_both_kinds stdout ----
panicked at crates/xerj-autoindex/src/extract/code.rs:580:9:
got [("arrowFn", "function", 1), ("arrowFn", "function", 1), ("exprFn", "function", 2)]

test result: FAILED. 28 passed; 2 failed
```

The first shows the hole: only the function, none of the module constants.

## Verified — commands run in this environment, output observed

- `cargo test -p xerj-autoindex --lib extract::code` on unfixed `main` → the failures above
- same on this branch → `ok. 30 passed; 0 failed`
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- ES-YAML conformance on this branch's tree → `1366 passed · 0 failed · 3 skipped · 1369 total`,
  runner exit 0
- **Real extractor entry point**, not just the unit fixture — following your review method on
  #285. Ran `extract::code::extract` (so `read_whole` → `decode_text` → `parse_symbols` →
  `emit_code_doc`) over real files on disk, one per claimed extension, same source in each:

  ```
  plain.js    records=1  lang=javascript  defs="const users\nconst ROUTES\nfunction f"
  esm.mjs     records=1  lang=javascript  defs="const users\nconst ROUTES\nfunction f"
  legacy.cjs  records=1  lang=javascript  defs="const users\nconst ROUTES\nfunction f"
  view.jsx    records=1  lang=javascript  defs="const users\nconst ROUTES\nfunction f"
  ```

  The same file also contained `const PRIVATE_ONE = 1`, `export let cursor = 0`, and a
  function-local `const local` — none of the three appear, so all three boundaries hold
  through the real path and not merely in the query.

## Observation, not fixed here

The pre-fix failure output shows `("arrowFn", "function", 1)` **twice**. That is pre-existing
in `JS_Q`: an exported arrow const matches both the generic `variable_declarator` pattern and
the `export_statement` one, so it lands in `symbols` twice and inflates `symbol_count` by one
per occurrence. `defs` dedups on (kind, name) so it is invisible there, which is presumably
why it went unnoticed. Out of scope for this PR and not touched — flagging it rather than
folding an unrelated change in. Happy to open it separately if you want it.

## Assumed — NOT tested

- `export const { a, b } = f();` (destructuring) is assumed to behave as it does in TS — not
  captured, because `object_pattern` is not an `identifier`, and no panic. You verified that
  for TS on #285; I did not re-run it for the JS grammar.
- Namespace/ambient blocks have no JS equivalent, so the TS caveat about `program`-anchoring
  losing them does not apply here. Not separately exercised.

## Not run

- Pre-existing macOS-only failure in the crate's wider suite
  (`content::tests::lossy_display_collisions_keep_distinct_alias_identities`,
  `Os { code: 92, "Illegal byte sequence" }`), reproduced on unmodified `main` in this
  environment and unrelated to this change. You noted it does not arise on Linux.
