### PR TITLE
fix(autoindex): explicitly release journal state locks

### DIFF
--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -370,7 +370,7 @@ pub struct FileDone {
 pub struct Journal {
     path: PathBuf,
     file: std::fs::File,
-    _state_lock: std::fs::File,
+    _state_lock: StateLock,
     pub run_id: String,
     pub resumed: bool,
     pub done: HashMap<String, FileDone>,
@@ -386,6 +386,20 @@ pub struct Journal {
     pub committed_manifest: Option<crate::sync::CommittedManifest>,
     pub pending_sync: Option<crate::sync::PendingSync>,
     pub legacy_migration_reasons: Vec<String>,
+}
+
+/// Owns the process-wide state-directory exclusion lock.
+///
+/// Closing the file normally releases an `flock`, but a concurrently forked
+/// child can temporarily retain the same open-file description until it
+/// execs. Explicitly unlocking before close keeps a completed Journal from
+/// spuriously blocking its immediate successor during that window.
+struct StateLock(std::fs::File);
+
+impl Drop for StateLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
 }
 
 /// Per-process monotonic suffix for [`new_run_id`].
@@ -591,7 +605,7 @@ fn read_plan_for_preflight(
 
 pub struct JournalPreflight {
     state_dir: PathBuf,
-    state_lock: std::fs::File,
+    state_lock: StateLock,
     pub plan: Option<Plan>,
     pub committed_manifest: Option<crate::sync::CommittedManifest>,
     pub pending_sync: Option<crate::sync::PendingSync>,
@@ -620,19 +634,22 @@ impl Journal {
         std::fs::create_dir_all(state_dir)
             .with_context(|| format!("create state dir {}", state_dir.display()))?;
         let lock_path = state_dir.join(".autoindex.lock");
-        let state_lock = std::fs::OpenOptions::new()
+        let state_lock_file = std::fs::OpenOptions::new()
             .create(true)
             .truncate(false)
             .read(true)
             .write(true)
             .open(&lock_path)?;
-        state_lock.try_lock_exclusive().with_context(|| {
+        state_lock_file.try_lock_exclusive().with_context(|| {
             format!(
                 "autoindex state {} is already in use by another process; wait for it to \
                  finish or choose a different --state-dir",
                 state_dir.display()
             )
         })?;
+        // Wrap immediately after acquisition so every later preflight exit
+        // explicitly unlocks before closing the file descriptor.
+        let state_lock = StateLock(state_lock_file);
         let journal_path = state_dir.join("journal.ndjson");
         let journal_exists = journal_path.exists();
         let (plan, committed_manifest, pending_sync, legacy_migration_reasons, unreadable_plan) =

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -50,7 +50,57 @@ pub struct PlanDataset {
 
 #[cfg(test)]
 mod tests {
-    use super::{run_id_in_second, Journal};
+    use super::{run_id_in_second, Journal, StateLock};
+
+    /// `flock` ownership follows the open file description, so an inherited
+    /// descriptor can unlock the acquiring parent's lock. Model that post-fork
+    /// relationship deterministically with `try_clone`: a guard whose recorded
+    /// owner is a different PID must close only, while the acquiring owner's
+    /// guard must still release the lock.
+    #[cfg(unix)]
+    #[test]
+    fn foreign_pid_drop_preserves_lock_until_owner_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.lock");
+        let owner_file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        fs2::FileExt::try_lock_exclusive(&owner_file).unwrap();
+        let inherited_file = owner_file.try_clone().unwrap();
+        let owner_pid = std::process::id();
+        let foreign_pid = if owner_pid == u32::MAX {
+            owner_pid - 1
+        } else {
+            owner_pid + 1
+        };
+        let owner = StateLock {
+            file: owner_file,
+            owner_pid,
+        };
+        let inherited = StateLock {
+            file: inherited_file,
+            owner_pid: foreign_pid,
+        };
+
+        drop(inherited);
+
+        let contender = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        fs2::FileExt::try_lock_exclusive(&contender)
+            .expect_err("a foreign-PID drop must not unlock the live owner's flock");
+
+        drop(owner);
+        fs2::FileExt::try_lock_exclusive(&contender)
+            .expect("the acquiring owner's drop must release its flock");
+        fs2::FileExt::unlock(&contender).unwrap();
+    }
 
     #[test]
     fn legacy_journal_can_resume_with_a_custom_operational_timeout() {
@@ -392,13 +442,20 @@ pub struct Journal {
 ///
 /// Closing the file normally releases an `flock`, but a concurrently forked
 /// child can temporarily retain the same open-file description until it
-/// execs. Explicitly unlocking before close keeps a completed Journal from
-/// spuriously blocking its immediate successor during that window.
-struct StateLock(std::fs::File);
+/// execs. The acquiring process explicitly unlocks before close so its
+/// completed Journal cannot be retained by that child. An inherited copy must
+/// only close: `LOCK_UN` on the shared open-file description would also release
+/// the still-live parent's lock.
+struct StateLock {
+    file: std::fs::File,
+    owner_pid: u32,
+}
 
 impl Drop for StateLock {
     fn drop(&mut self) {
-        let _ = fs2::FileExt::unlock(&self.0);
+        if std::process::id() == self.owner_pid {
+            let _ = fs2::FileExt::unlock(&self.file);
+        }
     }
 }
 
@@ -647,9 +704,13 @@ impl Journal {
                 state_dir.display()
             )
         })?;
-        // Wrap immediately after acquisition so every later preflight exit
-        // explicitly unlocks before closing the file descriptor.
-        let state_lock = StateLock(state_lock_file);
+        // Capture the acquiring process before any later fallible work. A
+        // forked child inherits this value and therefore closes without
+        // unlocking the parent's shared open-file description.
+        let state_lock = StateLock {
+            file: state_lock_file,
+            owner_pid: std::process::id(),
+        };
         let journal_path = state_dir.join("journal.ndjson");
         let journal_exists = journal_path.exists();
         let (plan, committed_manifest, pending_sync, legacy_migration_reasons, unreadable_plan) =

--- a/engine/crates/xerj-autoindex/tests/journal_lock_inheritance.rs
+++ b/engine/crates/xerj-autoindex/tests/journal_lock_inheritance.rs
@@ -1,0 +1,157 @@
+#![cfg(all(any(target_os = "linux", target_vendor = "apple"), not(miri)))]
+
+use xerj_autoindex::state::Journal;
+
+struct ForkedLockHolder {
+    child: libc::pid_t,
+    release_fd: libc::c_int,
+    parent_read_fd: libc::c_int,
+}
+
+impl ForkedLockHolder {
+    fn close_fd(fd: &mut libc::c_int) -> std::io::Result<()> {
+        if *fd < 0 {
+            return Ok(());
+        }
+        let owned_fd = *fd;
+        *fd = -1;
+        if unsafe { libc::close(owned_fd) } == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    fn close_parent_read(&mut self) -> std::io::Result<()> {
+        Self::close_fd(&mut self.parent_read_fd)
+    }
+
+    fn release_and_reap(mut self) {
+        let close_result = Self::close_fd(&mut self.release_fd);
+        let wait_result = waitpid_retry(self.child);
+
+        close_result.expect("close parent pipe writer");
+        let status = wait_result.expect("wait for forked lock holder");
+        assert!(
+            libc::WIFEXITED(status),
+            "forked lock holder did not exit normally: status={status}"
+        );
+        assert_eq!(
+            libc::WEXITSTATUS(status),
+            0,
+            "forked lock holder reported a child-side syscall failure"
+        );
+        self.child = -1;
+    }
+}
+
+impl Drop for ForkedLockHolder {
+    fn drop(&mut self) {
+        let _ = Self::close_fd(&mut self.release_fd);
+        let _ = Self::close_fd(&mut self.parent_read_fd);
+        if self.child > 0 {
+            let _ = waitpid_retry(self.child);
+            self.child = -1;
+        }
+    }
+}
+
+fn waitpid_retry(child: libc::pid_t) -> std::io::Result<libc::c_int> {
+    loop {
+        let mut status = 0;
+        let waited = unsafe { libc::waitpid(child, &mut status, 0) };
+        if waited == child {
+            return Ok(status);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn child_errno() -> libc::c_int {
+    extern "C" {
+        fn __errno_location() -> *mut libc::c_int;
+    }
+    unsafe { *__errno_location() }
+}
+
+#[cfg(target_vendor = "apple")]
+unsafe fn child_errno() -> libc::c_int {
+    unsafe { *libc::__error() }
+}
+
+#[test]
+fn journal_drop_unlocks_before_a_fork_inherited_descriptor_closes() {
+    let state_dir = tempfile::tempdir().unwrap();
+    let journal =
+        Journal::open(state_dir.path(), "root", "http://engine", "ax", 300, false).unwrap();
+
+    // The child blocks on this pipe while retaining every descriptor that
+    // existed at fork. It performs only async-signal-safe libc calls: a fork
+    // from the multithreaded test harness must not touch Rust runtime state in
+    // the child before `_exit`.
+    let mut pipe_fds = [-1; 2];
+    if unsafe { libc::pipe(pipe_fds.as_mut_ptr()) } != 0 {
+        panic!("pipe failed: {}", std::io::Error::last_os_error());
+    }
+    let child = unsafe { libc::fork() };
+    if child < 0 {
+        let error = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(pipe_fds[0]);
+            libc::close(pipe_fds[1]);
+        }
+        panic!("fork failed: {error}");
+    }
+    if child == 0 {
+        unsafe {
+            if libc::close(pipe_fds[1]) != 0 {
+                libc::_exit(2);
+            }
+            let mut byte = 0_u8;
+            loop {
+                let read = libc::read(
+                    pipe_fds[0],
+                    (&mut byte as *mut u8).cast::<libc::c_void>(),
+                    1,
+                );
+                if read == 0 {
+                    break;
+                }
+                if read < 0 && child_errno() == libc::EINTR {
+                    continue;
+                }
+                libc::_exit(3);
+            }
+            if libc::close(pipe_fds[0]) != 0 {
+                libc::_exit(4);
+            }
+            libc::_exit(0);
+        }
+    }
+
+    // Own child cleanup immediately. Any later panic closes the writer and
+    // reaps the child instead of retaining the inherited lock or a zombie.
+    let mut child = ForkedLockHolder {
+        child,
+        release_fd: pipe_fds[1],
+        parent_read_fd: pipe_fds[0],
+    };
+    child
+        .close_parent_read()
+        .expect("close unused parent pipe reader");
+
+    drop(journal);
+    let reopened = Journal::open(state_dir.path(), "root", "http://engine", "ax", 300, false);
+
+    // Release and reap before checking the result. The pre-fix EAGAIN remains
+    // observable without leaving a child behind when the assertion fails.
+    child.release_and_reap();
+    let reopened = reopened
+        .expect("dropping Journal must explicitly unlock before an inherited descriptor is closed");
+    drop(reopened);
+}


### PR DESCRIPTION
## Summary

Autoindex now explicitly releases its state-directory `flock` only when the lock guard is destroyed by the process that acquired it. This closes two opposite fork-inheritance failure modes:

- When the acquiring process finishes while a child temporarily retains the inherited descriptor, the owner explicitly unlocks so an immediate successor is not falsely rejected as concurrent.
- When an inherited child destroys its copy while the acquiring parent is still live, the child closes only and cannot unlock the parent's active exclusion lock.

PR #305 has been advanced from public head `51fbb4eb21d79457fe83396ab9be40f05a3658d6` to `7e75c2840664d9f8424193130a5b75af93968e68` with one ordinary fast-forward commit containing the acquiring-PID correction and converse oracle. No rebase, amend, force-push, workflow change, or public-history rewrite was used.

The published branch remains focused and does not carry unrelated upstream history. A source-only merge-tree proof composes published head `7e75c284` with current upstream `main` at `b0d480dd` and produces exact tree `231b6671`, byte-identical to the independently reviewed and fully Linux-qualified current-main tree. The net PR diff after that composition changes exactly two public paths:

- `engine/crates/xerj-autoindex/src/state.rs`
- `engine/crates/xerj-autoindex/tests/journal_lock_inheritance.rs`

It has no prerequisite PR.

## Why this matters

The original failure appeared as a rare autoindex lock refusal after the prior journal owner had completed. A synchronized fork/open-file-description control reproduced the same `EAGAIN`: closing the owner's descriptor is insufficient while a child retains an inherited descriptor for the same open file description.

The first prototype made every `StateLock::drop` issue `LOCK_UN`. Independent review identified the converse defect in that design: `flock` operations apply to the shared open file description, so a post-fork child could unlock the still-live parent's lock merely by destroying its inherited guard. That prototype is withdrawn and was never pushed.

Autoindex starts helper processes for isolated extraction, and library users may invoke it while other threads start processes. The lock guard therefore needs both properties: prompt release by the acquiring process and no release by a foreign post-fork process.

This PR fixes only journal state-lock ownership. It is independent of graph lifecycle and corpus publication work.

## Root cause

The lock was stored as a bare `std::fs::File`. On Unix, a child forked while the journal is live inherits the descriptor and shares the same open file description until it execs or exits. `O_CLOEXEC` closes the descriptor at `exec`; it does not prevent inheritance during the interval after `fork`.

Two consequences follow:

1. If the owner drops its `File` first, that close is not the final close while the child retains its inherited descriptor, so the `flock` can remain held and an immediate `Journal::open` fails with OS error 11.
2. If every destructor calls `LOCK_UN`, an inherited child's destructor acts on the same open file description and releases the live parent's lock.

Correctness therefore requires process ownership, not unconditional explicit unlock.

## What changes

`Journal` and `JournalPreflight` now own a private `StateLock { file, owner_pid }`.

The acquiring PID is captured immediately after successful fail-fast lock acquisition and before any subsequent fallible journal work. The guard then moves unchanged from `JournalPreflight` into the authoritative `Journal`, preserving the existing continuous exclusion interval.

`StateLock::drop` compares the current PID with `owner_pid`:

- In the acquiring process, it makes a best-effort, fully qualified `fs2::FileExt::unlock` call before normal file close.
- In a foreign post-fork process, it skips `LOCK_UN` and only closes that process's descriptor.

Drop remains non-panicking. Ordinary descriptor close remains the owner's fallback if explicit unlock fails.

Lock acquisition is still fail-fast. A genuine concurrent owner receives the existing actionable `already in use` refusal; this PR adds no retry, wait, sleep, or takeover.

## Two-direction causal coverage

### Owner-drop direction

The Unix integration test opens a real `Journal`, creates a pipe, and forks. The child blocks in async-signal-safe `read` while retaining every descriptor inherited at fork, including the journal lock. The parent drops the journal and immediately reopens the same state directory before releasing the child.

Without owner-side explicit unlock, the immediate reopen fails with EAGAIN. Cleanup releases and reaps the child before checking the reopen result, so a failed assertion cannot leak a lock holder or zombie. The child uses only async-signal-safe libc calls between `fork` and `_exit`.

This integration test is selected on Linux and Apple targets and excluded under Miri.

### Foreign-drop direction

The converse unit oracle uses `File::try_clone` to create two descriptors for the same open file description without running Rust destructors unsafely after a real multithreaded fork. One `StateLock` records the current acquiring PID; the cloned guard records a synthetic foreign PID.

Dropping the foreign guard must leave the lock held, so an independently opened contender must still receive EAGAIN. Dropping the acquiring guard must then release the lock, allowing that same contender to acquire it. Removing the PID check makes the first assertion fail because the foreign guard issues `LOCK_UN` on the shared open file description.

The converse oracle is selected on Unix, where the tested `flock` open-file-description semantics apply.

## Composition with current main

The only overlapping upstream production change is `eb25c0040762933c01d7bf772c1786103d984d9b`, which makes durable sync JSON decoding and float replay exact. It changes journal parsing and regression fixtures but does not change lock acquisition, ownership, the preflight-to-journal transfer, or release.

The source-only current-main composition retains all of those upstream changes. Its corrected merge tree is byte-identical to the independently prepared PID-guarded tree. No synthetic merge commit was pushed; the proof uses Git's merge-tree calculation and GitHub may merge or squash the one-commit PR normally.

Exact source identity:

- Base: `b0d480dd9cf3544156f14991f431a0e711ea5f56`
- Previous public head: `51fbb4eb21d79457fe83396ab9be40f05a3658d6`
- Published correction head: `7e75c2840664d9f8424193130a5b75af93968e68`
- Published head tree: `e9093bc52868c5e83bc0d3deaa95fe2c4be9f887`
- Current-main composed tree: `231b6671d03e94d2fda3223668733f5cb6248410`
- Net stable patch ID against current `main`: `2a9443788dca846ba717bd4b434b9cb997e87499`
- Additive correction commit patch ID: `a95e4b1797f07eeca856f954ade58e88094606fe`
- Published-head `state.rs` SHA-256: `c9dde122e895582e18ba9440c128eef356a168fbc063adb24aec165b78002720`
- Current-main composed `state.rs` SHA-256: `093e7cedc78b7180e46240d85aaa651fc1cfe3abac81f2d204c1ca60c4bbae85`
- Integration regression SHA-256: `91c0feeaad06652f5252db32722cf06b0755407d2ef0f4570888a631a540987c`

## Corrected-tree verification status

The following checks passed against exact corrected current-main composed tree `231b6671d03e94d2fda3223668733f5cb6248410`:

- Exact two-path net scope against current `main`.
- The previous public head is the direct parent of published head `7e75c284`; publication was a normal fast-forward.
- Published head `7e75c284` changes only `state.rs` relative to the previous public head and carries stable patch ID `a95e4b17`.
- `git merge-tree --write-tree b0d480dd 7e75c284` returns exact tree `231b6671d03e94d2fda3223668733f5cb6248410` without a conflict.
- That composed tree equals the independently prepared and reviewed PID-guarded current-main tree.
- `git diff --check`.
- `cargo fmt --all -- --check`.
- Author and committer are `buger <leonsbox@gmail.com>`.
- Full commit body and AI disclosure are present; no `Co-Authored-By` trailer is present.
- Exact foreign-PID converse unit: 1 passed, 0 failed, 523 filtered.
- Causal converse mutation: bypassing only the PID equality made that exact unit fail at the intended foreign-drop assertion; restoring the exact source bytes made it pass again.
- Exact actual-fork owner-release integration: 1 passed, 0 failed.
- Ordinary full `xerj-autoindex` package: 524 library tests plus 2 integration tests passed, 0 failed; doc-tests contained 0 tests.
- Strict all-target `xerj-autoindex` Clippy with `-D warnings`: passed.

The four corrected-tree commands were launched sequentially against the shared target with development LTO explicitly disabled. The converse unit compiled in 22.70 seconds and executed in 0.00 seconds. The actual-fork integration compiled in 12.64 seconds and executed in 0.00 seconds. The already-warm full package compiled in 2.19 seconds; its 524-test library phase finished in 13.70 seconds, and both integration tests finished in 0.00 seconds. An unrelated Cargo build overlapped part of the Clippy run, so Clippy's green correctness result is retained but its duration is deliberately not presented as performance evidence.

For the causal mutation proof, only `StateLock::drop` was temporarily changed to issue unconditional `LOCK_UN`. The exact converse unit then returned Cargo exit 101 because the independent contender unexpectedly acquired after the synthetic foreign guard dropped: `a foreign-PID drop must not unlock the live owner's flock: ()`. The PID equality was restored with the composed source file returning to SHA-256 `093e7cedc78b7180e46240d85aaa651fc1cfe3abac81f2d204c1ca60c4bbae85`, the worktree returned to tree `231b6671d03e94d2fda3223668733f5cb6248410`, and the same exact unit passed 1/1.

A scoped thin-LTO profiling build also passed on the exact corrected current-main composed tree for `xerj-server` and `es-yaml-runner`. The immutable artifacts used for conformance were then hashed before and after the run:

- `xerj`: 481,676,936 bytes; SHA-256 `34229bd86396c60925f117cf66c5d5069dcf888f0447c62325c19367ca720325` before and after.
- `es-yaml-runner`: 71,660,968 bytes; SHA-256 `00956e21a2b0ee5d84c2308e975521c982ad600c23f3f0c09f69c8f7cbf06e81` before and after.

Those exact binaries completed the full ES-YAML suite with runner exit 0: 1,366 passed, 0 failed, 3 skipped, 1,369 total. The owned server process was reaped afterward, and its REST, gRPC, and ES ports were each successfully rebound. An unrelated build overlapped the conformance run, so this result is correctness evidence only; no duration or throughput claim is made from it.

## Withdrawn prototype and evidence boundary

The earlier current-main prototype at `89414d4666956d1c026ec1f24444ca9f6434c40a` unconditionally called `LOCK_UN`. Its actual-fork owner-drop regression passed 1/1, while an exact-parent control containing only that regression failed 1/1 at the intended immediate reopen with `already in use` and `Resource temporarily unavailable (os error 11)`.

That evidence proves only the owner-drop direction. It does not prove that a foreign inherited destructor preserves the live parent's exclusion lock, and it does not qualify the corrected tree. The unsafe prototype is withdrawn and must not be pushed or reviewed as the proposed implementation.

Earlier 6/6 negative controls, 11-run candidate observations, full `xerj-autoindex` package runs, strict Clippy, profiling builds, and the 1,366 passed / 0 failed / 3 skipped ES-YAML result were collected on an `ee29361`-based source tree. They establish repeatability of the original owner-release defect but do not qualify this current composition.

No local or private evidence files are part of the branch or required to review it.

## Reproduction commands

Run the deterministic foreign-drop converse oracle:

```bash
cd engine
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo test --locked -j 32 -p xerj-autoindex --lib -- --exact state::tests::foreign_pid_drop_preserves_lock_until_owner_drop
```

Run the owner-drop integration oracle:

```bash
cd engine
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo test --locked -j 32 -p xerj-autoindex --test journal_lock_inheritance -- --exact journal_drop_unlocks_before_a_fork_inherited_descriptor_closes
```

Then run proportional package gates:

```bash
cd engine
cargo fmt --all -- --check
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo test --locked -j 32 -p xerj-autoindex -- --test-threads=1
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo test --locked -j 32 -p xerj-autoindex
CARGO_PROFILE_DEV_LTO=false CARGO_PROFILE_DEV_CODEGEN_UNITS=16 cargo clippy --locked -j 32 -p xerj-autoindex --all-targets -- -D warnings
cargo build --locked --profile profiling -j 32 -p xerj-server -p es-yaml-runner
```

## Remaining qualification

- Fresh GitHub CI on published head `7e75c284`.
- macOS runtime regression.
- Windows compilation and runtime behavior for the unchanged non-fork path.

These are explicit merge gates, not hidden evidence.

## Limits

This change does not recover a lock from a genuinely live owner, retry acquisition, wait for another owner, take over after `SIGKILL`, or change crash recovery. If owner-side explicit unlock fails, Drop remains non-panicking and ordinary descriptor close remains the fallback.

The actual fork proof and deterministic converse proof are runtime-validated on Linux for this corrected tree. The fork test source is selected for Apple targets, but macOS runtime behavior is not claimed. Windows has no fork-based regression.

This PR makes no graph lifecycle, indexing performance, embedding, ranking, storage, or conformance improvement claim.