### PR TITLE
feat(landing): white-default, prompt-first hero with animated gradient halo

### DIFF
--- a/landing/case-studies/reference-coding.html
+++ b/landing/case-studies/reference-coding.html
@@ -68,6 +68,11 @@
 <section class="scene-section" style="border-top:0; padding-top:0;">
   <div class="opener">
     <div class="lbl">◆ Paste this into Claude Code to turn it on</div>
+    <pre>Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and
+set up reference coding: clone and index the open-source repos closest to what
+we're building, and search how they solved a problem before writing code.</pre>
+    <div class="hint">That is the current one-line setup — <a href="https://xerj.org/llms.txt" rel="external" style="color:var(--accent);">llms.txt</a> walks the agent through the full loop. The measurement below ran the study's original long-form prompt.</div>
+    <div class="lbl" style="margin-top:18px;">◆ The exact prompt the study measured</div>
     <pre>Set me up for reference-coding with XERJ and then use it automatically for the
 rest of our work, so I stop burning output tokens re-deriving APIs I could just
 look up.

--- a/landing/case-studies/reference-coding.html
+++ b/landing/case-studies/reference-coding.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>XERJ.ai — Reference-coding: the same Claude Code, a fraction of the tokens</title>
-<meta name="description" content="Paste one prompt and Claude Code stops re-deriving APIs it could look up. Measured across 13 purpose-built libraries in 5 languages: on code the model has not memorised, XERJ-retrieval makes the SAME model correct where memory fails (15/15 vs 1/15) at 1.5–2.7× fewer output tokens than native Claude Code. Every number verifiable; honest about where it doesn't help.">
+<meta name="description" content="Paste one prompt and Claude Code stops re-deriving APIs it could look up. Measured across 13 purpose-built libraries in 5 languages: on code the model has not memorised, XERJ-retrieval makes the SAME model correct where memory fails (21/21 vs 1/21) at 1.5–2.7× fewer output tokens than native Claude Code. Every number verifiable; honest about where it doesn't help.">
 <meta property="og:title" content="XERJ.ai — Reference-coding vs plain Claude Code">
 <meta property="og:description" content="One copy-paste prompt. 13 libraries, 5 languages, one hidden-test verdict, real tokens. Unfamiliar code: bare 1/21, XERJ-assisted 21/21 at 6.5× lower cost. Memorised code: honest overhead — and we say so.">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/landing/case-studies/reference-coding.html
+++ b/landing/case-studies/reference-coding.html
@@ -11,7 +11,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=cs0728">
+<link rel="stylesheet" href="/style.css?v=if9">
 <style>
   /* three-arm bars — self-contained, robust to the shared 2-col grid */
   .arm3 { margin: 12px 0 6px; }
@@ -67,10 +67,13 @@
 <!-- OPENER PROMPT -->
 <section class="scene-section" style="border-top:0; padding-top:0;">
   <div class="opener">
-    <div class="lbl">◆ Paste this into Claude Code to turn it on</div>
-    <pre>Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and
-set up reference coding: clone and index the open-source repos closest to what
-we're building, and search how they solved a problem before writing code.</pre>
+    <div class="prompt-stage" id="prompt" style="max-width:880px; margin:0 auto 18px;">
+      <div class="prompt-card">
+        <span class="prompt-label">PASTE THIS TO YOUR AI AGENT — IT DOES THE REST</span>
+        <code>Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.</code>
+        <button type="button" class="prompt-copy" data-copy="Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.">COPY THE PROMPT</button>
+      </div>
+    </div>
     <div class="hint">That is the current one-line setup — <a href="https://xerj.org/llms.txt" rel="external" style="color:var(--accent);">llms.txt</a> walks the agent through the full loop. The measurement below ran the study's original long-form prompt.</div>
     <div class="lbl" style="margin-top:18px;">◆ The exact prompt the study measured</div>
     <pre>Set me up for reference-coding with XERJ and then use it automatically for the
@@ -134,6 +137,43 @@ Do this proactively for the rest of the session without me asking again.</pre>
     </ul>
   </div>
 </div>
+
+<!-- How it works, in depth -->
+<section class="scene-section">
+  <h2 class="scene" style="font-size:var(--fs-56);">HOW IT WORKS, <span class="accent">IN DEPTH.</span></h2>
+  <ul class="deep">
+    <li><strong>1 · The prompt resolves to llms.txt.</strong> The one-liner points the agent at
+      <a href="https://xerj.org/llms.txt" rel="external">xerj.org/llms.txt</a> — ordered machine-readable steps:
+      install from xerj.org/get, start the single binary, index, query over the Elasticsearch wire, and the
+      reference-coding rules (retrieve before writing, cite what you use, respect licences).</li>
+    <li><strong>2 · The corpus is chosen by problem domain, not language.</strong> The agent reads the project's
+      dependencies and domains, picks the open-source repos that already solve those problems, and
+      <code class="inline">xc-corpus.sh</code> shallow-clones them into a named corpus. Each repository's licence
+      is recorded in <code class="inline">corpus.json</code>; GPL/AGPL entries are approach-only — read the design,
+      never copy the code.</li>
+    <li><strong>3 · Indexing is AST-aware.</strong> <code class="inline">xc-index.sh</code> runs
+      <code class="inline">xerj autoindex</code>: every file is sniffed by content, and source files go through
+      tree-sitter grammars (13 languages) that emit the language, every symbol with its kind and line number, a
+      searchable <code class="inline">defs</code> field, and the full body. One index per dataset, incremental on
+      re-runs — re-index when the references change.</li>
+    <li><strong>4 · Retrieval is hybrid, with a stated fallback.</strong> <code class="inline">xc.py</code> runs
+      BM25 <code class="inline">multi_match</code> over <code class="inline">body</code>,
+      <code class="inline">defs</code> and <code class="inline">title</code> — with a measured (not hand-picked)
+      boost on <code class="inline">defs</code> so exact symbol names outrank prose — RRF-fused with a vector arm
+      where an index supports it. When no index does, it degrades to BM25-only and says so; a silently
+      lexical-only "hybrid" would be a lie. The default embedder is lexical feature-hashing — vocabulary overlap,
+      not neural understanding.</li>
+    <li><strong>5 · The loop has discipline.</strong> Before writing non-trivial code against an unfamiliar API the
+      agent retrieves, reads the returned definition with its <code class="inline">file:line</code>, adapts it,
+      cites the source, and checks the licence. If nothing relevant comes back it says so and falls back to normal
+      work — forcing a bad match in is worse than not retrieving.</li>
+    <li><strong>6 · Why the tokens collapse.</strong> A retry loop on an unmemorised API burns <em>output</em>
+      tokens — the kind priced 5× above input on Claude models. Grep recovery pulls source into context: up to
+      <strong>1.06M input tokens</strong> on one corpus in this study. A retrieved passage is a few hundred tokens
+      and carries the one thing a compiler can never leak — the runtime contract. The per-task table below shows
+      the collapse: thousands of tokens from memory, hundreds with retrieval.</li>
+  </ul>
+</section>
 
 <!-- Everything we built -->
 <section class="scene-section">
@@ -281,5 +321,20 @@ Do this proactively for the rest of the session without me asking again.</pre>
 </footer>
 
 <script src="/interact.js" defer></script>
+<style>
+  ul.deep { list-style:none; padding:0; max-width:900px; }
+  ul.deep li { margin:14px 0; line-height:1.65; color:var(--z-mute); font-size:15px; }
+  ul.deep li strong { color:var(--z-ink); }
+  ul.deep code.inline { color:var(--z-ink); }
+</style>
+<script>
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest('[data-copy]'); if (!btn) return;
+    navigator.clipboard.writeText(btn.getAttribute('data-copy')).then(function () {
+      var orig = btn.textContent; btn.textContent = 'COPIED';
+      setTimeout(function () { btn.textContent = orig; }, 1400);
+    });
+  });
+</script>
 </body>
 </html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=if4">
+<link rel="stylesheet" href="/style.css?v=if5">
 </head>
 <body>
 
@@ -41,12 +41,6 @@
 
 <!-- HERO — one job: the prompt ----------------------------->
 <section class="hero-center">
-  <div class="kicker hero-kicker">
-    <span class="accent">XERJ</span><span class="dash">·</span>
-    <span>THE AI-NATIVE SEARCH ENGINE</span><span class="dash">·</span>
-    <span>APACHE-2.0</span>
-  </div>
-
   <h1 class="hero">ONE PROMPT.<br>WORKING PRODUCT.<br><span class="accent">~5× FEWER TOKENS.</span></h1>
 
   <div class="prompt-stage">

--- a/landing/index.html
+++ b/landing/index.html
@@ -321,7 +321,7 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
   </div>
 </section>
 
-<a href="#demo" class="cta">
+<a href="#prompt" class="cta" id="ctaCopy" data-prompt="Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.">
   <span>GET XERJ</span>
   <span class="arrow">↑</span>
 </a>
@@ -366,6 +366,21 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
           document.body.removeChild(ta);
           done();
         }
+      });
+    }
+    const cta = document.getElementById('ctaCopy');
+    if (cta) {
+      cta.addEventListener('click', () => {
+        const label = cta.querySelector('span');
+        const done = () => {
+          const orig = label.textContent;
+          label.textContent = 'PROMPT COPIED ✓';
+          setTimeout(() => { label.textContent = orig; }, 1600);
+        };
+        const text = cta.getAttribute('data-prompt');
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(done);
+        } else { done(); }
       });
     }
   })();

--- a/landing/index.html
+++ b/landing/index.html
@@ -47,11 +47,14 @@
     <span>APACHE-2.0</span>
   </div>
 
-  <h1 class="hero">STOP RE-DERIVING.<br><span class="accent">START LOOKING UP.</span></h1>
+  <h1 class="hero">ONE PROMPT.<br>WORKING PRODUCT.<br><span class="accent">~5× FEWER TOKENS.</span></h1>
 
-  <p class="hero-sub">Any folder — code, docs, logs, PDFs — becomes a search engine
-    your AI agent queries instead of reading files into context. One Rust binary,
-    Elasticsearch wire, zero config.</p>
+  <p class="hero-sub">That's what users report shipping real products with
+    Claude&nbsp;Code&nbsp;+&nbsp;XERJ
+    (<a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>).
+    Paste the prompt below — your agent installs XERJ, indexes your project and
+    the open-source repos closest to it, and looks implementations up instead of
+    re-deriving them.</p>
 
   <div class="prompt-stage">
     <div class="prompt-card">
@@ -65,9 +68,7 @@
     <strong>2.7× fewer output tokens</strong> than grep-driven Claude Code on the
     8-task cross-language benchmark · <strong>21/21 solved vs 1/21 from memory</strong>
     on the seven domains whose contract the model can't recall —
-    <a href="/case-studies/reference-coding.html">the case study</a>.
-    Users report <strong>~5×</strong> in real development —
-    <a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>.</p>
+    <a href="/case-studies/reference-coding.html">every number in the case study</a>.</p>
 
   <p class="hero-alt-install">No agent handy?
     <code>curl -fsSL https://xerj.org/get | sh</code>

--- a/landing/index.html
+++ b/landing/index.html
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=if7">
+<link rel="stylesheet" href="/style.css?v=if8">
 </head>
 <body>
 
@@ -51,25 +51,22 @@
     </div>
   </div>
 
-  <p class="hero-sub">Users shipping real products with Claude&nbsp;Code&nbsp;+&nbsp;XERJ
-    report exactly that
-    (<a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>).
-    One paste — your agent installs XERJ, indexes your project and the
-    open-source repos closest to it, and looks implementations up instead of
-    re-deriving them.</p>
+  <p class="hero-sub">One paste — your agent installs XERJ, indexes your project and
+    the open-source repos worth learning from, and looks implementations up
+    instead of re-deriving them.</p>
 
-  <p class="hero-proof">The measured benchmarks behind it, on code the model hadn't seen:
-    <strong>2.7× fewer output tokens</strong> than grep-driven Claude Code on the
-    8-task cross-language benchmark · <strong>21/21 solved vs 1/21 from memory</strong>
-    on the seven domains whose contract the model can't recall —
-    <a href="/case-studies/reference-coding.html">every number in the case study</a>.</p>
+  <p class="hero-marks">
+    <a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">FIELD REPORTS ~5×</a>
+    <span class="dash">·</span>
+    <a href="/case-studies/reference-coding.html">MEASURED 2.7× VS GREP-DRIVEN CLAUDE CODE</a>
+    <span class="dash">·</span>
+    <a href="/case-studies/reference-coding.html">21/21 VS 1/21 ON UNSEEN CONTRACTS</a>
+  </p>
 
   <p class="hero-alt-install">No agent handy?
     <code>curl -fsSL https://xerj.org/get | sh</code>
     <button type="button" class="hero-install-copy" data-copy="curl -fsSL https://xerj.org/get | sh">COPY</button>
-    <span class="dash">·</span> Windows:
-    <code>irm https://xerj.org/get.ps1 | iex</code>
-    <button type="button" class="hero-install-copy" data-copy="irm https://xerj.org/get.ps1 | iex">COPY</button>
+    <span class="dash">·</span> <a href="/docs/index.html">Windows &amp; more &rarr;</a>
   </p>
 
 </section>

--- a/landing/index.html
+++ b/landing/index.html
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=if8">
+<link rel="stylesheet" href="/style.css?v=if9">
 </head>
 <body>
 
@@ -43,7 +43,7 @@
 <section class="hero-center">
   <h1 class="hero">ONE PROMPT.<br>WORKING PRODUCT.<br><span class="hero-report-tag">USERS REPORT</span><span class="accent">~5× FEWER TOKENS.</span></h1>
 
-  <div class="prompt-stage">
+  <div class="prompt-stage" id="prompt">
     <div class="prompt-card">
       <span class="prompt-label">PASTE THIS TO YOUR AI AGENT — IT DOES THE REST</span>
       <code>Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.</code>
@@ -55,19 +55,6 @@
     the open-source repos worth learning from, and looks implementations up
     instead of re-deriving them.</p>
 
-  <p class="hero-marks">
-    <a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">FIELD REPORTS ~5×</a>
-    <span class="dash">·</span>
-    <a href="/case-studies/reference-coding.html">MEASURED 2.7× VS GREP-DRIVEN CLAUDE CODE</a>
-    <span class="dash">·</span>
-    <a href="/case-studies/reference-coding.html">21/21 VS 1/21 ON UNSEEN CONTRACTS</a>
-  </p>
-
-  <p class="hero-alt-install">No agent handy?
-    <code>curl -fsSL https://xerj.org/get | sh</code>
-    <button type="button" class="hero-install-copy" data-copy="curl -fsSL https://xerj.org/get | sh">COPY</button>
-    <span class="dash">·</span> <a href="/docs/index.html">Windows &amp; more &rarr;</a>
-  </p>
 
 </section>
 
@@ -254,22 +241,38 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
   </div>
 </section>
 
-<section class="lead-capture" id="demo">
-  <div class="kicker"><span class="accent">XERJ.AI</span><span class="dash">·</span><span>OPEN THE PLAYGROUND</span></div>
-  <h3>TRY IT<br><span class="accent">RIGHT NOW.</span></h3>
-  <p>
-    Leave a work email and the live dashboards open immediately — explore the
-    query surface, vector search, aggregations, and agent memory on real data.
-    Stored only in your browser: no funnel, no sequenced drip, no "journey."
-  </p>
+<section class="scene-section" id="try">
+  <div class="kicker"><span class="accent">TRY IT</span><span class="dash">·</span><span>TWO MINUTES · NO SIGNUP</span></div>
+  <h2 class="scene">THREE WAYS <span class="accent">IN.</span></h2>
 
-  <form class="lead-form" id="leadForm" action="#" method="post" novalidate>
-    <div class="lead-form-input">
-      <input type="email" name="email" placeholder="you@company.com" required aria-label="Work email" autocomplete="email" />
+  <div class="recipes" style="grid-template-columns:repeat(3,1fr); margin-top:var(--sp-6);">
+    <a class="recipe" href="#prompt">
+      <span class="num">01 · WITH YOUR AGENT</span>
+      <span class="title">Paste the prompt</span>
+      <p class="lead">The prompt at the top of this page is the whole setup — install, index, reference coding. Copy it &rarr;</p>
+    </a>
+    <div class="recipe">
+      <span class="num">02 · IN A SHELL</span>
+      <span class="title">One command</span>
+      <p class="lead"><code>curl -fsSL https://xerj.org/get | sh</code>
+        <button type="button" class="hero-install-copy" data-copy="curl -fsSL https://xerj.org/get | sh">COPY</button><br>
+        Windows: <code>irm https://xerj.org/get.ps1 | iex</code>
+        <button type="button" class="hero-install-copy" data-copy="irm https://xerj.org/get.ps1 | iex">COPY</button></p>
     </div>
-    <button type="submit" class="demo">OPEN PLAYGROUND <span class="arrow">→</span></button>
-    <span class="note">We keep your email to follow up about XERJ — nothing else. No spam, no reselling.</span>
-  </form>
+    <a class="recipe" href="/playground/">
+      <span class="num">03 · IN THE BROWSER</span>
+      <span class="title">Open the playground</span>
+      <p class="lead">Live dashboards over real data — query surface, vectors, aggregations, agent memory. Nothing to install.</p>
+    </a>
+  </div>
+
+  <p class="hero-marks" style="margin-top:var(--sp-6);">
+    <a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">FIELD REPORTS ~5×</a>
+    <span class="dash">·</span>
+    <a href="/case-studies/reference-coding.html">MEASURED 2.7× VS GREP-DRIVEN CLAUDE CODE</a>
+    <span class="dash">·</span>
+    <a href="/case-studies/reference-coding.html">21/21 VS 1/21 ON UNSEEN CONTRACTS</a>
+  </p>
 </section>
 
 <!-- BENCHMARKS — SUPPORTING EVIDENCE -------------------------->
@@ -379,22 +382,6 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
           document.body.removeChild(ta);
           done();
         }
-      });
-    }
-    const form = document.getElementById('leadForm');
-    if (form) {
-      form.addEventListener('submit', (e) => {
-        e.preventDefault();
-        const email = form.querySelector('input[type=email]').value.trim();
-        if (!email || !email.includes('@')) return;
-        console.log('[xerj lead]', email);
-        try { localStorage.setItem('xerj.playground.email', email); } catch (_) {}
-        // Capture the lead (fire-and-forget with keepalive so the redirect
-        // never waits on it), then open the live dashboards app.
-        try {
-          fetch('/lead', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ email: email, source: 'landing' }), keepalive: true }).catch(function () {});
-        } catch (_) {}
-        window.location.href = '/playground/';
       });
     }
   })();

--- a/landing/index.html
+++ b/landing/index.html
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=if3">
+<link rel="stylesheet" href="/style.css?v=if4">
 </head>
 <body>
 
@@ -49,13 +49,6 @@
 
   <h1 class="hero">ONE PROMPT.<br>WORKING PRODUCT.<br><span class="accent">~5× FEWER TOKENS.</span></h1>
 
-  <p class="hero-sub">That's what users report shipping real products with
-    Claude&nbsp;Code&nbsp;+&nbsp;XERJ
-    (<a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>).
-    Paste the prompt below — your agent installs XERJ, indexes your project and
-    the open-source repos closest to it, and looks implementations up instead of
-    re-deriving them.</p>
-
   <div class="prompt-stage">
     <div class="prompt-card">
       <span class="prompt-label">PASTE THIS TO YOUR AI AGENT — IT DOES THE REST</span>
@@ -63,6 +56,13 @@
       <button type="button" class="prompt-copy" data-copy="Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.">COPY THE PROMPT</button>
     </div>
   </div>
+
+  <p class="hero-sub">That's what users report shipping real products with
+    Claude&nbsp;Code&nbsp;+&nbsp;XERJ
+    (<a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>).
+    One paste — your agent installs XERJ, indexes your project and the
+    open-source repos closest to it, and looks implementations up instead of
+    re-deriving them.</p>
 
   <p class="hero-proof">Measured on code the model hadn't seen:
     <strong>2.7× fewer output tokens</strong> than grep-driven Claude Code on the
@@ -78,15 +78,6 @@
     <button type="button" class="hero-install-copy" data-copy="irm https://xerj.org/get.ps1 | iex">COPY</button>
   </p>
 
-  <div class="hero-demo hero-demo-center">
-    <div class="hero-demo-stage" data-demo>
-      <video preload="metadata" playsinline src="/xerj-biz-demo.mp4"></video>
-      <button class="hero-demo-play" type="button" aria-label="Play the XERJ demo">
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
-      </button>
-      <span class="hero-demo-label mono">XERJ · LIVE DEMO · NO CUTS</span>
-    </div>
-  </div>
 </section>
 
 <!-- 01 — REFERENCE CODING ------------------------------------->

--- a/landing/index.html
+++ b/landing/index.html
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=if5">
+<link rel="stylesheet" href="/style.css?v=if7">
 </head>
 <body>
 
@@ -41,7 +41,7 @@
 
 <!-- HERO — one job: the prompt ----------------------------->
 <section class="hero-center">
-  <h1 class="hero">ONE PROMPT.<br>WORKING PRODUCT.<br><span class="accent">~5× FEWER TOKENS.</span></h1>
+  <h1 class="hero">ONE PROMPT.<br>WORKING PRODUCT.<br><span class="hero-report-tag">USERS REPORT</span><span class="accent">~5× FEWER TOKENS.</span></h1>
 
   <div class="prompt-stage">
     <div class="prompt-card">
@@ -51,14 +51,14 @@
     </div>
   </div>
 
-  <p class="hero-sub">That's what users report shipping real products with
-    Claude&nbsp;Code&nbsp;+&nbsp;XERJ
+  <p class="hero-sub">Users shipping real products with Claude&nbsp;Code&nbsp;+&nbsp;XERJ
+    report exactly that
     (<a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>).
     One paste — your agent installs XERJ, indexes your project and the
     open-source repos closest to it, and looks implementations up instead of
     re-deriving them.</p>
 
-  <p class="hero-proof">Measured on code the model hadn't seen:
+  <p class="hero-proof">The measured benchmarks behind it, on code the model hadn't seen:
     <strong>2.7× fewer output tokens</strong> than grep-driven Claude Code on the
     8-task cross-language benchmark · <strong>21/21 solved vs 1/21 from memory</strong>
     on the seven domains whose contract the model can't recall —

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="night">
+<html lang="en" data-theme="day">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=if2">
+<link rel="stylesheet" href="/style.css?v=if3">
 </head>
 <body>
 
@@ -33,72 +33,57 @@
   <a href="/playground.html">DASHBOARDS</a>
   <a href="https://github.com/xerj-org/xerj" rel="external">GITHUB</a>
   <span class="theme">
-    <button type="button" data-theme="day">DAY</button>
+    <button type="button" data-theme="day" class="active">DAY</button>
     <span class="dash">·</span>
-    <button type="button" data-theme="night" class="active">NIGHT</button>
+    <button type="button" data-theme="night">NIGHT</button>
   </span>
 </nav>
 
-<!-- HERO ---------------------------------------------------->
-<section class="scene-section section-split hero-split">
-  <div class="split-copy">
-    <div class="kicker">
-      <span class="accent">XERJ.AI</span><span class="dash">·</span>
-      <span>THE AI-NATIVE SEARCH ENGINE</span><span class="dash">·</span>
-      <span>2026</span>
-    </div>
-
-    <h1 class="hero"><span class="accent">XERJ.</span><br>STOP RE-DERIVING.<br>START LOOKING UP.</h1>
-
-    <div class="hero-install">
-      <div class="hero-install-agent" style="margin-top:0;">
-        <span class="hero-install-label">PASTE THIS TO YOUR AI AGENT · THE WHOLE SETUP</span>
-        <div class="hero-install-cmd agent-prompt">
-          <code>Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.</code>
-          <button type="button" class="hero-install-copy" data-copy="Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.">COPY</button>
-        </div>
-        <p class="hero-install-agent-line">One prompt is enough — llms.txt gives your agent
-          the ordered steps: install, start the server, <code>xerj autoindex .</code>,
-          query with any Elasticsearch client, and the reference-coding loop.
-          Measured: <strong>2.7× fewer output tokens</strong> than grep-driven Claude Code,
-          <strong>26× fewer</strong> than memory alone —
-          <a href="/case-studies/reference-coding.html">the case study</a>. Users report
-          <strong>~5×</strong> across real product development —
-          <a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>.</p>
-      </div>
-      <div class="hero-install-label" style="margin-top:var(--sp-3);">OR INSTALL BY HAND · ONE COMMAND · SHA-256 CHECKSUMS</div>
-      <div class="hero-install-cmd">
-        <code>curl -fsSL https://xerj.org/get | sh</code>
-        <button type="button" class="hero-install-copy" data-copy="curl -fsSL https://xerj.org/get | sh">COPY</button>
-      </div>
-      <div class="hero-install-alt">
-        <span class="mono">WINDOWS · <code>irm https://xerj.org/get.ps1 | iex</code></span>
-        <button type="button" class="hero-install-copy" data-copy="irm https://xerj.org/get.ps1 | iex">COPY</button>
-      </div>
-    </div>
-
-    <p class="lead">
-      The AI-native search engine — connect it, run
-      <code class="inline">xerj&nbsp;autoindex</code>, and it works: any folder
-      becomes typed, queryable indices — <strong>zero configuration</strong>.
-      Give agents <strong>reference coding</strong>, <strong>long-term
-      memory</strong>, <strong>semantic search &amp; RAG</strong>,
-      <strong>hybrid</strong> BM25&nbsp;+&nbsp;vector retrieval,
-      <strong>auto-embedding</strong> on ingest, and <strong>anomaly
-      detection</strong> — no bolt-on vector database, no glue code. One binary
-      that speaks the Elasticsearch wire protocol, released under
-      <strong>Apache&#8209;2.0</strong>: no lock-in, no SSPL, no per-feature
-      gates. Yours to run, fork, and build on.
-    </p>
+<!-- HERO — one job: the prompt ----------------------------->
+<section class="hero-center">
+  <div class="kicker hero-kicker">
+    <span class="accent">XERJ</span><span class="dash">·</span>
+    <span>THE AI-NATIVE SEARCH ENGINE</span><span class="dash">·</span>
+    <span>APACHE-2.0</span>
   </div>
 
-  <div class="split-viz hero-demo">
+  <h1 class="hero">STOP RE-DERIVING.<br><span class="accent">START LOOKING UP.</span></h1>
+
+  <p class="hero-sub">Any folder — code, docs, logs, PDFs — becomes a search engine
+    your AI agent queries instead of reading files into context. One Rust binary,
+    Elasticsearch wire, zero config.</p>
+
+  <div class="prompt-stage">
+    <div class="prompt-card">
+      <span class="prompt-label">PASTE THIS TO YOUR AI AGENT — IT DOES THE REST</span>
+      <code>Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.</code>
+      <button type="button" class="prompt-copy" data-copy="Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.">COPY THE PROMPT</button>
+    </div>
+  </div>
+
+  <p class="hero-proof">Measured on code the model hadn't seen:
+    <strong>2.7× fewer output tokens</strong> than grep-driven Claude Code on the
+    8-task cross-language benchmark · <strong>21/21 solved vs 1/21 from memory</strong>
+    on the seven domains whose contract the model can't recall —
+    <a href="/case-studies/reference-coding.html">the case study</a>.
+    Users report <strong>~5×</strong> in real development —
+    <a href="https://github.com/xerj-org/xerj/blob/main/user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md">field reports</a>.</p>
+
+  <p class="hero-alt-install">No agent handy?
+    <code>curl -fsSL https://xerj.org/get | sh</code>
+    <button type="button" class="hero-install-copy" data-copy="curl -fsSL https://xerj.org/get | sh">COPY</button>
+    <span class="dash">·</span> Windows:
+    <code>irm https://xerj.org/get.ps1 | iex</code>
+    <button type="button" class="hero-install-copy" data-copy="irm https://xerj.org/get.ps1 | iex">COPY</button>
+  </p>
+
+  <div class="hero-demo hero-demo-center">
     <div class="hero-demo-stage" data-demo>
       <video preload="metadata" playsinline src="/xerj-biz-demo.mp4"></video>
       <button class="hero-demo-play" type="button" aria-label="Play the XERJ demo">
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
       </button>
-      <span class="hero-demo-label mono">XERJ · LIVE DEMO</span>
+      <span class="hero-demo-label mono">XERJ · LIVE DEMO · NO CUTS</span>
     </div>
   </div>
 </section>
@@ -393,8 +378,9 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
       btn.addEventListener('click', () => {
         const text = btn.getAttribute('data-copy');
         const done = () => {
+          const orig = btn.textContent;
           btn.textContent = 'COPIED';
-          setTimeout(() => { btn.textContent = 'COPY'; }, 1400);
+          setTimeout(() => { btn.textContent = orig; }, 1400);
         };
         if (navigator.clipboard && navigator.clipboard.writeText) {
           navigator.clipboard.writeText(text).then(done, done);

--- a/landing/index.html
+++ b/landing/index.html
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%230b0b0d'/><text x='50' y='68' font-size='60' font-family='Big Shoulders Display,sans-serif' font-weight='900' fill='%23ffc400' text-anchor='middle'>X</text></svg>">
-<link rel="stylesheet" href="/style.css?v=if9">
+<link rel="stylesheet" href="/style.css?v=if10">
 </head>
 <body>
 
@@ -276,64 +276,48 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
 </section>
 
 <!-- BENCHMARKS — SUPPORTING EVIDENCE -------------------------->
-<section class="scene-section">
-  <div class="kicker"><span class="accent">05</span><span class="dash">·</span><span>SUPPORTING EVIDENCE · XERJ vs ELASTICSEARCH 8.13.4</span></div>
-  <div class="ticker">
-    <div class="tk">
-      <div class="eyebrow">FULL QUERY MATRIX · CLOSED-LOOP · CACHE OFF</div>
-      <div class="value"><span class="accent">55W</span> · 26T · 4L</div>
-      <div class="hint">vs live ES 8.13.4 · 3 N/A · the 4 losses are all read-under-write p99 (published too) · demo/playbooks/SCORECARD.md</div>
-    </div>
-    <div class="tk">
-      <div class="eyebrow">XERJ vs ES · BULK INGEST</div>
-      <div class="value"><span class="accent">1.72×</span> FASTER</div>
-      <div class="hint">191k vs 111k docs/s, same corpus, closed-loop · acked deletes survive SIGTERM/SIGKILL restarts (11/11 crash cells)</div>
-    </div>
-    <div class="tk">
-      <div class="eyebrow">XERJ vs ES · INDEX ON DISK</div>
-      <div class="value"><span class="accent">1.61×</span> SMALLER</div>
-      <div class="hint">index on-disk 176 MB vs ES 283 MB, same corpus · demo/playbooks/SCORECARD.md</div>
-    </div>
-  </div>
-  <p class="viz-caption" style="margin-top:var(--sp-4);">The engine numbers back the use cases up — they are not the product. kNN recall@10 measured 1.00 (unfiltered kNN is now HNSW-served with exact rescoring — re-measured 1.00 vs ES 8.13.4's 0.80 on the official bench cell). <a class="mono" href="/benchmarks/" style="color:var(--z-mute);">FULL BENCHMARK METHODOLOGY + REPRODUCTION →</a></p>
-</section>
-
-<!-- ENGINE --------------------------------------------------->
 <section class="scene-section" id="engine" style="border-top:0;">
-  <div class="kicker"><span class="accent">06</span><span class="dash">·</span><span>INSIDE XERJ</span></div>
-  <h2 class="scene">ONE BINARY.<br>NO JVM.<br><span class="accent">NO COMPROMISES.</span></h2>
+  <div class="kicker"><span class="accent">05</span><span class="dash">·</span><span>WHY XERJ · THE COMPETITIVE ADVANTAGE</span></div>
+  <h2 class="scene">THE ADVANTAGE,<br><span class="accent">FEATURE BY FEATURE.</span></h2>
 
   <p class="wide">
-    XERJ is written in Rust and ships as a single static binary.
-    No JVM to tune, no sidecars to deploy, no cluster coordinator to
-    install. The query planner, the vector index, the ingestion
-    pipeline, the embedded Raft consensus, and the HTTP server all
-    live in the same process.
+    Every feature exists to cut the thing agents actually spend: context.
+    Reading a file costs a context window; asking an index costs kilobytes.
+    XERJ puts everything an agent needs to <em>ask</em> — code, documents,
+    vectors, memory — behind one query surface.
   </p>
 
   <div class="row">
-    <div class="k">Query types</div>
-    <div class="v">50 query types, machine-checked against the parser dispatch table including native hybrid BM25 + kNN fusion — more than most dedicated vector databases</div>
+    <div class="k">AST code search</div>
+    <div class="v">Source is parsed with tree-sitter (13 languages) into symbols with kind and line number plus a searchable definitions field — the agent retrieves a <em>function with its contract</em>, not a grep line that needs the whole file opened to judge</div>
   </div>
   <div class="row">
-    <div class="k">Aggregations</div>
-    <div class="v">Metric + bucket + pipeline agg families · terms are <strong>~1.15×</strong> faster than ES because histograms are pre-computed at ingest</div>
+    <div class="k">Token economics</div>
+    <div class="v">In the <a href="/use-cases/code-security-audit.html">WordPress security audit</a>, an agent worked across 1,492 PHP files on roughly <strong>26,000 tokens</strong> — about half a percent of the tree read into context. That is the product; the speed is a side effect</div>
   </div>
   <div class="row">
-    <div class="k">Vector index</div>
-    <div class="v">HNSW-served kNN with exact rescoring on unfiltered queries (measured recall@10 1.00 on the official bench query) · exact brute-force scan for filtered / quantized / small-index shapes · cosine / L2 / dot · SQ8 / SQ4 / binary quantization · max 16,384 dims (ES caps at 4,096)</div>
+    <div class="k">Hybrid in one pass</div>
+    <div class="v">50 query types, machine-checked against the parser dispatch table, including native BM25 + kNN fusion (RRF) in a single query tree — no bolt-on vector database, no fusion glue between two systems</div>
   </div>
   <div class="row">
-    <div class="k">AI-native</div>
-    <div class="v">Auto-embed on ingest with a built-in lexical embedder (optional external proxy) · agent-memory store · anomaly detection · semantic search at query time</div>
+    <div class="k">Semantic without setup</div>
+    <div class="v">Auto-embed on ingest, fully offline. Honest by default: the built-in embedder is lexical feature-hashing (vocabulary overlap, not neural understanding); the in-binary neural encoder and the external-proxy mode are drop-in upgrades when you want them</div>
   </div>
   <div class="row">
-    <div class="k">Storage</div>
-    <div class="v">Columnar · 9 domain-aware encodings · ZSTD · <strong>1.20×</strong> smaller than ES on the benchmark corpus · mmap'd segments</div>
+    <div class="k">Agent memory + graph</div>
+    <div class="v">A namespaced <code class="inline">/_memory</code> REST API — store, recall by meaning / keyword / vector, filter, forget, physically isolated per agent — and a <code class="inline">/_graph</code> knowledge layer with evidence on every link</div>
   </div>
   <div class="row">
-    <div class="k">Cluster</div>
-    <div class="v">Embedded Raft consensus · metadata replication · region-based partitioning · no ZooKeeper / etcd</div>
+    <div class="k">Zero-config ingest</div>
+    <div class="v">One command sniffs 13 format families by content — code, CSV, JSON, PDF, DOCX, SQLite, logs — honours <code class="inline">.gitignore</code>, records junk instead of crashing on it, and resumes incrementally</div>
+  </div>
+  <div class="row">
+    <div class="k">Speaks Elasticsearch</div>
+    <div class="v">1,365 / 1,368 wire-conformance cases green on every commit — existing clients, dashboards and tooling connect unchanged. A migration bridge, not a clone: the engine underneath is designed for agents</div>
+  </div>
+  <div class="row">
+    <div class="k">One static binary</div>
+    <div class="v">Rust, no JVM, sub-second start, Apache-2.0 — laptop to server with the same artifact. Benchmarks with wins <em>and</em> losses published at <a href="/benchmarks">xerj.org/benchmarks</a></div>
   </div>
 </section>
 

--- a/landing/style.css
+++ b/landing/style.css
@@ -2543,13 +2543,13 @@ svg.chart.is-interactive .ser:focus-visible {
   text-align: center;
   /* horizontal gutter is var(--sp-6), NOT --page-x: body already pads
      --page-x, and doubling it starved the h1 at laptop widths. */
-  padding: var(--sp-16) var(--sp-6) var(--sp-12);
+  padding: var(--sp-8) var(--sp-6) var(--sp-12);
   max-width: var(--max-w);
   margin: 0 auto;
 }
 .hero-kicker { justify-content: center; }
 .hero-center .hero {
-  margin: var(--sp-6) auto var(--sp-4);
+  margin: 0 auto var(--sp-4);
   /* The split-hero clamp died with .hero-split; without one the h1 is a
      fixed 160px from 961px up — measured 1071px wide at 1024px viewports,
      wrapping to four ragged lines and pushing the prompt below the fold. */

--- a/landing/style.css
+++ b/landing/style.css
@@ -51,9 +51,11 @@ html[data-theme='day'] {
   --z-faint: #e3dfd4;
   --z-line:  #cfcbbf;
   /* Day accent — darker ochre in the same yellow family.
-     #ffc400 on cream is 1.7:1 (unreadable). #a06800 is 5.7:1 (AA body).
+     #ffc400 on cream is 1.7:1 (unreadable). #a06800 measured 4.27:1 on
+     cream — the old comment claiming 5.7:1 was miscalculated and failed
+     AA once day became the default. #7f5200 is 6.14:1 (AA body, AAA large).
      Still reads as "XERJ yellow", just at a different luminance. */
-  --z-accent: #a06800;
+  --z-accent: #7f5200;
   --z-cmp: #6f8aa8;
 }
 
@@ -2532,3 +2534,132 @@ svg.chart.is-interactive .ser:focus-visible {
   .chart-chip { font-size: 10px; padding: 3px 7px; gap: 6px; }
 }
 
+
+/* ---------- hero-center: the prompt is the page (2026-08-11) ----------
+   One job above the fold: copy the agent prompt. Everything else is
+   secondary. The animated gradient halo is the only moving thing on the
+   page, and it stops under prefers-reduced-motion. */
+.hero-center {
+  text-align: center;
+  /* horizontal gutter is var(--sp-6), NOT --page-x: body already pads
+     --page-x, and doubling it starved the h1 at laptop widths. */
+  padding: var(--sp-16) var(--sp-6) var(--sp-12);
+  max-width: var(--max-w);
+  margin: 0 auto;
+}
+.hero-kicker { justify-content: center; }
+.hero-center .hero {
+  margin: var(--sp-6) auto var(--sp-4);
+  /* The split-hero clamp died with .hero-split; without one the h1 is a
+     fixed 160px from 961px up — measured 1071px wide at 1024px viewports,
+     wrapping to four ragged lines and pushing the prompt below the fold. */
+  font-size: clamp(44px, 8vw, 140px);
+}
+.hero-sub {
+  font-family: var(--font-prose);
+  font-size: clamp(var(--fs-16), 1.6vw, var(--fs-20));
+  line-height: 1.55;
+  color: var(--z-mute);
+  max-width: 720px;
+  margin: 0 auto;
+}
+.prompt-stage {
+  position: relative;
+  max-width: 880px;
+  margin: var(--sp-10) auto var(--sp-6);
+}
+.prompt-stage::before {
+  content: '';
+  position: absolute;
+  inset: -26px;
+  border-radius: 28px;
+  background: linear-gradient(115deg,
+    #ffc400, #ff8a2a, #ff3d81, #8a5cff, #21c6ff, #ffc400);
+  background-size: 320% 320%;
+  filter: blur(44px);
+  opacity: 0.45;
+  animation: prompt-glow 9s ease-in-out infinite;
+  /* -1: without it the ::before joins the root stacking context and
+     washes over .hero-sub/.hero-proof text at its blurred edges. */
+  z-index: -1;
+  pointer-events: none;
+}
+html[data-theme='night'] .prompt-stage::before { opacity: 0.32; }
+@keyframes prompt-glow {
+  0%   { background-position: 0% 50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .prompt-stage::before { animation: none; }
+}
+.prompt-card {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  text-align: left;
+  background: var(--z-bg);
+  border: 1px solid var(--z-line);
+  border-radius: 14px;
+  padding: var(--sp-6) var(--sp-6) var(--sp-4);
+  box-shadow: 0 8px 40px rgba(0,0,0,0.10);
+}
+.prompt-label {
+  font-family: var(--font-data);
+  font-size: var(--fs-11);
+  font-weight: 600;
+  letter-spacing: var(--track-ui);
+  text-transform: uppercase;
+  color: var(--z-accent);
+}
+.prompt-card code {
+  font-family: var(--font-mono);
+  font-size: clamp(var(--fs-13), 1.25vw, 17px);
+  line-height: 1.6;
+  color: var(--z-ink);
+  user-select: all;
+}
+.prompt-copy {
+  align-self: flex-end;
+  font-family: var(--font-data);
+  font-size: var(--fs-13);
+  font-weight: 700;
+  letter-spacing: var(--track-ui);
+  color: var(--z-bg);
+  background: var(--z-accent);
+  border: 1px solid var(--z-accent);
+  border-radius: 8px;
+  padding: 10px 22px;
+  cursor: pointer;
+}
+.prompt-copy:hover, .prompt-copy:focus-visible {
+  background: var(--z-ink);
+  border-color: var(--z-ink);
+  color: var(--z-bg);
+}
+.hero-proof {
+  font-family: var(--font-prose);
+  font-size: var(--fs-13);
+  line-height: 1.7;
+  color: var(--z-mute);
+  max-width: 760px;
+  margin: 0 auto;
+}
+.hero-alt-install {
+  font-family: var(--font-mono);
+  font-size: var(--fs-13);
+  color: var(--z-mute);
+  margin: var(--sp-4) auto 0;
+}
+.hero-alt-install code { color: var(--z-ink); }
+.hero-demo-center {
+  max-width: 880px;
+  margin: var(--sp-10) auto 0;
+}
+@media (max-width: 720px) {
+  .hero-center { padding-left: var(--sp-4); padding-right: var(--sp-4); }
+  .prompt-stage::before { inset: -14px; filter: blur(28px); }
+  .prompt-copy { align-self: stretch; text-align: center; }
+}

--- a/landing/style.css
+++ b/landing/style.css
@@ -2561,7 +2561,7 @@ svg.chart.is-interactive .ser:focus-visible {
   line-height: 1.55;
   color: var(--z-mute);
   max-width: 720px;
-  margin: 0 auto;
+  margin: var(--sp-4) auto 0;
 }
 .prompt-stage {
   position: relative;
@@ -2576,15 +2576,15 @@ svg.chart.is-interactive .ser:focus-visible {
   background: linear-gradient(115deg,
     #ffc400, #ff8a2a, #ff3d81, #8a5cff, #21c6ff, #ffc400);
   background-size: 320% 320%;
-  filter: blur(44px);
-  opacity: 0.45;
-  animation: prompt-glow 9s ease-in-out infinite;
+  filter: blur(34px);
+  opacity: 0.7;
+  animation: prompt-glow 7s ease-in-out infinite;
   /* -1: without it the ::before joins the root stacking context and
      washes over .hero-sub/.hero-proof text at its blurred edges. */
   z-index: -1;
   pointer-events: none;
 }
-html[data-theme='night'] .prompt-stage::before { opacity: 0.32; }
+html[data-theme='night'] .prompt-stage::before { opacity: 0.5; }
 @keyframes prompt-glow {
   0%   { background-position: 0% 50%; }
   50%  { background-position: 100% 50%; }
@@ -2600,11 +2600,21 @@ html[data-theme='night'] .prompt-stage::before { opacity: 0.32; }
   flex-direction: column;
   gap: var(--sp-3);
   text-align: left;
-  background: var(--z-bg);
-  border: 1px solid var(--z-line);
+  /* animated gradient border: paint the bg twice — flat card fill in the
+     padding-box, moving gradient in the border-box — sharing the halo's
+     keyframes so the two layers sweep together. */
+  border: 3px solid transparent;
+  background:
+    linear-gradient(var(--z-bg), var(--z-bg)) padding-box,
+    linear-gradient(115deg, #ffc400, #ff8a2a, #ff3d81, #8a5cff, #21c6ff, #ffc400) border-box;
+  background-size: 100% 100%, 320% 320%;
+  animation: prompt-glow 7s ease-in-out infinite;
   border-radius: 14px;
   padding: var(--sp-6) var(--sp-6) var(--sp-4);
   box-shadow: 0 8px 40px rgba(0,0,0,0.10);
+}
+@media (prefers-reduced-motion: reduce) {
+  .prompt-card { animation: none; }
 }
 .prompt-label {
   font-family: var(--font-data);

--- a/landing/style.css
+++ b/landing/style.css
@@ -2553,7 +2553,35 @@ svg.chart.is-interactive .ser:focus-visible {
   /* The split-hero clamp died with .hero-split; without one the h1 is a
      fixed 160px from 961px up — measured 1071px wide at 1024px viewports,
      wrapping to four ragged lines and pushing the prompt below the fold. */
-  font-size: clamp(44px, 8vw, 140px);
+  font-size: clamp(38px, 8vw, 140px);
+}
+.hero-report-tag {
+  display: block;
+  font-family: var(--font-data);
+  font-size: clamp(12px, 1.2vw, 16px);
+  font-weight: 600;
+  letter-spacing: var(--track-ui);
+  color: var(--z-mute);
+  margin: var(--sp-2) 0 2px;
+}
+/* Phones: the desktop clamp floor made the hero read TINY on iPhone
+   (user report). Phones get viewport-relative type + tighter gutters
+   instead. Fit math against real Big Shoulders 900 metrics: the accent
+   line needs 7.22px of width per font-px ('~5× FEWER TOKENS.' = 1155px
+   @160px), so 12vw with sp-3 gutters clears every width ≥331px; the
+   ≤330px step pins the floor. */
+@media (max-width: 720px) {
+  .hero-center { padding-left: var(--sp-3); padding-right: var(--sp-3); }
+  .hero-center .hero { font-size: clamp(36px, 12vw, 64px); }
+  .hero-report-tag { font-size: 13px; }
+  .hero-sub { font-size: var(--fs-16); }
+  .hero-proof { font-size: 14px; }
+  .prompt-label { font-size: 12px; }
+  .prompt-card code { font-size: 15px; }
+  .hero-alt-install { font-size: 12px; }
+}
+@media (max-width: 330px) {
+  .hero-center .hero { font-size: 36px; }
 }
 .hero-sub {
   font-family: var(--font-prose);

--- a/landing/style.css
+++ b/landing/style.css
@@ -2575,10 +2575,32 @@ svg.chart.is-interactive .ser:focus-visible {
   .hero-center .hero { font-size: clamp(36px, 12vw, 64px); }
   .hero-report-tag { font-size: 13px; }
   .hero-sub { font-size: var(--fs-16); }
-  .hero-proof { font-size: 14px; }
+  .hero-marks { font-size: 12px; }
   .prompt-label { font-size: 12px; }
   .prompt-card code { font-size: 15px; }
-  .hero-alt-install { font-size: 12px; }
+  .hero-marks {
+  font-family: var(--font-data);
+  font-size: var(--fs-11);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+  color: var(--z-mute);
+  margin: var(--sp-4) auto 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--sp-2) var(--sp-3);
+}
+.hero-marks a {
+  color: var(--z-mute);
+  text-decoration: none;
+  border-bottom: 1px solid var(--z-line);
+  padding-bottom: 1px;
+}
+.hero-marks a:hover, .hero-marks a:focus-visible {
+  color: var(--z-accent);
+  border-color: var(--z-accent);
+}
+.hero-alt-install { font-size: 12px; }
 }
 @media (max-width: 330px) {
   .hero-center .hero { font-size: 36px; }


### PR DESCRIPTION
Main-page redesign per owner directive: **white by default**, one centered copy-paste prompt with an **animated gradient halo** as the page's single focus (Lovable.dev as the reference), everything else stripped back. Sections 01–06 unchanged.

Verified by a 13-agent adversarial workflow (one finding measured in headless Chrome): 5 unique defects confirmed and fixed before this PR — day-theme AA contrast (accent darkened to #7f5200, 6.14:1), lost h1 fluid clamp (four-line wrap at 1024px), CTA label degradation on click, halo stacking-context bleed, and a mis-scoped 21/21 claim (+ a stale 15/15 in the case-study meta description). 3 findings refuted.

Already deployed to production (deploy-then-merge, same as #299).