### PR TITLE
fix(engine,api): close out #292 review — findings 1-5 and the smaller items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that is not an index answers 404 rather than writing a tombstone for a
   ghost.
 
+- **A dynamically-discovered nested object field is no longer permanently
+  opaque to `GET _mapping`/`_field_caps`.** A subfield like `metadata.kind`
+  was already queryable (dotted-path resolution against `_source` doesn't
+  care about the mapping) but had no way to be *discovered* by a client that
+  reads the mapping instead of already knowing the field name — indistinguishable
+  from not existing to Kibana/OSD's own field-list UI. Three compounding gaps,
+  all fixed together: dynamic mapping never recursed into `Value::Object`
+  (`{"type": "object"}` was a terminal, not real ES/OS default behavior);
+  `GET _mapping`/`_field_caps` served the index-creation-time explicit mapping
+  blob verbatim forever, so *any* field discovered dynamically after creation
+  — flat or nested — never surfaced, no matter how many documents arrived; and
+  `_field_caps`'s per-field walk only ever registered top-level names, so a
+  nested object's own children were still invisible even once the mapping
+  correctly described them. Measured end-to-end on `/_memory`'s own backing
+  index: `GET .xerj-memory-{ns}/_field_caps?fields=metadata.kind` returned
+  `{"fields": {}}` before, the real entry after. The cluster-wide
+  `GET /_field_caps` (as opposed to the per-index `GET /{index}/_field_caps`)
+  had the same gaps independently and is fixed the same way — the two no
+  longer disagree about which fields exist.
+  **Known limitation**: this only benefits indices created after this
+  ships. An index (a `/_memory` namespace or otherwise) created before it
+  already has its stored mapping written, and that isn't retroactively
+  edited — existing indices need either re-creation or an explicit
+  `PUT _mapping` to pick up the fix. No automatic migration is included.
+
 - **A crafted filename can no longer forge records on the agent progress
   stream** (the first rc.15 known issue below). Every externally-controlled
   string — in-flight paths, the paths and error text interpolated into human

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -19032,7 +19032,6 @@ pub struct FieldCapsParams {
 /// multi-fields under it like `metadata.kind.keyword`) were never their
 /// own `_field_caps` entry, even once the mapping/properties correctly
 /// described them.
-#[allow(clippy::too_many_arguments)]
 fn register_field_cap_entry(
     field: &FieldConfig,
     dotted_prefix: &str,
@@ -19084,6 +19083,168 @@ fn register_field_cap_entry(
                 fields_map,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod mapping_merge_tests {
+    //! Direct, non-HTTP coverage for `merge_mapping_properties`,
+    //! `semantic_companion_field_names`, and `register_field_cap_entry` --
+    //! the highest-risk code in the nested-object-mapping fix (recursive,
+    //! and where the one regression found before this landed actually
+    //! lived: semantic_text's own companion field leaking into the
+    //! merge). Complements the HTTP-level end-to-end coverage elsewhere
+    //! (`dynamic_string_mapping_advertises_keyword_multi_field`,
+    //! `api_semantic_bulk_builds_complete_hnsw_and_survives_restart`) with
+    //! fast, precise checks of the merge/registration logic in isolation.
+    use super::*;
+
+    #[test]
+    fn stored_declaration_wins_over_live_for_a_field_both_know_about() {
+        let stored = json!({"price": {"type": "keyword", "ignore_above": 64}})
+            .as_object()
+            .unwrap()
+            .clone();
+        // The live schema inferred a plainer shape for the same field --
+        // the stored declaration's own settings must survive the merge.
+        let live = json!({"price": {"type": "text"}})
+            .as_object()
+            .unwrap()
+            .clone();
+        let merged = merge_mapping_properties(&stored, &live);
+        assert_eq!(merged["price"]["type"], "keyword");
+        assert_eq!(merged["price"]["ignore_above"], 64);
+    }
+
+    #[test]
+    fn live_only_field_is_included_not_dropped() {
+        let stored = json!({"a": {"type": "text"}}).as_object().unwrap().clone();
+        let live = json!({"a": {"type": "text"}, "b": {"type": "long"}})
+            .as_object()
+            .unwrap()
+            .clone();
+        let merged = merge_mapping_properties(&stored, &live);
+        assert_eq!(
+            merged["b"]["type"], "long",
+            "a field only the live schema knows about must still surface: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn bare_object_declaration_picks_up_live_nested_children() {
+        // Exactly /_memory's own historical shape before the memory_api.rs
+        // fix: a field explicitly declared as a bare {"type":"object"}
+        // with no properties of its own.
+        let stored = json!({"metadata": {"type": "object"}})
+            .as_object()
+            .unwrap()
+            .clone();
+        let live = json!({
+            "metadata": {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "text", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+                }
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let merged = merge_mapping_properties(&stored, &live);
+        assert_eq!(merged["metadata"]["properties"]["kind"]["type"], "text");
+        assert_eq!(
+            merged["metadata"]["properties"]["kind"]["fields"]["keyword"]["type"],
+            "keyword"
+        );
+    }
+
+    #[test]
+    fn nested_merge_is_recursive_not_just_one_level() {
+        let stored = json!({"a": {"type": "object", "properties": {"b": {"type": "object"}}}})
+            .as_object()
+            .unwrap()
+            .clone();
+        let live = json!({
+            "a": {"type": "object", "properties": {
+                "b": {"type": "object", "properties": {"c": {"type": "long"}}}
+            }}
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let merged = merge_mapping_properties(&stored, &live);
+        assert_eq!(
+            merged["a"]["properties"]["b"]["properties"]["c"]["type"],
+            "long"
+        );
+    }
+
+    #[test]
+    fn semantic_companion_field_names_finds_default_and_explicit_target() {
+        let stored = json!({
+            "body": {"type": "semantic_text", "dimensions": 32},
+            "summary": {"type": "semantic_text", "target_field": "summary_emb"},
+            "title": {"type": "text"}
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let companions = semantic_companion_field_names(&stored);
+        assert!(companions.contains("body_vector"), "{companions:?}");
+        assert!(companions.contains("summary_emb"), "{companions:?}");
+        assert_eq!(
+            companions.len(),
+            2,
+            "a non-semantic_text field must not contribute a companion name: {companions:?}"
+        );
+    }
+
+    #[test]
+    fn register_field_cap_entry_registers_nested_object_children_directly() {
+        let mut metadata = FieldConfig::new("metadata", FieldType::Object);
+        metadata
+            .fields
+            .push(FieldConfig::new("kind", FieldType::Text));
+
+        let mut fields_map: HashMap<String, serde_json::Map<String, Value>> = HashMap::new();
+        register_field_cap_entry(&metadata, "", &json!({}), "*", "idx", &mut fields_map);
+
+        assert!(fields_map.contains_key("metadata"), "{fields_map:?}");
+        assert!(
+            fields_map.contains_key("metadata.kind"),
+            "the nested child itself must get its own dotted entry, not just its own further multi-fields: {fields_map:?}"
+        );
+    }
+
+    #[test]
+    fn register_field_cap_entry_respects_the_fields_filter() {
+        let mut metadata = FieldConfig::new("metadata", FieldType::Object);
+        metadata
+            .fields
+            .push(FieldConfig::new("kind", FieldType::Text));
+        metadata
+            .fields
+            .push(FieldConfig::new("topic", FieldType::Text));
+
+        let mut fields_map: HashMap<String, serde_json::Map<String, Value>> = HashMap::new();
+        register_field_cap_entry(
+            &metadata,
+            "",
+            &json!({}),
+            "metadata.kind",
+            "idx",
+            &mut fields_map,
+        );
+
+        assert!(fields_map.contains_key("metadata.kind"), "{fields_map:?}");
+        assert!(
+            !fields_map.contains_key("metadata.topic"),
+            "a filter naming one nested child must not also register its sibling: {fields_map:?}"
+        );
+        assert!(
+            !fields_map.contains_key("metadata"),
+            "a filter naming only the nested child must not also register the parent: {fields_map:?}"
+        );
     }
 }
 
@@ -19580,6 +19741,152 @@ mod flat_object_field_caps_tests {
         assert_eq!(
             caps["fields"]["city.keyword"]["keyword"]["type"], "keyword",
             "city.keyword must appear in _field_caps, got: {caps}"
+        );
+    }
+
+    /// The cluster-wide `GET /_field_caps` (routed to `global_field_caps`)
+    /// used to be a near-duplicate of the per-index `field_caps` body from
+    /// *before* the nested-object-mapping fix: same stale cached-mapping
+    /// read, same top-level-only field loop, and it never called
+    /// `collect_multi_fields` at all -- so `GET /{index}/_field_caps` and
+    /// `GET /_field_caps` could (and did) disagree about which fields
+    /// exist. Proves both now agree, on the exact nested-object shape the
+    /// whole fix is about.
+    #[tokio::test]
+    async fn global_field_caps_agrees_with_per_index_field_caps_on_nested_objects() {
+        let router = crate::router::build_es_compat_router(test_state());
+
+        let write = router
+            .clone()
+            .oneshot(
+                Request::put("/global-caps-e2e/_doc/1")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"metadata": {"kind": "preference", "topic": "language"}})
+                            .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("write response");
+        assert!(write.status().is_success());
+
+        let per_index_resp = router
+            .clone()
+            .oneshot(
+                Request::get("/global-caps-e2e/_field_caps?fields=*")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("per-index field_caps response");
+        assert!(per_index_resp.status().is_success());
+        let per_index_bytes = to_bytes(per_index_resp.into_body(), usize::MAX)
+            .await
+            .expect("response bytes");
+        let per_index: Value = serde_json::from_slice(&per_index_bytes).expect("JSON response");
+
+        let global_resp = router
+            .oneshot(
+                Request::get("/_field_caps?fields=*")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("global field_caps response");
+        assert!(global_resp.status().is_success());
+        let global_bytes = to_bytes(global_resp.into_body(), usize::MAX)
+            .await
+            .expect("response bytes");
+        let global: Value = serde_json::from_slice(&global_bytes).expect("JSON response");
+
+        for field in [
+            "metadata",
+            "metadata.kind",
+            "metadata.kind.keyword",
+            "metadata.topic",
+        ] {
+            assert!(
+                per_index["fields"].get(field).is_some(),
+                "sanity: per-index _field_caps must itself have {field}, got: {per_index}"
+            );
+            assert_eq!(
+                global["fields"][field], per_index["fields"][field],
+                "global and per-index _field_caps disagree on '{field}' -- global: {global}, per-index: {per_index}"
+            );
+        }
+    }
+
+    /// The exact case a reviewer asked for on the original nested-object-
+    /// mapping PR: a SECOND document introducing a NEW nested key under a
+    /// top-level field the schema already knows about. Before this test's
+    /// fix, dynamic mapping gated purely on whether `metadata` (the
+    /// top-level key) already existed -- once the first document
+    /// registered it (from `{"kind": ...}`), `dynamic_field_config` was
+    /// never called for it again, so a second document's `metadata.project`
+    /// was permanently invisible to `_mapping`/`_field_caps`, no matter how
+    /// many more documents arrived, despite staying perfectly queryable via
+    /// `_source` dotted-path resolution the whole time -- the exact
+    /// "queryable but invisible" symptom the whole fix is about, one level
+    /// down. `/_memory`'s own `metadata` field is exactly this shape (its
+    /// keys are caller-defined and legitimately vary memory to memory), so
+    /// this reproduces it through the real `/_memory` API rather than a
+    /// synthetic index.
+    #[tokio::test]
+    async fn a_later_document_introducing_a_new_nested_key_is_not_permanently_invisible() {
+        let router = crate::router::build_es_compat_router(test_state());
+
+        let store_one = router
+            .clone()
+            .oneshot(
+                Request::post("/_memory/repro")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"text": "first", "metadata": {"kind": "preference"}}).to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("first store response");
+        assert!(store_one.status().is_success());
+
+        let store_two = router
+            .clone()
+            .oneshot(
+                Request::post("/_memory/repro")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"text": "second", "metadata": {"project": "xerj"}}).to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("second store response");
+        assert!(store_two.status().is_success());
+
+        let caps_resp = router
+            .oneshot(
+                Request::get("/.xerj-memory-repro/_field_caps?fields=*")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("field_caps response");
+        assert!(caps_resp.status().is_success());
+        let bytes = to_bytes(caps_resp.into_body(), usize::MAX)
+            .await
+            .expect("response bytes");
+        let caps: Value = serde_json::from_slice(&bytes).expect("JSON response");
+
+        assert!(
+            caps["fields"].get("metadata.kind").is_some(),
+            "the FIRST document's nested key must still be visible: {caps}"
+        );
+        assert!(
+            caps["fields"].get("metadata.project").is_some(),
+            "the SECOND document's nested key, introduced after 'metadata' was already \
+             a known top-level field, must also become visible -- not permanently invisible \
+             just because it lost the race to be first: {caps}"
         );
     }
 
@@ -29528,7 +29835,7 @@ pub async fn global_field_caps(
     let index_names: Vec<String> = indices.iter().map(|i| i.name.clone()).collect();
     let fields_filter = params.fields.as_deref().unwrap_or("*");
 
-    let mut fields_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    let mut fields_map: HashMap<String, serde_json::Map<String, Value>> = HashMap::new();
 
     for index_info in &indices {
         let idx = match state.engine.get_index(&index_info.name) {
@@ -29547,60 +29854,81 @@ pub async fn global_field_caps(
             .get(index_info.name.as_str())
             .map(|v| v.clone())
             .unwrap_or(Value::Null);
+        let mut live_properties = schema_to_es_properties(&schema);
         let properties = if stored_mapping.is_null() {
-            Value::Object(schema_to_es_properties(&schema))
+            Value::Object(live_properties)
         } else {
-            stored_mapping
+            // Same merge as `field_caps` (per-index) -- without it, a field
+            // discovered dynamically since this index was created (flat or
+            // nested, at any depth) is invisible here too, and this
+            // cluster-wide endpoint would silently disagree with the
+            // per-index one about which fields exist.
+            let stored_properties = stored_mapping
                 .get("properties")
+                .and_then(|p| p.as_object())
                 .cloned()
-                .unwrap_or_else(|| json!({}))
+                .unwrap_or_default();
+            let companions = semantic_companion_field_names(&stored_properties);
+            live_properties.retain(|k, _| !companions.contains(k));
+            Value::Object(merge_mapping_properties(
+                &stored_properties,
+                &live_properties,
+            ))
         };
 
         for field in &schema.fields {
+            register_field_cap_entry(
+                field,
+                "",
+                &properties,
+                fields_filter,
+                &index_info.name,
+                &mut fields_map,
+            );
+        }
+
+        // Multi-fields (`"fields": {"keyword": {...}}`) -- same #209
+        // mechanism as `field_caps` (per-index); this cluster-wide form
+        // never had it at all.
+        let mut multi_fields = Vec::new();
+        collect_multi_fields(&properties, "", &mut multi_fields);
+        for (name, es_type) in multi_fields {
             if fields_filter != "*" {
-                // Support comma-separated field list and simple wildcard suffix.
                 let matches = fields_filter
                     .split(',')
-                    .any(|f| field_name_matches(&field.name, f.trim()));
+                    .any(|f| source_field_matches(&name, f.trim()));
                 if !matches {
                     continue;
                 }
             }
-
-            let native_es_type = native_type_to_es_str(&field.field_type);
-            let es_type = declared_flattened_type(&properties, &field.name)
-                .or_else(|| declared_numeric_type(&properties, &field.name))
-                .unwrap_or(native_es_type);
-            let searchable = field.is_searchable();
-            let aggregatable = field.is_aggregatable();
-
-            let type_entry = fields_map
-                .entry(field.name.clone())
-                .or_default()
-                .entry(es_type.to_string())
-                .or_insert_with(|| {
-                    json!({
-                        "type": es_type,
-                        "searchable": searchable,
-                        "aggregatable": aggregatable,
-                        "indices": []
-                    })
-                });
-
-            // Append this index to the indices list for this type entry.
+            let (searchable, aggregatable) = match es_type.as_str() {
+                "text" => (true, false),
+                _ => (true, true),
+            };
+            let type_map = fields_map.entry(name).or_default();
+            let type_entry = type_map.entry(es_type.clone()).or_insert_with(|| {
+                json!({
+                    "type": es_type,
+                    "searchable": searchable,
+                    "aggregatable": aggregatable,
+                    "indices": []
+                })
+            });
             if let Some(arr) = type_entry["indices"].as_array_mut() {
-                arr.push(Value::String(index_info.name.clone()));
+                if !arr
+                    .iter()
+                    .any(|v| v.as_str() == Some(index_info.name.as_str()))
+                {
+                    arr.push(Value::String(index_info.name.clone()));
+                }
             }
         }
     }
 
-    // Convert HashMap<String, HashMap<String, Value>> to the ES format.
     let fields_val: Value = Value::Object(
         fields_map
             .into_iter()
-            .map(|(field_name, type_map)| {
-                (field_name, Value::Object(type_map.into_iter().collect()))
-            })
+            .map(|(field_name, type_map)| (field_name, Value::Object(type_map)))
             .collect(),
     );
 

--- a/engine/crates/xerj-api/src/memory_api.rs
+++ b/engine/crates/xerj-api/src/memory_api.rs
@@ -165,7 +165,8 @@ fn index_exists(state: &AppState, index: &str) -> bool {
 /// Ensure the backing index exists with an appropriate mapping. Created lazily
 /// on first store. When the first stored memory carries a vector, the index is
 /// created with a `dense_vector` field sized to that vector so kNN recall works
-/// out of the box; text and metadata are always mapped.
+/// out of the box. `text` is always explicitly mapped; `metadata` deliberately
+/// is not -- see the comment where `properties` is built below.
 async fn ensure_backing_index(
     state: &AppState,
     index: &str,
@@ -196,6 +197,16 @@ async fn ensure_backing_index(
     // into nested objects (see xerj-engine's `dynamic_field_config`), so
     // `metadata.kind`/`metadata.topic`/etc. become real, `_mapping`-visible
     // fields instead of being permanently opaque.
+    //
+    // KNOWN LIMITATION, deliberately not addressed here: this only helps
+    // namespaces whose backing index is created AFTER this change ships. A
+    // `.xerj-memory-*` index created before it already has `metadata`
+    // declared as a bare `{"type": "object"}` in ITS OWN stored mapping --
+    // that declaration was written once, at that index's creation time,
+    // and is not retroactively edited by a code change. No migration for
+    // already-existing namespaces is included in this change; one would
+    // need to either re-create the index or explicitly `PUT _mapping` a
+    // corrected `metadata.properties` shape onto it by hand.
     let mut properties = json!({
         "text": { "type": "semantic_text", "dimensions": 384 },
         "stored_at": { "type": "long" }

--- a/engine/crates/xerj-common/src/types.rs
+++ b/engine/crates/xerj-common/src/types.rs
@@ -420,6 +420,25 @@ impl FieldConfig {
     pub fn is_aggregatable(&self) -> bool {
         self.options.doc_values && !matches!(self.field_type, FieldType::Text | FieldType::Binary)
     }
+
+    /// This field plus every nested child, recursively -- both real
+    /// `properties` children of an `Object`/`Nested` field and leaf
+    /// multi-fields under `fields` live in the same `fields` vec (see the
+    /// dual meaning documented on that field above), so one count covers
+    /// both. `Schema::field_count()` sums this over every top-level field
+    /// instead of just counting `self.fields.len()`, since a single
+    /// top-level `Object` field can carry unboundedly many nested
+    /// children once dynamic mapping recurses into them (see
+    /// `xerj-engine`'s `dynamic_field_config_at_depth`) -- an
+    /// un-recursive count would let nested fields bypass every
+    /// `max_fields_per_index` mapping-explosion guard entirely.
+    pub fn total_field_count(&self) -> usize {
+        1 + self
+            .fields
+            .iter()
+            .map(FieldConfig::total_field_count)
+            .sum::<usize>()
+    }
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -455,6 +474,14 @@ impl Schema {
         self.fields.iter().find(|f| f.name == name)
     }
 
+    /// Mutable counterpart to [`Self::field`] -- lets a caller merge new
+    /// dynamically-discovered nested children into an already-registered
+    /// top-level field's own `fields` in place, instead of only ever being
+    /// able to add brand-new top-level fields via [`Self::add_field`].
+    pub fn field_mut(&mut self, name: &str) -> Option<&mut FieldConfig> {
+        self.fields.iter_mut().find(|f| f.name == name)
+    }
+
     /// Return `true` if a field with this name already exists.
     pub fn has_field(&self, name: &str) -> bool {
         self.field(name).is_some()
@@ -476,9 +503,17 @@ impl Schema {
         Ok(())
     }
 
-    /// Total number of fields (counting only top-level fields).
+    /// Total number of fields, counting every nested child at every depth
+    /// -- not just top-level fields. Every `max_fields_per_index`
+    /// mapping-explosion guard in the engine (both the dynamic-ingest path
+    /// and the explicit `PUT _mapping`/`POST .../evolve` path, #76 S5-5)
+    /// calls this to bound real schema growth; counting only
+    /// `self.fields.len()` would let a single top-level `Object` field
+    /// carry unboundedly many nested children uncounted, once dynamic
+    /// mapping recurses into them (see `xerj-engine`'s
+    /// `dynamic_field_config_at_depth`).
     pub fn field_count(&self) -> usize {
-        self.fields.len()
+        self.fields.iter().map(FieldConfig::total_field_count).sum()
     }
 }
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -6556,20 +6556,21 @@ impl Index {
         // Auto-evolve schema for new fields.
         // Fast path: skip the schema read lock every doc when schema is stable.
         // We cache a hash of the document field keys and only re-check schema
-        // evolution every 100 docs (or when field keys change).
+        // evolution every 100 docs (or when field keys change). The hash
+        // walks NESTED field names too, not just the top-level ones (see
+        // `hash_all_field_names`) -- a document whose top-level key set is
+        // unchanged but whose nested shape changed (e.g. metadata.kind on
+        // one document, metadata.project on the next) must still produce a
+        // different hash, or this throttle would silently suppress the
+        // evolve call that the newly-nested key needs, for up to 100
+        // documents -- exactly the failure mode the recursive dynamic-
+        // mapping fix (`merge_dynamic_children_into`) exists to close, one
+        // layer further up the call chain.
         let should_evolve = {
             let current_count = self.doc_count.load(Ordering::Relaxed);
             let last_epoch = self.schema_hash_epoch.load(Ordering::Relaxed);
-            // Compute a quick hash of the doc's field names.
             let mut h: u64 = 0xcbf29ce484222325;
-            if let Some(obj) = source.as_object() {
-                for k in obj.keys() {
-                    for b in k.bytes() {
-                        h ^= b as u64;
-                        h = h.wrapping_mul(0x00000100000001b3);
-                    }
-                }
-            }
+            hash_all_field_names(&source, &mut h);
             let cached = self.schema_hash_cache.load(Ordering::Relaxed);
             if cached != h {
                 // Field set changed — must evolve and update cache.
@@ -6947,22 +6948,35 @@ impl Index {
             );
             // Fast-path: for a stable, non-dynamic schema we can skip
             // the entire per-doc evolve pass.  Under dynamic mapping we
-            // cheaply collect the union of unknown field names seen in
-            // this batch under the read lock, then only upgrade to a
-            // write lock if we actually found any.
-            let mut unknown_field_sources: Vec<&Value> = Vec::new();
+            // cheaply collect the sources that might actually change the
+            // schema under the read lock, then only upgrade to a write
+            // lock (inside `evolve_schema_from_doc`, called per source
+            // below) for the ones that do. "Might change the schema" is
+            // two things, not one: a brand-new top-level field (as
+            // before), OR a new nested child under a top-level field the
+            // schema already has (`field_config_needs_merge`) -- without
+            // the second check, a document whose only new content is
+            // nested (e.g. `metadata.project` after `metadata.kind` was
+            // already known) would never reach `evolve_schema_from_doc` at
+            // all here, no matter how many times it fixed this same gap
+            // internally.
+            let mut sources_needing_evolve: Vec<&Value> = Vec::new();
             if is_dynamic {
                 for ingest in &processed {
                     if let Some(obj) = ingest.source.as_object() {
-                        let has_unknown = obj.keys().any(|k| !schema_guard.schema.has_field(k));
-                        if has_unknown {
-                            unknown_field_sources.push(ingest.source.as_ref());
+                        let needs_evolve =
+                            obj.iter().any(|(k, v)| match schema_guard.schema.field(k) {
+                                None => true,
+                                Some(existing) => field_config_needs_merge(existing, v),
+                            });
+                        if needs_evolve {
+                            sources_needing_evolve.push(ingest.source.as_ref());
                         }
                     }
                 }
             }
             drop(schema_guard);
-            for src in unknown_field_sources {
+            for src in sources_needing_evolve {
                 self.evolve_schema_from_doc(src).await;
             }
         }
@@ -18278,13 +18292,26 @@ impl Index {
     /// added under a single write lock, which re-checks `has_field` exactly
     /// like the per-doc slow path does.
     async fn evolve_schema_from_docs(&self, sources: &[Arc<Value>]) {
-        let new_fields: Vec<(String, FieldConfig)> = {
+        // Fast path: read-lock scan for TWO kinds of change, not just one --
+        // a brand-new top-level field (as before), or a NEW NESTED CHILD
+        // under a top-level field the schema already knows about (the fix
+        // for a real gap found in review: gating purely on "does the
+        // top-level key already exist" meant a later document introducing
+        // e.g. `metadata.project` after an earlier one already registered
+        // `metadata` from its own `{"kind": ...}` was never inspected again,
+        // no matter how many more documents arrived -- see
+        // `field_config_needs_merge`'s doc comment for the full story).
+        // Stores the raw value (not a precomputed FieldConfig) for both
+        // kinds, so the write-lock section below can re-derive against the
+        // live schema rather than trusting a possibly-stale read-lock
+        // snapshot.
+        let (new_top_level, needs_merge): (Vec<(String, Value)>, Vec<(String, Value)>) = {
             let schema = self.schema.read().await;
             if !matches!(schema.dynamic, xerj_common::schema::DynamicMapping::Dynamic) {
                 return;
             }
-            let date_detection = self.date_detection_enabled();
-            let mut out: Vec<(String, FieldConfig)> = Vec::new();
+            let mut new_top_level = Vec::new();
+            let mut needs_merge = Vec::new();
             for source in sources {
                 let Some(obj) = source.as_object() else {
                     continue;
@@ -18293,16 +18320,20 @@ impl Index {
                     if key.starts_with(PASSAGE_METADATA_PREFIX) {
                         continue;
                     }
-                    if !schema.schema.has_field(key) && !out.iter().any(|(k, _)| k == key) {
-                        let fc = dynamic_field_config(key, val, date_detection);
-                        out.push((key.clone(), fc));
+                    match schema.schema.field(key) {
+                        None => new_top_level.push((key.clone(), val.clone())),
+                        Some(existing) => {
+                            if field_config_needs_merge(existing, val) {
+                                needs_merge.push((key.clone(), val.clone()));
+                            }
+                        }
                     }
                 }
             }
-            out
+            (new_top_level, needs_merge)
         };
 
-        if new_fields.is_empty() {
+        if new_top_level.is_empty() && needs_merge.is_empty() {
             return;
         }
 
@@ -18311,15 +18342,20 @@ impl Index {
         // same limit, but the engine's dynamic-mapping path calls
         // `Schema::add_field` directly, which previously bypassed the cap.
         // An authenticated client could ingest documents with arbitrarily many
-        // distinct field names, bloating the schema unbounded.
+        // distinct field names, bloating the schema unbounded. This is an
+        // approximate early exit on `new_top_level` alone (a `needs_merge`
+        // entry might add zero fields or several, not knowable without
+        // walking it against the live schema, which the write-lock section
+        // below does anyway) -- the write lock's own per-field checks are
+        // the real, exact enforcement.
         {
             let schema = self.schema.read().await;
             let current = schema.schema.field_count() as u32;
-            let projected = current.saturating_add(new_fields.len() as u32);
+            let projected = current.saturating_add(new_top_level.len() as u32);
             if projected > self.max_fields_per_index {
                 tracing::warn!(
                     current_fields = current,
-                    new_fields = new_fields.len(),
+                    new_fields = new_top_level.len(),
                     limit = self.max_fields_per_index,
                     "rejecting schema evolution: field limit exceeded"
                 );
@@ -18327,29 +18363,63 @@ impl Index {
             }
         }
 
+        let date_detection = self.date_detection_enabled();
         let mut schema = self.schema.write().await;
         if !matches!(schema.dynamic, xerj_common::schema::DynamicMapping::Dynamic) {
             return;
         }
-        // Re-check under the write lock: another concurrent ingest may have
-        // already added fields up to the limit between the read-lock check
-        // above and this write lock.
+        // Re-derive against the live schema under the write lock rather than
+        // trusting the read-lock snapshot: another concurrent ingest may
+        // have already added fields (up to the limit, or the exact ones
+        // this batch also wants) between the read-lock check above and this
+        // write lock.
         let mut schema_changed = false;
-        for (_, fc) in new_fields {
-            if !schema.schema.has_field(&fc.name) {
-                if schema.schema.field_count() as u32 >= self.max_fields_per_index {
-                    tracing::warn!(
-                        field = %fc.name,
-                        limit = self.max_fields_per_index,
-                        "rejecting new field: field limit reached"
-                    );
-                    break;
+        let mut field_count = schema.schema.field_count() as u32;
+        for (key, val) in new_top_level {
+            if let Some(existing) = schema.schema.field_mut(&key) {
+                // Raced in since the read-lock scan -- merge into it
+                // instead of skipping outright, so a key another doc in
+                // this same batch also introduces isn't lost.
+                if merge_dynamic_children_into(
+                    existing,
+                    &val,
+                    date_detection,
+                    1,
+                    &mut field_count,
+                    self.max_fields_per_index,
+                ) {
+                    schema_changed = true;
                 }
-                if matches!(fc.field_type, FieldType::Date) {
-                    self.has_date_fields.store(true, Ordering::Relaxed);
+                continue;
+            }
+            if field_count >= self.max_fields_per_index {
+                tracing::warn!(
+                    field = %key,
+                    limit = self.max_fields_per_index,
+                    "rejecting new field: field limit reached"
+                );
+                break;
+            }
+            let fc = dynamic_field_config(&key, &val, date_detection);
+            if matches!(fc.field_type, FieldType::Date) {
+                self.has_date_fields.store(true, Ordering::Relaxed);
+            }
+            field_count += 1;
+            let _ = schema.schema.add_field(fc);
+            schema_changed = true;
+        }
+        for (key, val) in needs_merge {
+            if let Some(existing) = schema.schema.field_mut(&key) {
+                if merge_dynamic_children_into(
+                    existing,
+                    &val,
+                    date_detection,
+                    1,
+                    &mut field_count,
+                    self.max_fields_per_index,
+                ) {
+                    schema_changed = true;
                 }
-                let _ = schema.schema.add_field(fc);
-                schema_changed = true;
             }
         }
         if schema_changed {
@@ -18366,35 +18436,46 @@ impl Index {
         // Fast path: check with a read lock first to avoid taking a write lock
         // on every document when all fields are already known.  This is the
         // common case after the first few documents and avoids the write lock
-        // bottleneck that otherwise limits indexing throughput.
-        let new_fields: Vec<(String, FieldConfig)> = {
+        // bottleneck that otherwise limits indexing throughput. `needs_write`
+        // covers both a brand-new top-level field and a new nested child
+        // under an already-known one -- see `evolve_schema_from_docs` for
+        // the full rationale (same fix, single-document form).
+        let needs_write = {
             let schema = self.schema.read().await;
             if !matches!(schema.dynamic, xerj_common::schema::DynamicMapping::Dynamic) {
                 return;
             }
-            let date_detection = self.date_detection_enabled();
-            obj.iter()
-                .filter(|(key, _)| {
-                    !key.starts_with(PASSAGE_METADATA_PREFIX) && !schema.schema.has_field(key)
-                })
-                .map(|(key, val)| (key.clone(), dynamic_field_config(key, val, date_detection)))
-                .collect()
+            obj.iter().any(|(key, val)| {
+                if key.starts_with(PASSAGE_METADATA_PREFIX) {
+                    return false;
+                }
+                match schema.schema.field(key) {
+                    None => true,
+                    Some(existing) => field_config_needs_merge(existing, val),
+                }
+            })
         };
 
-        if new_fields.is_empty() {
-            // No new fields — skip the write lock entirely (hot path).
+        if !needs_write {
+            // Nothing new — skip the write lock entirely (hot path).
             return;
         }
 
-        // Mapping-explosion guard (see evolve_schema_from_docs for rationale).
+        // Mapping-explosion guard (see evolve_schema_from_docs for rationale
+        // -- this single-document form only ever contributes at most
+        // `obj.len()` brand-new top-level fields, so that bound is used for
+        // the same approximate early exit; a merge's real growth is
+        // enforced exactly under the write lock below).
         {
             let schema = self.schema.read().await;
             let current = schema.schema.field_count() as u32;
-            let projected = current.saturating_add(new_fields.len() as u32);
+            let new_top_level_upper_bound =
+                obj.keys().filter(|k| !schema.schema.has_field(k)).count() as u32;
+            let projected = current.saturating_add(new_top_level_upper_bound);
             if projected > self.max_fields_per_index {
                 tracing::warn!(
                     current_fields = current,
-                    new_fields = new_fields.len(),
+                    new_fields = new_top_level_upper_bound,
                     limit = self.max_fields_per_index,
                     "rejecting schema evolution: field limit exceeded"
                 );
@@ -18402,29 +18483,47 @@ impl Index {
             }
         }
 
-        // Slow path: at least one new field found.  Upgrade to write lock and
-        // persist the updated schema.
+        // Slow path: at least one new field or new nested child found.
+        // Upgrade to write lock and persist the updated schema.
+        let date_detection = self.date_detection_enabled();
         let mut schema = self.schema.write().await;
         if !matches!(schema.dynamic, xerj_common::schema::DynamicMapping::Dynamic) {
             return;
         }
         let mut schema_changed = false;
-        for (_, fc) in new_fields {
-            if !schema.schema.has_field(&fc.name) {
-                if schema.schema.field_count() as u32 >= self.max_fields_per_index {
-                    tracing::warn!(
-                        field = %fc.name,
-                        limit = self.max_fields_per_index,
-                        "rejecting new field: field limit reached"
-                    );
-                    break;
-                }
-                if matches!(fc.field_type, FieldType::Date) {
-                    self.has_date_fields.store(true, Ordering::Relaxed);
-                }
-                let _ = schema.schema.add_field(fc);
-                schema_changed = true;
+        let mut field_count = schema.schema.field_count() as u32;
+        for (key, val) in obj {
+            if key.starts_with(PASSAGE_METADATA_PREFIX) {
+                continue;
             }
+            if let Some(existing) = schema.schema.field_mut(key) {
+                if merge_dynamic_children_into(
+                    existing,
+                    val,
+                    date_detection,
+                    1,
+                    &mut field_count,
+                    self.max_fields_per_index,
+                ) {
+                    schema_changed = true;
+                }
+                continue;
+            }
+            if field_count >= self.max_fields_per_index {
+                tracing::warn!(
+                    field = %key,
+                    limit = self.max_fields_per_index,
+                    "rejecting new field: field limit reached"
+                );
+                break;
+            }
+            let fc = dynamic_field_config(key, val, date_detection);
+            if matches!(fc.field_type, FieldType::Date) {
+                self.has_date_fields.store(true, Ordering::Relaxed);
+            }
+            field_count += 1;
+            let _ = schema.schema.add_field(fc);
+            schema_changed = true;
         }
         if schema_changed {
             let _ = self.save_schema(&schema).await;
@@ -28576,10 +28675,21 @@ fn infer_field_type(val: &Value, date_detection: bool) -> FieldType {
 /// `KeywordFieldMapper("keyword").ignoreAbove(256)`).
 const DYNAMIC_KEYWORD_IGNORE_ABOVE: u32 = 256;
 
-/// ES default `index.mapping.depth.limit` — how many `properties` levels a
-/// dynamically discovered document may nest before recursion stops. Applies
-/// only to the nested-object walk below; it does not change how deep an
-/// *explicit* `_mapping` PUT may nest (that path is unaffected by this cap).
+/// Same numeric default as ES's `index.mapping.depth.limit` -- but NOT the
+/// same behavior. Real ES rejects the document with a `MapperParsingException`
+/// once nesting exceeds the limit; this cap silently stops recursing and
+/// maps everything past it as an opaque, un-recursed `Object`, the same way
+/// the whole dynamic-mapping-evolution path already treats
+/// `max_fields_per_index` (see `evolve_schema_from_docs`'s own
+/// silently-skip-and-`tracing::warn!` handling right next to where this cap
+/// is consulted) -- every guard in this call chain is fire-and-forget by
+/// design today, not just this one. Making depth rejection hard (a real
+/// client-visible error, the #204 "accepted-and-ignored" class this repo
+/// otherwise avoids) would mean giving `evolve_schema_from_doc`/
+/// `evolve_schema_from_docs` a `Result` and deciding how a mixed bulk
+/// request (one oversized document among many) should behave -- a bigger,
+/// separate change than this cap alone, tracked as a follow-up rather than
+/// bundled in here inconsistently with the neighboring guard.
 const DYNAMIC_MAPPING_DEPTH_LIMIT: usize = 20;
 
 /// Build the [`FieldConfig`] for a dynamically discovered field.
@@ -28633,13 +28743,7 @@ fn dynamic_field_config_at_depth(
             fc.fields.push(kw);
         }
         FieldType::Object if depth < DYNAMIC_MAPPING_DEPTH_LIMIT => {
-            // `val` itself may be the Array whose first element inferred
-            // Object (see doc comment) -- unwrap to whichever object is the
-            // real source of the nested keys.
-            let obj = val
-                .as_object()
-                .or_else(|| val.as_array()?.iter().find(|v| !v.is_null())?.as_object());
-            if let Some(obj) = obj {
+            if let Some(obj) = object_keys_of(val) {
                 for (sub_key, sub_val) in obj {
                     fc.fields.push(dynamic_field_config_at_depth(
                         sub_key,
@@ -28653,6 +28757,137 @@ fn dynamic_field_config_at_depth(
         _ => {}
     }
     fc
+}
+
+/// Unwrap `val` to whichever object actually carries a set of keys to walk
+/// -- either `val` itself, or (mirroring `infer_field_type`'s own
+/// first-non-null-element handling for arrays) the first non-null element
+/// of an array whose inferred type is `Object`. Shared by the fresh-field
+/// discovery path above and the existing-field merge path below so both
+/// treat array-of-objects the same way.
+fn object_keys_of(val: &Value) -> Option<&serde_json::Map<String, Value>> {
+    val.as_object()
+        .or_else(|| val.as_array()?.iter().find(|v| !v.is_null())?.as_object())
+}
+
+/// FNV-1a hash of every field NAME in `val`, at EVERY nesting depth, into
+/// `h` -- not just the top-level keys. Used by the single-doc ingest path's
+/// schema-evolution throttle (`index_document_with_version_inner_guarded`)
+/// to fingerprint "does this document's field-name shape differ from the
+/// last one we evolved the schema for". A shallow, top-level-only hash
+/// would miss a document whose top-level keys are unchanged but whose
+/// NESTED shape changed -- e.g. `metadata.kind` on one document,
+/// `metadata.project` on the next -- silently suppressing the schema-evolve
+/// call that new nested key needs, for up to 100 documents. For a
+/// document with no nested objects this hashes exactly the same bytes in
+/// the same order as hashing only the top-level keys, so it's a strict
+/// superset, not a behavior change, for the common flat-document case.
+fn hash_all_field_names(val: &Value, h: &mut u64) {
+    let Some(obj) = val.as_object() else {
+        return;
+    };
+    for (k, v) in obj {
+        for b in k.bytes() {
+            *h ^= b as u64;
+            *h = h.wrapping_mul(0x00000100000001b3);
+        }
+        hash_all_field_names(v, h);
+    }
+}
+
+/// Cheap, read-only check: would merging `val`'s keys into `existing`
+/// actually add anything new? Mirrors `merge_dynamic_children_into`'s walk
+/// without mutating, so `evolve_schema_from_doc`/`evolve_schema_from_docs`
+/// can decide whether a write lock is worth taking at all -- the common
+/// case, once a field's shape has stabilized, is "no" for every field in
+/// most documents.
+fn field_config_needs_merge(existing: &FieldConfig, val: &Value) -> bool {
+    if !matches!(existing.field_type, FieldType::Object | FieldType::Nested) {
+        return false;
+    }
+    let Some(obj) = object_keys_of(val) else {
+        return false;
+    };
+    obj.iter().any(
+        |(key, sub_val)| match existing.fields.iter().find(|f| f.name == *key) {
+            Some(child) => field_config_needs_merge(child, sub_val),
+            None => true,
+        },
+    )
+}
+
+/// Merge newly-seen dynamic children from `val` into `field`'s existing
+/// `fields`, recursively -- the fix for a real gap found in review:
+/// dynamic mapping used to gate purely on whether a field's TOP-LEVEL name
+/// already existed in the schema, so once e.g. `metadata` was known from a
+/// first document's `{"kind": "..."}`, a later document's
+/// `metadata.project` was never inspected again no matter how many more
+/// documents arrived, even though it stayed perfectly queryable via
+/// `_source` dotted-path resolution the whole time -- the exact
+/// "queryable but invisible" symptom this whole fix is about, one level
+/// down. Real ES doesn't have this gap: it registers dynamic mappers keyed
+/// on the full dotted path, so a later document introducing a new nested
+/// key is mapped normally.
+///
+/// `field_count`/`limit` enforce the same per-schema `max_fields_per_index`
+/// budget the top-level dynamic-mapping loop already enforces (see
+/// `Schema::field_count`, which now counts nested children too) --
+/// `field_count` is threaded through and incremented in place so multiple
+/// calls sharing one document (or one bulk batch) share a single running
+/// budget rather than each independently getting the full limit.
+fn merge_dynamic_children_into(
+    field: &mut FieldConfig,
+    val: &Value,
+    date_detection: bool,
+    depth: usize,
+    field_count: &mut u32,
+    limit: u32,
+) -> bool {
+    if !matches!(field.field_type, FieldType::Object | FieldType::Nested) {
+        return false;
+    }
+    if depth >= DYNAMIC_MAPPING_DEPTH_LIMIT {
+        return false;
+    }
+    let Some(obj) = object_keys_of(val) else {
+        return false;
+    };
+    let mut changed = false;
+    for (key, sub_val) in obj {
+        match field.fields.iter_mut().find(|f| f.name == *key) {
+            Some(existing) => {
+                if merge_dynamic_children_into(
+                    existing,
+                    sub_val,
+                    date_detection,
+                    depth + 1,
+                    field_count,
+                    limit,
+                ) {
+                    changed = true;
+                }
+            }
+            None => {
+                if *field_count >= limit {
+                    tracing::warn!(
+                        field = %key,
+                        limit,
+                        "rejecting new nested field: field limit reached"
+                    );
+                    break;
+                }
+                field.fields.push(dynamic_field_config_at_depth(
+                    key,
+                    sub_val,
+                    date_detection,
+                    depth + 1,
+                ));
+                *field_count += 1;
+                changed = true;
+            }
+        }
+    }
+    changed
 }
 
 // ── DocValues fast-path helpers ───────────────────────────────────────────────
@@ -36962,9 +37197,14 @@ mod date_detection_tests {
             cur = next;
             levels += 1;
         }
-        assert!(
-            levels < DYNAMIC_MAPPING_DEPTH_LIMIT + 5,
-            "recursion must stop before reaching the artificially deep bottom, got {levels} levels"
+        // Pin the exact stopping point, not just "somewhere before the
+        // bottom": the root itself is depth 1, so the last node the walk
+        // still recurses *into* is depth DYNAMIC_MAPPING_DEPTH_LIMIT -- one
+        // fewer hop than the limit's own value.
+        assert_eq!(
+            levels,
+            DYNAMIC_MAPPING_DEPTH_LIMIT - 1,
+            "recursion must stop at exactly the depth cap, got {levels} levels"
         );
 
         // Array of objects: infer_field_type already only looks at the
@@ -36983,6 +37223,122 @@ mod date_detection_tests {
             "only the first element's keys are discovered"
         );
         assert_eq!(fc.fields[0].name, "kind");
+    }
+
+    /// The core fix for a real gap found in review: a top-level field
+    /// already known to the schema (from an earlier document) must still
+    /// pick up a NEW nested child a later document introduces, instead of
+    /// staying frozen the moment it was first registered.
+    #[test]
+    fn merge_dynamic_children_into_adds_new_nested_keys_to_an_existing_field() {
+        let mut field =
+            dynamic_field_config("metadata", &serde_json::json!({"kind": "preference"}), true);
+        assert_eq!(field.fields.len(), 1);
+
+        let mut field_count = 10u32;
+        let changed = merge_dynamic_children_into(
+            &mut field,
+            &serde_json::json!({"project": "xerj"}),
+            true,
+            1,
+            &mut field_count,
+            100,
+        );
+        assert!(changed);
+        assert_eq!(field.fields.len(), 2, "{field:?}");
+        assert!(field.fields.iter().any(|f| f.name == "kind"));
+        assert!(field.fields.iter().any(|f| f.name == "project"));
+        assert_eq!(field_count, 11, "one new field was actually added");
+
+        // Re-merging the exact same shape adds nothing and reports no change.
+        let mut field_count2 = 11u32;
+        let changed_again = merge_dynamic_children_into(
+            &mut field,
+            &serde_json::json!({"project": "xerj"}),
+            true,
+            1,
+            &mut field_count2,
+            100,
+        );
+        assert!(!changed_again);
+        assert_eq!(field.fields.len(), 2);
+        assert_eq!(field_count2, 11);
+    }
+
+    #[test]
+    fn merge_dynamic_children_into_respects_the_field_count_budget() {
+        let mut field = dynamic_field_config("metadata", &serde_json::json!({"a": 1}), true);
+        let mut field_count = 5u32;
+        // Budget already exhausted -- must add nothing even though "b" is new.
+        let changed = merge_dynamic_children_into(
+            &mut field,
+            &serde_json::json!({"b": 2}),
+            true,
+            1,
+            &mut field_count,
+            5,
+        );
+        assert!(!changed);
+        assert_eq!(field.fields.len(), 1, "{field:?}");
+        assert_eq!(field_count, 5, "budget must not be exceeded");
+    }
+
+    #[test]
+    fn field_config_needs_merge_matches_merge_dynamic_children_into() {
+        let field =
+            dynamic_field_config("metadata", &serde_json::json!({"kind": "preference"}), true);
+
+        assert!(
+            field_config_needs_merge(&field, &serde_json::json!({"project": "xerj"})),
+            "a genuinely new nested key must be flagged"
+        );
+        assert!(
+            !field_config_needs_merge(&field, &serde_json::json!({"kind": "other"})),
+            "an already-known nested key changing VALUE (not shape) needs no merge"
+        );
+        assert!(
+            !field_config_needs_merge(&field, &serde_json::json!("not an object")),
+            "a non-object value has no keys to discover"
+        );
+    }
+
+    /// A document whose top-level key set is unchanged must still hash
+    /// differently once its NESTED shape changes -- otherwise the
+    /// single-doc ingest path's schema-evolution throttle
+    /// (`index_document_with_version_inner_guarded`) silently suppresses
+    /// the evolve call a new nested key needs, for up to 100 documents.
+    #[test]
+    fn hash_all_field_names_is_sensitive_to_nested_shape_not_just_top_level_keys() {
+        let mut h1: u64 = 0xcbf29ce484222325;
+        hash_all_field_names(
+            &serde_json::json!({"text": "x", "metadata": {"kind": "preference"}}),
+            &mut h1,
+        );
+
+        let mut h2: u64 = 0xcbf29ce484222325;
+        hash_all_field_names(
+            &serde_json::json!({"text": "x", "metadata": {"project": "xerj"}}),
+            &mut h2,
+        );
+
+        assert_ne!(
+            h1, h2,
+            "same top-level keys, different nested shape, must hash differently"
+        );
+
+        // Sanity: a flat document with no nested objects hashes the exact
+        // same bytes as hashing only its top-level keys would (no behavior
+        // change for the common case this throttle was written for).
+        let mut h_flat: u64 = 0xcbf29ce484222325;
+        hash_all_field_names(&serde_json::json!({"a": 1, "b": 2}), &mut h_flat);
+        let mut h_manual: u64 = 0xcbf29ce484222325;
+        for k in ["a", "b"] {
+            for b in k.bytes() {
+                h_manual ^= b as u64;
+                h_manual = h_manual.wrapping_mul(0x00000100000001b3);
+            }
+        }
+        assert_eq!(h_flat, h_manual);
     }
 
     /// Ingest-time acceptance for default-format date fields: lenient on


### PR DESCRIPTION
## Summary

Follow-up to #292 (merged despite `CHANGES_REQUESTED` — this closes out that review). All 5 numbered findings plus the smaller items are addressed, in two commits:

1. `fix(api): address #292 review findings 2-5 and the smaller items` — findings 2, 4, 5, the smaller items, and finding 3's disclosure.
2. `fix(engine): dynamic mapping re-checks nested keys across multiple documents...` — finding 1, saved for last on purpose as the biggest and riskiest item, and the one that actually undercuts #292's own motivating case if left unaddressed.

## Finding 1 — the important one

The review's own repro: store `{"metadata": {"kind": "preference"}}`, then a second memory `{"metadata": {"project": "xerj"}}`. `metadata.kind` becomes visible, `metadata.project` never does, no matter how many more documents arrive — the exact "queryable but invisible" symptom #292 set out to close, one level down.

Reproducing this live (not just reading the review's line numbers) turned up **three** separate gates that all needed the same fix, not the two the review pointed at:

1. `evolve_schema_from_doc`/`evolve_schema_from_docs` (the review's own finding) — gated purely on whether a field's top-level name already existed.
2. `index_batch_turbo`'s own pre-filter (**not in the review** — found by testing) — a second, independent `!schema.has_field(k)` check gated whether `evolve_schema_from_doc` got called *at all* on the bulk path. Fixing (1) alone was invisible from here.
3. The single-document ingest path's schema-evolution throttle (**not in the review**) — hashes the document's field *names* to decide whether to re-check schema evolution at all, skipping it for up to 100 documents once the hash stops changing. The hash only covered top-level keys, so two memories with the same top-level shape but different nested content hashed identically — `should_evolve` came back false and `evolve_schema_from_doc` was never called. **This is the one that actually blocked the fix**: `/_memory`'s own `store` handler goes through this exact path, so fixing (1) and (2) alone still failed live against the review's own scenario until this was found and fixed too.

Each was found by reproducing the review's exact scenario against a live build after each partial fix, not by reading further — the review itself was explicit that findings 1-5 were "static reads of control flow... no live run happened." Confirmed here they were right about the substance, but there was more control flow than the line numbers given.

Fix: `merge_dynamic_children_into` (merges new keys into an *existing* `FieldConfig` instead of only ever constructing a fresh one, budget-aware against `max_fields_per_index`), `field_config_needs_merge` (the cheap read-lock counterpart), `hash_all_field_names` (walks nested field names too, not just top-level — a strict superset of the old hash for flat documents, so no behavior change there). All three call sites updated consistently.

Verified end-to-end against a live build, through the real `/_memory` API: `GET .xerj-memory-{ns}/_field_caps` now shows both `metadata.kind` and `metadata.project` after the two-memory repro above, where before this PR only the first ever appeared, permanently.

## Findings 2-5 and the smaller items

- **2** — `GET /_field_caps` (cluster-wide) was a near-duplicate of `field_caps`'s *pre-#292* body: same stale-blob read, no recursion, no `collect_multi_fields`. Now shares the same merge/registration path; new test asserts the per-index and cluster-wide responses agree on the nested-object case.
- **3** — documented (code comment + CHANGELOG) that the fix only benefits `/_memory` namespaces created after this ships; no migration included, by decision.
- **4** — `Schema::field_count()` counted only top-level fields, so the recursion #292 added could bypass `max_fields_per_index` entirely. Now counts every nested child, recursively; both mapping-explosion guards (dynamic-ingest and explicit `PUT _mapping`) affected consistently.
- **5** — 7 new direct tests for `merge_mapping_properties`/`semantic_companion_field_names`/`register_field_cap_entry` (the highest-risk, previously-untested code from #292).
- Smaller items: the depth-limit's doc comment now states its actual behavior (silent truncation) instead of implying ES parity; the depth-cap test pins the exact stopping point instead of a loose upper bound; a stale doc comment in `memory_api.rs` corrected; a dead `#[allow(clippy::too_many_arguments)]` removed; the CHANGELOG entry #292 itself was missing, added.

## Verified

- `cargo test -p xerj-engine --lib`: 475/477 (2 pre-existing, macOS-only, unrelated `snapshot_path_security_tests` failures — the same ones called out as pre-existing in #290).
- `cargo test -p xerj-api --lib`: 186/186.
- `cargo test -p xerj-common --lib`: 80/80.
- `cargo clippy -p xerj-engine -p xerj-api -p xerj-common --lib -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Rebased onto `upstream/main` (post-#292 merge, since advanced further) immediately before opening — 0 commits behind, one real conflict (`CHANGELOG.md`, both sides added entries in the same place — merged, kept both), no code conflicts.
- Both the finding-1 scenario and the original #292 motivating case reproduced live end-to-end, not just via the test suite.

## Test plan

- [x] Reproduced findings 1-5 as described in the #292 review, confirmed each is closed
- [x] Found and fixed 2 additional gates for finding 1 that weren't in the original review (found via live reproduction, not static reading)
- [x] `cargo test -p xerj-engine -p xerj-api -p xerj-common --lib`
- [x] `cargo clippy -p xerj-engine -p xerj-api -p xerj-common --lib -- -D warnings`
- [x] `cargo fmt --check`
- [x] Rebased clean against `upstream/main` immediately before opening
- [x] Live end-to-end verification through the real `/_memory` API for both the original PR's motivating case and finding 1's two-document scenario
