### PR TITLE
perf(xerj-engine): make the default _source arm a passthrough

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -24564,16 +24564,41 @@ fn apply_source_filter(
             hit
         })
         .collect();
-    let generated_companion_fields: Vec<String> =
-        generated_companion_fields.iter().cloned().collect();
     match filter {
-        SourceFilter::Default => hits
-            .into_iter()
-            .map(|mut h| {
-                h.source = filter_object(&h.source, &[], &generated_companion_fields);
-                h
-            })
-            .collect(),
+        // The default is a passthrough: only engine-generated embedding
+        // companions are stripped, so an index without embedding mappings
+        // must not pay a per-hit deep copy of its source (issue #311).
+        SourceFilter::Default => {
+            if generated_companion_fields.is_empty() {
+                return hits;
+            }
+            // A dotted companion (embedding target under a nested mapping)
+            // strips a *nested* key; a `*` would be a glob to
+            // `filter_object`'s matcher. Both need the general filter —
+            // plain names, the only shape the engine generates today, are
+            // removed in place without copying the kept values.
+            if generated_companion_fields
+                .iter()
+                .any(|f| f.contains('.') || f.contains('*'))
+            {
+                let excludes: Vec<String> = generated_companion_fields.iter().cloned().collect();
+                return hits
+                    .into_iter()
+                    .map(|mut h| {
+                        h.source = filter_object(&h.source, &[], &excludes);
+                        h
+                    })
+                    .collect();
+            }
+            hits.into_iter()
+                .map(|mut h| {
+                    if let Some(map) = h.source.as_object_mut() {
+                        map.retain(|k, _| !generated_companion_fields.contains(k));
+                    }
+                    h
+                })
+                .collect()
+        }
         SourceFilter::Enabled(true) => hits,
         // `_source: false`: keep the raw source so the response layer can
         // still resolve `fields` / `_ignored` / `highlight` against it —
@@ -24879,6 +24904,57 @@ mod source_filter_tests {
         );
 
         assert_eq!(filtered[0].source, original);
+    }
+
+    /// Heap-buffer pointer of a field's string value. Stable across map
+    /// mutation and moves; changes only if the value itself is deep-copied.
+    fn str_buf_ptr(source: &Value, field: &str) -> *const u8 {
+        source[field].as_str().unwrap().as_ptr()
+    }
+
+    // Issue #311: with no embedding mappings there is nothing to strip, so
+    // the default `_source` arm must hand every hit back untouched instead
+    // of deep-copying O(source bytes) per hit on the hottest read path.
+    #[test]
+    fn default_source_without_companions_is_a_zero_copy_passthrough() {
+        let companions = generated_embedding_companion_fields(&Schema::empty());
+        assert!(companions.is_empty());
+
+        let hits = vec![hit(
+            "doc",
+            0.9,
+            json!({"body": "the source text", "title": "a user field"}),
+        )];
+        let body_ptr = str_buf_ptr(&hits[0].source, "body");
+        let title_ptr = str_buf_ptr(&hits[0].source, "title");
+
+        let filtered = apply_source_filter(hits, &SourceFilter::Default, &companions);
+
+        assert_eq!(
+            filtered[0].source,
+            json!({"body": "the source text", "title": "a user field"})
+        );
+        assert_eq!(str_buf_ptr(&filtered[0].source, "body"), body_ptr);
+        assert_eq!(str_buf_ptr(&filtered[0].source, "title"), title_ptr);
+    }
+
+    // Issue #311, companion-bearing indexes: strip the companions in place
+    // rather than rebuilding the map with a deep clone of every kept value.
+    #[test]
+    fn default_source_with_companions_strips_in_place_without_deep_copy() {
+        let companions = generated_embedding_companion_fields(&embedded_schema());
+        let hits = vec![hit("doc", 0.9, generated_source())];
+        let body_ptr = str_buf_ptr(&hits[0].source, "body");
+        let title_ptr = str_buf_ptr(&hits[0].source, "title");
+
+        let filtered = apply_source_filter(hits, &SourceFilter::Default, &companions);
+
+        assert_eq!(
+            filtered[0].source,
+            json!({"body": "the source text", "title": "a user field"})
+        );
+        assert_eq!(str_buf_ptr(&filtered[0].source, "body"), body_ptr);
+        assert_eq!(str_buf_ptr(&filtered[0].source, "title"), title_ptr);
     }
 }
 


### PR DESCRIPTION
Fixes #311

## Problem

PR #309 changed `apply_source_filter`'s `SourceFilter::Default` arm to run `filter_object(&h.source, &[], &companions)` on every hit so engine-generated embedding companions never leak. `filter_object`'s non-dotted branch rebuilds the top-level map with a deep `v.clone()` of every field value — so every default `_search` on **any** index (including the common case with no embedding mappings) paid an O(source-bytes) allocation+copy per hit on the hottest read path. Pre-#309 the default was a zero-cost passthrough. Perf-only; correctness unaffected.

## Fix

All in `apply_source_filter` (`engine/crates/xerj-engine/src/index.rs`):

- **No companions** (no embedding mappings): return the hits unchanged — restores the pre-#309 zero-copy passthrough.
- **Plain companion names** (the only shape the engine generates today): strip in place with `map.retain()` instead of rebuilding the map — kept values are moved, never cloned.
- **Dotted / `*` companion names** (embedding target under a nested mapping): fall back to the previous `filter_object` path so nested-strip semantics are preserved.
- The per-call `HashSet` → `Vec<String>` clone of the companion set is gone; only the fallback path materializes a `Vec`.

The per-request companion-set rebuild at the 4 call sites (issue's third bullet) is left as-is: it's O(#embedding-fields) under a short read lock, not O(source bytes), and caching it in the schema wrapper is a larger change than this hot-path fix warrants.

Prior art (approach only, AGPL, no code copied): Elasticsearch's `FetchSourcePhase` adds the source **as-is** when the fetch context has no filter, and only calls `source.filter()` when one exists.

## Reproduction / regression tests

Two pointer-identity tests on the hits' inner string buffers — only a deep copy reallocates them. Both **fail at HEAD** before the fix and pass after:

- `default_source_without_companions_is_a_zero_copy_passthrough`
- `default_source_with_companions_strips_in_place_without_deep_copy`

## Numbers

1000 hits × ~105KB source, release build, the filter step in isolation: **5.902 ms → 0.0796 ms (~74× on the step)**. Constant-factor on the whole request (serialization is still O(source)), but it removes a full copy of every hit source per default search.

## Verification

- `cargo test -p xerj-engine --lib`: 486/486 green
- Live wire check on a scratch instance: plain index returns full `_source` untouched; embedding index still strips `body_vector`/`body_vector_chunks`
- ES-YAML gate against this branch's binary: **1366 passed / 0 failed / 3 skipped**