### PR TITLE
fix(autoindex): --no-graph durable path indexed zero documents for every code file

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -112,9 +112,14 @@ fn registry() -> &'static [LangDef] {
     })
 }
 
-pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
+pub fn extract(path: &Path, sn: &crate::sniff::Sniffed, sink: Sink) -> Result<ExtractStats> {
     let mut stats = ExtractStats::default();
-    let ext = path
+    // Grammar lookup and title are keyed on the LOGICAL name from `Sniffed`,
+    // never on `path`: durable preparation reads content-addressed snapshot
+    // blobs (`blobs/00000000`), so an extension recovered from the content
+    // path is empty there and classified every code file as junk (#294).
+    let named = sn.logical_name.as_deref().unwrap_or(path);
+    let ext = named
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("")
@@ -132,7 +137,7 @@ pub fn extract(path: &Path, sink: Sink) -> Result<ExtractStats> {
     // Parse + capture definitions. A parse failure (or an over-deep tree) is not
     // fatal — index the file as plain text so its content is still searchable.
     let symbols = parse_symbols(def, &text).unwrap_or_default();
-    emit_code_doc(path, def.name, &text, &symbols, &mut stats, sink);
+    emit_code_doc(named, def.name, &text, &symbols, &mut stats, sink);
     Ok(stats)
 }
 
@@ -530,6 +535,27 @@ mod tests {
     fn all_queries_compile() {
         // registry() builds every Query; a malformed query panics here.
         assert!(registry().len() >= 13);
+    }
+
+    /// #294 at this extractor's own boundary: content in an extensionless
+    /// snapshot blob, language resolved from the logical name on `Sniffed`.
+    #[test]
+    fn extracts_from_extensionless_blob_via_sniffed_logical_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob = dir.path().join("00000000");
+        std::fs::write(&blob, "def alpha_helper():\n    return 1\n").unwrap();
+        let sn = crate::sniff::sniff_with_name(&blob, Path::new("src/app.py")).unwrap();
+        assert_eq!(sn.family, crate::sniff::Family::Code);
+        let mut records: Vec<RawRecord> = Vec::new();
+        let stats = extract(&blob, &sn, &mut |record| {
+            records.push(record);
+            true
+        })
+        .unwrap();
+        assert_eq!((stats.records, stats.junk), (1, 0));
+        assert_eq!(records[0].fields["language"], "python");
+        // Title comes from the logical name, not the blob ordinal.
+        assert_eq!(records[0].fields["title"], "app.py");
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/extract/csv_x.rs
+++ b/engine/crates/xerj-autoindex/src/extract/csv_x.rs
@@ -97,6 +97,7 @@ mod tests {
                 decimal_comma,
             }),
             encoding: "utf-8",
+            logical_name: None,
         }
     }
 

--- a/engine/crates/xerj-autoindex/src/extract/mod.rs
+++ b/engine/crates/xerj-autoindex/src/extract/mod.rs
@@ -163,7 +163,7 @@ pub fn extract(
         Family::Docx => docx::extract(path, sink),
         Family::Sqlite => sqlite_x::extract(path, limit_bytes.map(|_| 500), sink),
         Family::SqlDump => sqldump::extract(path, sn.gzip, limit_bytes, sink),
-        Family::Code => code::extract(path, sink),
+        Family::Code => code::extract(path, sn, sink),
         Family::Binary => Ok(ExtractStats::default()),
     }
 }

--- a/engine/crates/xerj-autoindex/src/reconcile_plan.rs
+++ b/engine/crates/xerj-autoindex/src/reconcile_plan.rs
@@ -460,6 +460,7 @@ mod tests {
                 binary_kind: None,
                 csv: None,
                 encoding: "utf-8",
+                logical_name: None,
             }),
             sketches: vec![crate::GroupSketch {
                 group: None,

--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -69,6 +69,13 @@ pub struct Sniffed {
     pub csv: Option<CsvDialect>,
     /// "utf-8" or "windows-1252 (lossy)"
     pub encoding: &'static str,
+    /// File name of the LOGICAL source (`app.py`), even when the sniffed
+    /// content lives elsewhere. Durable preparation reads content-addressed
+    /// snapshot blobs (`blobs/00000000`), so an extractor that recovers a
+    /// parameter from its content path silently loses the name — that is how
+    /// #294 turned every code file into junk. Name-derived decisions after
+    /// sniffing must use this, never the content path.
+    pub logical_name: Option<std::path::PathBuf>,
 }
 
 fn read_prefix(path: &Path, gzip: bool, n: usize) -> Result<Vec<u8>> {
@@ -100,6 +107,7 @@ pub fn sniff_with_name(content_path: &Path, logical_path: &Path) -> Result<Sniff
     let prefix = read_prefix(content_path, gzip, 8192)?;
     let mut s = sniff_bytes(&prefix, content_path, logical_path, gzip)?;
     s.gzip = gzip;
+    s.logical_name = logical_path.file_name().map(std::path::PathBuf::from);
     Ok(s)
 }
 
@@ -115,6 +123,7 @@ fn sniff_bytes(
         binary_kind: None,
         csv: None,
         encoding: "utf-8",
+        logical_name: None,
     };
     if prefix.is_empty() {
         let mut s = mk(Family::Binary);

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -2052,6 +2052,60 @@ mod tests {
         );
     }
 
+    /// #294: snapshot blobs are content-addressed and extensionless
+    /// (`blobs/00000000`), and the code extractor keyed its grammar lookup on
+    /// the CONTENT path instead of the logical one carried by `Sniffed`. Every
+    /// source file on the durable path therefore prepared as junk — zero
+    /// documents — while the generation still committed and reported success.
+    #[test]
+    fn preparation_extracts_code_from_extensionless_snapshot_blobs() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let corpus = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        std::fs::write(
+            corpus.path().join("app.py"),
+            "def alpha_helper():\n    return 1\n",
+        )
+        .unwrap();
+        let inventory = inventory(corpus.path());
+        let plan = plan_for(&inventory);
+        let snapshot = create_prepared_snapshot(
+            state.path(),
+            "tx-code",
+            &inventory,
+            &plan,
+            "test-preparation-v1",
+            u64::MAX,
+        )
+        .unwrap();
+        let prepared = snapshot.files[0].prepared.as_ref().unwrap();
+        assert_eq!(
+            (prepared.records, prepared.junk),
+            (1, 0),
+            "a code file must prepare one document, not silent junk"
+        );
+        let ndjson = std::fs::read_to_string(
+            state
+                .path()
+                .join("sync-snapshots/tx-code")
+                .join(&prepared.relative_ndjson),
+        )
+        .unwrap();
+        let document: Value = serde_json::from_str(ndjson.lines().nth(1).unwrap()).unwrap();
+        assert_eq!(document["language"], "python", "{document}");
+        // The title must be the logical file name, not the blob ordinal.
+        assert_eq!(document["title"], "app.py", "{document}");
+        assert!(
+            document["defs"]
+                .as_str()
+                .unwrap_or("")
+                .contains("function alpha_helper"),
+            "{document}"
+        );
+    }
+
     #[test]
     fn prepared_snapshot_budget_aborts_and_removes_staging() {
         let corpus = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

On the durable-generation path (`--no-graph`), every source-code file was silently dropped: walked, sniffed correctly as `family: code`, counted, and then prepared as **zero documents**. The generation still committed and the run reported success (exit 3), so the loss was invisible — the #204 class of accepted-and-ignored input.

## Root cause

`prepare_artifact` sniffs with the logical path (`sniff_with_name(snapshot_blob, &source.path)`) but extracts with only the blob path. `code::extract` was the one family extractor that recovered a parameter — the language, via `path.extension()` — from its *content* path instead of from `Sniffed`. Snapshot blobs are content-addressed and extensionless (`sync-snapshots/<tx>/blobs/00000000`), so the registry lookup never matched and every code file, in every language, became junk.

## Fix

`Sniffed` now carries `logical_name`, set by `sniff_with_name`, and `code::extract` resolves both the grammar **and the document title** from it, falling back to the content path (which keeps the legacy path byte-identical: there logical == content). The title matters too — without it the fixed durable path would have indexed every code doc titled by blob ordinal `00000000`.

## Reproduction (run at HEAD, 803c85b8)

The new regression test `preparation_extracts_code_from_extensionless_snapshot_blobs` fails on the parent commit exactly as the issue describes:

```
assertion `left == right` failed: a code file must prepare one document, not silent junk
  left: (0, 1)      # (records, junk)
 right: (1, 0)
```

End-to-end with this fix (release binary, throwaway server on :9483), the issue's own repro corpus (`app.py` + `notes.txt`) under `--no-graph`:

```
generation 1 committed — 1 datasets, 2 records live
{'ax_path': 'app.py',    'ax_format': 'py',  'title': 'app.py', 'language': 'python', 'defs': 'function alpha_helper'}
{'ax_path': 'notes.txt', 'ax_format': 'txt', ...}
```

and the issue's real-tree case (`crates/xerj-autoindex/src`, 53 `.rs` files) goes from `0 records live` / `count: 0` to `53 records live` / `count: 53`.

## Tests

- `sync_executor::tests::preparation_extracts_code_from_extensionless_snapshot_blobs` — the durable-path regression the issue asked for (fails before the fix).
- `extract::code::tests::extracts_from_extensionless_blob_via_sniffed_logical_name` — the same contract at the extractor's own boundary.

## Local gate

- `cargo test -p xerj-autoindex --lib`: 530 passed / 0 failed
- `cargo fmt --all --check`: clean
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`: clean
- ES-YAML conformance suite: **1366 passed · 0 failed · 3 skipped**

## Noted, out of scope

Other extractors (`txt`, `html`, `pdf`, `docx`) use their content path only as a *fallback* title when the document has no intrinsic one, so on the durable path a titleless file can still get a blob-ordinal title. Cosmetic, no document loss — worth a small follow-up that threads `logical_name` into those fallbacks.

Fixes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)