### PR TITLE
test(autoindex): lock in the #294 fix at the observable level, and make silent code-coverage loss impossible

### DIFF
--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -239,6 +239,11 @@ pub fn help_text() -> String {
              terminal line, in every progress mode EXCEPT `none` (which --quiet\n\
              selects), so an outcome never has to be guessed from silence:\n\
                xerj-done ok=true exit=3 reason=completed-with-junk wall=57.6s …\n\
+             The terminal line also carries code coverage — code_files=N\n\
+             code_files_indexed=M code_files_junked=K — so a corpus whose\n\
+             source files were ALL dropped cannot print the same line as a\n\
+             healthy one. code_files>0 with code_files_indexed=0 is always a\n\
+             defect, and the run says so in words as well.\n\
              --quiet/--progress none prints no progress and NO terminal line\n\
              (only a fatal `error:` line, if any) — poll `autoindex status\n\
              --state-dir <dir>` or read the exit code instead of waiting for\n\

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -648,6 +648,69 @@ fn assert_unsupported_delta_without_remote_mutation(
 /// The documented headline workflow: point autoindex at a folder, add a file,
 /// rerun. The rerun must not fail, must say plainly that the added file was
 /// not indexed, and `--fresh` must then absorb it in place.
+/// Code/AST coverage on the LEGACY (graph-enabled) path.
+///
+/// #294 only ever affected the generated `--no-graph` executor, and that
+/// asymmetry is exactly why it survived: the two paths reported identically,
+/// so comparing their terminal lines told a caller nothing. The counters exist
+/// on both, from one definition (`CodeCoverage`), so the next divergence
+/// between them is visible in the output rather than only in the index.
+#[test]
+fn the_legacy_terminal_line_and_run_document_report_code_coverage() {
+    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("alpha.rs"),
+        "pub struct AlphaConfig {\n    pub retries: u32,\n}\n\n\
+         pub fn alpha_connect(cfg: &AlphaConfig) -> bool {\n    cfg.retries > 0\n}\n",
+    )
+    .unwrap();
+    fs::write(corpus.path().join("rows.csv"), "id,value\n1,first\n").unwrap();
+    let endpoint = MockEndpoint::start(usize::MAX);
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url);
+    assert!(!config.no_graph, "this module covers the legacy path");
+    config.quiet = false;
+    config.progress = crate::progress::ProgressMode::Plain;
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let (code, report) = {
+        let _sink = crate::progress::install_test_sink(&buffer);
+        run_index_report(config).unwrap()
+    };
+    assert_eq!(code, 0);
+    let report = report.unwrap();
+    assert_eq!(report["code_files"], 1, "{report}");
+    assert_eq!(report["code_files_indexed"], 1, "{report}");
+    assert_eq!(report["code_files_junked"], 0, "{report}");
+    let stream = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    let done = stream
+        .lines()
+        .find(|line| line.starts_with("xerj-done "))
+        .unwrap_or_else(|| panic!("{stream}"));
+    assert!(
+        done.contains("code_files=1 code_files_indexed=1 code_files_junked=0"),
+        "{done}"
+    );
+    assert!(!stream.contains("warning:"), "{stream}");
+    let locked = endpoint.state.lock().unwrap();
+    let ast = locked
+        .docs
+        .values()
+        .find(|doc| doc.get("language").is_some())
+        .unwrap_or_else(|| panic!("the legacy path indexes an AST document for alpha.rs"));
+    assert_eq!(ast["language"], "rust", "{ast}");
+    assert_eq!(ast["title"], "alpha.rs", "{ast}");
+    assert!(
+        ast["defs"]
+            .as_str()
+            .is_some_and(|defs| defs.contains("struct AlphaConfig")),
+        "{ast}"
+    );
+}
+
 #[test]
 fn a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it() {
     let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();

--- a/engine/crates/xerj-autoindex/src/generation_catalog.rs
+++ b/engine/crates/xerj-autoindex/src/generation_catalog.rs
@@ -95,6 +95,9 @@ pub fn project_generation(
         .as_ref()
         .context("catalog generation has no execution identity")?;
     let mut documents = BTreeMap::new();
+    // #294 tripwire: counted from the sealed manifest, so a resumed or no-op
+    // generation republishes the same coverage instead of an empty one.
+    let mut code = crate::CodeCoverage::default();
 
     for group in &desired.groups {
         let assignment = desired.plan.files.get(&group.content_id).with_context(|| {
@@ -104,6 +107,7 @@ pub fn project_generation(
             )
         })?;
         let format = assignment_format(assignment.family.as_str(), assignment.gzip);
+        code.observe(&format, group.expected_records);
         let (id, doc) = catalog::file_doc(
             &group.content_id,
             &group.canonical.rel,
@@ -130,6 +134,9 @@ pub fn project_generation(
     }
 
     for junk in &desired.plan.junk_files {
+        // A junk/skipped file has no `plan.files` entry by construction, so
+        // these cannot double-count the groups above.
+        code.observe(&junk.format, 0);
         let (id, doc) = catalog::file_doc(
             &junk.file_key,
             &junk.rel,
@@ -216,6 +223,12 @@ pub fn project_generation(
         "files_junk": desired.plan.junk_files.len(),
         "records_total": total_records,
         "junk_records_total": total_junk_records,
+        // Code/AST coverage (`CodeCoverage`): `records_total` counts records,
+        // not families, so it cannot say that every source file in the corpus
+        // was junked. These three can, and they travel to the terminal line.
+        "code_files": code.files,
+        "code_files_indexed": code.indexed,
+        "code_files_junked": code.junked,
         "semantic": desired
             .plan
             .datasets
@@ -441,6 +454,82 @@ mod tests {
             generation_id: id.into(),
             started: "2026-08-03T00:00:00Z".into(),
         }
+    }
+
+    /// #294 dropped every source file on this path — prepared as zero
+    /// documents, then committed and reported as a success. The run document
+    /// could not say so: `records_total` counts records, not families, so a
+    /// corpus whose whole code half was junked projected the same shape as a
+    /// healthy one-prose-file corpus. Coverage is what distinguishes them, and
+    /// it is what the terminal line reads.
+    #[test]
+    fn the_run_document_reports_code_coverage_for_junked_and_indexed_source_files() {
+        let mut code_assignment = assignment("app.py");
+        code_assignment.family = "code".into();
+        let mut plan = Plan {
+            datasets: vec![dataset()],
+            ..Plan::default()
+        };
+        plan.files.insert("prose".into(), assignment("notes.md"));
+        plan.files.insert("code".into(), code_assignment);
+        let base = committed(manifest(0, "generation-0", Plan::default(), vec![]));
+
+        // The defect: the code file prepared nothing at all.
+        let mut junked = group("code", "app.py", vec![]);
+        junked.expected_records = 0;
+        junked.expected_junk_records = 1;
+        let desired = manifest(
+            1,
+            "generation-1",
+            plan.clone(),
+            vec![group("prose", "notes.md", vec![]), junked],
+        );
+        let projection = project_generation(
+            &base,
+            &desired,
+            &metadata("generation-1"),
+            &stats(),
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        let run = &projection.documents["run:generation-1"];
+        assert_eq!(run["code_files"], 1);
+        assert_eq!(
+            run["code_files_indexed"], 0,
+            "a corpus that indexed no source code must say so: {run}"
+        );
+        assert_eq!(run["code_files_junked"], 1);
+
+        // The healthy shape of the same corpus.
+        let desired = manifest(
+            1,
+            "generation-1",
+            plan,
+            vec![
+                group("prose", "notes.md", vec![]),
+                group("code", "app.py", vec![]),
+            ],
+        );
+        let projection = project_generation(
+            &base,
+            &desired,
+            &metadata("generation-1"),
+            &stats(),
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        let run = &projection.documents["run:generation-1"];
+        assert_eq!(
+            (
+                run["code_files"].clone(),
+                run["code_files_indexed"].clone(),
+                run["code_files_junked"].clone()
+            ),
+            (json!(1), json!(1), json!(0)),
+            "{run}"
+        );
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -1272,6 +1272,105 @@ fn a_junk_record_is_counted_into_the_generation_and_never_fatal() {
 /// narrated (it is a per-file, minutes-long phase here exactly as on the legacy
 /// path), the stream closes with a truthful terminal line, and `--progress
 /// none` on the same path stays completely silent.
+/// #294, at the level where the loss actually happened: a mixed corpus of
+/// source code and prose, over the generated (`--no-graph`) path, through the
+/// real HTTP client.
+///
+/// Every code file was walked, sniffed as family `code`, counted — and then
+/// prepared as ZERO documents, so the generation committed and the run
+/// reported success while the entire code half of the corpus was missing.
+/// `sync_executor` pins the extraction half of that regression; this pins what
+/// a caller can actually observe: the documents that reach the endpoint carry
+/// their AST fields, and the run document and terminal line carry coverage
+/// counters that a wholly-junked corpus could not fake.
+#[test]
+fn code_files_index_with_ast_fields_and_the_run_reports_code_coverage() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap();
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("alpha.rs"),
+        "pub struct AlphaConfig {\n    pub retries: u32,\n}\n\n\
+         pub fn alpha_connect(cfg: &AlphaConfig) -> bool {\n    cfg.retries > 0\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        corpus.path().join("gamma.py"),
+        "def gamma_load(path):\n    return open(path).read()\n\n\n\
+         class GammaStore:\n    def __init__(self, root):\n        self.root = root\n",
+    )
+    .unwrap();
+    fs::write(
+        corpus.path().join("notes.md"),
+        "# Fixture notes\n\nTwo source files and this prose file, so the corpus is mixed.\n",
+    )
+    .unwrap();
+    let endpoint = HttpEndpoint::start();
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    config.quiet = false;
+    config.progress = crate::progress::ProgressMode::Plain;
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let (code, summary) = {
+        let _sink = crate::progress::install_test_sink(&buffer);
+        run_index_report(config).unwrap()
+    };
+    assert_eq!(code, 0, "nothing in this corpus is unparseable");
+    let summary = summary.expect("a generated run returns its committed run projection");
+    assert_eq!(summary["code_files"], 2, "{summary}");
+    assert_eq!(
+        summary["code_files_indexed"], 2,
+        "both source files must reach the index: {summary}"
+    );
+    assert_eq!(summary["code_files_junked"], 0, "{summary}");
+
+    let docs = endpoint.data_docs();
+    let mut code_docs: Vec<&Value> = docs
+        .iter()
+        .filter(|doc| doc.get("language").is_some())
+        .collect();
+    code_docs.sort_by_key(|doc| doc["language"].as_str().unwrap_or("").to_owned());
+    assert_eq!(
+        code_docs.len(),
+        2,
+        "one AST document per source file: {docs:?}"
+    );
+    assert_eq!(code_docs[0]["language"], "python");
+    assert_eq!(code_docs[1]["language"], "rust");
+    for doc in &code_docs {
+        assert!(
+            doc["defs"].as_str().is_some_and(|defs| !defs.is_empty()),
+            "{doc}"
+        );
+        assert!(
+            doc["symbols"]
+                .as_array()
+                .is_some_and(|symbols| !symbols.is_empty()),
+            "{doc}"
+        );
+    }
+    // The title comes from the logical file name, never the content-addressed
+    // snapshot blob's ordinal — the other half of #294.
+    assert_eq!(code_docs[0]["title"], "gamma.py");
+    assert_eq!(code_docs[1]["title"], "alpha.rs");
+    let rendered = serde_json::to_string(&code_docs).unwrap();
+    assert!(rendered.contains("struct AlphaConfig"), "{rendered}");
+    assert!(rendered.contains("class GammaStore"), "{rendered}");
+
+    let stream = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    let done = stream
+        .lines()
+        .find(|line| line.starts_with("xerj-done "))
+        .unwrap_or_else(|| panic!("{stream}"));
+    assert!(
+        done.contains("code_files=2 code_files_indexed=2 code_files_junked=0"),
+        "the terminal line carries the coverage that made #294 invisible: {done}"
+    );
+    assert!(!stream.contains("warning:"), "{stream}");
+}
+
 #[test]
 fn a_generated_run_narrates_its_scan_and_closes_its_own_stream() {
     let _guard = HTTP_E2E_LOCK.lock().unwrap();

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -212,6 +212,88 @@ fn project_reconcile_plan(
     reconcile_plan::reconcile_plan(inventory, base_plan, scans, cfg.sample)
 }
 
+/// Code/AST coverage for one corpus: how much of what a person would call
+/// "the source code" actually reached the index.
+///
+/// This exists because success looked identical to total loss. #294 junked
+/// EVERY source file on the durable `--no-graph` path, and the run still
+/// printed
+///
+/// ```text
+/// xerj-done ok=true exit=3 reason=completed-with-junk wall=0.6s files=4 records=1 generation=1
+/// ```
+///
+/// over a corpus of three source files and one `.md` — the same line a healthy
+/// one-prose-file corpus prints. `records` counts records, not families, so
+/// nothing on that line could distinguish "small corpus" from "the entire code
+/// half is gone". These three counters make that state unrepresentable: a run
+/// whose `code_files` is non-zero while `code_files_indexed` is zero can never
+/// again print the same terminal line as a healthy one, on either path.
+///
+/// Counted per FILE, not per record, and derived from the same durable
+/// artifacts the catalog is projected from (the plan's family strings plus the
+/// per-file record counts), so a resumed run reports the corpus it holds rather
+/// than the slice this invocation happened to touch.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CodeCoverage {
+    /// Source files classified into `Family::Code`, junked ones included.
+    pub files: u64,
+    /// …of those, the ones that produced at least one indexed record.
+    pub indexed: u64,
+    /// …of those, the ones that produced none.
+    pub junked: u64,
+}
+
+impl CodeCoverage {
+    /// Both call sites hold a catalog FORMAT string, which is the plan's
+    /// family (`Family::as_str`) plus the `(gzip)` suffix `format_str` and
+    /// `assignment_format` append — match the family, not the compression.
+    fn is_code_format(format: &str) -> bool {
+        format.strip_suffix("(gzip)").unwrap_or(format) == Family::Code.as_str()
+    }
+
+    /// Count one file the run classified as `format` and which produced
+    /// `records` indexed records. Non-code files are ignored, so both paths can
+    /// feed this their whole file list without pre-filtering.
+    pub fn observe(&mut self, format: &str, records: u64) {
+        if !Self::is_code_format(format) {
+            return;
+        }
+        self.files += 1;
+        if records > 0 {
+            self.indexed += 1;
+        } else {
+            self.junked += 1;
+        }
+    }
+
+    /// The terminal-line and run-document fields, in a fixed order. One
+    /// definition, so the legacy and generated paths cannot drift into
+    /// spelling the same measurement differently.
+    pub fn fields(&self) -> [(&'static str, u64); 3] {
+        [
+            ("code_files", self.files),
+            ("code_files_indexed", self.indexed),
+            ("code_files_junked", self.junked),
+        ]
+    }
+
+    /// The one state that is always a defect: source code was found, and none
+    /// of it reached the index. Cheap to compute and worth a sentence, because
+    /// the counters alone still need a reader who knows to look at them.
+    pub fn warning(&self) -> Option<String> {
+        (self.files > 0 && self.indexed == 0).then(|| {
+            format!(
+                "warning: {} source-code file(s) were detected and NONE produced an indexed \
+                 record — code search over this corpus will return nothing. Check the catalog's \
+                 file documents (doc_kind=file, status=indexed, records=0) before trusting \
+                 this index.",
+                self.files
+            )
+        })
+    }
+}
+
 /// Exit code for a run that committed (or confirmed) a corpus generation.
 ///
 /// `3` is "completed with junk — recorded, never fatal", the same contract the
@@ -240,6 +322,24 @@ fn generated_exit_code(summary: &Value) -> i32 {
 /// out in words rather than left as a bare number.
 fn finish_generated_progress(pr: &Progress, code: i32, summary: &Value) {
     let count = |field: &str| summary.get(field).and_then(Value::as_u64).unwrap_or(0);
+    // Read back from the committed generation's own run document, exactly like
+    // every other number on this line — a resumed or no-op run therefore
+    // reports the corpus's coverage, not an empty one.
+    let coverage = CodeCoverage {
+        files: count("code_files"),
+        indexed: count("code_files_indexed"),
+        junked: count("code_files_junked"),
+    };
+    // Before `finish`: the terminal line is the last thing this stream emits.
+    if let Some(warning) = coverage.warning() {
+        pr.note(&warning);
+    }
+    let mut extra = vec![
+        ("files", count("files_indexed")),
+        ("records", count("records_total")),
+        ("generation", count("generation")),
+    ];
+    extra.extend(coverage.fields());
     pr.finish(
         true,
         code,
@@ -248,11 +348,7 @@ fn finish_generated_progress(pr: &Progress, code: i32, summary: &Value) {
         } else {
             "completed"
         },
-        &[
-            ("files", count("files_indexed")),
-            ("records", count("records_total")),
-            ("generation", count("generation")),
-        ],
+        &extra,
     );
 }
 
@@ -4404,6 +4500,11 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     }
 
     // file docs — indexed (from journal) + junk/skipped (from plan + this run)
+    //
+    // The same pass produces this path's code/AST coverage (`CodeCoverage`):
+    // the journal's completions are the corpus, not just this invocation's
+    // slice, so a resume reports what is live rather than what it re-parsed.
+    let mut code_coverage = CodeCoverage::default();
     {
         let j = journal_mx.lock().unwrap();
         for fd in j.done.values() {
@@ -4423,6 +4524,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                     }
                 })
                 .unwrap_or_else(|| "unknown".into());
+            code_coverage.observe(&fmt, fd.records);
             let (id, doc) = catalog::file_doc(
                 &fd.file_key,
                 current_path,
@@ -4450,6 +4552,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // junk-plan update below mutates.
     let junk_file_count = all_junk.len();
     for jf in &all_junk {
+        // Disjoint from the journal completions above: a file that reached
+        // `file_done` never appears here, so nothing is counted twice.
+        code_coverage.observe(&jf.format, 0);
         let (id, doc) = catalog::file_doc(
             &jf.file_key,
             &jf.rel,
@@ -4604,6 +4709,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     if let Some(g) = &graph_summary {
         run_doc["graph"] = g.clone();
     }
+    // Appended rather than written into the literal above: `serde_json::json!`
+    // recurses once per key and that literal is already 30 deep — the same
+    // reason `catalog::catalog_mapping` inserts its tail fields.
+    for (key, value) in code_coverage.fields() {
+        run_doc[key] = json!(value);
+    }
     push_doc(&format!("run:{run_id}"), &run_doc, &mut cat_buf);
 
     if !cat_buf.is_empty() {
@@ -4712,6 +4823,16 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // selects, and which prints nothing by definition). Exit 3 means
     // "completed, some files were unparseable" — success — and an agent reading
     // a bare `3` off a silent stream reads failure (#241 §9). Say it in words.
+    if let Some(warning) = code_coverage.warning() {
+        pr.note(&warning);
+    }
+    let mut done_fields = vec![
+        ("files", files_done.load(Ordering::Relaxed)),
+        ("records", total_records),
+        ("datasets", plan.datasets.len() as u64),
+        ("junk_files", junk_file_count as u64),
+    ];
+    done_fields.extend(code_coverage.fields());
     pr.finish(
         true,
         code,
@@ -4720,12 +4841,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         } else {
             "completed"
         },
-        &[
-            ("files", files_done.load(Ordering::Relaxed)),
-            ("records", total_records),
-            ("datasets", plan.datasets.len() as u64),
-            ("junk_files", junk_file_count as u64),
-        ],
+        &done_fields,
     );
     drop(ticker);
     Ok((code, Some(run_doc)))
@@ -5705,6 +5821,118 @@ mod generation_contract_identity_tests {
         assert_eq!(PREPARED_RECORDS_IDENTITY, "prepared-records-v1");
         assert_eq!(DOCUMENT_IDS_IDENTITY, "document-ids-v1");
         assert_eq!(DETECTOR_DISABLED_IDENTITY, "disabled");
+    }
+}
+
+#[cfg(test)]
+mod code_coverage_tests {
+    use super::*;
+
+    fn captured(buffer: &std::sync::Arc<Mutex<Vec<u8>>>) -> String {
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
+
+    /// The exact line that made #294 survivable for a whole release: over a
+    /// corpus of three source files and one `.md`, with every source file
+    /// junked, the run printed `files=4 records=1` — indistinguishable from a
+    /// healthy one-file corpus. Coverage plus a warning is what makes those
+    /// two runs print different lines.
+    #[test]
+    fn the_generated_terminal_line_carries_coverage_and_warns_when_no_code_indexed() {
+        let (pr, buffer) = progress::Progress::capture(
+            progress::Surface::Plain,
+            std::time::Duration::from_secs(3600),
+        );
+        finish_generated_progress(
+            &pr,
+            3,
+            &json!({
+                "files_indexed": 4,
+                "records_total": 1,
+                "generation": 1,
+                "code_files": 3,
+                "code_files_indexed": 0,
+                "code_files_junked": 3,
+            }),
+        );
+        let text = captured(&buffer);
+        let done = text
+            .lines()
+            .find(|line| line.starts_with("xerj-done "))
+            .unwrap_or_else(|| panic!("{text}"));
+        assert!(
+            done.contains("code_files=3 code_files_indexed=0 code_files_junked=3"),
+            "{done}"
+        );
+        assert!(
+            text.lines()
+                .any(|line| line.starts_with("warning:") && line.contains("NONE")),
+            "a corpus that indexed no source code is warned about in words: {text}"
+        );
+        assert!(
+            text.trim_end()
+                .lines()
+                .next_back()
+                .unwrap()
+                .starts_with("xerj-done "),
+            "the terminal line stays terminal — the warning precedes it: {text}"
+        );
+    }
+
+    #[test]
+    fn a_healthy_corpus_reports_its_coverage_without_a_warning() {
+        let (pr, buffer) = progress::Progress::capture(
+            progress::Surface::Plain,
+            std::time::Duration::from_secs(3600),
+        );
+        finish_generated_progress(
+            &pr,
+            0,
+            &json!({
+                "files_indexed": 4,
+                "records_total": 8,
+                "generation": 1,
+                "code_files": 3,
+                "code_files_indexed": 3,
+                "code_files_junked": 0,
+            }),
+        );
+        let text = captured(&buffer);
+        assert!(
+            text.contains("code_files=3 code_files_indexed=3 code_files_junked=0"),
+            "{text}"
+        );
+        assert!(!text.contains("warning:"), "{text}");
+    }
+
+    /// A corpus with no source code in it at all must not start warning, and a
+    /// gzipped source file is still a source file.
+    #[test]
+    fn coverage_counts_families_not_compression_and_stays_quiet_without_code() {
+        let mut coverage = CodeCoverage::default();
+        coverage.observe("txt-prose", 4);
+        coverage.observe("csv", 0);
+        assert_eq!(coverage, CodeCoverage::default());
+        assert!(coverage.warning().is_none());
+
+        coverage.observe("code", 1);
+        coverage.observe("code(gzip)", 0);
+        assert_eq!(
+            (coverage.files, coverage.indexed, coverage.junked),
+            (2, 1, 1)
+        );
+        assert!(
+            coverage.warning().is_none(),
+            "partial loss is reported by the counters, not by the warning"
+        );
+        assert_eq!(
+            coverage.fields(),
+            [
+                ("code_files", 2),
+                ("code_files_indexed", 1),
+                ("code_files_junked", 1)
+            ]
+        );
     }
 }
 


### PR DESCRIPTION
Follow-up to #294 / #316. An empirical A/B against a binary built from main confirms the `--no-graph` code-junking bug **does not reproduce** — `f9d76b5b` fixed it. The original report was produced by a pre-fix binary.

Two gaps remain, and this closes both.

**The fix shipped with a prepare-level test only.** `preparation_extracts_code_from_extensionless_snapshot_blobs` asserts at the wrong altitude — the loss happened at the run/observable level. Added a regression test over the generated executor and real HTTP with a mixed code+prose corpus, asserting AST fields, logical titles, and the run document's coverage counters.

**The failure was invisible.** A corpus where every code file was junked printed a `xerj-done` line identical to a healthy one. `xerj-done` now carries `code_files`/`code_files_indexed`/`code_files_junked` on both the generated and legacy paths, plus a warning emitted before the terminal line when code files were detected and none indexed. Counters derive from the durable artifacts, so a resumed run reports the corpus rather than the slice it re-parsed. Named `code_files_indexed` rather than `ast=` deliberately: a code file with no captured symbols still indexes correctly, so `ast` would overstate.

**Release exposure:** `f9d76b5b` is NOT in v1.0.0-rc.15. Every user installing today still gets `--no-graph` silently indexing none of their source. Cutting the next rc is what actually reaches them.