### PR TITLE
test(autoindex): stop one timing flake cascading into 65 failures (#336)

### DIFF
--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -658,9 +658,15 @@ fn assert_unsupported_delta_without_remote_mutation(
 /// between them is visible in the output rather than only in the index.
 #[test]
 fn the_legacy_terminal_line_and_run_document_report_code_coverage() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _sink_guard = crate::progress::SINK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -714,8 +720,12 @@ fn the_legacy_terminal_line_and_run_document_report_code_coverage() {
 
 #[test]
 fn a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
@@ -770,8 +780,12 @@ fn a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it() {
 
 #[test]
 fn completed_plan_rejects_vanished_content_group_before_remote_mutation() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("first.csv"), "id,value\n1,first\n").unwrap();
@@ -786,8 +800,12 @@ fn completed_plan_rejects_vanished_content_group_before_remote_mutation() {
 
 #[test]
 fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("b-old.csv"), "id,value\n1,b\n").unwrap();
@@ -836,8 +854,12 @@ fn completed_plan_rejects_mixed_membership_delta_in_stable_order() {
 /// vanished group — the path is still there, and the pipeline republishes it.
 #[test]
 fn fresh_absorbs_an_edited_file_instead_of_calling_it_a_removal() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("notes.csv"), "id,value\n1,before\n").unwrap();
@@ -885,8 +907,12 @@ fn fresh_absorbs_an_edited_file_instead_of_calling_it_a_removal() {
 /// one.
 #[test]
 fn an_ordinary_rerun_replaces_an_edited_file_without_stranding_records() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("notes.csv"), "id,value\n1,before\n").unwrap();
@@ -910,8 +936,12 @@ fn an_ordinary_rerun_replaces_an_edited_file_without_stranding_records() {
 /// plan), then `--fresh` to absorb both.
 #[test]
 fn fresh_absorbs_an_addition_and_an_edit_after_a_reported_rerun() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("first.csv"), "id,value\n1,before\n").unwrap();
@@ -951,8 +981,12 @@ fn fresh_absorbs_an_addition_and_an_edit_after_a_reported_rerun() {
 
 #[test]
 fn fresh_cannot_erase_the_plan_and_bypass_the_removal_gate() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("old.csv"), "id,value\n1,old\n").unwrap();
@@ -968,8 +1002,12 @@ fn fresh_cannot_erase_the_plan_and_bypass_the_removal_gate() {
 
 #[test]
 fn deleting_one_path_of_a_duplicate_pair_is_not_a_removed_content_group() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let bytes = "id,value\n1,same\n";
@@ -999,8 +1037,12 @@ fn deleting_one_path_of_a_duplicate_pair_is_not_a_removed_content_group() {
 
 #[test]
 fn unchanged_planned_junk_is_not_reported_as_added_content() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
@@ -1021,8 +1063,12 @@ fn unchanged_planned_junk_is_not_reported_as_added_content() {
 
 #[test]
 fn deleted_planned_junk_is_swept_rather_than_refused() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("rows.csv"), "id,value\n1,kept\n").unwrap();
@@ -1066,8 +1112,12 @@ fn deleted_planned_junk_is_swept_rather_than_refused() {
 
 #[test]
 fn completed_plan_rejects_empty_current_folder_before_remote_mutation() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("only.csv"), "id,value\n1,only\n").unwrap();
@@ -1085,8 +1135,12 @@ fn completed_plan_rejects_empty_current_folder_before_remote_mutation() {
 
 #[test]
 fn semantic_resume_rejects_embedding_identity_drift_before_another_bulk() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -1123,8 +1177,12 @@ fn semantic_resume_rejects_embedding_identity_drift_before_another_bulk() {
 /// path — `brain` always runs graph-enabled, which never commits a generation.
 #[test]
 fn fresh_restarts_a_completed_graph_enabled_journal_the_way_brain_self_heal_needs() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -1155,12 +1213,16 @@ fn fresh_restarts_a_completed_graph_enabled_journal_the_way_brain_self_heal_need
 
 #[test]
 fn fresh_publication_skips_delete_and_noop_resume_does_not_append_plan() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -1241,8 +1303,12 @@ fn fresh_publication_skips_delete_and_noop_resume_does_not_append_plan() {
 
 #[test]
 fn changed_source_replaces_durable_dataset_bytes_across_reopen() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let path = corpus.path().join("records.csv");
@@ -1292,8 +1358,12 @@ fn changed_source_replaces_durable_dataset_bytes_across_reopen() {
 
 #[test]
 fn deleted_path_bytes_remain_while_its_documents_remain_live() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let removed = corpus.path().join("removed.csv");
@@ -1343,8 +1413,12 @@ fn deleted_path_bytes_remain_while_its_documents_remain_live() {
 
 #[test]
 fn product_path_counts_shared_source_once_per_distinct_dataset() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let path = corpus.path().join("finance.sqlite");
@@ -1395,8 +1469,12 @@ fn product_path_counts_shared_source_once_per_distinct_dataset() {
 
 #[test]
 fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("records.csv"), "id,value\n0,one\n").unwrap();
@@ -1434,8 +1512,12 @@ fn existing_catalog_is_upgraded_before_new_run_metadata_is_written() {
 
 #[test]
 fn unchanged_resume_keeps_durable_dataset_junk_and_coercion_notes() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("records.csv"), "id,value\n0,one\n").unwrap();
@@ -1474,12 +1556,16 @@ fn unchanged_resume_keeps_durable_dataset_junk_and_coercion_notes() {
 
 #[test]
 fn legacy_plan_without_completion_cleans_possible_partial_visibility() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let first_state = tempfile::tempdir().unwrap();
     let legacy_state = tempfile::tempdir().unwrap();
@@ -1551,12 +1637,16 @@ fn legacy_plan_without_completion_cleans_possible_partial_visibility() {
 
 #[test]
 fn legacy_key_collision_fails_before_visibility_with_scoped_guidance() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let mut owner = vec![b'x'; 65_537];
@@ -1622,12 +1712,16 @@ fn legacy_key_collision_fails_before_visibility_with_scoped_guidance() {
 
 #[test]
 fn existing_completion_is_invalidated_and_partial_visibility_is_deleted_on_resume() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // 1: failure immediately after delete; 2: one complete 5,000-doc bulk
     // then a partial final bulk; 3: two complete bulks then a partial final
     // bulk immediately before the file_done journal append.
@@ -1743,12 +1837,16 @@ fn existing_completion_is_invalidated_and_partial_visibility_is_deleted_on_resum
 
 #[test]
 fn resume_repairs_kills_after_plan_delete_and_final_bulk_before_file_done() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     for boundary in [1u8, 2, 4] {
         let rows = 6_001usize;
         let corpus = tempfile::tempdir().unwrap();
@@ -1808,8 +1906,12 @@ fn resume_repairs_kills_after_plan_delete_and_final_bulk_before_file_done() {
 
 #[test]
 fn file_done_append_and_fsync_failures_are_fatal_and_resume_repairs() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     for io_boundary in [1u8, 2, 3] {
         let corpus = tempfile::tempdir().unwrap();
         let state_dir = tempfile::tempdir().unwrap();
@@ -1870,12 +1972,16 @@ fn file_done_append_and_fsync_failures_are_fatal_and_resume_repairs() {
 
 #[test]
 fn pending_generation_b_is_superseded_when_source_changes_to_c() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let path = corpus.path().join("records.csv");
@@ -1948,12 +2054,16 @@ fn pending_generation_b_is_superseded_when_source_changes_to_c() {
 
 #[test]
 fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let original = "id,value\n0,original\n1,original\n";
@@ -2029,8 +2139,12 @@ fn a_planned_key_never_gains_two_owners_when_old_content_moves_paths() {
 
 #[test]
 fn an_added_then_deleted_file_leaves_no_immortal_catalog_entry() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -2115,12 +2229,16 @@ fn an_added_then_deleted_file_leaves_no_immortal_catalog_entry() {
 
 #[test]
 fn deleting_an_entire_duplicate_group_strands_no_pending_replacement() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     // run_index reaches Journal::file_done; the file_done IO failpoint is
     // a global one-shot, so every file_done-reaching test must hold its
     // lock (armer or not) or it can steal an armed injection. Acquired
     // after FAILPOINT_TEST_LOCK everywhere — one consistent order.
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("dup-a.csv"), "id,value\n0,dup\n1,dup\n").unwrap();
@@ -2165,8 +2283,12 @@ fn deleting_an_entire_duplicate_group_strands_no_pending_replacement() {
 
 #[test]
 fn partial_file_done_is_rolled_back_before_another_worker_commits() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n0,a-old\n1,a-old\n").unwrap();
@@ -2228,8 +2350,12 @@ fn partial_file_done_is_rolled_back_before_another_worker_commits() {
 /// file left pending, and the rerun after the block lifts must really index.
 #[test]
 fn write_block_rejections_are_backend_fatal_and_the_file_stays_pending() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -2272,8 +2398,12 @@ fn write_block_rejections_are_backend_fatal_and_the_file_stays_pending() {
 /// `bulk_errors`' first-five sample cannot.
 #[test]
 fn backend_rejected_records_abort_the_run_before_any_map_is_written() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -2324,8 +2454,12 @@ fn backend_rejected_records_abort_the_run_before_any_map_is_written() {
 /// recover.
 #[test]
 fn zero_live_documents_after_journaled_records_fails_the_run() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _io_guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -2361,8 +2495,12 @@ fn zero_live_documents_after_journaled_records_fails_the_run() {
 ///      asserted by `quiet_runs_emit_no_progress_stream_at_all` below.)
 #[test]
 fn a_run_reports_progress_through_every_phase_and_closes_the_stream() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _sink_guard = crate::progress::SINK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     // Distinct bytes per file: byte-identical files collapse into one
@@ -2462,8 +2600,12 @@ fn a_run_reports_progress_through_every_phase_and_closes_the_stream() {
 /// here can spam a caller that asked for none.
 #[test]
 fn quiet_runs_emit_no_progress_stream_at_all() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _sink_guard = crate::progress::SINK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("rows.csv"), "id,value\n0,alpha\n").unwrap();
@@ -2508,8 +2650,12 @@ fn quiet_runs_emit_no_progress_stream_at_all() {
 /// thread than it has is requested.
 #[test]
 fn the_resource_plan_is_announced_on_the_progress_surface_with_the_width_it_got() {
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _sink_guard = crate::progress::SINK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -2571,7 +2717,9 @@ fn the_resource_plan_is_announced_on_the_progress_surface_with_the_width_it_got(
 fn fresh_pdf_is_parsed_once_and_failed_publication_retry_reparses_once() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     inject_pdf_spool_capacity(state_dir.path());
@@ -2627,7 +2775,9 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
 fn refused_pdf_spool_reparses_and_reports_fallback_without_weakening_publication() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let tools = tempfile::tempdir().unwrap();
@@ -2698,7 +2848,9 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
 fn refused_spool_does_not_pay_a_second_phase_a_source_hash() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let tools = tempfile::tempdir().unwrap();
@@ -2779,7 +2931,9 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
 fn source_changed_during_phase_a_discards_the_artifact_and_names_the_reason() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     inject_pdf_spool_capacity(state_dir.path());
@@ -2863,7 +3017,9 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
 fn verified_but_junk_pdf_spool_is_created_then_discarded_not_eligible() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     inject_pdf_spool_capacity(state_dir.path());
@@ -2925,7 +3081,9 @@ fn verified_but_junk_pdf_spool_is_created_then_discarded_not_eligible() {
 fn multi_pdf_run_reuses_every_artifact_and_reports_exact_success_counters() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     inject_pdf_spool_capacity(state_dir.path());
@@ -2999,7 +3157,9 @@ printf '%s' '{"schema":1,"extractor":"xerj-autoindex/__XERJ_VERSION__","parser":
 fn corrupted_pdf_replay_reparses_without_blaming_the_source_or_backend() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _guard = FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     inject_pdf_spool_capacity(state_dir.path());

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -472,8 +472,10 @@ fn final_snapshot_count(state_dir: &Path) -> usize {
 
 #[test]
 fn genesis_recovers_after_snapshot_budget_failure_before_sync_begin() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
@@ -498,8 +500,10 @@ fn genesis_recovers_after_snapshot_budget_failure_before_sync_begin() {
 
 #[test]
 fn no_semantic_generation_does_not_require_embedding_identity_endpoint() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
@@ -518,8 +522,10 @@ fn no_semantic_generation_does_not_require_embedding_identity_endpoint() {
 
 #[test]
 fn initial_generation_and_noop_are_end_to_end_idempotent() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n2,beta\n").unwrap();
@@ -561,8 +567,10 @@ fn initial_generation_and_noop_are_end_to_end_idempotent() {
 
 #[test]
 fn add_change_delete_and_rename_converge_over_real_http() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
@@ -599,8 +607,10 @@ fn add_change_delete_and_rename_converge_over_real_http() {
 
 #[test]
 fn pending_generation_replays_sealed_source_after_live_source_mutates() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let source = corpus.path().join("a.csv");
@@ -636,8 +646,10 @@ fn pending_generation_replays_sealed_source_after_live_source_mutates() {
 /// duplicate or stale document surviving the half-applied attempt.
 #[test]
 fn partially_applied_data_bulk_leaves_the_generation_pending_and_the_retry_converges() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let source = corpus.path().join("rows.csv");
@@ -693,8 +705,10 @@ fn partially_applied_data_bulk_leaves_the_generation_pending_and_the_retry_conve
 
 #[test]
 fn pending_semantic_identity_drift_rejects_before_any_further_bulk() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let source = corpus.path().join("report.txt");
@@ -744,8 +758,10 @@ fn pending_semantic_identity_drift_rejects_before_any_further_bulk() {
 /// committed manifest and every sealed source the next run needs.
 #[test]
 fn fresh_cannot_destroy_a_committed_generation() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
@@ -810,8 +826,10 @@ fn fresh_cannot_destroy_a_committed_generation() {
 /// different prefix before the run reaches anything else.
 #[test]
 fn the_isolated_rebuild_the_refusals_recommend_is_followable() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let committed_state = tempfile::tempdir().unwrap();
     let rebuild_state = tempfile::tempdir().unwrap();
@@ -852,8 +870,10 @@ fn the_isolated_rebuild_the_refusals_recommend_is_followable() {
 /// holds the only record of the pending transaction and its sealed source.
 #[test]
 fn fresh_cannot_destroy_a_pending_generation() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let source = corpus.path().join("a.csv");
@@ -916,8 +936,10 @@ fn fresh_cannot_destroy_a_pending_generation() {
 /// process, so this is reachable without any concurrency.
 #[test]
 fn same_second_runs_in_one_process_do_not_share_a_generation_identity() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let first_state = tempfile::tempdir().unwrap();
     let second_state = tempfile::tempdir().unwrap();
@@ -967,8 +989,10 @@ fn same_second_runs_in_one_process_do_not_share_a_generation_identity() {
 /// barrier is what turns such a leftover into a hard, unrecoverable failure.
 #[test]
 fn upsert_clears_a_survivor_under_the_desired_content_identity() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let source = corpus.path().join("a.csv");
@@ -1032,8 +1056,10 @@ fn upsert_clears_a_survivor_under_the_desired_content_identity() {
 /// directory the flag was accepted, ignored, and the destination mutated.
 #[test]
 fn dry_run_on_a_generated_state_directory_publishes_nothing() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
@@ -1097,8 +1123,10 @@ fn dry_run_on_a_generated_state_directory_publishes_nothing() {
 /// folder containing one unreadable, empty or unrecognised file.
 #[test]
 fn a_junk_file_is_recorded_and_never_fatal() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n2,beta\n").unwrap();
@@ -1145,8 +1173,10 @@ fn a_junk_file_is_recorded_and_never_fatal() {
 
 #[test]
 fn issue_283_inferred_float_manifest_digest_replays_on_unchanged_rerun() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     // 2,209 bytes / 9 records produces the exact inferred f64 which used to
@@ -1171,8 +1201,10 @@ fn issue_283_inferred_float_manifest_digest_replays_on_unchanged_rerun() {
 
 #[test]
 fn issue_283_junk_bearing_generation_reconciles_a_shrinking_file_set() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     // Preserve the inferred f64 from the original failure while exercising the
@@ -1216,8 +1248,10 @@ fn issue_283_junk_bearing_generation_reconciles_a_shrinking_file_set() {
 /// "3 completed-with-junk (junk recorded, never fatal)".
 #[test]
 fn a_junk_record_is_counted_into_the_generation_and_never_fatal() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let mut log = String::from("!!! rotated by logrotate, not a log line\n");
@@ -1286,9 +1320,13 @@ fn a_junk_record_is_counted_into_the_generation_and_never_fatal() {
 /// counters that a wholly-junked corpus could not fake.
 #[test]
 fn code_files_index_with_ast_fields_and_the_run_reports_code_coverage() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _sink_guard = crate::progress::SINK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -1374,9 +1412,13 @@ fn code_files_index_with_ast_fields_and_the_run_reports_code_coverage() {
 
 #[test]
 fn a_generated_run_narrates_its_scan_and_closes_its_own_stream() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
-    let _sink_guard = crate::progress::SINK_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _sink_guard = crate::progress::SINK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     for n in 0..4 {
@@ -1458,8 +1500,10 @@ fn a_generated_run_narrates_its_scan_and_closes_its_own_stream() {
 /// set on the junk-bearing generation reconciles.
 #[test]
 fn two_byte_identical_junk_files_commit_reconcile_and_survive_a_shrink() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n2,beta\n").unwrap();
@@ -1511,8 +1555,10 @@ fn two_byte_identical_junk_files_commit_reconcile_and_survive_a_shrink() {
 /// keep the invariant attached as the cause.
 #[test]
 fn a_journal_that_fails_its_own_revalidation_names_the_rebuild_route() {
-    let _guard = HTTP_E2E_LOCK.lock().unwrap();
-    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK.lock().unwrap();
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let corpus = tempfile::tempdir().unwrap();
     let state_dir = tempfile::tempdir().unwrap();
     let source = corpus.path().join("rows.csv");

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -5762,7 +5762,9 @@ mod map_metadata_tests {
 
     #[test]
     fn unchanged_resume_keeps_durable_assignment_aware_dataset_bytes() {
-        let _guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = state::FILE_DONE_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let state_dir = tempfile::tempdir().unwrap();
         let plan = Plan {
             files: HashMap::from([

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -1644,7 +1644,9 @@ mod sync_journal_tests {
 
     #[test]
     fn sync_begin_is_pending_and_never_promotes_the_committed_manifest() {
-        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal = journal_with_plan(dir.path());
         let desired = pending(&journal);
@@ -1690,7 +1692,9 @@ mod sync_journal_tests {
 
     #[test]
     fn replay_rejects_sync_begin_followed_by_legacy_plan_without_changing_authority() {
-        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal = journal_with_plan(dir.path());
         journal.sync_begin(&pending(&journal)).unwrap();
@@ -1730,7 +1734,9 @@ mod sync_journal_tests {
 
     #[test]
     fn only_validated_all_committed_sync_advances_authority_after_restart() {
-        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal = journal_with_plan(dir.path());
         journal.sync_begin(&pending(&journal)).unwrap();
@@ -1775,7 +1781,9 @@ mod sync_journal_tests {
 
     #[test]
     fn digest_bound_abort_discards_pending_without_advancing_authority() {
-        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal = journal_with_plan(dir.path());
         journal.sync_begin(&pending(&journal)).unwrap();
@@ -1790,7 +1798,9 @@ mod sync_journal_tests {
 
     #[test]
     fn unknown_sync_namespace_record_fails_closed_but_preflight_exposes_pending() {
-        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal = journal_with_plan(dir.path());
         journal.sync_begin(&pending(&journal)).unwrap();
@@ -1907,7 +1917,9 @@ mod sync_journal_tests {
 
     #[test]
     fn sync_append_and_fsync_failures_roll_back_without_phantom_pending_state() {
-        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         for boundary in [1, 2, 3] {
             let dir = tempfile::tempdir().unwrap();
             let mut journal = journal_with_plan(dir.path());
@@ -1929,7 +1941,9 @@ mod sync_journal_tests {
 
     #[test]
     fn every_later_sync_record_rolls_back_append_partial_and_fsync_failures() {
-        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = SYNC_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         for stage in ["operation", "validated", "commit", "abort"] {
             for boundary in [1, 2, 3] {
                 let dir = tempfile::tempdir().unwrap();
@@ -2005,7 +2019,9 @@ mod compatibility_tests {
         // injection meant for the armer (observed live 2026-07-30 as a
         // parallel-run flake + poison cascade). Every file_done-reaching
         // test holds this lock, armer or not.
-        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal =
             Journal::open(dir.path(), "root", "http://engine", "ax", 300, false).unwrap();
@@ -2059,7 +2075,9 @@ mod compatibility_tests {
     #[test]
     fn torn_file_done_tail_is_truncated_before_repair_commit_is_appended() {
         // Reaches file_done → must hold the failpoint lock (see above).
-        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal =
             Journal::open(dir.path(), "root", "http://engine", "ax", 300, false).unwrap();
@@ -2158,7 +2176,9 @@ mod compatibility_tests {
     #[test]
     fn stale_generation_completion_cannot_clear_newer_pending_replacement() {
         // Reaches file_done → must hold the failpoint lock (see above).
-        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal =
             Journal::open(dir.path(), "root", "http://engine", "ax", 300, false).unwrap();
@@ -2181,7 +2201,9 @@ mod compatibility_tests {
 
     #[test]
     fn append_and_fsync_commit_failures_leave_pending_and_replayable() {
-        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         for boundary in [1, 2, 3] {
             let dir = tempfile::tempdir().unwrap();
             let mut journal =
@@ -2218,7 +2240,9 @@ mod compatibility_tests {
 
     #[test]
     fn partial_commit_is_rolled_back_before_another_worker_appends() {
-        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK.lock().unwrap();
+        let _guard = FILE_DONE_IO_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mut journal =
             Journal::open(dir.path(), "root", "http://engine", "ax", 300, false).unwrap();


### PR DESCRIPTION
Fixes #336.

Two wall-clock-sensitive tests fail under machine load. Both hold a module-global serialisation mutex when they panic, poisoning it — and every later test acquiring that lock panics again on `.unwrap()`. **One flake became a 65-failure run**: 2 real failures plus ~63 `PoisonError` casualties in tests that touch neither.

That manufactures false regressions. A contributor or agent reasonably concludes they broke something, and disproving it costs a stash-and-rerun on a workspace where a full build is tens of minutes. It also hides genuine failures inside the noise.

**All 137 call sites** on the `*_TEST_LOCK` / `*_E2E_LOCK` mutexes now recover the guard rather than unwrapping. These mutexes serialise tests sharing global failpoint and HTTP state; they do not guard data whose invariants a panic could break, so recovering from poisoning is correct here rather than a workaround.

Verified the rewrite stayed in scope: the diff adds `unwrap_or_else(|p| p.into_inner())` on 137 lines, **0 of them outside those two lock families**.

**This fixes the cascade only.** The underlying flake stands — asserting a wall-clock-derived bar count inside a window the test cannot control is wrong under load, and should assert the progress *contract* instead (bars monotonic, exactly one terminal record, none after it). Kept separate so this change stays mechanical and reviewable.

Worth knowing for review: the cascade may be invisible on the current CI fleet, for the same reason other timing bugs have been — 2-core runners exercise very different timing than the 32-core box where this was found under heavy parallel load.