### PR TITLE
fix(build): align tree-sitter to 0.26 — main has been unbuildable since a9013f7a

### DIFF
--- a/engine/crates/xerj-engine/Cargo.toml
+++ b/engine/crates/xerj-engine/Cargo.toml
@@ -51,7 +51,7 @@ rustc-hash = { workspace = true }
 # (`xerj-autoindex/src/extract/code.rs`) — this module re-parses at RESPONSE
 # time rather than depending on that crate (autoindex depends on the engine,
 # not the other way around; a reverse dependency would be circular). ---
-tree-sitter = "0.25"
+tree-sitter = "0.26"
 tree-sitter-python = "0.23"
 tree-sitter-c = "0.23"
 tree-sitter-rust = "0.23"


### PR DESCRIPTION
**Main does not build.** Every release target has failed since `a9013f7a`, and the failure is now hitting every open PR:

```
error: failed to select a version for `tree-sitter`
package `tree-sitter` links to the native library `tree-sitter`,
  but it conflicts with a previous package which links to `tree-sitter`
    tree-sitter v0.26.3 ... satisfies `tree-sitter = "^0.26"` of xerj-autoindex
    ... required by xerj-engine, which needs `^0.25`
```

**Cause:** #317 added 21 grammars and moved `xerj-autoindex` to `tree-sitter = "0.26"`, while `xerj-engine` stayed on `"0.25"`. The crate declares `links = "tree-sitter"`, so exactly one version may exist in the graph — two requirements that cannot unify is a hard resolution failure, not a duplicate-dependency warning.

**Why it reached main:** a plain `cargo build` resolves freely and never sees this. It surfaces only in the release job, which builds `--locked` against a cross target. And I merged #317 when only 4 of its 16 checks had reported — a watcher of mine treated "zero pending" as "all passed" while CI had not yet registered its runs. The release job was among the 12 that had not reported. That is on me.

**The fix** is a one-line version alignment. `xerj-engine` uses 14 tree-sitter references — `Language`, `Parser`, `Tree`, and `.into()` on grammar `LANGUAGE` constants — none of which changed between 0.25 and 0.26.

Verified rather than assumed: `cargo check -p xerj-engine -p xerj-server -p xerj-autoindex` is clean against 0.26, and the lockfile now carries a single `tree-sitter 0.26.12`. Grammar crates keep their own version lines — they depend on the `tree-sitter-language` shim, not on `tree-sitter` itself, so they are unaffected.

**This should merge ahead of everything else** — the other open PRs are failing on this, not on their own content.