### PR TITLE
fix(deps): align tree-sitter so the workspace links one native library (main is red)

### DIFF
--- a/engine/crates/xerj-engine/Cargo.toml
+++ b/engine/crates/xerj-engine/Cargo.toml
@@ -51,7 +51,7 @@ rustc-hash = { workspace = true }
 # (`xerj-autoindex/src/extract/code.rs`) — this module re-parses at RESPONSE
 # time rather than depending on that crate (autoindex depends on the engine,
 # not the other way around; a reverse dependency would be circular). ---
-tree-sitter = "0.25"
+tree-sitter = "0.26"
 tree-sitter-python = "0.23"
 tree-sitter-c = "0.23"
 tree-sitter-rust = "0.23"


### PR DESCRIPTION
Written by an AI coding agent (Claude Opus 5, via Claude Code), run by @buger, who has reviewed this change.

# `main` does not build

```
error: failed to select a version for `tree-sitter`.
package `tree-sitter` links to the native library `tree-sitter`, but it
conflicts with a previous package which links to `tree-sitter` as well
note: only one package in the dependency graph may specify the same links value
      to ensure that only one copy of a native library is linked in the final binary
```

`xerj-engine` asks for `tree-sitter = "0.25"`; `xerj-autoindex` asks for `"0.26"`. Cargo permits exactly one crate to `links` a given native library, so the workspace cannot resolve — **every build, every test, every CI job**. Reproduced on a clean checkout of `b36b86fe`.

## Why it slipped through

Neither PR is at fault on its own:

- **#327** brought `code_blocks.rs`, written and verified against **0.25**.
- **#317** moved autoindex to **0.26** for the Kotlin, Swift, Scala and Dart grammars.

Each merged green. Together they do not compile. A PR that only builds its own branch cannot see this class of collision — it appears at the merge, not in either diff.

## The fix

One line: align `xerj-engine` to `0.26`.

That direction is the safe one because **both crates already pin identical grammar versions** — every `tree-sitter-*` grammar is `0.23` on both sides. Only the core binding moves, and node-kind names come from the grammars, not the core. That is what makes this a one-line change rather than a re-verification of every table in `code_blocks.rs`.

`Cargo.lock` is unchanged: `0.26.12` was already locked for autoindex, so the engine now resolves to the copy that was being compiled anyway.

## Verified

| gate | result |
|---|---|
| `cargo check -p xerj-server` | **builds** — was a hard resolution failure |
| `cargo test -p xerj-engine --lib code_blocks` | **15 passed, 0 failed** |
| `cargo test --lib` (engine, autoindex, api, query, server) | **1503 passed, 0 failed** |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| ES-YAML conformance | **1366 passed · 0 failed · 3 skipped** (1369 total) |

The `code_blocks` row is the one that mattered. Those node-kind tables were hand-checked against each grammar's `node-types.json` under the 0.25 bindings, so a core bump that shifted any kind name would have surfaced exactly there. It did not.

## Reviewer notes

- This is the minimal unblock. It does not attempt to prevent recurrence — a workspace-level dependency on `tree-sitter`, or a CI check that resolves the workspace against `main` before merge, would stop the next one. Worth a follow-up issue rather than widening this PR while the tree is red.
- `cargo test -p xerj-engine --test painless_script_limits` aborts with a stack overflow. Pre-existing and unrelated; it reproduces on clean `main` once the build is unblocked.
