### PR TITLE
feat(xc): add apache/lucene to the xerj-search hub corpus

### DIFF
--- a/tools/xerj-code/SKILL.md
+++ b/tools/xerj-code/SKILL.md
@@ -48,7 +48,7 @@ at the same commits anyone else is using:
 
 | corpus | projects | use it for |
 |---|---|---|
-| `xerj-search` | tantivy, meilisearch, quickwit, sonic, elasticsearch | FTS, BM25, postings, merge policy, typo tolerance, segment layout, ES wire semantics |
+| `xerj-search` | lucene, tantivy, meilisearch, quickwit, sonic, elasticsearch | FTS, BM25, postings, merge policy, typo tolerance, segment layout, ES wire semantics |
 | `xerj-vector` | qdrant, usearch, instant-distance, hnswlib | HNSW build, neighbour heuristics, quantisation, filtered kNN |
 | `xerj-storage` | sled, fjall, redb | WAL, flush epochs, crash recovery, compaction, page allocation |
 | `xerj-columnar` | clickhouse | columnar storage, aggregation execution, compression codecs, vectorised scans |

--- a/tools/xerj-code/hub/README.md
+++ b/tools/xerj-code/hub/README.md
@@ -10,7 +10,7 @@ tools/xerj-code/scripts/xc-index.sh  xerj-storage
 
 | corpus | projects | use it for | approx. checkout |
 |---|---|---|---|
-| [`xerj-search`](xerj-search.json) | tantivy, quickwit, meilisearch, sonic, elasticsearch | FTS, BM25, postings, merge policy, typo tolerance, segment layout, ES wire semantics | ~680 MB |
+| [`xerj-search`](xerj-search.json) | lucene, tantivy, quickwit, meilisearch, sonic, elasticsearch | FTS, BM25, postings, merge policy, typo tolerance, segment layout, ES wire semantics | ~880 MB |
 | [`xerj-vector`](xerj-vector.json) | qdrant, usearch, instant-distance, hnswlib | HNSW construction, neighbour heuristics, quantisation, filtered kNN | ~44 MB |
 | [`xerj-storage`](xerj-storage.json) | sled, fjall, redb | WAL, flush epochs, crash recovery, compaction, page allocation | ~28 MB |
 | [`xerj-columnar`](xerj-columnar.json) | clickhouse | columnar storage, aggregation execution, compression codecs, vectorised scans | ~1.2 GB |

--- a/tools/xerj-code/hub/xerj-search.json
+++ b/tools/xerj-code/hub/xerj-search.json
@@ -12,5 +12,8 @@
              "note":"File-level copyleft. XERJ is Apache-2.0, so read the design and write your own code; do not lift MPL files in."}},
   {"repo":"elasticsearch","url":"https://github.com/elastic/elasticsearch","licence":"AGPL","sha":"ac375eb50ac52fb9438b26bca7cfe9ecd93e60ad","files":46387,"bytes":586728834,
    "review":{"spdx":"AGPL-3.0-only OR SSPL-1.0 OR Elastic-2.0","use":"approach-only","by":"xerj-org","at":"2026-08-12",
-             "note":"Triple-licensed; the detector reports only the first (most restrictive) match. Never copy ES code into XERJ — beyond the licence, XERJ's public position is that it shares no code and no architecture with Elasticsearch."}}
+             "note":"Triple-licensed; the detector reports only the first (most restrictive) match. Never copy ES code into XERJ — beyond the licence, XERJ's public position is that it shares no code and no architecture with Elasticsearch."}},
+  {"repo":"lucene","url":"https://github.com/apache/lucene","licence":"Apache-2.0","sha":"9cda46563a4bb30f26fd120ab9bc1397106bf945","files":7557,"bytes":197804184,
+   "review":{"spdx":"Apache-2.0","use":"adapt-with-attribution","by":"xerj-org","at":"2026-08-14",
+             "note":"Plain Apache-2.0 — the same licence as XERJ — so unlike elasticsearch in this corpus it is adapt-with-attribution, not approach-only. Lucene is the library elasticsearch is built on, so it is the primary source for postings, codecs, segment merge, BM25 scoring and HNSW; prefer it over the ES entry."}}
 ]}


### PR DESCRIPTION
Written by an agent (Claude Opus 5) driven by @xerj-org.

`xerj-search` reaches for elasticsearch as its reference on postings, codecs, segment merge and BM25. But elasticsearch is `approach-only` in this corpus (AGPL-3.0 / SSPL-1.0 / Elastic-2.0), so the one Java reference we ship is the one nothing may be adapted from — you read it, then write from scratch anyway.

Lucene is the library elasticsearch is built on, and it is plain Apache-2.0, same as XERJ. So it lands as `adapt-with-attribution`: the primary source for exactly the subsystems this corpus exists to serve, and the only Java one that can actually be adapted.

Rebuild with:

```sh
scripts/xc-corpus.sh --from hub/xerj-search.json && scripts/xc-index.sh xerj-search
```

**Verified** (commands run, output observed):
- metadata generated by `scripts/xc-corpus.sh`, not hand-written — sha `9cda4656`, 7,557 files, 197,804,184 bytes, licence `Apache-2.0` detected from the `LICENSE.txt` Lucene ships
- `python3 tests/validate_manifest.py --hub hub/*.json` — passes
- `bash tests/test_xc_corpus.sh` — 28 passed, 0 failed
- the corpus is real, not just a manifest entry: I indexed this exact Lucene checkout with `xerj autoindex` and retrieved from it (73,383 Lucene symbols; 75,578 with usearch alongside)

**Assumed** (not tested by me):
- the `~880 MB` disk figure in `hub/README.md` is the existing ~680 MB row plus my 197 MB clone; I did not rebuild all six repos on one machine to confirm the total.
