### PR TITLE
style(engine): satisfy clippy on older stable toolchains

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -11185,8 +11185,8 @@ async fn search_impl(
                                         }
                                     }
                                 }
-                            } else {
-                                if cur.get(seg).is_some() { matched = Some(seg.to_string()); }
+                            } else if cur.get(seg).is_some() {
+                                matched = Some(seg.to_string());
                             }
                             let Some(resolved_seg) = matched else { break };
                             let spec = match cur.get(&resolved_seg).cloned() {

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -1653,7 +1653,7 @@ fn pending_for_phase_b(
         .filter(|&i| {
             !keys[i].is_empty()
                 && plan.files.contains_key(&keys[i])
-                && !(done.contains(&keys[i]) && !content_changed.contains(&keys[i]))
+                && (!done.contains(&keys[i]) || content_changed.contains(&keys[i]))
         })
         .collect()
 }


### PR DESCRIPTION
Written by an agent (Claude Opus 5) driven by @xerj-org.

On Rust 1.92.0, a clean checkout of `main` fails the lint gate:

```
error: this boolean expression can be simplified
    --> crates/xerj-autoindex/src/lib.rs:1654:13
error: this `else { if .. }` block can be collapsed
    --> crates/xerj-api/src/es_compat.rs:11188:36
```

Both are pure simplifications with no behaviour change.

The autoindex one is also a readability win. The doc comment directly above says the predicate means *"either never finished or finished against different bytes"* — which is literally `!done || content_changed`. The old `!(done && !content_changed)` made the reader apply De Morgan to check the code against its own comment.

**Verified** (commands run, output observed, on this branch):
- `cargo clippy --workspace --all-targets -- -D warnings` — exits 0 (on unpatched `origin/main` it exits 101)
- `cargo fmt --all --check` — clean
- `cargo build --workspace --profile ci-test` — green, 2m28s

**Assumed** (not tested by me):
- CI is green on `main` today because it installs `dtolnay/rust-toolchain@stable`, which currently does not report these two lints. I did not bisect which toolchain version changed that.
- I did not run the full test suite on this branch; the change is two boolean rewrites in paths covered by existing tests.
