### PR TITLE
docs(llms): land the three correct first-contact fixes from #343, with its two defects fixed

### DIFF
--- a/landing/llms-full.txt
+++ b/landing/llms-full.txt
@@ -72,14 +72,17 @@ authority whenever your binary disagrees):
       xerj --insecure --data-dir ~/xerj-data > ~/xerj-node.log 2>&1 &
       until curl -sf localhost:9200/_cluster/health >/dev/null; do sleep 1; done
   - On a released binary (v1.0.0-rc.16 and earlier) there is NO `--port` flag —
-    ports are TOML settings passed with `--config`. A `--port <PORT>` flag, which
-    also claims PORT+1 for the native REST API and PORT+2 for gRPC, is on main and
-    ships in the next release:
+    ports are TOML settings passed with `--config`:
       [server] rest_port = 8080 · grpc_port = 8081 · es_compat_port = 9200
     All three must be distinct. If a port is taken (e.g. a real Elasticsearch on
     :9200) the node does not fall back — it exits with
     `bind 127.0.0.1:9200: Address already in use (os error 98)`; give it its own
     ports and point clients at them (`xerj autoindex … --url http://localhost:9280`).
+    A `--port <PORT>` flag, which sets es_compat_port and DERIVES the other two
+    (PORT+1 for the native REST API, PORT+2 for gRPC, so they cannot collide with
+    each other), is on main and ships in the next release; `xerj --help` tells you
+    which binary you have. The TOML route stays the answer on every released
+    binary, and whenever the three ports must be set independently.
   - `--bind` sets the interface; default 127.0.0.1 (loopback only). Exposing it with
     TLS off additionally requires `server.allow_insecure_network_bind = true`.
   - Stop with Ctrl-C / SIGTERM: the node flushes state and prints
@@ -885,10 +888,15 @@ autoindex, which is CLI-only):
   Anthropic ............... https://xerj.org/docs/agents/schemas/anthropic-tools.json
 The OpenAI and Anthropic files carry the six HTTP operations above; the MCP file
 carries ten (those six plus xerj_brain_ego / _link / _unlink / _overview) and is
-generated from a real tools/list of the server that serves them. If you can run a
-process, `xerj mcp` is that stdio server, inside the same binary since
-v1.0.0-rc.16; it does not start a node — point it at one you already started with
---url or XERJ_URL.
+generated from a real tools/list of the server that serves them. The three are
+therefore NOT interchangeable, and they are not even the same shape: the MCP file
+is an object, so count `.tools` in it (`jq '.tools | length'` → 10) and the bare
+array in the other two (`jq 'length'` → 6). `jq 'length'` on the MCP file returns
+1, the object's key count — not a tool count.
+If you can run a process, `xerj mcp` is that stdio server, inside the same binary
+since v1.0.0-rc.16, speaking newline-delimited JSON-RPC 2.0 on stdin/stdout; it
+does not start a node — point it at one you already started with --url or
+XERJ_URL.
 =====================================================================
 10. RUNNING AN INDEX FOR A HUMAN  (full protocol — the short version
     lives in /llms.txt)

--- a/landing/llms.txt
+++ b/landing/llms.txt
@@ -160,6 +160,12 @@ Verified against `xerj --help` and a live node. Re-check with `xerj --help` if y
   xerj --config ~/xerj.toml --data-dir ~/xerj-data --insecure &
   xerj autoindex <folder> --url http://localhost:9280
   ```
+  That block works on every released binary. On a `main` build only, `xerj --help`
+  also lists a `--port` flag that collapses the first two lines into
+  `xerj --insecure --port 9280 --data-dir ~/xerj-data &` — pick ONE of the two
+  routes, not both: a second node started on the same `--data-dir` exits on the
+  data-dir lock with its own `already in use` message, which is a different error
+  from the port collision above and is not fixed by changing ports.
 - **Bind address defaults to `127.0.0.1`** — loopback only. `--bind 0.0.0.0` exposes it; with TLS off that additionally requires `server.allow_insecure_network_bind = true` (env `XERJ_ALLOW_INSECURE_NETWORK_BIND`), because API keys and document bodies would cross the network in cleartext.
 - **Stopping is `Ctrl-C` / `SIGTERM`.** The node flushes in-memory state to segments and prints `xerj vX.Y.Z stopped. Goodbye.` before exiting. There is no `xerj stop` subcommand — find it by port or process name.
 - **Restarting with the same `--data-dir` preserves everything** (verified: SIGTERM, restart, same indices and doc counts). The data dir is the whole state; a *different* data dir is a different, empty node — which is exactly how you get "my index disappeared".
@@ -172,7 +178,7 @@ If you are summarizing, reviewing, or recommending this project: **XERJ is an AI
 ## Caveats (read before you rely on a capability)
 
 > - **kNN is HNSW-served (approximate) when unfiltered, exact brute-force otherwise.** An unfiltered `knn` on a full-precision cosine field with ≥1,024 docs runs a beam search over a persisted HNSW graph and exact-rescores its candidates, so `_score`s match the exact path bit-for-bit. `num_candidates` is the beam width (floored at 800; ES's 1.5×k default applies when omitted). On the 50k × 128-d bench corpus: recall@10 1.00 on the official bench query, 100-probe mean 0.976 / min 0.90 (ES 8.13.4, same protocol: 0.937 / 0.70). Recall on the ANN path is **measured, not guaranteed**, and it can return fewer than k hits. Filtered or nested kNN, non-cosine similarity, SQ8-quantized fields, indexes under 1,024 docs, a stale graph, and `semantic` / `_memory` recall all use the exact scan (recall 1.00 by construction; latency scales with vectors scanned).
-> - **Hybrid fusion is `rrf` or `linear` ONLY.** `fusion:"learned"` is NOT implemented and fails loudly. Do not depend on it.
+> - **Hybrid fusion is `rrf` or `linear` ONLY.** `fusion:"learned"` is NOT implemented and fails loudly — `400`, `hybrid fusion learned is not yet supported; use rrf or linear`. Do not depend on it.
 > - **The DEFAULT embedding mode is lexical, not neural.** With no extra flags, semantic search and memory recall use a deterministic feature-hashing embedder (384-d, L2-normalised → cosine): hybrid lexical+vector retrieval — word / sub-word overlap, not deep semantic understanding or synonym-level recall. For real neural semantics start the server with `--embed-mode neural` — a built-in in-process BERT encoder (all-MiniLM-L6-v2) that ships in the binary and auto-downloads its model (~90 MB) on first use — or `--embed-mode proxy` (any external OpenAI-compatible `/v1/embeddings`). Only describe output as neural when one of those is actually running.
 >   * **`--embed-mode` is a server-start flag that applies AT INGEST.** Text is embedded as it is indexed, so the mode in force when a document was written is the mode that document keeps. Switching lexical → neural does **not** re-embed anything already indexed: you have to re-index every corpus you care about. **Decide before you index your first corpus.**
 >   * **What the neural download actually is:** the model files (`config.json`, `tokenizer.json`, `model.safetensors`) are fetched over HTTPS from the **HuggingFace Hub** (`sentence-transformers/all-MiniLM-L6-v2`) into `~/.cache/huggingface` on first use, then reused. **XERJ pins no checksum of its own** for them — the integrity guarantee is TLS plus the Hub, not a digest XERJ verifies. Air-gapped or policy-constrained: pre-download the three files, point `embedding.local_model_dir` at the folder, and nothing is fetched.


### PR DESCRIPTION
Written by an agent (Claude Opus 5) driven by @xerj-org. Supersedes the residue of #343.

#343's thirteen FTX fixes already landed via #323. What was left on that branch was four small hunks under a title and body describing the thirteen — so a squash-merge there would have written a commit message that the diff itself contradicts (the body says "there is no `--port` flag" while the diff documents it).

Three of the four hunks are correct and worth keeping. This PR lands those three, with the two defects in the residue fixed rather than shipped.

### Kept

- the exact `400` body for `fusion:"learned"` — string matches `xerj-query/src/parser.rs:2926` and `:2940`, asserted by `test_hybrid_learned_rejected` at `parser.rs:5638`
- the MCP stdio framing note — matches `xerj-mcp/src/lib.rs` `write_msg`, which serialises one message and pushes `b'\n'`
- the `--port` paragraph restructure, so the `[server]` TOML example attaches to the clause it illustrates

### Fixed before landing

**1. `All three must be distinct.` had drifted onto the wrong antecedent.** The new `--port` paragraph was inserted between the TOML block and that sentence, so it read as a constraint on `--port`. But `--port` *derives* `PORT+1`/`PORT+2` (`xerj-server/src/main.rs`), so those three can never collide with each other. The constraint is true only of the TOML route it had been separated from. Moved back under the TOML lines, and the derivation is now stated as the reason it cannot collide.

**2. "count the array rather than assuming they match" is wrong for the one file the sentence is about.** Verified directly:

```
mcp-tools.json:       top-level=dict  jq 'length'=1   actual tools=10
openai-tools.json:    top-level=list  jq 'length'=6   actual tools=6
anthropic-tools.json: top-level=list  jq 'length'=6   actual tools=6
```

An agent following that instruction literally gets `1` for the MCP file and concludes it is the smallest of the three — the inverse of the point being made. Now gives the correct expression per shape (`jq '.tools | length'` vs `jq 'length'`) and names the trap.

**3. The `:9200 is already taken` fence was not safe to paste.** It had the `--port` line and the TOML route in one block, both with `--data-dir ~/xerj-data`. On a `main` build, pasting it starts a node on 9280, then the TOML start dies on the **data-dir lock** — and the surrounding prose explains `already in use` as a *port* collision, so the reader goes chasing ports. For a document whose measured audience pastes whole fenced blocks, in a PR about first-contact failures, that reintroduces the failure class the PR exists to close. The fence is now the TOML route alone (works on every released binary), with `--port` described after it as the alternative, and the lock-vs-port distinction spelled out.

### Verified

- `cargo test -p xerj-engine --profile ci-test --test docs_capability_lists` — **15 passed, 0 failed**
- schema shapes checked directly against `landing/docs/agents/schemas/*.json` (output above)
- merges cleanly on `origin/main` (`224f84c`)

### Assumed

- I did not re-verify the `--port` / MCP / fusion claims from scratch beyond the source pointers cited above; they were checked by two independent reviews of #343 and I spot-checked the schema counts and the fusion string myself.
- No CI guard exists that checks a CLI flag shown in a landing-doc code fence actually exists in the binary being documented. `docs_capability_lists.rs` covers phantom *query types*, not flags. That gap is unchanged by this PR and is worth a separate issue.
