### PR TITLE
fix(xc): make the documented reference-coding loop work end to end

### DIFF
--- a/tools/xerj-code/scripts/xc-index.sh
+++ b/tools/xerj-code/scripts/xc-index.sh
@@ -38,6 +38,14 @@ curl -fsS -m 5 "$URL/_cluster/health" >/dev/null 2>&1 || {
 
 echo "indexing corpus '$name' from $dir"
 
+# Recorded before the run so a failure can tell "this run wrote records" apart
+# from "an earlier run's records are still lying around". Salvaging the latter
+# would date stale data to now, which is the failure mode SKILL.md calls worse
+# than no index at all.
+docs_before="$(curl -fsS -m 5 "$URL/xc-$name*/_count" 2>/dev/null \
+               | sed 's/.*"count":\([0-9]*\).*/\1/' || echo "")"
+[ -n "$docs_before" ] || docs_before=0
+
 # --no-graph: reference code needs ranked passages, not a relationship map. The
 # graph detectors cost real time on a large tree and nothing here consumes edges.
 set +e
@@ -49,20 +57,58 @@ set +e
 rc=$?
 set -e
 
+# How many records actually landed. This is the ground truth about whether the
+# corpus is usable, and it is the check SKILL.md already tells people to run by
+# hand ("Always verify: curl -s "$URL/xc-<corpus>*/_count" must be > 0").
+count_records() {
+  curl -fsS -m 5 "$URL/xc-$name*/_count" 2>/dev/null \
+    | sed 's/.*"count":\([0-9]*\).*/\1/' || echo ""
+}
+
 # Exit 3 is "completed, some files were unparseable" — expected on any real
 # repository (binaries, fixtures, vendored blobs). Treat it as success.
+#
+# Any other non-zero code is NOT taken at face value, because autoindex can
+# abort in finalisation *after* every document has been written — a whole-corpus
+# read-back or generation-cutover reconciliation failure leaves a complete,
+# queryable index behind and still exits 1 (see issue #367; observed on
+# apache/lucene on both embedding modes, 6,032 java records live). Discarding
+# that corpus sends the user back to a step that will fail again, so ask the
+# engine what is actually there before deciding. An empty or unreachable index
+# still fails, and a salvaged run is reported loudly rather than silently.
+docs=""
+salvaged=false
 case $rc in
   0) echo "indexed cleanly" ;;
   3) echo "indexed (exit 3: some files skipped as junk — normal for real repos)" ;;
-  *) echo "xc-index: autoindex failed with exit $rc" >&2; exit $rc ;;
+  *)
+    docs="$(count_records)"
+    if [ -n "$docs" ] && [ "$docs" -gt "$docs_before" ] 2>/dev/null; then
+      salvaged=true
+      echo "xc-index: WARNING — autoindex exited $rc, but this run wrote records" >&2
+      echo "xc-index: ($docs_before -> $docs). The corpus is queryable and is being" >&2
+      echo "xc-index: recorded as indexed, with autoindex_exit=$rc in its state file." >&2
+      echo "xc-index: That exit usually means finalisation failed AFTER the writes." >&2
+      echo "xc-index: Coverage is not guaranteed — please report the error above." >&2
+    elif [ -n "$docs" ] && [ "$docs" -gt 0 ] 2>/dev/null; then
+      echo "xc-index: autoindex failed with exit $rc and wrote no new records" >&2
+      echo "xc-index: ($docs already present from an earlier run — not treating" >&2
+      echo "xc-index: those as this run's output; a stale corpus dated to now is" >&2
+      echo "xc-index: worse than none)." >&2
+      exit $rc
+    else
+      echo "xc-index: autoindex failed with exit $rc and left no records" >&2
+      exit $rc
+    fi
+    ;;
 esac
 
 mkdir -p "$ROOT/state"
 cat > "$ROOT/state/$name.json" <<EOF
-{"corpus":"$name","indexed_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","prefix":"xc-$name","url":"$URL","autoindex_exit":$rc}
+{"corpus":"$name","indexed_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","prefix":"xc-$name","url":"$URL","autoindex_exit":$rc,"salvaged":$salvaged}
 EOF
 
-docs=$(curl -fsS -m 5 "$URL/xc-$name*/_count" 2>/dev/null \
-       | sed 's/.*"count":\([0-9]*\).*/\1/' || echo "?")
+[ -n "$docs" ] || docs="$(count_records)"
+[ -n "$docs" ] || docs="?"
 echo "corpus '$name' searchable: $docs records"
 echo "next: xc.py $name \"<what you need>\""

--- a/tools/xerj-code/scripts/xc.py
+++ b/tools/xerj-code/scripts/xc.py
@@ -448,10 +448,16 @@ def main():
     # Reference coding needs the actual implementation, not a keyword-in-context
     # snippet. A 320-char highlight tells the agent a file is relevant; it does
     # not tell it how the algorithm works.
-    ap.add_argument("--full", type=int, metavar="CHARS",
-                    help="emit up to CHARS of each passage's real source instead of highlights")
+    # Defaulted, not opt-in. This used to be None, which meant the documented
+    # invocation `xc.py <corpus> "<query>"` skipped the symbol path entirely and
+    # fell through to a branch that prints body[:400] — the licence header, on
+    # every Apache/BSD/MIT file in every corpus (issue #368). Retrieving the
+    # definition IS the feature; capping its length is the knob.
+    ap.add_argument("--full", type=int, metavar="CHARS", default=800,
+                    help="cap each passage at CHARS of real source (default 800; "
+                         "0 prints only the file head)")
     ap.add_argument("--no-symbol", action="store_true",
-                    help="with --full, use a raw byte window instead of the matching definition")
+                    help="use a raw byte window instead of the matching definition")
     # Default is BM25, decided on TWO corpora after an earlier default (hybrid)
     # was chosen on one and turned out to be corpus-specific.
     #
@@ -559,15 +565,15 @@ def main():
                           f"chars from offset {start:,}, window centred on the match]")
                 print(window)
         else:
-            frags = []
-            for vals in (h.get("highlight") or {}).values():
-                frags.extend(vals)
-            if frags:
-                for f in frags[:2]:
-                    print("    " + f.replace("\n", "\n    ")[:600])
-            else:
-                body = src.get("body") or ""
-                print("    " + str(body)[:400].replace("\n", "\n    "))
+            # Only reachable via `--full 0`. `highlight` is never requested
+            # (issue #177 — it reorders hits), so this is the file head and is
+            # labelled as such rather than passed off as a matching passage.
+            body = str(src.get("body") or "")
+            head = body[:400]
+            if len(body) > len(head):
+                print(f"    [file head; {len(head):,} of {len(body):,} chars — "
+                      f"pass --full N for the matching definition]")
+            print("    " + head.replace("\n", "\n    "))
         if lic and any(r in lic for r in RESTRICTED):
             print(f"    !! {lic}: adapt the APPROACH, do not copy the code")
 


### PR DESCRIPTION
Written by an agent (Claude Opus 5) driven by @xerj-org.

Fixes #368, and the wrapper half of #367.

After #358 added `apache/lucene` to `hub/xerj-search.json` I ran the three documented commands against it. Steps 2 and 3 both fail. Neither failure is in the corpus definition.

## 1. `xc.py` printed each file's licence header instead of the definition (#368)

The documented invocation:

```
$ python3 scripts/xc.py lucene-meta "how does the merge policy pick segments"

─── lucene/.../index/IndexWriter.java  (score 33.11, Apache-2.0)
    /*
     * Licensed to the Apache Software Foundation (ASF) under one or more
─── lucene/.../index/TieredMergePolicy.java  (score 29.34, Apache-2.0)
    /*
     * Licensed to the Apache Software Foundation (ASF) under one or more
```

The ranking is right — `TieredMergePolicy` and `LogMergePolicy` are the correct files. Every passage is the ASF banner.

`--full` was declared with no `default=`, so it was `None`; the symbol path is gated on `if args.full:` so `symbol_passage()` never ran; the `else` branch reads `h.get("highlight")`, which `xc.py` deliberately never requests (#177, because it reorders hits), so `frags` was always empty and it fell through to `body[:400]`.

This is the exact regression `SKILL.md` describes as fixed:

> a query about null replies correctly ranked `networking.c` and then returned its licence banner, because `addReplyNull` lives at line 1460

And `SKILL.md` already documents `--full N` as *"caps each passage at N chars"* — a limit on a passage that was supposed to be there by default. So the missing default was the bug, not the gate.

`--full` now defaults to 800. Same query, after:

```
─── lucene/.../index/IndexWriter.java  (score 33.11, Apache-2.0)
    [method length @ line 5268 — 847 of 260,158 chars]
                          public int length() {
                            return hardLiveDocs.length();
```

`--full 0` keeps head-only mode and now labels it, instead of passing a licence banner off as a matching passage.

## 2. `xc-index.sh` discarded a fully populated corpus (#367)

`autoindex` exits 1 on `apache/lucene` on **both** embedding modes, with two different reconciliation errors, *after* every document has been written. The wrapper treated anything but 0/3 as fatal and exited before writing its state file, so `xc.py` then said the corpus was not indexed — sending the user back to the step that had just failed.

It now asks the engine what landed:

```
xc-index: WARNING — autoindex exited 1, but this run wrote records
xc-index: (0 -> 108588). The corpus is queryable and is being
xc-index: recorded as indexed, with autoindex_exit=1 in its state file.
xc-index: That exit usually means finalisation failed AFTER the writes.
xc-index: Coverage is not guaranteed — please report the error above.
corpus 'lucene-meta' searchable: 108588 records
```

A run that wrote **no new** records still fails, including when an earlier run left records behind — the `docs_before` snapshot exists for exactly that case, because dating a stale corpus to now is the failure `SKILL.md` calls worse than no index at all.

**This does not fix the aborts.** #367 tracks those; they need engine work. This stops a bookkeeping failure from destroying a usable corpus.

## Why one PR

Both are the same bug report — the documented loop does not complete — found in one end-to-end run, in one directory, and either one alone still leaves the loop broken. Happy to split if preferred.

## Verified

On `v1.0.0-rc.16` (release binary, `aarch64-unknown-linux-gnu`) against `apache/lucene` at the `9cda4656` the hub pins, 108,588 records live:

- default `xc.py` returns `[method length @ line 5268 — 847 of 260,158 chars]` plus source, where it previously returned the licence header
- `--full 0` → `[file head; 400 of 260,158 chars — pass --full N for the matching definition]`
- `--no-symbol` → `[no symbol match; showing 779 of 260,158 chars from offset 99,721]`
- the salvage path exercised on a real exit-1 run, state file written, `xc.py` then answers
- `tests/test_xc_corpus.sh` — 28 passed, 0 failed
- `validate_manifest.py --hub hub/*.json` — passes
- `python3 -m py_compile scripts/xc.py`, `bash -n scripts/xc-index.sh` — clean

## Assumed

- I did not test `--mode hybrid` / `--mode semantic`, only the default BM25 arm.
- 800 is a judgement call, picked to comfortably hold a typical method while staying well under the old 8 KB window. No measurement backs that specific number.
- The corpus used for verification was itself indexed through the salvage path, so it is a real-world case rather than a clean one; its `symbols` arrays are complete and the display fault reproduces regardless.
