### PR TITLE
fix(engine): `_count` stops answering from an oracle `_search` never uses; `case_insensitive` is honoured on prefix/wildcard (#362)

### DIFF
--- a/engine/crates/xerj-api/tests/multi_term_case_rule_is_one_rule.rs
+++ b/engine/crates/xerj-api/tests/multi_term_case_rule_is_one_rule.rs
@@ -1,0 +1,286 @@
+//! The term-level family obeys ONE case rule, and `_count` agrees with
+//! `_search` — #362, from the outside.
+//!
+//! The report was "`term` normalises case but `prefix`/`wildcard` do not": a
+//! document you can find with `term title=TestSegmentReader.java` is invisible
+//! to `prefix title=Test`. The attribution turned out to be backwards in a way
+//! that made it worse. `prefix`/`wildcard` are the ES-correct half — a
+//! multi-term query is not analysed, Lucene builds the automaton straight off
+//! the query bytes (`PrefixQuery.toAutomaton`, PrefixQuery.java:44) — and
+//! `term` was not normalising at all. What normalised was the `_count`
+//! shortcut, which retried the FTS term-dictionary lookup with a lowercased
+//! spelling of a term the caller never wrote, while the hit-materialising path
+//! stayed on the raw one. So `_count` reported a document that `_search` could
+//! not produce, and it did so for every `term` on a `text` field, cased or not.
+//!
+//! Two invariants are pinned here.
+//!
+//! 1. **count == hits**, Lucene's own `QueryUtils.checkCount`
+//!    (QueryUtils.java:680) invariant, asserted across the whole term-level
+//!    family in both cases on both a `text` and a `keyword` field. Lucene gets
+//!    this for free because `IndexSearcher.count` (IndexSearcher.java:495)
+//!    derives its answer from the SAME rewritten query and Weight `search()`
+//!    uses; its only shortcuts are algebraic rewrites, never a re-spelling of
+//!    the term. A count no `_search` can reproduce is worse than a slow one.
+//!
+//! 2. **`case_insensitive` is honoured**, not accepted and dropped. It is the
+//!    documented escape hatch for exactly the reporter's case — the ES
+//!    parameter backed in Lucene by `Automata.makeCaseInsensitiveString`
+//!    (Automata.java:573), an opt-in rather than a default — and the parser
+//!    used to parse it and throw it away, so the one correct answer to the
+//!    problem silently returned zero.
+//!
+//! Elasticsearch and Lucene are referenced for semantics only.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn send(app: &axum::Router, req: Request<Body>) -> (StatusCode, Value) {
+    let response = app.clone().oneshot(req).await.expect("response");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let value: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+async fn json_req(
+    app: &axum::Router,
+    method: &str,
+    path: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    send(
+        app,
+        Request::builder()
+            .method(method)
+            .uri(path)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request"),
+    )
+    .await
+}
+
+/// `title` — text (analyzed, so the term dictionary is lowercased).
+/// `code`  — keyword (whole-value, stored as written).
+///
+/// The corpus is the reporter's: CamelCase source-file names, plus one
+/// ordinary prose document to cover the all-lowercase `term` case where the
+/// old count shortcut's lowercase retry was a no-op and the dictionary hit was
+/// real — that one lied too.
+///
+/// **The flush is load-bearing.** Both halves of #362 live on the segment
+/// side: the count shortcut only reaches its FTS term-dictionary fallback for
+/// a field with no doc-values column (a `text` field), and the multi-term
+/// queries only reach the FST expansion once there is a segment to expand
+/// against. A memtable-resident corpus answers every one of these from the
+/// stored-document scan and reproduces neither. The reporter had 11,450
+/// flushed documents; this has four.
+async fn app_with_corpus() -> (axum::Router, tempfile::TempDir) {
+    let (app, dir) = app().await;
+    let (status, body) = json_req(
+        &app,
+        "PUT",
+        "/refs",
+        json!({
+            "mappings": {
+                "properties": {
+                    "title": { "type": "text" },
+                    "code":  { "type": "keyword" }
+                }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create index failed: {body}");
+
+    for (id, title, code) in [
+        (1, "TestSegmentReader.java", "TestSegmentReader"),
+        (2, "TestIndexWriter.java", "TestIndexWriter"),
+        (3, "HnswGraphBuilder.java", "HnswGraphBuilder"),
+        (4, "the quick brown fox", "quick-brown-fox"),
+    ] {
+        let (status, body) = json_req(
+            &app,
+            "PUT",
+            &format!("/refs/_doc/{id}?refresh=true"),
+            json!({ "title": title, "code": code }),
+        )
+        .await;
+        assert!(
+            status.is_success(),
+            "index doc {id} failed: {status} {body}"
+        );
+    }
+
+    let (status, body) = json_req(&app, "POST", "/refs/_flush", json!({})).await;
+    assert!(status.is_success(), "flush failed: {status} {body}");
+    let (status, body) = json_req(&app, "POST", "/refs/_refresh", json!({})).await;
+    assert!(status.is_success(), "refresh failed: {status} {body}");
+
+    // Guard the guard: if the flush stopped producing a segment this suite
+    // would keep passing while testing nothing, because the stored-doc scan
+    // answers everything and is not where either bug lives.
+    let (status, stats) = send(
+        &app,
+        Request::get("/refs/_stats")
+            .body(Body::empty())
+            .expect("req"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "_stats failed: {stats}");
+    let segments = stats["_all"]["primaries"]["segments"]["count"]
+        .as_u64()
+        .unwrap_or(0);
+    assert!(
+        segments > 0,
+        "corpus must be segment-resident for this suite to test anything: {stats}"
+    );
+
+    (app, dir)
+}
+
+/// Run one query through `_count` and `_search` and return
+/// `(count, search_total, returned_hits)`.
+async fn count_and_search(app: &axum::Router, query: &Value) -> (u64, u64, usize) {
+    let (status, counted) = json_req(app, "POST", "/refs/_count", json!({ "query": query })).await;
+    assert_eq!(status, StatusCode::OK, "_count failed: {counted}");
+    let count = counted["count"].as_u64().expect("count field");
+
+    let (status, found) = json_req(
+        app,
+        "POST",
+        "/refs/_search",
+        json!({ "query": query, "size": 100 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "_search failed: {found}");
+    let total = found["hits"]["total"]["value"]
+        .as_u64()
+        .expect("hits.total.value");
+    let returned = found["hits"]["hits"].as_array().expect("hits array").len();
+
+    (count, total, returned)
+}
+
+/// `_count` must never claim a document `_search` cannot hand back.
+///
+/// Before the fix the shortcut retried the term-dictionary lookup lowercased,
+/// so `{"term":{"title":"testsegmentreader.java"}}` counted 1 against a
+/// `_search` total of 0 — and so did the already-lowercase
+/// `{"term":{"title":"quick"}}`, where the retry changes nothing and the
+/// dictionary hit is genuine but the raw-`_source` comparison that
+/// materialises hits still cannot see it.
+#[tokio::test]
+async fn count_never_exceeds_the_hits_search_can_return() {
+    let (app, _dir) = app_with_corpus().await;
+
+    let queries = [
+        json!({"term": {"title": "TestSegmentReader.java"}}),
+        json!({"term": {"title": "testsegmentreader.java"}}),
+        json!({"term": {"title": "quick"}}),
+        json!({"term": {"title": "Quick"}}),
+        json!({"term": {"code": "TestSegmentReader"}}),
+        json!({"term": {"code": "testsegmentreader"}}),
+        json!({"prefix": {"title": "Test"}}),
+        json!({"prefix": {"title": "test"}}),
+        json!({"prefix": {"title": {"value": "Test", "case_insensitive": true}}}),
+        json!({"prefix": {"code": "Test"}}),
+        json!({"prefix": {"code": {"value": "test", "case_insensitive": true}}}),
+        json!({"wildcard": {"title": "Hnsw*"}}),
+        json!({"wildcard": {"title": "hnsw*"}}),
+        json!({"wildcard": {"title": {"value": "Hnsw*", "case_insensitive": true}}}),
+        json!({"wildcard": {"code": "Hnsw*"}}),
+        json!({"wildcard": {"code": {"value": "hnsw*", "case_insensitive": false}}}),
+    ];
+
+    for query in &queries {
+        let (count, total, returned) = count_and_search(&app, query).await;
+        assert_eq!(
+            count, total,
+            "_count and _search disagree for {query}: count={count} total={total}"
+        );
+        assert_eq!(
+            total as usize, returned,
+            "hits.total is not the number of hits returned for {query}"
+        );
+    }
+}
+
+/// The reporter's exact sequence, and the answer to it.
+///
+/// `prefix title=Test` returning 0 stays correct — ES does not analyse a
+/// multi-term query, so an uppercase prefix against a lowercased text
+/// dictionary matches nothing. What changes is that the documented way to say
+/// "I meant either case" now works instead of silently returning the same
+/// zero.
+#[tokio::test]
+async fn case_insensitive_is_honoured_on_prefix_and_wildcard() {
+    let (app, _dir) = app_with_corpus().await;
+
+    // Case-sensitive is the default, on both field types: unchanged, ES-correct.
+    let (_, cased, _) = count_and_search(&app, &json!({"prefix": {"title": "Test"}})).await;
+    assert_eq!(cased, 0, "a cased prefix on text must stay case-sensitive");
+    let (_, lowered, _) = count_and_search(&app, &json!({"prefix": {"title": "test"}})).await;
+    assert_eq!(lowered, 2, "`test` matches both Test*.java titles");
+
+    // ... and `case_insensitive: true` is the escape hatch out of it.
+    let (_, opt_in, _) = count_and_search(
+        &app,
+        &json!({"prefix": {"title": {"value": "Test", "case_insensitive": true}}}),
+    )
+    .await;
+    assert_eq!(
+        opt_in, lowered,
+        "`case_insensitive: true` must find what the lowercase prefix finds"
+    );
+
+    let (_, cased, _) = count_and_search(&app, &json!({"wildcard": {"title": "Hnsw*"}})).await;
+    assert_eq!(
+        cased, 0,
+        "a cased wildcard on text must stay case-sensitive"
+    );
+    let (_, opt_in, _) = count_and_search(
+        &app,
+        &json!({"wildcard": {"title": {"value": "Hnsw*", "case_insensitive": true}}}),
+    )
+    .await;
+    assert_eq!(opt_in, 1, "`case_insensitive: true` finds HnswGraphBuilder");
+
+    // Keyword fields take the same parameter. The default there is XERJ's
+    // historical case-INsensitive one rather than ES's, and #362 does not flip
+    // it — but an explicit value now wins in both directions.
+    let (_, folded, _) = count_and_search(
+        &app,
+        &json!({"prefix": {"code": {"value": "test", "case_insensitive": true}}}),
+    )
+    .await;
+    assert_eq!(folded, 2, "folded keyword prefix matches both Test* codes");
+    let (_, raw, _) = count_and_search(&app, &json!({"prefix": {"code": "test"}})).await;
+    assert_eq!(raw, 0, "keyword prefix is case-sensitive by default");
+
+    let (_, strict, _) = count_and_search(
+        &app,
+        &json!({"wildcard": {"code": {"value": "hnsw*", "case_insensitive": false}}}),
+    )
+    .await;
+    assert_eq!(
+        strict, 0,
+        "an explicit `case_insensitive: false` must not be dropped on a keyword wildcard"
+    );
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -20181,7 +20181,6 @@ impl Index {
             Value::String(s) => s.as_str().to_string(),
             other => other.to_string(),
         };
-        let lowered = raw.to_ascii_lowercase();
         // Same bool coercion as the memtable side above — `value.as_f64()`
         // alone returns `None` for a JSON boolean, which used to make
         // `served_by_dv` false for every segment whose on-disk column for
@@ -20224,25 +20223,43 @@ impl Index {
                 continue;
             }
 
-            // Fallback: FTS term dictionary.  This is the slow path that
-            // parses meta.json; we only take it when the field isn't in
-            // the segment's doc-values (e.g. text fields with positions).
-            let reader = match FtsIndexReader::open(&segments_dir, &meta.id, &[field]) {
-                Ok(r) => r,
-                Err(_) => return None, // FST missing — abandon
-            };
-            reader.field_stats(field)?;
-            let df = reader
-                .term_doc_freq(field, &raw)
-                .or_else(|| {
-                    if raw == lowered {
-                        None
-                    } else {
-                        reader.term_doc_freq(field, &lowered)
-                    }
-                })
-                .unwrap_or(0);
-            seg_matches = seg_matches.saturating_add(df as u64);
+            // No doc-values column for this field in this segment — ABANDON
+            // to the real scan (#362).
+            //
+            // This branch used to answer from the FTS term dictionary, and
+            // that is a different question from the one `_search` answers. A
+            // field reaches here precisely because it has no column, which on
+            // this engine means a `text` field (or an explicit
+            // `doc_values: false`), and `_search` resolves a `term` on such a
+            // field through `doc_matches_query` — a comparison against the
+            // whole `_source` value, not against the analyzed dictionary. The
+            // two coincide only by accident, so the shortcut published counts
+            // no `_search` could reproduce:
+            //
+            //   {"term":{"title":"TestSegmentReader.java"}}         count 1, hits 0
+            //   {"term":{"title":"quick"}} / "the quick brown fox"  count 1, hits 0
+            //
+            // The first was masked further by a lowercase RETRY on the lookup,
+            // which answered from a term the caller never wrote and is what
+            // made `term` look like it normalised case while `prefix` did not
+            // — the report that opened #362. Deleting the retry alone would
+            // only flip the error's sign (count 0, hits 1); the dictionary is
+            // the wrong oracle either way.
+            //
+            // Lucene has no equivalent hazard because `IndexSearcher.count`
+            // (IndexSearcher.java:495) derives its answer from the SAME
+            // rewritten query and Weight as `search()`, taking only algebraic
+            // rewrites as shortcuts and otherwise collecting for real;
+            // `QueryUtils.checkCount` (QueryUtils.java:680) exists to assert
+            // exactly that. Abandoning here is that fallback: `_count` on a
+            // `term` over a text field costs a scan now, and is right.
+            //
+            // (The deeper issue — that `term` on a `text` field compares
+            // against `_source` at all, where ES compares against the analyzed
+            // dictionary — is a separate, visible behaviour change and is not
+            // resolved here. This makes `_count` agree with whatever `_search`
+            // does; it does not decide what `_search` should do.)
+            return None;
         }
 
         Some(mem_matches + seg_matches)
@@ -21514,23 +21531,47 @@ impl Index {
                             ords,
                         });
                     }
-                    ScoredFilterLeaf::KeywordPrefix { field, prefix } => {
+                    ScoredFilterLeaf::KeywordPrefix {
+                        field,
+                        prefix,
+                        case_insensitive,
+                    } => {
                         let Some(Column::Keyword(k)) = cols.get(field.as_str()) else {
                             return None;
                         };
-                        // `terms` is lexicographically sorted: the prefix's
-                        // matches form the contiguous ordinal range
-                        // [lo, hi) bounded by two partition_points.
-                        let lo = k.terms.partition_point(|t| t.as_str() < prefix.as_str());
-                        let hi =
-                            lo + k.terms[lo..].partition_point(|t| t.starts_with(prefix.as_str()));
+                        let ords: Vec<u32> = if *case_insensitive {
+                            // A folded prefix cannot bound a byte-ordered range
+                            // (`Ab` would have to cover both `AB…` and `ab…`),
+                            // so walk the distinct-term dictionary with a
+                            // folded compare — exactly what the KeywordWildcard
+                            // leaf below does, and what `expand_prefix`'s
+                            // folded branch does on the FST route.
+                            let pfx_lc = prefix.to_lowercase();
+                            (0..k.terms.len() as u32)
+                                .filter(|&o| {
+                                    k.terms[o as usize].to_lowercase().starts_with(&pfx_lc)
+                                })
+                                .collect()
+                        } else {
+                            // `terms` is lexicographically sorted: the prefix's
+                            // matches form the contiguous ordinal range
+                            // [lo, hi) bounded by two partition_points.
+                            let lo = k.terms.partition_point(|t| t.as_str() < prefix.as_str());
+                            let hi = lo
+                                + k.terms[lo..].partition_point(|t| t.starts_with(prefix.as_str()));
+                            (lo as u32..hi as u32).collect()
+                        };
                         fev.push(FilterEval::Kw {
                             col: k,
                             no_nulls: k.null_bitmap.is_empty(),
-                            ords: (lo as u32..hi as u32).collect(),
+                            ords,
                         });
                     }
-                    ScoredFilterLeaf::KeywordWildcard { field, pattern } => {
+                    ScoredFilterLeaf::KeywordWildcard {
+                        field,
+                        pattern,
+                        case_insensitive,
+                    } => {
                         let Some(Column::Keyword(k)) = cols.get(field.as_str()) else {
                             return None;
                         };
@@ -21543,11 +21584,22 @@ impl Index {
                         // from segments while the memtable matched.  A folded
                         // pattern cannot bound a byte-ordered prefix range, so
                         // walk the whole (distinct-term) dictionary — the same
-                        // cost class as the FST expansion.
-                        let pat_lc = pattern.to_lowercase();
+                        // cost class as the FST expansion.  An explicit
+                        // `case_insensitive: false` (#362) drops the folding
+                        // and compares raw, matching `expand_wildcard`'s
+                        // case-sensitive branch on the FST route.
+                        let pat_lc = if *case_insensitive {
+                            pattern.to_lowercase()
+                        } else {
+                            pattern.clone()
+                        };
                         let ords: Vec<u32> = (0..k.terms.len())
                             .filter(|&o| {
-                                let lc = k.terms[o].to_lowercase();
+                                let lc = if *case_insensitive {
+                                    k.terms[o].to_lowercase()
+                                } else {
+                                    k.terms[o].clone()
+                                };
                                 wildcard_match(&lc, &pat_lc)
                                     || lc
                                         .split(|c: char| !c.is_alphanumeric())
@@ -30757,12 +30809,14 @@ mod lexically_typeless_lowering_tests {
                 value: "0".into(),
                 boost: None,
                 constant_score: true,
+                case_insensitive: None,
             },
             QueryNode::Wildcard {
                 field: "emb".into(),
                 value: "0*".into(),
                 boost: None,
                 constant_score: true,
+                case_insensitive: None,
             },
             QueryNode::Match {
                 field: "emb".into(),
@@ -31358,22 +31412,26 @@ fn strip_nested_path_in_query(q: &QueryNode, path: &str) -> QueryNode {
             value,
             boost,
             constant_score,
+            case_insensitive,
         } => QueryNode::Prefix {
             field: strip(field),
             value: value.clone(),
             boost: *boost,
             constant_score: *constant_score,
+            case_insensitive: *case_insensitive,
         },
         QueryNode::Wildcard {
             field,
             value,
             boost,
             constant_score,
+            case_insensitive,
         } => QueryNode::Wildcard {
             field: strip(field),
             value: value.clone(),
             boost: *boost,
             constant_score: *constant_score,
+            case_insensitive: *case_insensitive,
         },
         QueryNode::Exists { field } => QueryNode::Exists {
             field: strip(field),
@@ -33114,15 +33172,32 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
             _ => get_field_value(source, field).is_some(),
         },
 
-        QueryNode::Prefix { field, value, .. } => {
+        QueryNode::Prefix {
+            field,
+            value,
+            case_insensitive,
+            ..
+        } => {
             // ES Prefix matches against analyzed tokens for text fields and
             // against the raw value for keyword fields. Without schema info
             // at this layer we check both: either the whole value starts
             // with the pattern (keyword semantics) OR any whitespace-
             // separated token does (analyzed-text semantics).
-            let value_lc = value.to_lowercase();
+            //
+            // An EXPLICIT `case_insensitive: false` is honoured here (#362) so
+            // a caller who asks for ES's case-sensitive rule gets the same hit
+            // set from this fallback scan as from the FST route, which has
+            // always been case-sensitive. `None` keeps folding: this arm also
+            // serves fields with no mapping at all, where there is no indexed
+            // route to agree with.
+            let fold = case_insensitive.unwrap_or(true);
+            let value_lc = if fold {
+                value.to_lowercase()
+            } else {
+                value.clone()
+            };
             let matches_str = |s: &str| -> bool {
-                let lc = s.to_lowercase();
+                let lc = if fold { s.to_lowercase() } else { s.to_owned() };
                 if lc.starts_with(&value_lc) {
                     return true;
                 }
@@ -33144,13 +33219,21 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
         QueryNode::Wildcard {
             field,
             value: pattern,
+            case_insensitive,
             ..
         } => {
             // Match against the raw value AND against every whitespace/
             // non-alnum token — matches both keyword and text semantics.
-            let pat_lc = pattern.to_lowercase();
+            // See the Prefix arm for why an explicit `false` folds nothing
+            // while `None` still folds (#362).
+            let fold = case_insensitive.unwrap_or(true);
+            let pat_lc = if fold {
+                pattern.to_lowercase()
+            } else {
+                pattern.clone()
+            };
             let matches_str = |s: &str| -> bool {
-                let lc = s.to_lowercase();
+                let lc = if fold { s.to_lowercase() } else { s.to_owned() };
                 if wildcard_match(&lc, &pat_lc) {
                     return true;
                 }
@@ -37612,6 +37695,29 @@ fn collect_field_boosts(q: &QueryNode, out: &mut HashMap<String, f32>) {
     }
 }
 
+// ── `case_insensitive` defaults for the multi-term family ────────────────────
+//
+// `QueryNode::{Prefix,Wildcard}::case_insensitive` is `Option<bool>`: `None`
+// means the request said nothing, and each execution path falls back to the
+// constant below.  They are named, not inlined, because they are the ONE place
+// the routes for a given (query, field-type) pair — FST expansion and columnar
+// filter leaf — agree, and #362 is exactly those routes disagreeing.  Change
+// one and the other must move with it.
+//
+// Lucene's own answer is a single case-sensitive rule (`PrefixQuery
+// .toAutomaton`, PrefixQuery.java:44, builds a byte-exact automaton off the
+// query bytes) with folding as an explicit opt-in (`Automata
+// .makeCaseInsensitiveString`, Automata.java:573).  Only the keyword-wildcard
+// constant still departs from that; it is `true` because every keyword wildcard
+// XERJ has shipped folded, and because `term{case_insensitive:true}` lowers to
+// a Wildcard node that depends on it.  Flipping it to `false` is the
+// ES-faithful end state and a visible hit-set change, so it is a separate
+// issue — but it is now a ONE-LINE change here rather than a rewrite, which was
+// the point.
+const PREFIX_CASE_INSENSITIVE_DEFAULT: bool = false;
+const TEXT_WILDCARD_CASE_INSENSITIVE_DEFAULT: bool = false;
+const KEYWORD_WILDCARD_CASE_INSENSITIVE_DEFAULT: bool = true;
+
 #[cfg(test)]
 fn query_node_to_fts(
     q: &QueryNode,
@@ -38230,6 +38336,7 @@ fn query_node_to_fts_with_keyword_fields(
                     boost: 1.0,
                     max_expansions: *max_expansions as usize,
                     constant_score: false,
+                    case_insensitive: false,
                 }));
             }
             // TEXT field: analyze the query with the standard analyzer (the
@@ -38266,6 +38373,7 @@ fn query_node_to_fts_with_keyword_fields(
             value,
             boost,
             constant_score,
+            case_insensitive,
         } => {
             // `prefix` on a KEYWORD field: whole-value, case-sensitive prefix
             // match over the keyword FST term dictionary — byte-identical to ES
@@ -38293,6 +38401,7 @@ fn query_node_to_fts_with_keyword_fields(
                     // query_string / match_bool_prefix lowerings pass `false` and
                     // keep BM25.
                     constant_score: *constant_score,
+                    case_insensitive: case_insensitive.unwrap_or(PREFIX_CASE_INSENSITIVE_DEFAULT),
                 }));
             }
             // TEXT field: expand the prefix against the analyzed term dictionary
@@ -38300,7 +38409,8 @@ fn query_node_to_fts_with_keyword_fields(
             // the prefix pattern — it is matched CASE-SENSITIVELY against the
             // already-lowercased terms, so an uppercase pattern matches nothing.
             // `expand_prefix` is a raw `starts_with` (no folding), reproducing
-            // that exactly.  No `max_expansions` cap (ES `prefix` matches every
+            // that exactly, and `case_insensitive: true` is the caller's opt-out
+            // of it (#362).  No `max_expansions` cap (ES `prefix` matches every
             // term sharing the prefix) so `hits.total` stays exact.  ES rewrites
             // `prefix` to a `constant_score` query, so every match scores `boost`
             // (`constant_score: true`).
@@ -38311,6 +38421,7 @@ fn query_node_to_fts_with_keyword_fields(
                     boost: boost.unwrap_or(1.0),
                     max_expansions: usize::MAX,
                     constant_score: true,
+                    case_insensitive: case_insensitive.unwrap_or(PREFIX_CASE_INSENSITIVE_DEFAULT),
                 }));
             }
             None
@@ -38320,6 +38431,7 @@ fn query_node_to_fts_with_keyword_fields(
             value,
             boost,
             constant_score,
+            case_insensitive,
         } => {
             // `wildcard` on a KEYWORD field: expand the keyword FST term
             // dictionary to every term matching the pattern (`*`=0+ chars,
@@ -38329,17 +38441,21 @@ fn query_node_to_fts_with_keyword_fields(
             // exactly the doc-scan's — only sourced from the term dictionary
             // (≪ docs) instead of a per-doc O(N) scan (~150 ms/100k → ~1 ms).
             //
-            // Case-insensitivity is REQUIRED, not a shortcut: XERJ's parser
-            // drops `case_insensitive` and rewrites `term{case_insensitive:true}`
-            // to a Wildcard, both relying on the matcher folding case — so a
-            // case-sensitive FST route would break those (passing) paths.
+            // Case-insensitivity is this arm's DEFAULT, not a shortcut: the
+            // `term{case_insensitive:true}` lowering rewrites to a Wildcard and
+            // needs the matcher to fold, and every keyword wildcard shipped so
+            // far has folded here — a blanket flip to ES's case-SENSITIVE
+            // default is a hit-set change and is not part of #362.  What #362
+            // does buy is that an explicit `case_insensitive` now wins over the
+            // default in both directions, instead of being parsed and dropped.
             // TEXT fields keep the doc-scan (None): analyzed-token semantics.
             if exact_fields.contains(field.as_str()) {
                 return Some(FtsQuery::Wildcard(xerj_fts::search::WildcardQuery {
                     field: field.clone(),
                     pattern: value.clone(),
                     boost: boost.unwrap_or(1.0),
-                    case_insensitive: true,
+                    case_insensitive: case_insensitive
+                        .unwrap_or(KEYWORD_WILDCARD_CASE_INSENSITIVE_DEFAULT),
                     // ES rewrites a standalone `wildcard` query to a
                     // constant_score.  The `term{case_insensitive}` /
                     // query_string lowerings that SHARE this node pass `false`
@@ -38352,16 +38468,19 @@ fn query_node_to_fts_with_keyword_fields(
             // the standard analyzer; ES does not analyze a RAW `wildcard`
             // pattern, so it is matched literally against those terms (an
             // uppercase pattern matches nothing).  `case_insensitive: false`
-            // gives exactly that.  (query_string lowercases its wildcard terms
-            // at parse time, so `q=field:BA*` still matches — that lowering is
-            // done in the parser, not here.)  ES rewrites `wildcard` to a
-            // `constant_score` query, so every match scores `boost`.
+            // gives exactly that, and an explicit `case_insensitive: true` is
+            // the way out of it (#362).  (query_string lowercases its wildcard
+            // terms at parse time, so `q=field:BA*` still matches — that
+            // lowering is done in the parser, not here.)  ES rewrites
+            // `wildcard` to a `constant_score` query, so every match scores
+            // `boost`.
             if text_fields.iter().any(|f| f == field) {
                 return Some(FtsQuery::Wildcard(xerj_fts::search::WildcardQuery {
                     field: field.clone(),
                     pattern: value.clone(),
                     boost: boost.unwrap_or(1.0),
-                    case_insensitive: false,
+                    case_insensitive: case_insensitive
+                        .unwrap_or(TEXT_WILDCARD_CASE_INSENSITIVE_DEFAULT),
                     constant_score: true,
                 }));
             }
@@ -38976,13 +39095,24 @@ enum ScoredFilterLeaf {
     /// Standalone constant-score `prefix` on a keyword field — resolved
     /// per segment to the contiguous ordinal range of matching dictionary
     /// terms (`terms` is lexicographically sorted, so two partition_points
-    /// bound the prefix).  LOSS_BATTLE_PLAN B3.
-    KeywordPrefix { field: String, prefix: String },
+    /// bound the prefix).  LOSS_BATTLE_PLAN B3.  Under `case_insensitive`
+    /// the folded prefix cannot bound a byte-ordered range, so that variant
+    /// walks the distinct-term dictionary instead — same shape as
+    /// `KeywordWildcard`, same cost class as the FST expansion.
+    KeywordPrefix {
+        field: String,
+        prefix: String,
+        case_insensitive: bool,
+    },
     /// Standalone constant-score `wildcard` on a keyword field — resolved
     /// per segment by matching the (distinct) dictionary terms with the
     /// SAME `wildcard_match` the brute path uses, narrowed to the leading
     /// literal's prefix range first.
-    KeywordWildcard { field: String, pattern: String },
+    KeywordWildcard {
+        field: String,
+        pattern: String,
+        case_insensitive: bool,
+    },
     /// `term` on a numeric/boolean field, or `range` on a numeric field —
     /// both evaluate as an inclusive/exclusive f64 window over the numeric
     /// doc-values column (a term is the degenerate `[v, v]` window;
@@ -39592,6 +39722,7 @@ fn scored_fast_plan(
             filter: vec![ScoredFilterLeaf::KeywordPrefix {
                 field: field.clone(),
                 prefix: String::new(),
+                case_insensitive: false,
             }],
             must_not: Vec::new(),
             score: 1.0,
@@ -39623,10 +39754,15 @@ fn scored_fast_plan(
             value,
             boost,
             constant_score: true,
+            case_insensitive,
         } if fs.kw.contains(field) => Some(ScoredPlan::Filtered {
             filter: vec![ScoredFilterLeaf::KeywordPrefix {
                 field: field.clone(),
                 prefix: value.clone(),
+                // Same constant the FST arm resolves against, so this plan and
+                // `query_node_to_fts_with_keyword_fields` cannot disagree —
+                // the divergence #362 is about.
+                case_insensitive: case_insensitive.unwrap_or(PREFIX_CASE_INSENSITIVE_DEFAULT),
             }],
             must_not: Vec::new(),
             score: scoring_boost(boost)?,
@@ -39636,10 +39772,13 @@ fn scored_fast_plan(
             value,
             boost,
             constant_score: true,
+            case_insensitive,
         } if fs.kw.contains(field) => Some(ScoredPlan::Filtered {
             filter: vec![ScoredFilterLeaf::KeywordWildcard {
                 field: field.clone(),
                 pattern: value.clone(),
+                case_insensitive: case_insensitive
+                    .unwrap_or(KEYWORD_WILDCARD_CASE_INSENSITIVE_DEFAULT),
             }],
             must_not: Vec::new(),
             score: scoring_boost(boost)?,
@@ -41472,11 +41611,13 @@ mod fts_projection_tests {
             value: "run".into(),
             boost: None,
             constant_score: true,
+            case_insensitive: None,
         };
         match query_node_to_fts(&q, &tf, &kw(&[])).expect("text prefix projects") {
             FtsQuery::Prefix(p) => {
                 assert_eq!(p.prefix, "run", "pattern NOT lowercased/analyzed");
                 assert_eq!(p.max_expansions, usize::MAX);
+                assert!(!p.case_insensitive, "text prefix is case-sensitive");
             }
             other => panic!("expected prefix, got {:?}", other),
         }
@@ -41486,6 +41627,7 @@ mod fts_projection_tests {
             value: "run*".into(),
             boost: None,
             constant_score: true,
+            case_insensitive: None,
         };
         match query_node_to_fts(&q, &tf, &kw(&[])).expect("text wildcard projects") {
             FtsQuery::Wildcard(w) => {
@@ -41521,6 +41663,50 @@ mod fts_projection_tests {
                 assert_eq!(p.max_expansions, 50);
             }
             other => panic!("expected phrase_prefix, got {:?}", other),
+        }
+    }
+
+    /// `case_insensitive: true` reaches the FST expansion instead of being
+    /// parsed and dropped (#362) — on BOTH field types, and on both prefix and
+    /// wildcard.  This is the projection half of the escape hatch that answers
+    /// the reporter's `prefix title=Test`; the end-to-end half lives in
+    /// `xerj-api/tests/multi_term_case_rule_is_one_rule.rs`.
+    #[test]
+    fn explicit_case_insensitive_reaches_the_fst_arms() {
+        let tf = ["body".to_string()];
+        for (field, exact) in [("body", kw(&[])), ("top_doc", kw(&["top_doc"]))] {
+            let q = QueryNode::Prefix {
+                field: field.into(),
+                value: "Run".into(),
+                boost: None,
+                constant_score: true,
+                case_insensitive: Some(true),
+            };
+            match query_node_to_fts(&q, &tf, &exact).expect("prefix projects") {
+                FtsQuery::Prefix(p) => {
+                    assert_eq!(p.prefix, "Run", "the pattern itself is never rewritten");
+                    assert!(
+                        p.case_insensitive,
+                        "{field}: opt-in must reach the searcher"
+                    );
+                }
+                other => panic!("expected prefix, got {:?}", other),
+            }
+            let q = QueryNode::Wildcard {
+                field: field.into(),
+                value: "Run*".into(),
+                boost: None,
+                constant_score: true,
+                case_insensitive: Some(false),
+            };
+            match query_node_to_fts(&q, &tf, &exact).expect("wildcard projects") {
+                FtsQuery::Wildcard(w) => {
+                    // Explicit `false` must win even on the keyword arm, whose
+                    // default is the one XERJ default that folds.
+                    assert!(!w.case_insensitive, "{field}: opt-OUT must reach it too");
+                }
+                other => panic!("expected wildcard, got {:?}", other),
+            }
         }
     }
 

--- a/engine/crates/xerj-engine/src/sql.rs
+++ b/engine/crates/xerj-engine/src/sql.rs
@@ -637,6 +637,7 @@ fn parse_condition(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<Qu
                 value: pattern,
                 boost: None,
                 constant_score: false,
+                case_insensitive: None,
             }
         }
         "not_like" => {
@@ -654,6 +655,7 @@ fn parse_condition(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<Qu
                     value: pattern,
                     boost: None,
                     constant_score: false,
+                    case_insensitive: None,
                 }],
                 minimum_should_match: None,
             }

--- a/engine/crates/xerj-engine/tests/count_matches_search_on_text_term.rs
+++ b/engine/crates/xerj-engine/tests/count_matches_search_on_text_term.rs
@@ -1,0 +1,255 @@
+//! Regression tests for #362 — `_count` must answer the same question
+//! `_search` does for a `term` query on a `text` field.
+//!
+//! The count-only (`size:0`) path resolved a `term` through the segment FTS
+//! term dictionary and additionally re-spelled the term lowercase when the
+//! byte-exact lookup missed:
+//!
+//! ```text
+//! reader.term_doc_freq(field, &raw).or_else(|| reader.term_doc_freq(field, &lowered))
+//! ```
+//!
+//! The hit-materialising path never did either, so the two APIs disagreed
+//! about one and the same query:
+//!
+//! ```text
+//! term title=TestSegmentReader.java   _count=1   _search total=1  hits=1
+//! term title=testsegmentreader.java   _count=1   _search total=0  hits=0   <- disagree
+//! ```
+//!
+//! Not just casing: the dictionary holds ANALYSED tokens, so
+//! `{"term":{"title":"quick"}}` against `"the quick brown fox"` also counted
+//! 1 while `_search` returned nothing. A count that describes a hit set
+//! nobody can retrieve is worse than a slow count.
+//!
+//! Deleting the `.or_else(&lowered)` re-spelling on its own is NOT the fix,
+//! and these tests are what showed it. With the re-spelling gone but the
+//! dictionary lookup kept, the first two tests below still fail (the
+//! dictionary already holds the lowercased token, so `raw` hits it directly,
+//! and `quick` is a token outright) AND the third starts failing: the
+//! byte-exact `term title=TestSegmentReader.java`, which `_search` answers
+//! `1`, misses the lowercased dictionary and counts `0`. The re-spelling was
+//! scaffolding over the real defect — consulting an ANALYSED dictionary for a
+//! question the hit path answers against the raw `_source`. So the shortcut
+//! now ABANDONS when the segment has no doc-values column for the field, and
+//! the ordinary scan — the code that produces the hits — answers.
+//!
+//! The tests below are written against the property, not the symptom:
+//! whatever the answer is, `size:0` and `size:10` must agree on it.
+
+use serde_json::json;
+use std::sync::Arc;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldOptions, FieldType, Schema};
+use xerj_engine::{Engine, Index};
+use xerj_query::parse_request;
+
+fn make_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    config.engine.ingest_shards = 1;
+    Engine::new(config).expect("engine::new")
+}
+
+/// An ES `{"type": "text"}` field as `es_properties_to_fields` builds it:
+/// analysed, indexed, and — like ES — **no doc-values column**
+/// (`es_compat.rs:15400`, `doc_values_default`). That last part is what puts
+/// the count shortcut on its FTS term-dictionary fallback, which is where the
+/// two APIs part ways.
+fn es_text_field(name: &str) -> FieldConfig {
+    FieldConfig::new(name, FieldType::Text).with_options(FieldOptions {
+        doc_values: false,
+        ..FieldOptions::default()
+    })
+}
+
+fn text_schema() -> Schema {
+    let mut s = Schema::empty();
+    s.add_field(es_text_field("title")).unwrap();
+    s.add_field(es_text_field("body")).unwrap();
+    s
+}
+
+/// `_count` total (the `size:0` shortcut) and `_search` total + materialised
+/// hit count for the same `term` query.
+async fn count_vs_search(idx: &Arc<Index>, field: &str, value: &str) -> (u64, u64, usize) {
+    let q = json!({"term": {field: value}});
+    let count = idx
+        .search(&parse_request(&json!({"size": 0, "query": q})).expect("parse size:0"))
+        .await
+        .expect("count search")
+        .total
+        .value;
+    let res = idx
+        .search(&parse_request(&json!({"size": 10, "query": q})).expect("parse size:10"))
+        .await
+        .expect("hit search");
+    (count, res.total.value, res.hits.len())
+}
+
+async fn corpus(dir: &TempDir) -> Arc<Index> {
+    let engine = make_engine(dir);
+    engine.create_index("t", text_schema()).unwrap();
+    let idx = engine.get_index("t").unwrap();
+    idx.index_document(
+        Some("d1".into()),
+        json!({"title": "TestSegmentReader.java", "body": "the quick brown fox"}),
+    )
+    .await
+    .unwrap();
+    idx.index_document(
+        Some("d2".into()),
+        json!({"title": "HnswGraphBuilder.java", "body": "lazy dogs sleep"}),
+    )
+    .await
+    .unwrap();
+    // The disagreement lives in the SEGMENT arm of the count shortcut, so the
+    // docs have to be flushed out of the memtable to reach it.
+    idx.flush().await.unwrap();
+    idx
+}
+
+/// The exact row from the issue that disagreed: a lowercased spelling of a
+/// mixed-case value. `_count` re-spelled the term and reported 1; `_search`
+/// stayed byte-exact and returned 0.
+#[tokio::test]
+async fn count_does_not_respell_a_term_lowercase() {
+    let dir = TempDir::new().unwrap();
+    let idx = corpus(&dir).await;
+
+    let (count, total, hits) = count_vs_search(&idx, "title", "testsegmentreader.java").await;
+    assert_eq!(
+        count, total,
+        "#362: _count={count} but _search total={total} (hits={hits}) for the same \
+         term query — the count path re-spelled the term lowercase and reported a \
+         document _search cannot return"
+    );
+    assert_eq!(
+        count, hits as u64,
+        "#362: _count={count} but _search materialised {hits} hit(s) for the same term query"
+    );
+}
+
+/// The half that is NOT about casing: the FTS term dictionary holds analysed
+/// tokens, so a single word out of a multi-token `text` value resolved to a
+/// non-zero doc-freq for `_count` while `_search` matched nothing.
+#[tokio::test]
+async fn count_does_not_match_a_single_token_of_an_analysed_text_value() {
+    let dir = TempDir::new().unwrap();
+    let idx = corpus(&dir).await;
+
+    let (count, total, hits) = count_vs_search(&idx, "body", "quick").await;
+    assert_eq!(
+        count, total,
+        "#362: _count={count} but _search total={total} (hits={hits}) for \
+         {{\"term\":{{\"body\":\"quick\"}}}} against \"the quick brown fox\" — the count \
+         path consulted the analysed term dictionary, the hit path did not"
+    );
+    assert_eq!(
+        count, hits as u64,
+        "#362: _count={count} but _search materialised {hits} hit(s)"
+    );
+}
+
+/// The other way a field reaches this fallback: `build_doc_value_columns`
+/// poisons a MULTI-VALUED field (it ships no column at all), so a `keyword`
+/// field with an array value lands on the same code path, where flush
+/// flattened `["AB-1","CD-2"]` into the single token `"AB-1 CD-2"` (#332).
+///
+/// Honest status of this test: it passes on unmodified `main` too — checked,
+/// not assumed — because on this corpus both APIs answer 0 and therefore
+/// already agree. It is a guard, not a reproduction: it pins the agreement
+/// for the shape most likely to regress if the abandon is ever narrowed to
+/// "analysed fields only", since a `keyword` field is exactly what such a
+/// narrowing would let back onto the dictionary.
+#[tokio::test]
+async fn count_matches_search_on_a_multi_valued_keyword_field() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let mut schema = Schema::empty();
+    schema
+        .add_field(FieldConfig::new("code", FieldType::Keyword))
+        .unwrap();
+    engine.create_index("m", schema).unwrap();
+    let idx = engine.get_index("m").unwrap();
+    idx.index_document(Some("m0".into()), json!({"code": ["AB-1", "CD-2"]}))
+        .await
+        .unwrap();
+    idx.index_document(Some("m1".into()), json!({"code": ["EF-3"]}))
+        .await
+        .unwrap();
+    idx.flush().await.unwrap();
+
+    let (count, total, hits) = count_vs_search(&idx, "code", "AB-1").await;
+    assert_eq!(
+        count, total,
+        "#362: _count={count} but _search total={total} (hits={hits}) for a term on a \
+         multi-valued keyword field — the count path read a flattened dictionary token"
+    );
+    assert_eq!(
+        count, hits as u64,
+        "#362: _count={count} but _search materialised {hits} hit(s)"
+    );
+}
+
+/// A `keyword` field with `doc_values: false` has no `.dv` column either and
+/// reaches the same fallback. `_count` and `_search` must agree here too —
+/// and the case-insensitive fudge the count path used to apply must be gone,
+/// so a lowercased spelling of a mixed-case keyword value counts 0.
+#[tokio::test]
+async fn keyword_field_without_doc_values_agrees_with_search() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let mut schema = Schema::empty();
+    schema
+        .add_field(
+            FieldConfig::new("code", FieldType::Keyword).with_options(FieldOptions {
+                doc_values: false,
+                ..FieldOptions::default()
+            }),
+        )
+        .unwrap();
+    engine.create_index("k", schema).unwrap();
+    let idx = engine.get_index("k").unwrap();
+    for (i, code) in ["AB-1", "AB-1", "CD-2"].iter().enumerate() {
+        idx.index_document(Some(format!("k{i}")), json!({ "code": code }))
+            .await
+            .unwrap();
+    }
+    idx.flush().await.unwrap();
+
+    let (count, total, hits) = count_vs_search(&idx, "code", "AB-1").await;
+    assert_eq!(
+        (count, total, hits),
+        (2, 2, 2),
+        "keyword term count: _count={count}, _search total={total}, hits={hits}"
+    );
+    // And the case-sensitivity the count path used to fudge away stays gone.
+    let (lc_count, lc_total, lc_hits) = count_vs_search(&idx, "code", "ab-1").await;
+    assert_eq!(
+        (lc_count, lc_total, lc_hits),
+        (0, 0, 0),
+        "a lowercased spelling of a keyword value must not count: _count={lc_count}, \
+         _search total={lc_total}, hits={lc_hits}"
+    );
+}
+
+/// The byte-exact spelling has to keep working — the fix must not turn a
+/// correct count into a zero.
+#[tokio::test]
+async fn count_and_search_agree_on_the_byte_exact_spelling() {
+    let dir = TempDir::new().unwrap();
+    let idx = corpus(&dir).await;
+
+    let (count, total, hits) = count_vs_search(&idx, "title", "TestSegmentReader.java").await;
+    // Stated as an absolute, not just as agreement: the two disagreement
+    // tests above are satisfied by `0 == 0`, so something has to prove the
+    // corpus is really there and the fix did not simply zero the count.
+    assert_eq!(
+        (count, total, hits),
+        (1, 1, 1),
+        "the byte-exact spelling must still find d1: _count={count}, \
+         _search total={total}, hits={hits}"
+    );
+}

--- a/engine/crates/xerj-fts/src/search.rs
+++ b/engine/crates/xerj-fts/src/search.rs
@@ -208,6 +208,16 @@ pub struct PrefixQuery {
     /// path), the per-expansion BM25 scores are summed.
     #[serde(default)]
     pub constant_score: bool,
+    /// When `true` the prefix and each indexed term are case-folded before
+    /// comparing.  `false` (the default, both the keyword and the text path)
+    /// matches the RAW prefix against the whole indexed term — Lucene builds a
+    /// prefix automaton straight off the query bytes and never analyses them
+    /// (`PrefixQuery.toAutomaton`, PrefixQuery.java:44), so an uppercase prefix
+    /// against a lowercased text dictionary correctly matches nothing.  Folding
+    /// is the opt-in ES exposes as `case_insensitive`, backed in Lucene by
+    /// `Automata.makeCaseInsensitiveString` (Automata.java:573).
+    #[serde(default)]
+    pub case_insensitive: bool,
 }
 
 fn default_max_expansions() -> usize {
@@ -222,6 +232,7 @@ impl PrefixQuery {
             boost: 1.0,
             max_expansions: 50,
             constant_score: false,
+            case_insensitive: false,
         }
     }
 }
@@ -798,7 +809,9 @@ impl FtsSearcher {
         let last = ppq.terms.last().expect("non-empty");
         // Expand the trailing prefix against the field's term dictionary in FST
         // (lexicographic) order — matches ES's first-`max_expansions` selection.
-        let expansions = self.expand_prefix(&ppq.field, last, ppq.max_expansions);
+        // Case-sensitive: `terms` reach here already analyzed by the caller
+        // (standard analyzer → lowercased), so both sides are folded already.
+        let expansions = self.expand_prefix(&ppq.field, last, ppq.max_expansions, false);
         if expansions.is_empty() {
             return Ok(Vec::new());
         }
@@ -857,7 +870,12 @@ impl FtsSearcher {
 
     fn execute_prefix(&self, pq: &PrefixQuery, explain: bool) -> Result<Vec<ScoredHit>> {
         // Expand prefix to term list using FST range scan
-        let expanded_terms = self.expand_prefix(&pq.field, &pq.prefix, pq.max_expansions);
+        let expanded_terms = self.expand_prefix(
+            &pq.field,
+            &pq.prefix,
+            pq.max_expansions,
+            pq.case_insensitive,
+        );
         self.score_expanded_terms(
             &pq.field,
             &expanded_terms,
@@ -867,18 +885,38 @@ impl FtsSearcher {
         )
     }
 
-    fn expand_prefix(&self, field: &str, prefix: &str, max: usize) -> Vec<String> {
+    /// Enumerate the field's FST term dictionary and keep every term starting
+    /// with `prefix`, up to `max` of them.
+    ///
+    /// - case-**sensitive** (the default): raw `starts_with` against the whole
+    ///   indexed term, reproducing Lucene's byte-exact prefix automaton.
+    /// - `case_insensitive`: fold both sides — the `case_insensitive: true`
+    ///   opt-in.  Only the whole term is compared, unlike the wildcard/fuzzy
+    ///   folded branches which additionally split sub-tokens to stay identical
+    ///   to the doc-scan predicate; a prefix has no sub-token analogue there.
+    fn expand_prefix(
+        &self,
+        field: &str,
+        prefix: &str,
+        max: usize,
+        case_insensitive: bool,
+    ) -> Vec<String> {
         // Streaming FST scan with a cooperative deadline poll every 1 024
         // terms (RC4 blocker 12) — a wide dictionary made the old
         // materialise-then-filter walk a multi-second uninterruptible unit.
         let mut out: Vec<String> = Vec::new();
         let mut seen = 0usize;
+        let folded = case_insensitive.then(|| prefix.to_lowercase());
         self.reader.for_each_term(field, |t| {
             seen += 1;
             if seen & 1023 == 0 && self.deadline_hit() {
                 return false;
             }
-            if t.starts_with(prefix) {
+            let hit = match &folded {
+                Some(p) => t.to_lowercase().starts_with(p.as_str()),
+                None => t.starts_with(prefix),
+            };
+            if hit {
                 out.push(t.to_owned());
                 if out.len() >= max {
                     return false;

--- a/engine/crates/xerj-query/src/ast.rs
+++ b/engine/crates/xerj-query/src/ast.rs
@@ -356,6 +356,9 @@ pub enum QueryNode {
         /// match_bool_prefix) that keep BM25 scoring.
         #[serde(default, skip_serializing_if = "is_false")]
         constant_score: bool,
+        /// ES's `case_insensitive` parameter — see [`QueryNode::Wildcard`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        case_insensitive: Option<bool>,
     },
 
     /// Wildcard pattern match (`?` = any char, `*` = zero-or-more chars).
@@ -369,6 +372,27 @@ pub enum QueryNode {
         /// `term{case_insensitive}` / query_string lowerings that keep BM25.
         #[serde(default, skip_serializing_if = "is_false")]
         constant_score: bool,
+        /// ES's `case_insensitive` parameter, tri-state on purpose (#362).
+        ///
+        /// A multi-term query is NOT analysed — Lucene builds the automaton
+        /// straight off the raw bytes (`PrefixQuery.toAutomaton`,
+        /// PrefixQuery.java:44) and folds case only when asked, via
+        /// `Automata.makeCaseInsensitiveString` (Automata.java:573).  So the
+        /// pattern is compared literally against a term dictionary the analyzer
+        /// already lowercased, and `Test*` on a text field matches nothing.
+        /// `Some(true)` is the documented escape hatch out of that; the parser
+        /// used to accept the parameter and drop it, which is what left #362's
+        /// reporter with a silent empty set.
+        ///
+        /// `None` means "caller said nothing", and each execution path keeps
+        /// its own historical default: case-INsensitive for a keyword
+        /// `wildcard` (the FST/columnar arms and the `term{case_insensitive}`
+        /// lowering have always folded there), case-sensitive everywhere else.
+        /// Those two defaults disagree and only one of them is ES's; unifying
+        /// them is a visible hit-set change and is deliberately NOT bundled
+        /// here.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        case_insensitive: Option<bool>,
     },
 
     /// Matches documents where the field has any non-null value.

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -891,6 +891,7 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
                     value: tokens[0].clone(),
                     boost: fb,
                     constant_score: false,
+                    case_insensitive: None,
                 };
                 should.push(prefix);
                 continue;
@@ -921,6 +922,7 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
                 value: tokens[last].clone(),
                 boost: None,
                 constant_score: false,
+                case_insensitive: None,
             });
             let (im, is, imm) = if operator_and {
                 (inner_clauses, vec![], None)
@@ -1032,14 +1034,21 @@ fn parse_term(params: &Value) -> Result<QueryNode> {
                     // `term{case_insensitive:true}` to a case-insensitive
                     // automaton query with the CONSTANT_SCORE rewrite
                     // (max_score 1.0), while this keeps BM25 (1.2821425).
-                    // `constant_score: true` here is NOT safe yet: it
-                    // admits the shape to the columnar KeywordWildcard
-                    // leaf, whose dictionary narrowing is CASE-SENSITIVE —
-                    // a mixed-case value then returns 0 hits (hit-set
-                    // regression ≫ score diff). Fixing the score requires
-                    // threading `case_insensitive` through
-                    // QueryNode::Wildcard into the columnar/FST arms.
+                    // The blocker used to be a hit-set one — `true` admits
+                    // the shape to the columnar KeywordWildcard leaf, whose
+                    // dictionary narrowing was unconditionally CASE-SENSITIVE
+                    // — and #362 removed it by making that leaf honour the
+                    // flag below. What remains is only the score difference,
+                    // so flipping this is now a self-contained scoring fix
+                    // rather than a rewrite; it is still a visible change and
+                    // is not bundled into #362.
                     constant_score: false,
+                    // State the requirement instead of relying on the
+                    // matcher's historical fold (#362): this lowering is only
+                    // correct if every arm it can reach folds case, and `None`
+                    // would leave that to a per-path default that the
+                    // ES-faithful direction is to flip.
+                    case_insensitive: Some(true),
                 };
                 return Ok(maybe_named(node, name));
             }
@@ -1250,6 +1259,7 @@ fn parse_prefix(params: &Value) -> Result<QueryNode> {
             value: value.to_string(),
             boost: None,
             constant_score: true,
+            case_insensitive: None,
         });
     }
 
@@ -1268,6 +1278,10 @@ fn parse_prefix(params: &Value) -> Result<QueryNode> {
         value,
         boost,
         constant_score: true,
+        // Accepted AND honoured (#362): this used to parse and vanish, so the
+        // one documented way out of "`Test` matches nothing, `test` matches
+        // 1735" silently did nothing.
+        case_insensitive: inner.get("case_insensitive").and_then(Value::as_bool),
     })
 }
 
@@ -1288,6 +1302,7 @@ fn parse_wildcard(params: &Value) -> Result<QueryNode> {
             value: value.to_string(),
             boost: None,
             constant_score: true,
+            case_insensitive: None,
         });
     }
 
@@ -1306,6 +1321,8 @@ fn parse_wildcard(params: &Value) -> Result<QueryNode> {
         value,
         boost,
         constant_score: true,
+        // See `parse_prefix`.
+        case_insensitive: inner.get("case_insensitive").and_then(Value::as_bool),
     })
 }
 
@@ -2107,6 +2124,10 @@ fn parse_qs_unary(toks: &[QsTok], pos: &mut usize, ctx: QsFields<'_>) -> Option<
                             value: lowered.clone(),
                             boost,
                             constant_score: true,
+                            // query_string lowercases its own wildcard term
+                            // (`lowered` above), so it needs no folding from
+                            // the matcher and takes the path default.
+                            case_insensitive: None,
                         })
                         .collect(),
                 );
@@ -4232,6 +4253,7 @@ fn parse_match_bool_prefix(params: &Value) -> Result<QueryNode> {
             value: fold(&raw_tokens[0]),
             boost: None,
             constant_score: true,
+            case_insensitive: None,
         });
     }
 
@@ -4264,6 +4286,7 @@ fn parse_match_bool_prefix(params: &Value) -> Result<QueryNode> {
         value: fold(&raw_tokens[last_idx]),
         boost: None,
         constant_score: false,
+        case_insensitive: None,
     });
 
     // operator:and → every clause must match; otherwise should + mm.


### PR DESCRIPTION
Prepared by an agent (Claude Opus 5) driven by @xerj-org. **Opened early so CI runs while independent adversarial verification is still in progress — do not merge until that verification passes.**

Part of #362.

The report was "`term` normalises case but `prefix`/`wildcard` do not": on a
`text` field, `term title=TestSegmentReader.java` finds a document that
`prefix title=Test` cannot see. Reproduced verbatim on ca4d75a. The attribution
is backwards, and the truth is worse than the report.

`prefix`/`wildcard` are the ES-CORRECT half. A multi-term query is not
analysed: Lucene builds the automaton straight off the query bytes
(`PrefixQuery.toAutomaton`, lucene/core/src/java/org/apache/lucene/search/
PrefixQuery.java:44), and case handling happens one layer up, in a code path
deliberately separate from indexing analysis — `QueryParserBase.getPrefixQuery`
(lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/
QueryParserBase.java:750) calls `Analyzer.normalize`, which
(lucene/core/src/java/org/apache/lucene/analysis/Analyzer.java:213) documents
why: normalize "without tokenizing or stemming, which are undesirable if the
string to analyze is a partial word". So an uppercase prefix against a
lowercased text dictionary matching nothing is the correct answer.

`term` was not normalising at all. What normalised was `_count`.

`try_shortcut_count`'s FTS fallback looked the term up in the segment's term
dictionary and, on a miss, RETRIED with a lowercased spelling the caller never
wrote. That is what made `term` look case-insensitive. But the dictionary is
the wrong oracle in the first place: a field reaches that fallback precisely
because it has no doc-values column — a `text` field — and `_search` resolves a
`term` on a text field through `doc_matches_query`, comparing against the whole
`_source` value, not against analyzed terms. Measured on ca4d75a, both of these
returned a count no `_search` could reproduce:

    {"term":{"title":"TestSegmentReader.java"}}         count 1, hits 0
    {"term":{"title":"quick"}} / "the quick brown fox"  count 1, hits 0

The second has no case component at all — the retry is a no-op there and the
dictionary hit is genuine — which is the proof that deleting the retry alone
would only flip the error's sign (count 0, hits 1), not fix it. So the shortcut
now ABANDONS when the field has no column, and the real scan answers. Lucene
has no equivalent hazard because `IndexSearcher.count`
(lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java:495) derives
its answer from the same rewritten query and Weight as `search()`, taking only
algebraic rewrites as shortcuts and otherwise collecting for real;
`QueryUtils.checkCount` (lucene/test-framework/src/java/org/apache/lucene/

---
**Status:** fix pushed, adversarial verification in flight. A second agent is independently re-running the issue's repro against this branch, reverting only the source hunk to confirm the new test genuinely fails without it, and hunting for changed hit sets / changed `_score` / silent scan fallbacks / untrue claims. This PR should be merged only after that returns clean and all 16 checks are green.