### PR TITLE
fix(api): warn when a full-text query targets a semantic_text field (#363)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -7162,6 +7162,197 @@ fn unknown_field_hint(
     }))
 }
 
+/// Field names a full-text, BM25-scored clause searches.
+///
+/// Deliberately narrower than [`referenced_query_fields`]: only the analysed
+/// clause kinds, the ones whose whole point is "find me the text I mean". A
+/// `term`/`range`/`exists` against a `semantic_text` field is an ordinary
+/// filter and nobody expects embeddings out of it, so reporting those would
+/// be exactly the noise that gets a hint channel ignored wholesale.
+fn lexical_text_query_fields(q: &Value, out: &mut Vec<String>) {
+    /// `{"match": {"<field>": ...}}` — the field is the inner key.
+    const FIELD_KEYED: &[&str] = &[
+        "match",
+        "match_phrase",
+        "match_phrase_prefix",
+        "match_bool_prefix",
+    ];
+    /// `{"multi_match": {"fields": [...]}}` — the fields are listed inside.
+    const FIELD_LISTED: &[&str] = &[
+        "multi_match",
+        "combined_fields",
+        "query_string",
+        "simple_query_string",
+    ];
+    match q {
+        Value::Object(o) => {
+            for (k, v) in o {
+                if FIELD_KEYED.contains(&k.as_str()) {
+                    if let Value::Object(inner) = v {
+                        for f in inner.keys() {
+                            out.push(f.clone());
+                        }
+                    }
+                } else if FIELD_LISTED.contains(&k.as_str()) {
+                    if let Some(Value::Array(fs)) = v.get("fields") {
+                        for f in fs.iter().filter_map(Value::as_str) {
+                            // `body^3` — the boost is not part of the name.
+                            out.push(f.split('^').next().unwrap_or(f).to_string());
+                        }
+                    }
+                    if let Some(f) = v.get("default_field").and_then(Value::as_str) {
+                        out.push(f.split('^').next().unwrap_or(f).to_string());
+                    }
+                } else {
+                    lexical_text_query_fields(v, out);
+                }
+            }
+        }
+        Value::Array(a) => a.iter().for_each(|v| lexical_text_query_fields(v, out)),
+        _ => {}
+    }
+}
+
+/// Fields the caller is already searching by vector, in either spelling: the
+/// `semantic` query (which names the `semantic_text` field itself) and `knn`
+/// (which names the companion vector field). Collected from anywhere in the
+/// tree, because a `bool.should` or a `hybrid` sub-query is where the honest
+/// both-signals shapes actually put them.
+fn vector_searched_fields(q: &Value, out: &mut Vec<String>) {
+    match q {
+        Value::Object(o) => {
+            for (k, v) in o {
+                if k == "semantic" || k == "knn" {
+                    if let Some(f) = v.get("field").and_then(Value::as_str) {
+                        out.push(f.to_string());
+                    }
+                }
+                vector_searched_fields(v, out);
+            }
+        }
+        Value::Array(a) => a.iter().for_each(|v| vector_searched_fields(v, out)),
+        _ => {}
+    }
+}
+
+/// Hint for a full-text query against a `semantic_text` field.
+///
+/// A `semantic_text` field is indexed BOTH ways here: the text goes into the
+/// ordinary inverted index AND into a companion vector field. That is
+/// deliberate and tested (it is what `hybrid` fuses), so unlike the Lucene
+/// precedent this is not a type mismatch and must not throw — the lexical
+/// answer the caller got is a real answer. It is just not the answer they
+/// almost certainly meant: `match` never consults the embeddings, so a
+/// paraphrase sharing no words with the target is not found, after paying
+/// roughly 12x the indexing cost to make it findable (#363).
+///
+/// Adapted from Lucene's uniform "say what was indexed, say what the query
+/// assumed, name the remedy" shape — `DocValues.checkField`
+/// (lucene/core/src/java/org/apache/lucene/index/DocValues.java:206) even ends
+/// with "Re-index with correct docvalues type."; see also
+/// `FloatVectorValues.checkField` (…/index/FloatVectorValues.java:53) and
+/// `RangeFieldQuery.checkFieldInfo` (…/document/RangeFieldQuery.java:371).
+/// Lucene has no non-fatal advisory channel at all — every analogue throws —
+/// so only the message shape is borrowed; the delivery is this codebase's own
+/// `_xerj.hints`.
+///
+/// Fires regardless of hit count, for the same reason [`unknown_field_hint`]
+/// does: the failure mode here is a plausible wrong answer, not zero hits.
+fn semantic_text_lexical_hint(
+    index: &str,
+    body: &EsSearchBody,
+    schema: &xerj_common::types::Schema,
+) -> Option<Value> {
+    let query = body.query.as_ref()?;
+
+    // Most indexes have no `semantic_text` field at all, and this runs on every
+    // `_search`. One pass over the field list is cheaper than two walks of the
+    // query tree, so answer the common case before doing any work.
+    if !schema.fields.iter().any(|f| f.embedding.is_some()) {
+        return None;
+    }
+
+    // `hybrid` is the documented way to ask for both signals at once, and its
+    // lexical leg is supposed to be lexical. Nagging there would train callers
+    // to ignore the channel — taking the other hints down with it.
+    if query.get("hybrid").is_some() {
+        return None;
+    }
+
+    let mut referenced = Vec::new();
+    lexical_text_query_fields(query, &mut referenced);
+    if referenced.is_empty() {
+        return None;
+    }
+
+    // Everything the caller is already reaching for by vector. `knn` names the
+    // companion vector field rather than the `semantic_text` field, so both
+    // spellings have to be checked below.
+    let mut covered = Vec::new();
+    vector_searched_fields(query, &mut covered);
+    // Top-level ES 8.x `knn`, which sits beside `query` rather than inside it —
+    // `{"query": {"match": …}, "knn": {"field": "body_vector", …}}` is ordinary
+    // hybrid retrieval and must stay quiet. Accepts the single-object and the
+    // array-of-specs shapes ES takes.
+    if let Some(knn) = body.knn.as_ref() {
+        let specs: &[Value] = match knn {
+            Value::Array(a) => a,
+            other => std::slice::from_ref(other),
+        };
+        for f in specs
+            .iter()
+            .filter_map(|s| s.get("field").and_then(Value::as_str))
+        {
+            covered.push(f.to_string());
+        }
+    }
+
+    let semantic: Vec<String> = referenced
+        .iter()
+        .filter(|f| {
+            let Some(emb) = schema.field(f).and_then(|fc| fc.embedding.as_ref()) else {
+                return false;
+            };
+            // Same target derivation the executor uses when it resolves a
+            // `semantic` query onto the companion vector field.
+            let target = emb
+                .target_field
+                .clone()
+                .unwrap_or_else(|| format!("{f}_vector"));
+            !covered.iter().any(|c| c == *f || *c == target)
+        })
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let first = semantic.first()?;
+
+    let names = semantic
+        .iter()
+        .map(|f| format!("`{f}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(json!({
+        "hints": [{
+            "code": "lexical_on_semantic_text",
+            "reason": format!(
+                "{names} {} `semantic_text` in `{index}`, and this query scored {} with BM25 \
+                 over the lexical index — the embeddings were not used, so a paraphrase that \
+                 shares no words with the target will not be found. Use the `semantic` query \
+                 for vector search, or `hybrid` to fuse both signals in one request.",
+                if semantic.len() == 1 { "is" } else { "are" },
+                if semantic.len() == 1 { "it" } else { "them" },
+            ),
+            "try": {
+                "request": format!("POST /{index}/_search"),
+                "body": {
+                    "query": {"semantic": {"field": first.clone(), "query": "<your text>", "k": 10}},
+                },
+            },
+        }],
+    }))
+}
+
 /// `term`/`terms` clauses in a query, as (field, value) pairs.
 ///
 /// Only exact-match clauses: a `match` against text is analysed and a zero
@@ -7653,6 +7844,173 @@ mod search_response_hint_tests {
             .expect("hints array present");
         assert_eq!(hints[0]["candidates"], json!([]));
         assert!(hints[0]["reason"].as_str().unwrap().contains("ax-*"));
+    }
+
+    // ── `lexical_on_semantic_text` (#363) ────────────────────────────────────
+    //
+    // The trap: `match` on a `semantic_text` field runs BM25 and returns
+    // plausible lexical hits, giving none of the semantics the caller paid ~12x
+    // the indexing time for. The lexical index is deliberate (it is what
+    // `hybrid` fuses), so the fix is the loud message, not a behaviour change —
+    // which puts the whole burden on the suppression cases below.
+
+    /// `ctx` mapped `semantic_text` (text + an `EmbeddingConfig`, exactly what
+    /// `es_type == "semantic_text"` builds), `title` plain text.
+    fn semantic_text_schema() -> Schema {
+        let mut schema = Schema::empty();
+        schema
+            .fields
+            .push(FieldConfig::new("ctx", FieldType::Text).with_embedding(
+                xerj_common::types::EmbeddingConfig {
+                    endpoint: None,
+                    model: None,
+                    target_field: Some("ctx_vector".to_string()),
+                },
+            ));
+        schema
+            .fields
+            .push(FieldConfig::new("title", FieldType::Text));
+        schema
+    }
+
+    fn hint_for(body: Value) -> Option<Value> {
+        let body: EsSearchBody = serde_json::from_value(body).expect("valid search body");
+        semantic_text_lexical_hint("sem", &body, &semantic_text_schema())
+    }
+
+    #[test]
+    fn match_on_a_semantic_text_field_is_reported() {
+        let hint = hint_for(json!({"query": {"match": {"ctx": "prune redundant edges"}}}))
+            .expect("hint for match on semantic_text");
+        let h = &hint["hints"][0];
+        assert_eq!(h["code"], "lexical_on_semantic_text");
+        let reason = h["reason"].as_str().unwrap();
+        assert!(reason.contains("`ctx`"), "must name the field: {reason}");
+        assert!(reason.contains("BM25"), "must name what ran: {reason}");
+        // The remedy, not just the diagnosis — Lucene's DocValues.checkField
+        // ends with "Re-index with correct docvalues type." for the same reason.
+        assert!(
+            reason.contains("semantic"),
+            "must name the remedy: {reason}"
+        );
+        assert!(reason.contains("hybrid"), "must name hybrid too: {reason}");
+        assert_eq!(h["try"]["body"]["query"]["semantic"]["field"], "ctx");
+    }
+
+    /// `multi_match`, `query_string` and `match_phrase` are the shapes #363
+    /// flagged as untested but expected to share the trap. They do.
+    #[test]
+    fn other_full_text_clause_shapes_are_reported_too() {
+        for body in [
+            json!({"query": {"match_phrase": {"ctx": "prune edges"}}}),
+            json!({"query": {"multi_match": {"query": "x", "fields": ["title", "ctx^2"]}}}),
+            json!({"query": {"query_string": {"query": "x", "default_field": "ctx"}}}),
+            json!({"query": {"bool": {"must": [{"match": {"ctx": "x"}}]}}}),
+        ] {
+            assert!(
+                hint_for(body.clone()).is_some(),
+                "expected a hint for {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn match_on_a_plain_text_field_is_not_reported() {
+        assert!(hint_for(json!({"query": {"match": {"title": "x"}}})).is_none());
+    }
+
+    /// A filter is not a full-text query: nobody expects embeddings out of
+    /// `exists`/`term`/`range`, and hinting there is pure noise.
+    #[test]
+    fn filter_clauses_on_a_semantic_text_field_are_not_reported() {
+        for body in [
+            json!({"query": {"exists": {"field": "ctx"}}}),
+            json!({"query": {"term": {"ctx": "x"}}}),
+        ] {
+            assert!(hint_for(body.clone()).is_none(), "unexpected hint: {body}");
+        }
+    }
+
+    #[test]
+    fn a_semantic_query_is_not_reported() {
+        assert!(
+            hint_for(json!({"query": {"semantic": {"field": "ctx", "query": "x", "k": 10}}}))
+                .is_none()
+        );
+    }
+
+    /// The shape most likely to nag on correct usage: an ES-style hybrid, where
+    /// the lexical leg sits in `bool.should` and the vector leg is the
+    /// top-level `knn` naming the COMPANION field (`ctx_vector`), not `ctx`.
+    #[test]
+    fn match_alongside_a_top_level_knn_on_the_same_field_is_not_reported() {
+        assert!(hint_for(json!({
+            "query": {"bool": {"should": [{"match": {"ctx": "x"}}]}},
+            "knn": {"field": "ctx_vector", "query_vector": [0.1, 0.2], "k": 10},
+        }))
+        .is_none());
+        // Array-of-specs spelling of the same thing.
+        assert!(hint_for(json!({
+            "query": {"bool": {"should": [{"match": {"ctx": "x"}}]}},
+            "knn": [{"field": "ctx_vector", "query_vector": [0.1, 0.2], "k": 10}],
+        }))
+        .is_none());
+    }
+
+    #[test]
+    fn a_hybrid_wrapper_is_not_reported() {
+        assert!(hint_for(json!({
+            "query": {"hybrid": {"queries": [
+                {"query": {"match": {"ctx": "x"}}},
+                {"query": {"semantic": {"field": "ctx", "query": "x"}}},
+            ]}}
+        }))
+        .is_none());
+    }
+
+    /// End to end over the wire, and — the load-bearing half — the hits are
+    /// untouched. This fix must be observably behaviour-preserving.
+    #[tokio::test]
+    async fn semantic_text_hint_rides_along_without_changing_the_hits() {
+        let state = test_state();
+        state
+            .engine
+            .create_index("sem-hint", semantic_text_schema())
+            .unwrap();
+        let idx = state.engine.get_index("sem-hint").unwrap();
+        idx.index_document(
+            Some("1".into()),
+            json!({"ctx": "quick brown fox", "title": "a"}),
+        )
+        .await
+        .unwrap();
+        idx.index_document(Some("2".into()), json!({"ctx": "lazy dog", "title": "b"}))
+            .await
+            .unwrap();
+        idx.refresh().await.unwrap();
+        let router = crate::router::build_es_compat_router(state);
+
+        let (json, _) = run_search(
+            &router,
+            "sem-hint",
+            json!({"query": {"match": {"ctx": "fox"}}}),
+        )
+        .await;
+        assert_eq!(
+            json["hits"]["hits"].as_array().map(Vec::len),
+            Some(1),
+            "lexical hits must be unchanged: {json}"
+        );
+        assert_eq!(json["hits"]["hits"][0]["_id"], "1");
+        let hints = json["_xerj"]["hints"]
+            .as_array()
+            .expect("hints array present");
+        assert!(
+            hints
+                .iter()
+                .any(|h| h["code"] == "lexical_on_semantic_text"),
+            "expected the semantic_text hint: {json}"
+        );
     }
 }
 
@@ -12930,6 +13288,16 @@ async fn search_impl(
         if let Ok(idx) = state.engine.get_index(first) {
             let schema = idx.schema().await;
             if let Some(h) = unknown_field_hint(&index, &body, &schema) {
+                if let Some(Value::Array(items)) = h.get("hints") {
+                    all_hints.extend(items.iter().cloned());
+                }
+            }
+            // Same shape of silence, one level subtler: the field exists, the
+            // query works, and the answer is lexical when the caller paid the
+            // embedding cost expecting semantics. Also hit-count independent —
+            // BM25 on a semantic_text field returns plenty of plausible-looking
+            // results, which is exactly what makes it undebuggable (#363).
+            if let Some(h) = semantic_text_lexical_hint(&index, &body, &schema) {
                 if let Some(Value::Array(items)) = h.get("hints") {
                     all_hints.extend(items.iter().cloned());
                 }

--- a/engine/crates/xerj-autoindex/src/catalog.rs
+++ b/engine/crates/xerj-autoindex/src/catalog.rs
@@ -114,6 +114,7 @@ pub fn catalog_mapping() -> Value {
 pub const GOTCHAS: &[&str] = &[
     "hybrid search: use {\"query\":{\"hybrid\":{\"queries\":[…]}}} ONLY — retriever.rrf is a silent stub and rank.rrf is ignored on this engine",
     "semantic_text fields are embedded server-side: the DEFAULT is the built-in LEXICAL feature-hash embedder (384-dim hybrid lexical+vector, NOT neural) — start the server with `--embed-mode neural` (built-in Candle BERT), `--embed-mode proxy`, or an ONNX-enabled build with `--embed-mode onnx-experimental --onnx-model … --onnx-tokenizer …` for neural semantics; ONNX runs only when this map shows a semantic_field, and its first real inference is confirmed by the server activation log",
+    "match/multi_match/query_string on a semantic_text field is BM25 over its lexical index, NOT vector search — only {\"semantic\":{…}} uses the embeddings (or {\"hybrid\":{…}} for both); the response carries an `_xerj.hints` entry coded lexical_on_semantic_text when you hit this",
     "semantic queries ignore _source filtering and return the ~8KB *_vector field in _source — strip client-side",
     "exact filters use TOP-LEVEL keyword fields (term on .keyword subfields returns 0 hits on this engine)",
     "all dates are normalized to RFC3339 UTC millis; mappings use strict_date_optional_time||epoch_millis",

--- a/engine/crates/xerj-mcp/src/lib.rs
+++ b/engine/crates/xerj-mcp/src/lib.rs
@@ -384,7 +384,10 @@ pub fn tool_specs() -> Value {
                 "Full-text / keyword / structured search over a XERJ index using \
                  the Elasticsearch query DSL. Proxies POST /{index}/_search. \
                  Provide `query` as an ES query object (e.g. {\"match\":{\"body\":\"rust\"}}, \
-                 {\"term\":{\"status\":\"open\"}}, or a bool clause). Omit `query` for match_all.",
+                 {\"term\":{\"status\":\"open\"}}, or a bool clause). Omit `query` for match_all. \
+                 This is LEXICAL only: `match` on a `semantic_text` field runs BM25 over its \
+                 inverted index and never touches the embeddings — use xerj_semantic_search \
+                 for meaning-based retrieval, or a `hybrid` query for both.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -407,7 +410,9 @@ pub fn tool_specs() -> Value {
                 "Meaning-based search over a `semantic_text` field. The query text is \
                  embedded SERVER-SIDE by XERJ's built-in lexical embedder (no external \
                  API key), then matched by vector similarity. Proxies POST /{index}/_search \
-                 with {\"query\":{\"semantic\":{...}}}.",
+                 with {\"query\":{\"semantic\":{...}}}. This is the ONLY tool that uses a \
+                 semantic_text field's embeddings — xerj_search's `match` on the same field \
+                 silently returns BM25 results instead.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/landing/docs/agents/schemas/mcp-tools.json
+++ b/landing/docs/agents/schemas/mcp-tools.json
@@ -2,7 +2,7 @@
   "tools": [
     {
       "name": "xerj_search",
-      "description": "Full-text / keyword / structured search over a XERJ index using the Elasticsearch query DSL. Proxies POST /{index}/_search. Provide `query` as an ES query object (e.g. {\"match\":{\"body\":\"rust\"}}, {\"term\":{\"status\":\"open\"}}, or a bool clause). Omit `query` for match_all.",
+      "description": "Full-text / keyword / structured search over a XERJ index using the Elasticsearch query DSL. Proxies POST /{index}/_search. Provide `query` as an ES query object (e.g. {\"match\":{\"body\":\"rust\"}}, {\"term\":{\"status\":\"open\"}}, or a bool clause). Omit `query` for match_all. This is LEXICAL only: `match` on a `semantic_text` field runs BM25 over its inverted index and never touches the embeddings — use xerj_semantic_search for meaning-based retrieval, or a `hybrid` query for both.",
       "inputSchema": {
         "properties": {
           "_source": {
@@ -36,7 +36,7 @@
     },
     {
       "name": "xerj_semantic_search",
-      "description": "Meaning-based search over a `semantic_text` field. The query text is embedded SERVER-SIDE by XERJ's built-in lexical embedder (no external API key), then matched by vector similarity. Proxies POST /{index}/_search with {\"query\":{\"semantic\":{...}}}.",
+      "description": "Meaning-based search over a `semantic_text` field. The query text is embedded SERVER-SIDE by XERJ's built-in lexical embedder (no external API key), then matched by vector similarity. Proxies POST /{index}/_search with {\"query\":{\"semantic\":{...}}}. This is the ONLY tool that uses a semantic_text field's embeddings — xerj_search's `match` on the same field silently returns BM25 results instead.",
       "inputSchema": {
         "properties": {
           "field": {


### PR DESCRIPTION
Prepared by an agent (Claude Opus 5) driven by @xerj-org. **Opened early so CI runs while independent adversarial verification is still in progress — do not merge until that verification passes.**

Part of #363.

A `match` against a `semantic_text` field runs BM25 over that field's lexical
index and returns lexical hits. Only `{"semantic":{...}}` reaches the
embeddings. Nothing said so, which is what made #363 undebuggable from the
outside: the reported repro returns a result list byte-identical to the pure
BM25 index, right down to the ordering, after paying ~12x the indexing time
(1.7s -> 20.7s on the same 321 documents) to make the semantic answer
reachable at all.

Root cause: `semantic_text` maps to `FieldType::Text` plus an
`EmbeddingConfig` (es_compat.rs), so the inverted index is built for it
deliberately. The scoring path never consults `fc.embedding`; the engine's
only semantic dispatch is a whole-query short-circuit on
`QueryNode::SemanticSearch` (index.rs `peel_semantic_query`). A `match` on a
semantic_text field is therefore byte-identical to a `match` on plain text.

This does NOT rewrite `match` to the semantic query, which is what the issue
proposes. Three blockers, to be filed separately: the semantic dispatch is a
top-level short-circuit with no vector sub-executor inside `bool`, so a
rewrite would apply at top level only and silently NOT apply inside
`bool.must` — a strictly worse trap than today's; it breaks
`test_semantic_text_match_survives_flush` (integration.rs), a deliberate,
previously-blocking tested behaviour; and it is a silent result-changing wire
break during an rc. The lexical index on these fields is also what
`{"hybrid":{...}}` fuses.

Instead, the existing `_xerj.hints` channel carries a
`lexical_on_semantic_text` entry naming the field, what actually ran, and the
remedy. Engine behaviour is unchanged — no engine crate is touched.

Reference coding (adapted, not copied; Lucene is Apache-2.0, same as XERJ):
Lucene's uniform rule is that when a query's assumption about how a field was
indexed does not match reality, it says so and never silently answers a
different question. The message shape here — name the field, name what was
actually indexed, name the remedy — is taken from:
  lucene/core/src/java/org/apache/lucene/index/DocValues.java:206
    checkField: "unexpected docvalues type ACTUAL for field 'X'
    (expected=...). Re-index with correct docvalues type."
  lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java:53
    checkField: "Unexpected vector encoding (...) for field X (expected=...)"
  lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java:53

---
**Status:** fix pushed, adversarial verification in flight. A second agent is independently re-running the issue's repro against this branch, reverting only the source hunk to confirm the new test genuinely fails without it, and hunting for changed hit sets / changed `_score` / silent scan fallbacks / untrue claims. This PR should be merged only after that returns clean and all 16 checks are green.