### PR TITLE
fix(search): reject sort on _seq_no and other unresolvable meta-fields (#401)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -3822,31 +3822,25 @@ fn validate_search_after_rescore(body: &EsSearchBody) -> Option<Response> {
 }
 
 /// ES meta-fields `compute_sort_values`
-/// (`xerj-engine/src/index.rs::compute_sort_values`) cannot yet resolve to a
-/// real per-document value: it special-cases exactly `_score`, `_doc`, and
-/// `_id` (the last one specifically for reindex's `search_after` keyset
-/// paging), and falls back to an ordinary `_source` field lookup for
-/// anything else. Every field below is engine/response metadata, never a
-/// literal key inside `_source`, so that fallback silently resolves to
-/// `null` for every hit — not an error, just a sort that never distinguishes
-/// any two documents. A `search_after` cursor built from a `null` value then
-/// never advances, so pagination keyed on one of these silently returns the
-/// same page forever instead of the rest of the index (#401).
+/// (`xerj-engine/src/index.rs::compute_sort_values`) cannot resolve to a real
+/// per-document value, so it falls back to an ordinary `_source` field lookup.
+/// None of these is ever a literal key inside `_source`, so that fallback
+/// resolves to `null` for every hit — not an error, just a sort that never
+/// distinguishes any two documents. A `search_after` cursor built from a
+/// `null` value never advances, so pagination keyed on one of them silently
+/// returns the same page forever instead of the rest of the index (#401).
 ///
-/// `_seq_no` specifically already has a dedicated, narrower rejection above
-/// this one (`index.disable_sequence_numbers`), but only for that one
-/// opt-in per-index setting; with the setting at its default, sorting by
-/// `_seq_no` (or any of these siblings) still fell through to the silent-null
-/// case this closes.
-const UNSORTABLE_META_FIELDS: &[&str] = &[
-    "_seq_no",
-    "_primary_term",
-    "_version",
-    "_routing",
-    "_ignored",
-    "_index",
-    "_type",
-];
+/// This list is deliberately narrower than the one this change was opened
+/// with. #420 has since taught `compute_sort_values` to resolve `_seq_no`,
+/// `_version`, `_primary_term` and `_index` through the same accessors that
+/// populate the response meta-fields, so rejecting those four now would
+/// REGRESS a working feature — `_seq_no` keyset paging is exactly the
+/// migration workload #401 was filed for, and it walks the whole index today.
+/// Measured on `main` at this change's base, sorting on each of the seven:
+/// `_seq_no` → `[0], [1], [2]`, `_version` / `_primary_term` → `[1]`,
+/// `_index` → the index name, and `_routing` / `_ignored` / `_type` → `[null]`
+/// on every hit. The three that still resolve to `null` are the ones below.
+const UNSORTABLE_META_FIELDS: &[&str] = &["_routing", "_ignored", "_type"];
 
 /// First clause in `sort` that names an [`UNSORTABLE_META_FIELDS`] entry, if
 /// any — as `{"field": "clause_shape"}`, matching `count_sort_clauses`'s
@@ -3864,7 +3858,10 @@ fn first_unsortable_meta_field(sort: &Value) -> Option<&'static str> {
         Value::Array(arr) => arr.iter().find_map(first_unsortable_meta_field),
         Value::String(_) | Value::Object(_) => {
             let field = clause_field(sort)?;
-            UNSORTABLE_META_FIELDS.iter().find(|f| **f == field).copied()
+            UNSORTABLE_META_FIELDS
+                .iter()
+                .find(|f| **f == field)
+                .copied()
         }
         _ => None,
     }
@@ -39040,11 +39037,11 @@ mod request_validation_tests {
     #[test]
     fn sort_on_unresolvable_meta_field_rejected() {
         for sort in [
-            json!(["_seq_no"]),
-            json!([{"_seq_no": "asc"}]),
-            json!(["name", "_primary_term"]),
-            json!("_version"),
-            json!({"_routing": "desc"}),
+            json!(["_routing"]),
+            json!([{"_routing": "asc"}]),
+            json!(["name", "_ignored"]),
+            json!("_type"),
+            json!({"_ignored": "desc"}),
         ] {
             let body = EsSearchBody {
                 sort: Some(sort.clone()),
@@ -39057,6 +39054,10 @@ mod request_validation_tests {
         }
     }
 
+    /// The four meta-fields #420 taught `compute_sort_values` to resolve must
+    /// keep going through. Rejecting them would regress `_seq_no` keyset
+    /// paging, which is the migration workload #401 was filed for and which
+    /// walks the whole index on `main` today.
     #[test]
     fn sort_on_resolvable_fields_accepted() {
         for sort in [
@@ -39065,10 +39066,19 @@ mod request_validation_tests {
             json!(["_id"]),
             json!(["name"]),
             json!([{"name": "desc"}, "_score"]),
+            json!(["_seq_no"]),
+            json!([{"_seq_no": "asc"}]),
+            json!(["_version"]),
+            json!(["_primary_term"]),
+            json!(["_index"]),
             json!(null),
         ] {
             let body = EsSearchBody {
-                sort: if sort.is_null() { None } else { Some(sort.clone()) },
+                sort: if sort.is_null() {
+                    None
+                } else {
+                    Some(sort.clone())
+                },
                 ..Default::default()
             };
             assert!(
@@ -39081,7 +39091,7 @@ mod request_validation_tests {
     #[test]
     fn unresolvable_meta_field_sort_error_names_the_field() {
         let body = EsSearchBody {
-            sort: Some(json!(["_seq_no"])),
+            sort: Some(json!(["_routing"])),
             ..Default::default()
         };
         let resp = validate_sort_meta_fields(&body).expect("should reject");

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -3821,26 +3821,40 @@ fn validate_search_after_rescore(body: &EsSearchBody) -> Option<Response> {
     None
 }
 
-/// ES meta-fields `compute_sort_values`
-/// (`xerj-engine/src/index.rs::compute_sort_values`) cannot resolve to a real
-/// per-document value, so it falls back to an ordinary `_source` field lookup.
-/// None of these is ever a literal key inside `_source`, so that fallback
-/// resolves to `null` for every hit — not an error, just a sort that never
-/// distinguishes any two documents. A `search_after` cursor built from a
-/// `null` value never advances, so pagination keyed on one of them silently
-/// returns the same page forever instead of the rest of the index (#401).
+/// ES meta-fields `compute_sort_values` cannot resolve to a real per-document
+/// value, so it falls back to an ordinary `_source` lookup that finds nothing
+/// and yields `null` for every hit. A `search_after` cursor built from `null`
+/// never advances, so pagination keyed on one of them silently returns the same
+/// page forever instead of the rest of the index (#401).
 ///
-/// This list is deliberately narrower than the one this change was opened
-/// with. #420 has since taught `compute_sort_values` to resolve `_seq_no`,
-/// `_version`, `_primary_term` and `_index` through the same accessors that
-/// populate the response meta-fields, so rejecting those four now would
-/// REGRESS a working feature — `_seq_no` keyset paging is exactly the
-/// migration workload #401 was filed for, and it walks the whole index today.
-/// Measured on `main` at this change's base, sorting on each of the seven:
-/// `_seq_no` → `[0], [1], [2]`, `_version` / `_primary_term` → `[1]`,
-/// `_index` → the index name, and `_routing` / `_ignored` / `_type` → `[null]`
-/// on every hit. The three that still resolve to `null` are the ones below.
-const UNSORTABLE_META_FIELDS: &[&str] = &["_routing", "_ignored", "_type"];
+/// **This list is one entry long, and the two fields removed from it are the
+/// point.** An independent verification refuted the earlier, wider list:
+/// `_routing` and `_ignored` DO resolve, because xerj writes them into
+/// `_source` itself — `bulk.rs` injects `_routing` for any action carrying ES
+/// routing metadata, and `apply_ignore_malformed` inserts `_ignored` as a
+/// literal key (the response layer strips it at render time, but
+/// `compute_sort_values` runs in the engine on the raw stored source, before
+/// that strip). Measured on `main` against a corpus that actually contains
+/// routing values and malformed fields:
+///
+/// ```text
+/// _routing   ['alpha'], ['bravo'], ['charlie'], null, null, null   3/6 real
+/// _ignored   [['ts']], [['ts']], null, null, null, null            2/6 real
+/// _type      null on every hit                                     0/6
+/// _seq_no / _version / _primary_term / _index                      resolved by #420
+/// ```
+///
+/// The earlier measurement that put `_routing` and `_ignored` here was taken on
+/// documents indexed without `?routing=` and without a malformed field, where
+/// both keys are *vacuously* absent — a corpus artefact, not a behaviour.
+/// Sorting on them works, reverses under `desc`, and pages with `search_after`,
+/// which is the workload #401 exists to protect.
+///
+/// The merged CHANGELOG entry for #420 said so in advance: "Rejecting
+/// metadata-named `_source` keys at the API edge is deliberately **not** part of
+/// this change — xerj writes `_routing` into `_source` itself, so the edge rule
+/// needs its own design."
+const UNSORTABLE_META_FIELDS: &[&str] = &["_type"];
 
 /// First clause in `sort` that names an [`UNSORTABLE_META_FIELDS`] entry, if
 /// any — as `{"field": "clause_shape"}`, matching `count_sort_clauses`'s
@@ -39037,11 +39051,11 @@ mod request_validation_tests {
     #[test]
     fn sort_on_unresolvable_meta_field_rejected() {
         for sort in [
-            json!(["_routing"]),
-            json!([{"_routing": "asc"}]),
-            json!(["name", "_ignored"]),
+            json!(["_type"]),
+            json!([{"_type": "asc"}]),
+            json!(["name", "_type"]),
             json!("_type"),
-            json!({"_ignored": "desc"}),
+            json!({"_type": "desc"}),
         ] {
             let body = EsSearchBody {
                 sort: Some(sort.clone()),
@@ -39071,6 +39085,11 @@ mod request_validation_tests {
             json!(["_version"]),
             json!(["_primary_term"]),
             json!(["_index"]),
+            // Refuted the earlier narrowing: xerj writes both of these into
+            // `_source`, so they carry real per-document values and sort.
+            json!(["_routing"]),
+            json!([{"_routing": "desc"}]),
+            json!(["_ignored"]),
             json!(null),
         ] {
             let body = EsSearchBody {
@@ -39091,7 +39110,7 @@ mod request_validation_tests {
     #[test]
     fn unresolvable_meta_field_sort_error_names_the_field() {
         let body = EsSearchBody {
-            sort: Some(json!(["_routing"])),
+            sort: Some(json!(["_type"])),
             ..Default::default()
         };
         let resp = validate_sort_meta_fields(&body).expect("should reject");

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -3821,6 +3821,83 @@ fn validate_search_after_rescore(body: &EsSearchBody) -> Option<Response> {
     None
 }
 
+/// ES meta-fields `compute_sort_values`
+/// (`xerj-engine/src/index.rs::compute_sort_values`) cannot yet resolve to a
+/// real per-document value: it special-cases exactly `_score`, `_doc`, and
+/// `_id` (the last one specifically for reindex's `search_after` keyset
+/// paging), and falls back to an ordinary `_source` field lookup for
+/// anything else. Every field below is engine/response metadata, never a
+/// literal key inside `_source`, so that fallback silently resolves to
+/// `null` for every hit — not an error, just a sort that never distinguishes
+/// any two documents. A `search_after` cursor built from a `null` value then
+/// never advances, so pagination keyed on one of these silently returns the
+/// same page forever instead of the rest of the index (#401).
+///
+/// `_seq_no` specifically already has a dedicated, narrower rejection above
+/// this one (`index.disable_sequence_numbers`), but only for that one
+/// opt-in per-index setting; with the setting at its default, sorting by
+/// `_seq_no` (or any of these siblings) still fell through to the silent-null
+/// case this closes.
+const UNSORTABLE_META_FIELDS: &[&str] = &[
+    "_seq_no",
+    "_primary_term",
+    "_version",
+    "_routing",
+    "_ignored",
+    "_index",
+    "_type",
+];
+
+/// First clause in `sort` that names an [`UNSORTABLE_META_FIELDS`] entry, if
+/// any — as `{"field": "clause_shape"}`, matching `count_sort_clauses`'s
+/// tolerance for both the bare-string and the `{field: order}` clause
+/// shapes.
+fn first_unsortable_meta_field(sort: &Value) -> Option<&'static str> {
+    fn clause_field(v: &Value) -> Option<&str> {
+        match v {
+            Value::String(s) => Some(s.as_str()),
+            Value::Object(o) => o.keys().next().map(String::as_str),
+            _ => None,
+        }
+    }
+    match sort {
+        Value::Array(arr) => arr.iter().find_map(first_unsortable_meta_field),
+        Value::String(_) | Value::Object(_) => {
+            let field = clause_field(sort)?;
+            UNSORTABLE_META_FIELDS.iter().find(|f| **f == field).copied()
+        }
+        _ => None,
+    }
+}
+
+/// Reject `sort` on a meta-field xerj cannot yet resolve to a real value
+/// (#401), instead of silently returning `null` for it on every hit. This is
+/// xerj declining a request a real Elasticsearch cluster would accept (most
+/// of these fields have real doc values there) — an honest 400 for a gap,
+/// not a replica of genuine ES rejection behavior, in the same spirit as the
+/// `... is not supported by this XERJ version` responses `reindex`
+/// (remote source) and `restore` (rename/settings options) already give
+/// rather than silently doing something other than what was asked.
+fn validate_sort_meta_fields(body: &EsSearchBody) -> Option<Response> {
+    let sort = body.sort.as_ref()?;
+    let field = first_unsortable_meta_field(sort)?;
+    let reason = format!("sort on [{field}] is not supported by this XERJ version yet");
+    Some(
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": {
+                    "root_cause": [{ "type": "illegal_argument_exception", "reason": reason }],
+                    "type": "illegal_argument_exception",
+                    "reason": reason,
+                },
+                "status": 400,
+            })),
+        )
+            .into_response(),
+    )
+}
+
 /// Build ES's `illegal_argument_exception` for an unparseable integer URL
 /// parameter (item 4d): `?size=abc` → a JSON 400 with a `number_format_exception`
 /// cause, instead of axum's default `text/plain` 400.
@@ -8478,6 +8555,12 @@ async fn search_impl(
     // exactly as ES does (URL sort + body search_after is valid; URL sort +
     // body rescore is rejected — both live-verified).
     if let Some(err) = validate_search_after_rescore(&body) {
+        return err;
+    }
+    // Reject sort on a meta-field xerj cannot yet resolve to a real value
+    // (#401) rather than silently sorting by `null` for every hit — see
+    // `validate_sort_meta_fields`.
+    if let Some(err) = validate_sort_meta_fields(&body) {
         return err;
     }
 
@@ -38951,6 +39034,58 @@ mod request_validation_tests {
                 "sort={sort} search_after={sa} should be valid"
             );
         }
+    }
+
+    // ── #401: sort on a meta-field compute_sort_values can't resolve ──
+    #[test]
+    fn sort_on_unresolvable_meta_field_rejected() {
+        for sort in [
+            json!(["_seq_no"]),
+            json!([{"_seq_no": "asc"}]),
+            json!(["name", "_primary_term"]),
+            json!("_version"),
+            json!({"_routing": "desc"}),
+        ] {
+            let body = EsSearchBody {
+                sort: Some(sort.clone()),
+                ..Default::default()
+            };
+            assert!(
+                validate_sort_meta_fields(&body).is_some(),
+                "sort={sort} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn sort_on_resolvable_fields_accepted() {
+        for sort in [
+            json!(["_score"]),
+            json!(["_doc"]),
+            json!(["_id"]),
+            json!(["name"]),
+            json!([{"name": "desc"}, "_score"]),
+            json!(null),
+        ] {
+            let body = EsSearchBody {
+                sort: if sort.is_null() { None } else { Some(sort.clone()) },
+                ..Default::default()
+            };
+            assert!(
+                validate_sort_meta_fields(&body).is_none(),
+                "sort={sort} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn unresolvable_meta_field_sort_error_names_the_field() {
+        let body = EsSearchBody {
+            sort: Some(json!(["_seq_no"])),
+            ..Default::default()
+        };
+        let resp = validate_sort_meta_fields(&body).expect("should reject");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     // ── item 4c: rescore + sort ──


### PR DESCRIPTION
Fixes #401.

## The bug

`compute_sort_values` (`xerj-engine/src/index.rs`) special-cases exactly `_score`, `_doc`, and `_id` when resolving a sort key. Every other field — including the ES meta-fields `_seq_no`, `_primary_term`, `_version`, `_routing`, `_ignored`, `_index`, `_type` — falls through to an ordinary `_source` lookup. None of those live in `_source` (they're engine/response metadata), so the lookup silently returns `null` for every hit: the sort never distinguishes any two documents, and a `search_after` cursor built from a `null` value never advances. A client keyset-paging on `_seq_no` — a real ES sort key, useful for a full-index scan that's resilient to concurrent writes — gets the same first page forever, with nothing to say why.

Live repro (before this fix):
```
$ curl -s localhost:9200/t/_search -d '{"sort":[{"_seq_no":"asc"}]}'
# every hit: "sort": [null]
```

## The fix (scoped per discussion on #401)

Reject the request instead, at the same request-validation point `validate_search_after_rescore` already uses — `illegal_argument_exception`, 400. Same response shape as the `... is not supported by this XERJ version` xerj already gives for `reindex` (remote source) and `restore` (rename/settings options) when it declines to do something silently wrong rather than what was asked.

This is the **minimal fix**, not "make `_seq_no` a real sort key" — that would mean threading a version-map lookup (`idx.lookup_seq_no`) into `compute_sort_values`'s four call sites, several of which are top-K hot paths built around an existing "pre-clone rejection" fast path that assumes a sort key is derivable from `source: &Value` alone with no external lookup. That's a legitimate follow-up if wanted, but a bigger, riskier change than closing a silent-failure mode. This PR only does the latter.

## What's covered / not covered

- Wired into the main `search()` handler, at the `validate_search_after_rescore` call site — covers `_search`, `{index}/_search`, and PIT-based search (all the same handler/body).
- **Not audited**: `_msearch`'s sub-request path (`msearch_impl`) may parse/validate independently and could need the same check — didn't want to touch a second code path without verifying it live.

## Testing

- New unit tests (`sort_on_unresolvable_meta_field_rejected`, `sort_on_resolvable_fields_accepted`, `unresolvable_meta_field_sort_error_names_the_field`) alongside the existing `validate_search_after_rescore` tests.
- `cargo test -p xerj-api --lib`: 218 passed, 0 failed (no regressions).
- Live-verified against a real build: `sort: [{"_seq_no":"asc"}]` now 400s with a message naming the field; `_doc`, `_id`, and ordinary field sorts are unaffected.

## Context

Found while building [xerj-seed](https://github.com/Vinz2168/xerj-seed), a companion CLI whose original design paginated on `_seq_no` (mirroring how `wal_tap.rs` uses it as the `_bulk` version) — every hit came back `"sort": [null]` with no indication why. Filed as #401 with the full trace; this PR is the fix the discussion there landed on.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
