### PR TITLE
DO NOT MERGE (verification rejected, 3 items) — fix(autoindex): scope the catalog canonical/alias barrier to its own run (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already indexed a byte-identical file** — the second of the three aborts
   [#360](https://github.com/xerj-org/xerj/issues/360) reports, and the one that
   killed the reporter's second corpus. A file's identity is derived from its
-  CONTENT alone (`ids::file_key`) and the catalog is one global index
+  CONTENT alone (`content::full_digest`) and the catalog is one global index
   (`autoindex-catalog`) that no `--prefix` namespaces, so two unrelated
   checkouts sharing one file — an Apache-2.0 `LICENSE` is the everyday case —
   share that file's catalog document IDs. A corpus holding the content five
   times publishes a canonical document plus four alias documents; a corpus
   holding it once republishes only the canonical, and the other corpus's four
-  alias documents survive under their own `run_id`. The generation-wide barrier
+  alias documents survive under their own `run_id`. Be clear about what that
+  does *not* mean: the shared file's canonical catalog document
+  (`file:<content_id>`) belongs to whichever run published it last, so after the
+  second corpus runs, the first corpus's alias documents point at a
+  `duplicate_of` whose canonical entry is now the other corpus's. That is
+  pre-existing — the binary before this change overwrites it too, then aborts —
+  and this change removes the false abort without repairing it. The catalog
+  identity collision itself is tracked in
+  [#416](https://github.com/xerj-org/xerj/issues/416). The generation-wide barrier
   counted every catalog document carrying the group's `file_key` — across every
   run on the node — against `1 + aliases.len()` for the group in front of it, so
   the second run exited `1` with `catalog canonical/alias count disagrees with
@@ -81,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documents carry `"time_field": null`, `"time_min": null`, `"time_max": null`
   and `"semantic_field": null`. The exact read-back is the tripwire that caught
   the engine rewriting a document, so it is deliberately left armed rather than
-  taught to ignore the difference.
+  taught to ignore the difference. Tracked as
+  [#415](https://github.com/xerj-org/xerj/issues/415).
 
 - **A lexical query on a `semantic_text` field now says so** (#363). `match`,
   `match_phrase`, `multi_match` and `query_string` against a `semantic_text`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   equality rather than failing it — the state directory left behind by the
   aborted repro run resumes and commits on the fixed binary.
 
+- **`xerj autoindex` aborted a run because *another* corpus on the same node had
+  already indexed a byte-identical file** — the second of the three aborts
+  [#360](https://github.com/xerj-org/xerj/issues/360) reports, and the one that
+  killed the reporter's second corpus. A file's identity is derived from its
+  CONTENT alone (`ids::file_key`) and the catalog is one global index
+  (`autoindex-catalog`) that no `--prefix` namespaces, so two unrelated
+  checkouts sharing one file — an Apache-2.0 `LICENSE` is the everyday case —
+  share that file's catalog document IDs. A corpus holding the content five
+  times publishes a canonical document plus four alias documents; a corpus
+  holding it once republishes only the canonical, and the other corpus's four
+  alias documents survive under their own `run_id`. The generation-wide barrier
+  counted every catalog document carrying the group's `file_key` — across every
+  run on the node — against `1 + aliases.len()` for the group in front of it, so
+  the second run exited `1` with `catalog canonical/alias count disagrees with
+  desired group axg1-…` on a corpus whose data was complete. The count is now
+  scoped to this generation's `run_id`, the same way the run-summary read-back
+  already is, so the barrier asks what it exists to ask: did *this* generation
+  publish one canonical document and its aliases.
+
+  Measured on the reporter's own corpora, one node, release binary,
+  `aarch64-unknown-linux-gnu`. `apache/lucene` and `unum-cloud/usearch` share
+  exactly one indexable content identity — the 11,357-byte Apache-2.0 `LICENSE`,
+  present 5× in lucene and 1× in usearch. Indexing lucene and then usearch on
+  one node, each with its own `--prefix` and `--state-dir`: **before**, usearch
+  exited `1` after 41.5s with `catalog canonical/alias count disagrees with
+  desired group axg1-f5c714bcb8c945dd3687e83218352c66`. **After**, the same
+  usearch run prints `generation 1 committed — 4 datasets, 308 records live` and
+  exits `3` (junk recorded, never fatal — `cli.rs` EXIT CODES) in 30.2s, and the
+  43 alias documents lucene published are still in the catalog: the barrier
+  stopped counting them, it does not delete them.
+
+  This does **not** close #360. The third abort the issue reports — `catalog
+  read-back for ds:… disagrees with the sealed generation projection`, which
+  ended the full `apache/lucene` run after 1,073s before this change and 663s
+  after it — reproduces on this branch and is not an autoindex defect:
+  `POST /_bulk` drops explicit `null` fields from `_source` once the request is
+  large enough (measured directly with `curl` against this binary: 1,500
+  documents / 129,786 B keeps them, 4,000 documents / 349,786 B loses them,
+  2,000 documents is where it starts to be mixed), and autoindex's dataset
+  documents carry `"time_field": null`, `"time_min": null`, `"time_max": null`
+  and `"semantic_field": null`. The exact read-back is the tripwire that caught
+  the engine rewriting a document, so it is deliberately left armed rather than
+  taught to ignore the difference.
+
 - **A lexical query on a `semantic_text` field now says so** (#363). `match`,
   `match_phrase`, `multi_match` and `query_string` against a `semantic_text`
   field score with BM25 over the analysed text and never consult the embedding

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -1477,7 +1477,7 @@ fn a_readme_documenting_two_tables_is_not_a_fatal_condition() {
 /// The second abort #360 reported — the one that killed both of the corpora
 /// the reporter pointed autoindex at, on one node, one after the other.
 ///
-/// `ids::file_key` derives a file's identity from its CONTENT alone, and
+/// `content::full_digest` derives a file's identity from its CONTENT alone, and
 /// `catalog::CATALOG_INDEX` is a single global index that no `--prefix`
 /// namespaces. Two unrelated checkouts that happen to share one byte-identical
 /// file — an Apache-2.0 `LICENSE`, a `.gitignore`, an empty `__init__.py` —

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -1474,6 +1474,83 @@ fn a_readme_documenting_two_tables_is_not_a_fatal_condition() {
     );
 }
 
+/// The second abort #360 reported — the one that killed both of the corpora
+/// the reporter pointed autoindex at, on one node, one after the other.
+///
+/// `ids::file_key` derives a file's identity from its CONTENT alone, and
+/// `catalog::CATALOG_INDEX` is a single global index that no `--prefix`
+/// namespaces. Two unrelated checkouts that happen to share one byte-identical
+/// file — an Apache-2.0 `LICENSE`, a `.gitignore`, an empty `__init__.py` —
+/// therefore share that file's catalog document IDs. A corpus holding the
+/// content twice publishes a canonical document plus one alias document; a
+/// corpus holding it once republishes only the canonical, so the *other*
+/// corpus's alias document survives under its own `run_id`. The generation-wide
+/// barrier counted every catalog document carrying that `file_key`, across every
+/// run on the node, against `1 + aliases.len()` for the group in front of it —
+/// so the second run aborted with `exit=1` while its data was complete.
+#[test]
+fn a_file_shared_with_another_corpus_on_the_same_node_is_not_a_fatal_condition() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let shared = "id,value\n1,apache-2.0\n2,copied-verbatim\n";
+    let first = tempfile::tempdir().unwrap();
+    let first_state = tempfile::tempdir().unwrap();
+    fs::create_dir(first.path().join("docs")).unwrap();
+    fs::write(first.path().join("LICENSE.csv"), shared).unwrap();
+    fs::write(first.path().join("docs").join("LICENSE.csv"), shared).unwrap();
+    let endpoint = HttpEndpoint::start();
+
+    let (code, summary) =
+        run_index_report(cfg(first.path(), first_state.path(), &endpoint.url, false))
+            .expect("the first corpus indexes");
+    let summary = summary.expect("the first corpus commits its generation");
+    assert_eq!(code, 0);
+    assert_eq!(
+        summary["duplicate_files"], 1,
+        "the first corpus must publish one alias document, or nothing is left \
+         behind for the second run to trip over: {summary}"
+    );
+
+    // A second, unrelated corpus on the same node, isolated exactly the way the
+    // CLI's refusals recommend: its own --state-dir and its own --prefix. Its
+    // one shared file is a group with no aliases at all.
+    let second = tempfile::tempdir().unwrap();
+    let second_state = tempfile::tempdir().unwrap();
+    fs::write(second.path().join("LICENSE.csv"), shared).unwrap();
+    fs::write(second.path().join("own.csv"), "id,value\n7,second\n").unwrap();
+    let mut config = cfg(second.path(), second_state.path(), &endpoint.url, false);
+    config.prefix = "incremental-http-second".into();
+
+    let (code, summary) = run_index_report(config)
+        .expect("a file shared with another corpus on the same node is not a fatal condition");
+    let summary = summary.expect("the second corpus commits its generation");
+    assert_eq!(code, 0, "the second corpus is a clean run: {summary}");
+    assert_eq!(summary["generation"], 1);
+    assert_eq!(summary["records_total"], 3);
+    assert_eq!(summary["duplicate_files"], 0);
+    assert_eq!(journal_events(second_state.path(), "sync_commit"), 1);
+
+    // And the first corpus's alias document is still there — the barrier stopped
+    // counting it, it was not swept away from under the other corpus's map.
+    let aliases = endpoint
+        .state
+        .lock()
+        .unwrap()
+        .docs
+        .iter()
+        .filter(|((index, _), doc)| {
+            index == catalog::CATALOG_INDEX
+                && doc.get("status").and_then(Value::as_str) == Some("duplicate")
+        })
+        .count();
+    assert_eq!(
+        aliases, 1,
+        "the other corpus's alias document must survive this run untouched"
+    );
+}
+
 /// Where this branch and #241 meet.
 ///
 /// The generated `--no-graph` route returns from inside `run_index_report`,

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -646,7 +646,7 @@ impl SyncOperationBackend for EsSyncBackend<'_> {
         &mut self,
         base: &CommittedManifest,
         desired: &GenerationManifest,
-        _snapshot: &SourceSnapshot,
+        snapshot: &SourceSnapshot,
     ) -> Result<()> {
         for dataset in &desired.plan.datasets {
             self.es.refresh(&dataset.index)?;
@@ -664,12 +664,26 @@ impl SyncOperationBackend for EsSyncBackend<'_> {
                 "live semantic count disagrees with desired group {}",
                 group.group_id
             );
+            // Scoped to this generation's `run_id`, the same way the run-summary
+            // read-back is (`lib.rs`). `file_key` is derived from CONTENT alone
+            // (`ids::file_key`) and the catalog is one global index that no
+            // `--prefix` namespaces, so an unscoped count also sees the
+            // canonical and alias documents that ANOTHER corpus on this node
+            // published for byte-identical content — two Apache-2.0 checkouts
+            // sharing a LICENSE is enough. Those documents are that run's, not
+            // this one's: counting them aborted a generation whose own
+            // publication was exactly right (#360). What this barrier is for is
+            // "this generation published one canonical document and its aliases",
+            // and that is what it now asks.
             let catalog = self.es.search(
                 crate::catalog::CATALOG_INDEX,
                 &serde_json::json!({
                     "size": 0,
                     "track_total_hits": true,
-                    "query": {"term": {"file_key": &group.content_id}}
+                    "query": {"bool": {"filter": [
+                        {"term": {"file_key": &group.content_id}},
+                        {"term": {"run_id": &snapshot.tx_id}}
+                    ]}}
                 }),
             )?;
             anyhow::ensure!(

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -666,7 +666,7 @@ impl SyncOperationBackend for EsSyncBackend<'_> {
             );
             // Scoped to this generation's `run_id`, the same way the run-summary
             // read-back is (`lib.rs`). `file_key` is derived from CONTENT alone
-            // (`ids::file_key`) and the catalog is one global index that no
+            // (`content::full_digest`) and the catalog is one global index that no
             // `--prefix` namespaces, so an unscoped count also sees the
             // canonical and alias documents that ANOTHER corpus on this node
             // published for byte-identical content — two Apache-2.0 checkouts


### PR DESCRIPTION
> **DO NOT MERGE — adversarial verification rejected this: 3 items**
>
> An adversarial verification round ran against this branch and returned
> `sound=false`. The defect fix itself was not disputed — the three items below are
> about claims the branch makes in prose (a citation that does not resolve to what it
> claims, a claim that understates the blast radius) and about follow-ups it names but
> never filed. This repo gates on exactly those. They are reproduced **verbatim** below
> and none of them has been addressed on this branch: the commit here is byte-identical
> to the one verification examined.

## Outstanding must-fix (verbatim from the verification report)

**1. Wrong symbol cited for the catalog file identity, in four places.** The catalog's `file_key` field holds `group.content_id`, which is `content::full_digest` (engine/crates/xerj-autoindex/src/content.rs:168-181) = `axf2-{xxh3_128 of the WHOLE file}-{size:x}`. It is NOT `ids::file_key` (engine/crates/xerj-autoindex/src/ids.rs:14-25), which is `{xxh3_64 of the first 64KB}-{size:x}` and is used only as a LEGACY key (lib.rs:1468, lib.rs:2233 `legacy_key`, lib.rs:6828). I confirmed against a real catalog document produced by the branch binary: `"file_key": "axf2-340d4d122cb1451a3b58353e45ac3f19-28"`. The wrong claim appears in CHANGELOG.md ("A file's identity is derived from its CONTENT alone (`ids::file_key`)"), in the commit body ("`ids::file_key` = xxh3 of the first 64 KB ‖ size"), in the new source comment at engine/crates/xerj-autoindex/src/sync_executor.rs:668-669, and in the test doc comment at engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs:1480. The fix's conclusion is unaffected (full_digest is content-only too, and I re-derived the reporter's exact group id from it), but a citation that does not resolve to what it claims is exactly what this repo gates on. Replace with `content::full_digest`, content.rs:168-181, and correct the description to whole-file xxh3_128 + size.

**2. Understated claim about what survives another corpus's run.** The commit says "Nothing is deleted — the other corpus's documents stay where they are" and CHANGELOG.md says only that the 43 alias documents survive. Verified on a real node with the branch binary: after the second corpus runs, the SHARED file's canonical document `file:<content_id>` carries the SECOND run's `run_id` — it is overwritten, and the first corpus's alias document now points at a `duplicate_of` whose canonical entry belongs to the other corpus. (I also verified the PRE-fix binary already overwrites it before aborting, so this is not caused by the change — but the wording invites a reader to conclude the other corpus is untouched, and it is not.) Say plainly that the shared file's canonical catalog document belongs to whichever run published it last, and that this change removes the false abort without repairing that.

**3. No follow-up issue exists for either defect this branch surfaces but does not fix.** (a) The engine `_source` null-drop that CHANGELOG.md now publicly describes as an unfixed data-fidelity bug affecting every client — I reproduced it independently on a binary I built from this branch (500/1000/1500 docs keep the four null keys, 2000 mixed at 5 kept / 2 lost, 4000 and 6000 lose all four), so the claim is true, which is precisely why it needs a tracking number the CHANGELOG can link. (b) The cross-corpus catalog identity collision (`file:<content_id>` and `ds:<slug>` are global, no `--prefix` namespaces `autoindex-catalog`) that this change converts from a loud abort into silence. File both and link (a) from the CHANGELOG entry before this ships.

### Where item 1 lands, for whoever picks this up

Line-exact locations of the four occurrences, all confirmed by reading this branch:

| file | what to correct |
|---|---|
| `CHANGELOG.md` | "A file's identity is derived from its CONTENT alone (`ids::file_key`)" |
| commit `79e4b1a` message body | "`ids::file_key` = xxh3 of the first 64 KB ‖ size" |
| `engine/crates/xerj-autoindex/src/sync_executor.rs:668-669` | "`file_key` is derived from CONTENT alone (`ids::file_key`)" |
| `engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs:1480` | "`ids::file_key` derives a file's identity from its CONTENT alone" |

Note that fixing the commit-message occurrence means rewriting `79e4b1a`, i.e. a
force-push, which will invalidate any CI run already attached to this branch.

---

## What this PR is

An agent (Claude Opus 5) wrote this branch, and a second agent (Claude Opus 5, this
session) opened this PR. Neither agent merged anything, and this PR must not be merged
in its current state.

**Part of #360.** It does not close it.

#360 reports three aborts of `xerj autoindex`. This branch is one of the three:

| # | abort | status |
|---|---|---|
| 1 | `dataset … exact read-back count N disagrees with sealed count M` (one file declaring 2+ SQL tables) | already fixed on `main` — 11ab6ad, PR #390 |
| 2 | `catalog canonical/alias count disagrees with desired group axg1-…` | **fixed here** |
| 3 | `catalog read-back for ds:… disagrees with the sealed generation projection` | **still open**, root-caused to the engine, not autoindex — see below |

### The change (abort 2)

`EsSyncBackend::validate` counted every `autoindex-catalog` document carrying a group's
`file_key` across the whole index — every run ever made on that node — and compared the
total against `1 + aliases.len()` for the group in front of it. `autoindex-catalog` is a
single global index that no `--prefix` namespaces, and the catalog document `_id` is
`file:{file_key}` (`catalog.rs:173-175`) where `file_key` is derived from file content
alone. Two unrelated checkouts sharing one byte-identical file therefore share that
file's catalog document IDs, and the second corpus to run aborted with `exit=1` on data
that was complete.

The count is now scoped to this generation's `run_id`, the idiom the run-summary
read-back in `lib.rs` already uses, so the barrier asks what it exists to ask: did *this*
generation publish one canonical document and its aliases.

Two hunks in `sync_executor.rs::validate` (`_snapshot` → `snapshot`; the query becomes a
`bool.filter` of `file_key` + `run_id`), one e2e regression test, one CHANGELOG entry.

### Deliberately out of scope

- **Abort 3.** Root-caused to `POST /_bulk` dropping explicit `null` fields from
  `_source` once the request is large enough — an ES-compat data-fidelity defect in
  xerj-api/xerj-engine that affects every client, not an autoindex defect. The cheap fix
  available from inside autoindex (stop emitting nulls, or relax the read-back) would
  silence the exact tripwire that caught the engine rewriting a document — the
  "fix that reintroduces the class it fixes" trap. It was not taken. See must-fix 3(a):
  this needs its own issue, its own repro suite and its own adversarial round, and no
  issue number exists yet.
- **Namespacing `autoindex-catalog` per `--prefix`/root.** The deeper problem remains:
  two corpora on one node still overwrite each other's `file:<content_id>` and
  `ds:<slug>` documents, so a shared file's map entry belongs to whichever run published
  it last. That is a catalog-identity redesign (#345 territory), not a one-round change.
  This commit does not claim to fix it — it stops the false abort and leaves the other
  run's documents in place. See must-fix 2 and 3(b).

---

## Verified

Split into what I ran in this session and what the implementing agent reported. Nothing
below is a number I invented; where I did not run the command myself I say so and name
who did.

### Verified by me, this session (commands run, output seen)

- `git merge-base --is-ancestor origin/main origin/fix/issue-360` succeeds and
  `git log --oneline origin/main..origin/fix/issue-360` prints exactly one commit,
  `79e4b1a`, on top of `origin/main` = `714616d`. **Step 1 of my instructions (merge
  `origin/main` into the branch) was therefore a no-op — there was no CHANGELOG conflict
  to resolve, and I did not push anything.**
- `git log -1 --format` on `79e4b1a`: author and committer are both
  `xerj-org <git@xerj.org>`; no `Co-Authored-By` trailer anywhere in the message.
- `git show --stat 79e4b1a`: 3 files changed, 137 insertions(+), 2 deletions(-) —
  `CHANGELOG.md`, `engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs`,
  `engine/crates/xerj-autoindex/src/sync_executor.rs`. No engine crate is touched.
- The CHANGELOG entry is under `## [Unreleased]` (line 8 of the file on this branch), not
  under a released heading.
- **Must-fix 1 confirmed by source reading**, independently of the verifier: production
  `file_key` values reaching the catalog come from `inventory.keys`, which is
  `resolved_keys` in `content.rs:87-142`, which is `digests.clone()` — the
  `content::full_digest` values formatted `axf2-{:032x}-{size:x}` at
  `content.rs:168-181`. `ids::file_key` (`ids.rs:13-25`, `xxh3_64` of the first 64 KB)
  appears in `lib.rs` only at 1468 and 6828 (both inside test helpers) and at 2233 as
  `legacy_key`. The cited symbol is the wrong one.
- **Must-fix 2 confirmed by source reading**: `catalog::file_id` is
  `format!("file:{file_key}")` (`catalog.rs:173-175`) — no run, no prefix — so a second
  corpus publishing the same content overwrites the first corpus's canonical document
  by `_id`. Nothing in the change or in the new test prevents that.
- **Must-fix 3 confirmed**: `gh issue list --repo xerj-org/xerj --state all` searched for
  both follow-ups returns no matching issue. There is no number for the CHANGELOG to
  link.
- The new test drives `run_index_report` end-to-end against a real `HttpEndpoint` twice
  (two corpora, separate `--state-dir` and `--prefix`), asserts `code == 0`,
  `records_total == 3`, `duplicate_files == 0` and `sync_commit == 1` on the second run,
  and then asserts the first corpus's alias document is still in the catalog. It calls
  the code it certifies and contains no `.iter().all(...)` over a possibly-empty
  collection.

### Verified by the implementing agent (reported in commit `79e4b1a`; I did NOT re-run any of it)

Reproduced first, on the reporter's own corpora, one node, release binary built with
default features, `aarch64-unknown-linux-gnu`, from `714616d`:

- **before** — `xerj autoindex /home/claude/ref/lucene --prefix lu --no-semantic
  --no-graph` → `catalog read-back for ds:dev-tools-aws-jmh disagrees with the sealed
  generation projection`, `wall=1073.51s`, exit 1; then
  `xerj autoindex /home/claude/ref/usearch --prefix us …` → `catalog canonical/alias
  count disagrees with desired group axg1-f5c714bcb8c945dd3687e83218352c66`,
  `wall=41.45s`, exit 1. The group id is the reporter's, in full — #360 quotes
  `axg1-f5c714bc…`.
- The two checkouts share exactly one indexable content identity: the 11,357-byte
  Apache-2.0 `LICENSE`, 5 copies in lucene, 1 in usearch.
- **after** — the same usearch run prints `generation 1 committed — 4 datasets, 308
  records live`, `wall=30.17s`, exit 3 (junk recorded, never fatal — `cli.rs` EXIT
  CODES), and lucene's 43 duplicate-status catalog documents are still present.
- Regression test fail-before/pass-after on pristine `main` source: `FAILED. 0 passed;
  1 failed; 640 filtered out` → `ok. 1 passed; 0 failed; 640 filtered out`.
- `cargo test -p xerj-autoindex --lib -- --test-threads=1`: 641 passed / 0 failed under
  the dev profile (overflow-checks ON) and again under `--profile ci-test`
  (overflow-checks OFF); 640 before this branch. `cargo fmt --all --check` clean,
  `cargo clippy -p xerj-autoindex --all-targets -- -D warnings` clean.
- The issue's own headline repro on the fixed release binary, 1/2/3 `CREATE TABLE`
  blocks in one markdown file: `1 datasets, 2 records` / `2 datasets, 4 records` /
  `3 datasets, 6 records`, exit 0 each — abort 1 is not regressed.
- Engine `_source` null-drop, measured with `curl` straight at the engine, one index per
  size, `_refresh` before reading: 500 docs / 42,284 B, 1000 / 85,786 B and 1500 /
  129,786 B preserve `"time_field":null`; 2000 / 173,786 B is mixed (3 of 7 sampled docs
  kept it); 4000 / 349,786 B loses it on every sampled doc. The stored lucene catalog
  document was fetched and diffed against `catalog::dataset_doc`: exactly the four
  null-valued keys `time_field`, `time_min`, `time_max`, `semantic_field` are missing.

---

## Assumed / not verified

- **I ran no build, no test, no clippy and no binary in this session.** Every cargo
  result and every wall time above is the implementing agent's measurement, not mine. I
  verified the branch's *content*, its git metadata, and the three must-fix claims by
  reading source; I did not re-run the suite. CI on this PR is the first independent
  execution.
- The test suite was not run under the release profile; the release binary was used only
  for the CLI runs.
- The release binary was built with the `neural` feature (default), but every autoindex
  run used `--no-semantic`, matching the issue's repro. The `--embed-mode neural` path
  was not exercised and no model download was attempted.
- No ES-YAML conformance run, and no other crate's tests. The argument that this is safe
  — one query changed inside `xerj-autoindex`, no engine code touched — is an argument,
  not a measurement.
- The *mechanism* of the engine `_source` null-drop is not verified. The behaviour was
  measured; the guess that it is a memtable-flush vs in-memory-source split is a guess,
  and a 1-document index plus an explicit `_flush` preserved nulls, which does not fit
  that guess cleanly. The five size points are five sampled points on one binary on one
  machine — they are not a boundary and should not be quoted as one.
- Machine load was high throughout the implementing agent's session (~80 concurrent
  `rustc` from other agents), so every wall time is an upper bound on a loaded box, not a
  benchmark. The 1073s vs 663s lucene difference is load, not this change.
- Per instruction I have not merged this PR, will not merge it, and did not wait on CI.
