### PR TITLE
Add SebTardif to .contributors (CLA)

### DIFF
--- a/.contributors
+++ b/.contributors
@@ -3,5 +3,6 @@
   "dependabot[bot]",
   "Vinz2168",
   "buger",
-  "pradaev"
+  "pradaev",
+  "SebTardif"
 ]


### PR DESCRIPTION
## What this changes, and why

Sign the contributor license agreement by adding `SebTardif` to `.contributors`. This pull request is the signature and contains no other change.

## Evidence

```
python3 -c "import json; print(json.load(open('.contributors')))"
# includes SebTardif
```

## Checks

- [x] `cargo fmt --all` (CI runs `rustfmt --check` and `clippy -D warnings`)
- [x] Scoped release build of the crates touched: not applicable (JSON list only)
- [x] `cargo test -p <crate>` passes: not applicable
- [x] ES-YAML conformance suite at **0 failed**: not applicable because this change is the CLA signature only
- [x] New ES-compatible behaviour has a matching YAML case: not applicable
- [x] Docs updated if user-visible behaviour changed: not applicable
- [x] For non-trivial changes: the applicable audit in `docs/CONTRIBUTION_REVIEW.md`: not applicable

**Not run:** engine build, tests, ES-YAML. This diff is `.contributors` only.

## Provenance

- Written by: AI agent (Grok), run by @SebTardif who has reviewed it
- **Verified** (commands run, output observed): `python3` parsed `.contributors` as a JSON array that includes `SebTardif`
- **Assumed** (not tested, and what would falsify it): cla-bot treats this username as a completed signature after merge. Falsified if `@cla-bot check` still fails after merge.
