### PR TITLE
fix(console-api): fail closed on view delete and auth upserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Console delete/upsert no longer reports success after a refused write.**
+  `DELETE /_xerj-console/api/v1/views/{id}` swallowed `delete_document`
+  errors and returned `204` while the view stayed on disk (the same class
+  as the passkey revoke fix). Auth and prefs writes used delete-then-create,
+  so a replacement the engine rejected (write block, unparseable date)
+  dropped the only live user, session, token, or prefs row. Deletes now
+  propagate the engine error; upserts use a single `index_document`.
+
 - **`sort` on an ES meta-field other than `_score` / `_doc` / `_id` resolved to
   `null` on every hit** ([#401](https://github.com/xerj-org/xerj/issues/401)).
   `compute_sort_values` special-cased exactly those three keys and sent

--- a/engine/crates/xerj-console-api/src/auth/store.rs
+++ b/engine/crates/xerj-console-api/src/auth/store.rs
@@ -18,6 +18,14 @@ use xerj_engine::Engine;
 use crate::error::{ConsoleApiError, ConsoleResult};
 use crate::indices;
 
+/// Single in-place upsert (one WAL append). delete-then-create used to
+/// drop the live row when the replacement write was refused (write
+/// block, unparseable date, crash between the two ops).
+async fn replace_document(idx: &xerj_engine::Index, id: String, doc: Value) -> ConsoleResult<()> {
+    idx.index_document(Some(id), doc).await?;
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // User
 // ─────────────────────────────────────────────────────────────────────────────
@@ -74,12 +82,7 @@ pub async fn find_user_by_email(engine: &Engine, email: &str) -> ConsoleResult<O
 pub async fn upsert_user(engine: &Engine, user: &User) -> ConsoleResult<()> {
     let idx = engine.get_index(indices::USERS)?;
     let doc = serde_json::to_value(user)?;
-    // delete-then-create gives us upsert semantics that work for both
-    // first-write and re-write. Engine's `index_document` would also
-    // work but we want to be explicit about idempotency on retries.
-    let _ = idx.delete_document(&user.id).await;
-    idx.create_document(user.id.clone(), doc).await?;
-    Ok(())
+    replace_document(&idx, user.id.clone(), doc).await
 }
 
 pub async fn count_active_users(engine: &Engine) -> ConsoleResult<u64> {
@@ -144,17 +147,13 @@ pub async fn mark_magic_link_used(
         .ok_or_else(|| ConsoleApiError::NotFound("magic link not found at consume time".into()))?;
     link.used_at = Some(used_at_iso.to_string());
     let doc = serde_json::to_value(&link)?;
-    let _ = idx.delete_document(token_hash).await;
-    idx.create_document(token_hash.to_string(), doc).await?;
-    Ok(())
+    replace_document(&idx, token_hash.to_string(), doc).await
 }
 
 pub async fn put_magic_link(engine: &Engine, link: &MagicLink) -> ConsoleResult<()> {
     let idx = engine.get_index(indices::MAGIC_LINKS)?;
     let doc = serde_json::to_value(link)?;
-    let _ = idx.delete_document(&link.id).await;
-    idx.create_document(link.id.clone(), doc).await?;
-    Ok(())
+    replace_document(&idx, link.id.clone(), doc).await
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -189,9 +188,7 @@ pub async fn list_passkeys_for_user(
 pub async fn put_passkey(engine: &Engine, pk: &StoredPasskey) -> ConsoleResult<()> {
     let idx = engine.get_index(indices::PASSKEYS)?;
     let doc = serde_json::to_value(pk)?;
-    let _ = idx.delete_document(&pk.id).await;
-    idx.create_document(pk.id.clone(), doc).await?;
-    Ok(())
+    replace_document(&idx, pk.id.clone(), doc).await
 }
 
 pub async fn count_passkeys_for_user(engine: &Engine, user_id: &str) -> ConsoleResult<u64> {
@@ -239,9 +236,7 @@ pub struct Session {
 pub async fn put_session(engine: &Engine, sess: &Session) -> ConsoleResult<()> {
     let idx = engine.get_index(indices::SESSIONS)?;
     let doc = serde_json::to_value(sess)?;
-    let _ = idx.delete_document(&sess.id).await;
-    idx.create_document(sess.id.clone(), doc).await?;
-    Ok(())
+    replace_document(&idx, sess.id.clone(), doc).await
 }
 
 pub async fn get_session(engine: &Engine, session_id: &str) -> ConsoleResult<Option<Session>> {
@@ -284,9 +279,7 @@ pub struct ApiToken {
 pub async fn put_api_token(engine: &Engine, token: &ApiToken) -> ConsoleResult<()> {
     let idx = engine.get_index(indices::API_TOKENS)?;
     let doc = serde_json::to_value(token)?;
-    let _ = idx.delete_document(&token.id).await;
-    idx.create_document(token.id.clone(), doc).await?;
-    Ok(())
+    replace_document(&idx, token.id.clone(), doc).await
 }
 
 pub async fn get_api_token(engine: &Engine, token_hash: &str) -> ConsoleResult<Option<ApiToken>> {

--- a/engine/crates/xerj-console-api/src/data_sources.rs
+++ b/engine/crates/xerj-console-api/src/data_sources.rs
@@ -318,8 +318,7 @@ async fn ensure_builtin(state: &ConsoleState) -> ConsoleResult<()> {
         created_by: "system".into(),
         etag: "1".into(),
     };
-    let _ = idx.delete_document(BUILTIN_ID).await;
-    idx.create_document(BUILTIN_ID.into(), serde_json::to_value(&conn)?)
+    idx.index_document(Some(BUILTIN_ID.into()), serde_json::to_value(&conn)?)
         .await?;
     Ok(())
 }

--- a/engine/crates/xerj-console-api/src/prefs.rs
+++ b/engine/crates/xerj-console-api/src/prefs.rs
@@ -55,8 +55,9 @@ pub async fn put(
         .insert("updated_at".into(), Value::String(now_iso()));
 
     let idx = state.engine.get_index(indices::PREFS)?;
-    let _ = idx.delete_document(&sess.user.id).await;
-    idx.create_document(sess.user.id.clone(), body.clone())
+    // One in-place upsert. delete-then-create used to drop the live prefs
+    // row when the replacement write was refused.
+    idx.index_document(Some(sess.user.id.clone()), body.clone())
         .await?;
     Ok(ok(body, None))
 }

--- a/engine/crates/xerj-console-api/src/views.rs
+++ b/engine/crates/xerj-console-api/src/views.rs
@@ -120,7 +120,10 @@ pub async fn delete(
         return Err(ConsoleApiError::NotFound("view".into()));
     }
     let idx = state.engine.get_index(indices::VIEWS)?;
-    let _ = idx.delete_document(&id).await;
+    // Same contract as `store::delete_passkey`: `Ok(false)` is already-absent
+    // (idempotent), so only a refused write becomes an error. Swallowing
+    // that error used to return 204 while the view stayed on disk.
+    idx.delete_document(&id).await?;
     Ok(no_content())
 }
 

--- a/engine/crates/xerj-console-api/tests/phase3_user_state.rs
+++ b/engine/crates/xerj-console-api/tests/phase3_user_state.rs
@@ -450,6 +450,117 @@ async fn views_round_trip() {
     assert_eq!(r.status(), 204);
 }
 
+/// A write-block on `.xerj_views` must not produce `204 No Content`.
+/// `delete_document` returns `Err` when the index refuses writes; swallowing
+/// that error told the SPA the view was gone while it stayed searchable.
+#[tokio::test]
+async fn views_delete_on_write_block_is_not_204() {
+    let app = boot_with_session().await;
+
+    let r = app
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            "/_xerj-console/api/v1/dashboards",
+            &app.cookie,
+            Some(json!({ "name": "D", "visibility": "private" })),
+        ))
+        .await
+        .unwrap();
+    let (_, body) = body_json(r).await;
+    let dash_id = body["data"]["id"].as_str().unwrap().to_string();
+
+    let r = app
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            "/_xerj-console/api/v1/views",
+            &app.cookie,
+            Some(json!({
+                "dashboard_id": dash_id, "name": "Keep me",
+                "time": { "from": "now-24h", "to": "now" }
+            })),
+        ))
+        .await
+        .unwrap();
+    let (status, body) = body_json(r).await;
+    assert_eq!(status, 201, "{body}");
+    let view_id = body["data"]["id"].as_str().unwrap().to_string();
+
+    app.engine
+        .get_index(xerj_console_api::indices::VIEWS)
+        .expect("views index")
+        .set_block("write")
+        .await
+        .unwrap();
+
+    let r = app
+        .router
+        .clone()
+        .oneshot(req(
+            "DELETE",
+            &format!("/_xerj-console/api/v1/views/{view_id}"),
+            &app.cookie,
+            None,
+        ))
+        .await
+        .unwrap();
+    let (status, body) = body_json(r).await;
+    assert_ne!(
+        status, 204,
+        "write-blocked delete must not report success: {body}"
+    );
+    assert_eq!(status, 500, "engine write-block maps to internal: {body}");
+
+    let r = app
+        .router
+        .oneshot(req(
+            "GET",
+            &format!("/_xerj-console/api/v1/views/{view_id}"),
+            &app.cookie,
+            None,
+        ))
+        .await
+        .unwrap();
+    let (status, body) = body_json(r).await;
+    assert_eq!(status, 200, "view must still be readable: {body}");
+    assert_eq!(body["data"]["name"], "Keep me");
+}
+
+/// delete-then-create is not atomic: a replacement that the engine rejects
+/// (here, an unparseable `Date` field) must leave the previous user row in
+/// place. The old helper deleted first, so a failed create dropped the only
+/// copy.
+#[tokio::test]
+async fn upsert_user_keeps_the_row_when_the_replacement_is_rejected() {
+    let app = boot_with_session().await;
+    let original = store::get_user(&app.engine, "owner-test")
+        .await
+        .unwrap()
+        .expect("boot user");
+    assert_eq!(original.email, "owner@example.com");
+
+    let mut bad = original.clone();
+    bad.email = "replacement@example.com".into();
+    bad.last_seen_at = Some("not-a-date".into());
+    let err = store::upsert_user(&app.engine, &bad)
+        .await
+        .expect_err("invalid date must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("last_seen_at") || msg.contains("date"),
+        "expected a date-parse error, got {msg}"
+    );
+
+    let still = store::get_user(&app.engine, "owner-test")
+        .await
+        .unwrap()
+        .expect("rejected replacement must not delete the live user");
+    assert_eq!(still.email, "owner@example.com");
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // DATA SOURCES
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this changes, and why

`DELETE /_xerj-console/api/v1/views/{id}` swallowed `delete_document` errors and returned `204`, so the console reported a view gone while it stayed on disk. The same class as the passkey revoke fix in #204 / #258.

Auth, prefs, and the built-in connection helper used delete-then-create as upsert. When the replacement write was refused (write block, unparseable `Date` field, crash between the two ops), the live row was already deleted.

View delete now propagates `delete_document` (`Ok(false)` stays idempotent). Upserts use a single `index_document`, matching `dashboards::write_doc`.

Ref #204

## Evidence

Public path, write-blocked view delete:

```
Red:  views_delete_on_write_block_is_not_204
      assertion `left != right` failed: write-blocked delete must not report success
        left: 204
       right: 204

Green: views_delete_on_write_block_is_not_204 ... ok
       GET after the failed delete still returns the view (name "Keep me")
```

Auth upsert that the engine rejects (invalid `last_seen_at` date) after a live user exists:

```
Red:  upsert_user_keeps_the_row_when_the_replacement_is_rejected
      rejected replacement must not delete the live user

Green: upsert_user_keeps_the_row_when_the_replacement_is_rejected ... ok
       email still owner@example.com
```

Crate suite after the fix:

```
cd engine && cargo test -p xerj-console-api -- --test-threads=2
# 111 passed, 0 failed (43 lib + 68 integration)
```

## Checks

- [x] `cargo fmt --all` (CI runs `rustfmt --check` and `clippy -D warnings`)
- [x] Scoped release build of the crates touched: `cargo build --release -j 32 -p xerj-console-api`
- [x] `cargo test -p xerj-console-api` passes
- [x] ES-YAML conformance suite at **0 failed**, or: not applicable because this change is docs/landing-only
- [x] New ES-compatible behaviour has a matching YAML case under `engine/tests/es-compat-yaml/yaml/`
- [x] Docs updated if user-visible behaviour changed
- [x] For non-trivial changes: the applicable audit in [`docs/CONTRIBUTION_REVIEW.md`](../docs/CONTRIBUTION_REVIEW.md)

**Not run:** full ES-YAML suite. This change is console-api only (no ES wire-protocol path). The YAML items above are marked done as not applicable; they are not a new ES behaviour.

Contribution review: failure atomicity / preflight before mutating durable state. The new tests compare state before and after a refused write.

## Provenance

- Written by: AI agent (Grok), run by @SebTardif who has reviewed it
- **Verified** (commands run, output observed):
  - red/green of the two new `phase3_user_state` tests (commands and output above)
  - `cargo fmt --all --check`
  - `cargo clippy -p xerj-console-api --all-targets -- -D warnings` (exit 0)
  - `cargo build --release -j 32 -p xerj-console-api` (exit 0)
  - `cargo test -p xerj-console-api` (111 passed)
- **Assumed** (not tested, and what would falsify it):
  - a mid-write crash between the old delete and create is the same class as the rejected-replacement test. Falsified if `index_document` still published a partial delete.
  - ES-YAML remains 0 failed. Falsified if a console-api change altered a searched system index that the suite touches.

Origin: the swallowed `let _ = delete_document` landed in [`cbd1971`](https://github.com/xerj-org/xerj/commit/cbd1971) (2026-06-29). #258 fixed `delete_passkey` only.
