### PR TITLE
fix(ci): main is red on the CI toolchain — one redundant reference blocks every open PR

### DIFF
--- a/engine/crates/xerj-engine/tests/sort_on_meta_fields.rs
+++ b/engine/crates/xerj-engine/tests/sort_on_meta_fields.rs
@@ -221,7 +221,7 @@ async fn search_after_on_seq_no_pages_the_whole_index() {
              (first repeat page starts at {:?})",
             collected.len(),
             total,
-            &collected[total.min(collected.len().saturating_sub(1))]
+            collected[total.min(collected.len().saturating_sub(1))]
         );
     }
 


### PR DESCRIPTION
## What this fixes

`cargo clippy --workspace --all-targets -- -D warnings` **exits 101 on clean `main`** under the toolchain CI actually uses.

```
error: redundant reference in `assert!` argument
  --> crates/xerj-engine/tests/sort_on_meta_fields.rs:224
     &collected[total.min(collected.len().saturating_sub(1))]
     ^ help: remove the redundant `&`
  = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
error: could not compile `xerj-engine` (test "sort_on_meta_fields")
```

## Why it got in, and why it matters more than one `&`

`useless_borrows_in_formatting` is not in rustc 1.92, which is what the change was developed and verified against. CI resolves `dtolnay/rust-toolchain@stable` to **1.97.1 (2026-07-14)** — five releases newer. So #420 was locally green, merged green, and has been failing `Format + Clippy` on **every pull request opened since**.

That includes two from outside contributors whose own code is fine:

| PR | author | fails | actually at fault |
|---|---|---|---|
| #419 | @SebTardif | Format + Clippy | this lint, in `main` |
| #402 | @Vinz2168 | Format + Clippy | partly this; also its own rustfmt diffs |

Four other PRs (#388, #410, #411) show 16/16 green from before the toolchain moved and would fail the same way on a re-run.

## Verification, under CI's exact toolchain

Not the local default — `rustup toolchain install 1.97.1` and run against that:

```
rustup run 1.97.1 cargo clippy --workspace --all-targets -- -D warnings   # exit 0  (101 before)
rustup run 1.97.1 cargo fmt --all --check                                 # exit 0
rustup run 1.97.1 cargo test -p xerj-engine --test sort_on_meta_fields    # 7 passed, 0 failed
```

`rustfmt` 1.97.1 reports **0 diffs** on clean `main`, so formatting is not implicated — this is clippy only.

## Follow-up (deliberately not in this PR)

**Nothing pins the toolchain.** `dtolnay/rust-toolchain@stable` appears 10 times in `ci.yml` with no `rust-toolchain.toml` anywhere in the tree. CI compiles with whatever `stable` means on the day it runs, so a Rust release can turn every open pull request red overnight with no commit to blame. That is exactly what happened here, and gating on `-D warnings` makes it a certainty rather than a risk. A pin needs its own change because the `cargo-fuzz` job legitimately needs `@nightly` and would have to opt out.

## Checks

- [x] `cargo fmt --all --check` under 1.97.1
- [x] `cargo clippy --workspace --all-targets -- -D warnings` under 1.97.1
- [x] `cargo test -p xerj-engine --test sort_on_meta_fields`
- [x] Docs updated if user-visible behaviour changed — n/a, test-only, no shipped code touched
