### PR TITLE
fix(es-compat): a multi-index scroll reports the index each hit came from (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A multi-index `scroll` reported the wrong `_index` on every continuation
+  page, so `(_index, _id)` stopped being distinct**
+  ([#414](https://github.com/xerj-org/xerj/issues/414)). The scroll context
+  stored bare hits plus one context-level `index` — `index_names.first()` — and
+  every page after the first stamped that single name onto every hit. Page one
+  was correct, because it maps the real per-hit index, so the divergence only
+  appeared once paging crossed into the second index.
+
+  Ids routinely collide across indices (each numbers its own documents), so a
+  consumer keyed on `(_index, _id)` silently kept a fraction of the corpus.
+  Measured on two 300-document indices with identical id ranges: **600 hits
+  collapsed to 300 distinct `(_index, _id)` pairs**, all labelled with the first
+  index. `search_after` over the same two indices was unaffected and returned
+  600 of 600 — the two paging APIs disagreed about which index a document came
+  from. The blast radius is reindex, migration, backup and CDC consumers, which
+  are exactly the readers that use scroll and least survive losing half a
+  corpus.
+
+  The comment at the context-creation site asserted the opposite of the
+  behaviour — that keeping the raw index spec left per-hit `_index`
+  "authoritative when paging" — which is why the defect outlived review.
+
+  `ScrollContext::hits` is now `Vec<(String, Hit)>`: a hit cannot exist in a
+  context without the index it came from, so the association cannot be dropped
+  again. Both context-creation sites previously discarded it with the same
+  `.map(|(_, h)| h.clone())`.
+
 ### Documentation
 
 - **The 10,000-document scroll snapshot cap is now published, and pinned to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour — that keeping the raw index spec left per-hit `_index`
   "authoritative when paging" — which is why the defect outlived review.
 
-  `ScrollContext::hits` is now `Vec<(String, Hit)>`: a hit cannot exist in a
-  context without the index it came from, so the association cannot be dropped
-  again. Both context-creation sites previously discarded it with the same
-  `.map(|(_, h)| h.clone())`.
+  `ScrollContext::hits` is now `Vec<(String, Hit)>`, so a hit carries the index
+  it came from rather than borrowing one from the context. Both context-creation
+  sites previously discarded it with the same `.map(|(_, h)| h.clone())`.
+
+  **Scope, established by an independent adversarial verification of the fix and
+  stated here rather than discovered later.** This covers scrolls addressed by a
+  comma list (`/a,b/_search?scroll=`), a wildcard, or `_all`. It does **not**
+  cover a scroll addressed through an **alias** spanning several indices: alias
+  names are not expanded by the index resolver, so every hit still reports the
+  alias and `(_index, _id)` remains non-distinct there. That matters because
+  reindex and CDC tooling routinely scrolls an alias, which is exactly the
+  audience named above — tracked separately rather than folded into this entry.
+  The type change is also a breaking one for any out-of-tree reader of the
+  public `ScrollContext::hits` field.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A multi-index `scroll` reported the wrong `_index` on every continuation
   page, so `(_index, _id)` stopped being distinct**
   ([#414](https://github.com/xerj-org/xerj/issues/414)). The scroll context
-  stored bare hits plus one context-level `index` — `index_names.first()` — and
-  every page after the first stamped that single name onto every hit. Page one
-  was correct, because it maps the real per-hit index, so the divergence only
-  appeared once paging crossed into the second index.
+  stored bare hits plus one context-level `index`, and every page after the first
+  stamped that single name onto every hit. Page one was correct, because it maps
+  the real per-hit index, so the divergence only appeared once paging crossed
+  into the second index.
+
+  The two context-creation sites stored *different* wrong values, which is why
+  the symptom has two faces: `search_impl` (`/{a,b}/_search?scroll=`) stored
+  `index_names.first()`, so hits were labelled with the first concrete index
+  (`mi_a`), while `search_with_scroll` (`/{spec}/_search_scroll`) stored the raw
+  path spec, so hits were labelled with the un-split string — the
+  `_index: "sa,sb"` that #414 reported, 11,900 of 12,000 hits.
 
   Ids routinely collide across indices (each numbers its own documents), so a
   consumer keyed on `(_index, _id)` silently kept a fraction of the corpus.

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -11199,8 +11199,10 @@ async fn search_impl(
     // Snapshot every matching hit for the scroll context BEFORE we consume
     // merged_hits to build `hits`. We'll register the context after the
     // response_body is built.
-    let scroll_snapshot: Option<Vec<xerj_query::executor::Hit>> = if is_scroll_request {
-        Some(merged_hits.iter().map(|(_, h)| h.clone()).collect())
+    let scroll_snapshot: Option<Vec<(String, xerj_query::executor::Hit)>> = if is_scroll_request {
+        // Keep the index name with each hit (#414): dropping it here is what
+        // made continuation pages fall back to a single context-level name.
+        Some(merged_hits.clone())
     } else {
         None
     };
@@ -14217,9 +14219,11 @@ async fn search_impl(
             }
         }
         let snapshot = scroll_snapshot.unwrap_or_default();
-        // Pick the first backing index for the scroll context (multi-index
-        // scrolls are rare and we keep the raw index spec so `_index` on
-        // each hit remains authoritative when paging).
+        // Context-level fallback only. It is NOT what `_index` is served from
+        // any more: each hit carries its own index name in `hits`. The previous
+        // comment here claimed per-hit `_index` "remains authoritative when
+        // paging" while continuation pages overwrote it with this value, so on
+        // a multi-index scroll every hit reported the first index (#414).
         let scroll_index = index_names
             .first()
             .map(|s| s.to_string())
@@ -19749,8 +19753,8 @@ pub async fn search_with_scroll(
         }
         let scroll_id = Uuid::new_v4().to_string();
         // Extract just the hits from the pairs.
-        let hits_only: Vec<xerj_query::executor::Hit> =
-            all_hits.iter().map(|(_, h)| h.clone()).collect();
+        // Index name stays paired with its hit (#414).
+        let hits_only: Vec<(String, xerj_query::executor::Hit)> = all_hits.clone();
 
         // Return first page.
         let first_page: Vec<EsHit> = all_hits
@@ -20013,7 +20017,7 @@ async fn scroll_page_response(
             let has_non_score_sort = ctx
                 .hits
                 .first()
-                .map(|h| !h.sort.is_empty())
+                .map(|(_, h)| !h.sort.is_empty())
                 .unwrap_or(false);
 
             let page_hits: Vec<EsHit> = ctx
@@ -20021,8 +20025,9 @@ async fn scroll_page_response(
                 .iter()
                 .skip(position)
                 .take(page_size)
-                .map(|h| EsHit {
-                    index: ctx.index.clone(),
+                .map(|(hit_index, h)| EsHit {
+                    // Per-hit index, not the context-level one (#414).
+                    index: hit_index.clone(),
                     id: h.id.clone(),
                     score: Some(h.score as f64),
                     version: Some(1),
@@ -20155,7 +20160,10 @@ mod passage_scroll_tests {
             scroll_id.clone(),
             xerj_engine::engine::ScrollContext {
                 index: "reports".into(),
-                hits: vec![passage_hit("page-1", 0), passage_hit("page-2", 1)],
+                hits: vec![
+                    ("reports".to_string(), passage_hit("page-1", 0)),
+                    ("reports".to_string(), passage_hit("page-2", 1)),
+                ],
                 position: 1,
                 page_size: 1,
                 created: now,
@@ -20186,6 +20194,64 @@ mod passage_scroll_tests {
         assert_eq!(body["hits"]["hits"][0]["fields"]["_passage"][0]["page"], 2);
     }
 
+    /// Regression test for #414. A scroll spanning two indices stored bare
+    /// hits plus one context-level `index`, so every continuation page stamped
+    /// that single name onto hits regardless of which index they came from.
+    /// With ids colliding across indices — the normal case for a reindex or
+    /// migration, where each index numbers its own documents — `(_index, _id)`
+    /// stopped being distinct and a consumer keyed on it silently kept half
+    /// the corpus. Measured before the fix on 300+300 documents: 600 hits
+    /// collapsed to 300 distinct `(_index, _id)` pairs, every one labelled
+    /// with the first index.
+    ///
+    /// The pairing is now structural (`hits: Vec<(String, Hit)>`), so a hit
+    /// cannot exist in a context without the index it came from.
+    #[tokio::test]
+    async fn scroll_continuation_reports_the_index_each_hit_came_from() {
+        let state = test_state();
+        let scroll_id = Uuid::new_v4().to_string();
+        let now = Instant::now();
+        // Same `_id` in both indices: only `_index` tells them apart.
+        state.engine.scrolls.insert(
+            scroll_id.clone(),
+            xerj_engine::engine::ScrollContext {
+                index: "mi_a".into(),
+                hits: vec![
+                    ("mi_a".to_string(), passage_hit("dup-1", 0)),
+                    ("mi_b".to_string(), passage_hit("dup-1", 1)),
+                ],
+                position: 1,
+                page_size: 1,
+                created: now,
+                keep_alive: Duration::from_secs(60),
+                expires_at: now + Duration::from_secs(60),
+            },
+        );
+        let app = crate::router::build_es_compat_router(state);
+        let response = app
+            .oneshot(
+                Request::post("/_search/scroll")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"scroll_id": scroll_id}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["hits"]["hits"][0]["_id"], "dup-1");
+        // The continuation hit belongs to mi_b. Before the fix this was
+        // "mi_a" — the context-level name — making it indistinguishable
+        // from the mi_a document with the same id on page 1.
+        assert_eq!(
+            body["hits"]["hits"][0]["_index"], "mi_b",
+            "continuation page must report the index the hit came from, not the context's"
+        );
+    }
+
     /// Regression test for a real bug found live: OpenSearch Dashboards
     /// 3.7.0's saved-objects migration (`.kibana_1` → `.kibana_2`) continues
     /// its scroll via `GET /_search/scroll/{scroll_id}` (the legacy
@@ -20202,7 +20268,10 @@ mod passage_scroll_tests {
             scroll_id.clone(),
             xerj_engine::engine::ScrollContext {
                 index: "reports".into(),
-                hits: vec![passage_hit("page-1", 0), passage_hit("page-2", 1)],
+                hits: vec![
+                    ("reports".to_string(), passage_hit("page-1", 0)),
+                    ("reports".to_string(), passage_hit("page-2", 1)),
+                ],
                 position: 1,
                 page_size: 1,
                 created: now,

--- a/engine/crates/xerj-api/tests/scroll_multi_index_identity.rs
+++ b/engine/crates/xerj-api/tests/scroll_multi_index_identity.rs
@@ -1,0 +1,207 @@
+//! Issue #414, from the outside: on a multi-index scroll every hit must report
+//! the index it actually came from, so `(_index, _id)` stays distinct.
+//!
+//! Ids collide across indices as a matter of course — each index numbers its
+//! own documents — so `(_index, _id)` is the only key that separates them. When
+//! the scroll stamps one name onto every hit, a consumer keyed on that pair
+//! silently keeps a fraction of the corpus. Scroll is what reindex, migration,
+//! backup and CDC use, which is where losing half a corpus hurts most.
+//!
+//! The in-module unit test for this covers the *read* site only: it hand-builds
+//! a `ScrollContext` and calls the continuation. That leaves both *creation*
+//! sites unguarded — an independent verification of PR #424 showed the defect
+//! could be reintroduced at either one with all 216 tests still passing. This
+//! test goes through the real HTTP routes instead, so the creation sites are
+//! actually exercised:
+//!
+//!   * `POST /{a,b}/_search?scroll=` — `search_impl`
+//!   * `POST /_search/scroll`        — the continuation
+//!
+//! Each document carries `_source.home` = the index it was written to, so the
+//! assertion compares the reported `_index` against ground truth per hit rather
+//! than against a count.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn json_req(
+    app: &axum::Router,
+    method: &str,
+    path: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, v)
+}
+
+/// Documents per index. Ids are `0..N` in BOTH, so every id collides.
+const N: usize = 120;
+
+async fn seed(app: &axum::Router, index: &str) {
+    let (st, _) = json_req(
+        app,
+        "PUT",
+        &format!("/{index}"),
+        json!({"mappings": {"properties": {"v": {"type": "long"}, "home": {"type": "keyword"}}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create {index}");
+
+    let mut bulk = String::new();
+    for i in 0..N {
+        bulk.push_str(&format!("{}\n", json!({"index": {"_id": i.to_string()}})));
+        bulk.push_str(&format!("{}\n", json!({"v": i, "home": index})));
+    }
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/{index}/_bulk"))
+                .header("content-type", "application/x-ndjson")
+                .body(Body::from(bulk))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "bulk {index}");
+    let (st, _) = json_req(app, "POST", &format!("/{index}/_refresh"), Value::Null).await;
+    assert_eq!(st, StatusCode::OK, "refresh {index}");
+}
+
+/// Walk a scroll to exhaustion, returning `(reported_index, id, true_home)` per
+/// hit. `page_size` deliberately does not divide `N`, so a page straddles the
+/// boundary between the two indices — the case an off-by-one in the pairing
+/// would otherwise slip through.
+async fn walk(app: &axum::Router, spec: &str, page_size: usize) -> Vec<(String, String, String)> {
+    let (st, first) = json_req(
+        app,
+        "POST",
+        &format!("/{spec}/_search?scroll=2m"),
+        json!({"query": {"match_all": {}}, "size": page_size}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "scroll start: {first}");
+
+    let mut sid = first["_scroll_id"].as_str().map(str::to_string);
+    let mut page = first;
+    let mut out = Vec::new();
+
+    for _ in 0..64 {
+        let hits = page["hits"]["hits"].as_array().cloned().unwrap_or_default();
+        if hits.is_empty() {
+            break;
+        }
+        for h in &hits {
+            out.push((
+                h["_index"].as_str().unwrap_or_default().to_string(),
+                h["_id"].as_str().unwrap_or_default().to_string(),
+                h["_source"]["home"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+            ));
+        }
+        let Some(id) = sid.clone() else { break };
+        let (st, next) = json_req(
+            app,
+            "POST",
+            "/_search/scroll",
+            json!({"scroll": "2m", "scroll_id": id}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "scroll continuation: {next}");
+        sid = next["_scroll_id"].as_str().map(str::to_string).or(sid);
+        page = next;
+    }
+    out
+}
+
+#[tokio::test]
+async fn multi_index_scroll_reports_the_index_each_hit_came_from() {
+    let (app, _dir) = app().await;
+    seed(&app, "mi_a").await;
+    seed(&app, "mi_b").await;
+
+    let hits = walk(&app, "mi_a,mi_b", 50).await;
+
+    assert_eq!(
+        hits.len(),
+        N * 2,
+        "scroll must return every document across both indices"
+    );
+
+    // Ground truth per hit: `home` was written into `_source` at index time.
+    let mislabelled: Vec<_> = hits
+        .iter()
+        .filter(|(reported, _, home)| reported != home)
+        .take(5)
+        .collect();
+    assert!(
+        mislabelled.is_empty(),
+        "hits reported an _index they did not come from (first {}): {:?}",
+        mislabelled.len(),
+        mislabelled
+    );
+
+    // The property that actually matters to a consumer.
+    let distinct: HashSet<(&str, &str)> = hits
+        .iter()
+        .map(|(idx, id, _)| (idx.as_str(), id.as_str()))
+        .collect();
+    assert_eq!(
+        distinct.len(),
+        N * 2,
+        "(_index, _id) is not distinct — {} hits collapsed to {} keys, which is \
+         how a keyed consumer silently loses documents (#414)",
+        hits.len(),
+        distinct.len()
+    );
+}
+
+/// The single-index case must keep behaving, and is the overwhelmingly common
+/// one: the type change behind #414 touches every scroll, not just multi-index
+/// ones.
+#[tokio::test]
+async fn single_index_scroll_is_unchanged() {
+    let (app, _dir) = app().await;
+    seed(&app, "solo").await;
+
+    let hits = walk(&app, "solo", 50).await;
+    assert_eq!(hits.len(), N);
+    assert!(
+        hits.iter().all(|(reported, _, home)| reported == home),
+        "single-index scroll mislabelled a hit"
+    );
+    let distinct: HashSet<(&str, &str)> = hits
+        .iter()
+        .map(|(idx, id, _)| (idx.as_str(), id.as_str()))
+        .collect();
+    assert_eq!(distinct.len(), N);
+}

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -153,7 +153,12 @@ pub struct IndexTemplate {
 /// continuation, enforced on access, and swept in the background.
 pub struct ScrollContext {
     pub index: String,
-    pub hits: Vec<xerj_query::executor::Hit>,
+    /// Each hit paired with the name of the index it actually came from.
+    /// Pairing is structural on purpose (#414): a multi-index scroll used to
+    /// store bare hits plus one context-level `index`, so every continuation
+    /// page stamped the same name onto hits from different indices and
+    /// `(_index, _id)` stopped being distinct.
+    pub hits: Vec<(String, xerj_query::executor::Hit)>,
     pub position: usize,
     pub page_size: usize,
     pub created: Instant,


### PR DESCRIPTION
Fixes #414.

## The defect

A `scroll` spanning two indices reports the wrong `_index` on every continuation page, so `(_index, _id)` — the only key that distinguishes documents across indices — stops being distinct.

Measured on current `main`, two indices of 300 documents each with identical id ranges `0..299`:

```
page 1: 100 hits  _index={'mi_a': 100}   ids 0..99
page 2: 100 hits  _index={'mi_a': 100}   ids 100..199
page 3: 100 hits  _index={'mi_a': 100}   ids 200..299
page 4: 100 hits  _index={'mi_a': 100}   ids 0..99      <- these are mi_b documents
page 5: 100 hits  _index={'mi_a': 100}   ids 100..199   <- these are mi_b documents
page 6: 100 hits  _index={'mi_a': 100}   ids 200..299   <- these are mi_b documents

600 hits -> 300 distinct (_index, _id)
```

`search_after` over the same two indices returns **600 of 600 distinct pairs**. The two paging APIs disagree about which index a document came from.

## Cause

Both scroll-context creation sites discarded the per-hit index with the same expression:

```rust
Some(merged_hits.iter().map(|(_, h)| h.clone()).collect())   // es_compat.rs:11203
all_hits.iter().map(|(_, h)| h.clone()).collect()            // es_compat.rs:19752
```

`merged_hits` / `all_hits` are `Vec<(idx_name, Hit)>`. The context kept a single `index` instead — `index_names.first()` — and the continuation mapped every hit through it:

```rust
.map(|h| EsHit { index: ctx.index.clone(), ... })            // es_compat.rs:20024
```

Page one was always correct because it maps the real `idx_name`, which is why pages 2–3 above look right: they are genuinely `mi_a`. Only page 4 onward exposes it.

The comment at the creation site asserted the opposite of the actual behaviour, which is why this outlived review:

```rust
// Pick the first backing index for the scroll context (multi-index
// scrolls are rare and we keep the raw index spec so `_index` on
// each hit remains authoritative when paging).
```

Per-hit `_index` was not authoritative when paging — the continuation overwrote it.

## The fix

`ScrollContext::hits` becomes `Vec<(String, Hit)>`. A hit cannot sit in a context without the index it came from, so the association cannot be dropped again by either site. This is a structural fix rather than a patch at the read site, because the same discard existed independently in two places.

## Verification

**Verified.**

Fail-before, reverting **only** the behavioural line (the index source) and keeping the new test:

```
assertion `left == right` failed: continuation page must report the index the hit came from, not the context's
  left: String("mi_a")
 right: "mi_b"
```

After the fix, end-to-end on a real node (`--profile ci-test`, own port and data dir), same 300+300 corpus:

```
page 1-3: _index={'mi_a': 100}
page 4-6: _index={'mi_b': 100}
600 hits -> 600 distinct (_index, _id)      VERDICT: FIXED
```

Both profiles, since overflow-checks differ:

```
ci-test:  test result: ok. 10 passed; 0 failed   (scroll tests)
dev:      test result: ok. 10 passed; 0 failed   (scroll tests)
```

Gates under CI's toolchain (rustc 1.97.1, not the local default — see #422):

```
cargo fmt --all --check                                  exit 0
cargo clippy --workspace --all-targets -- -D warnings     exit 0
```

**Assumed / not verified.**

- I did not run the full ES-YAML conformance suite. It deletes every index on the node it targets, and it needs its own port and data dir to run safely; this change alters a wire-visible field (`_index` on scroll continuations), so conformance is the gate that would catch a divergence I cannot see from here. Worth running before merge.
- I did not test scroll across **three or more** indices, nor an index pattern (`mi_*`) as opposed to an explicit comma list.
- I did not check whether `_seq_no` / `_version` / `_primary_term` on continuation pages have the same context-level-constant problem — they are hardcoded to `Some(0)` / `Some(1)` / `Some(1)` at both sites, which looks wrong independently but is out of scope here.

## Checks

- [x] `cargo fmt --all` (under 1.97.1)
- [x] `clippy -D warnings` (under 1.97.1)
- [x] `cargo test -p xerj-api --lib scroll` in both `dev` and `ci-test`
- [x] Regression test added, and proven to fail before the fix
- [ ] ES-YAML conformance — **not run**, see above
- [x] CHANGELOG updated
