### PR TITLE
fix(autoindex): skip hidden names that are not valid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used `file_name().to_str().starts_with('.')`. On Unix a name whose
   first byte is `.` and that is not valid UTF-8 (`to_str()` is `None`)
   was walked and indexed. The skip now compares the first encoded byte
-  to `.`. Typical UTF-8 secrets were already skipped.
+  to `.`. Typical UTF-8 secrets were already skipped. `--dry-run`'s
+  `ignored_files_in_pruned_dirs` count uses the same predicate, so a
+  hidden non-UTF-8 file (or the contents of a hidden non-UTF-8
+  directory) is no longer reported as a non-hidden file inside a
+  pruned directory.
+
+  **Upgrade.** A corpus indexed by a pre-fix binary that contains a
+  hidden non-UTF-8 name looks like a file removal to the graph-enabled
+  path (the default, and what `xerj brain` uses). Until
+  [#439](https://github.com/xerj-org/xerj/issues/439) lands, the first
+  rerun exits 1 with `unsupported_content_group_removal`, writes
+  nothing, and the already-indexed documents stay live. Do not follow
+  the refusal's first recovery route ("restore the removed file(s)"):
+  the file is still on disk, just no longer walked. Recovery that
+  works: delete the published indices and the state directory, then
+  re-index the folder. An isolated rebuild with a new `--state-dir` /
+  `--prefix` also exits 0, but leaves the old target's documents live
+  until those indices are deleted by hand.
 
 - **Autoindex snapshot and replay one-shot failpoints can no longer be stolen by unrelated parallel tests.** ([#385](https://github.com/xerj-org/xerj/issues/385)).
   The two test-only failpoints are now owned by the thread that arms them, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`xerj autoindex` now skips hidden names that are not valid UTF-8.**
+  The walker already refused `.env`, `.ssh`, and `.git`, but the check
+  used `file_name().to_str().starts_with('.')`. On Unix a name whose
+  first byte is `.` and that is not valid UTF-8 (`to_str()` is `None`)
+  was walked and indexed. The skip now compares the first encoded byte
+  to `.`. Typical UTF-8 secrets were already skipped.
+
 - **Autoindex snapshot and replay one-shot failpoints can no longer be stolen by unrelated parallel tests.** ([#385](https://github.com/xerj-org/xerj/issues/385)).
   The two test-only failpoints are now owned by the thread that arms them, while
   retaining their existing one-shot behavior and serialization locks.

--- a/engine/crates/xerj-autoindex/src/ignore_rules.rs
+++ b/engine/crates/xerj-autoindex/src/ignore_rules.rs
@@ -61,7 +61,15 @@
 use ignore::gitignore::{Gitignore, GitignoreBuilder, Glob};
 use ignore::Match;
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+
+/// Hidden names start with `.` even when they are not valid UTF-8.
+/// `OsStr::to_str()` is `None` for those, so a UTF-8 `starts_with('.')`
+/// would walk them (and, here, would count them as non-hidden).
+pub(crate) fn is_hidden_name(name: &OsStr) -> bool {
+    name.as_encoded_bytes().first() == Some(&b'.')
+}
 
 /// Ignore file honoured in every directory, ranked below `.xerjignore`.
 pub const GITIGNORE: &str = ".gitignore";
@@ -730,11 +738,7 @@ impl IgnoreStack {
             .follow_links(false)
             .min_depth(1)
             .into_iter()
-            .filter_entry(|e| {
-                !e.file_name()
-                    .to_str()
-                    .is_some_and(|name| name.starts_with('.'))
-            });
+            .filter_entry(|e| !is_hidden_name(e.file_name()));
         for entry in walker {
             if self.budget == 0 {
                 self.report.deep_count_complete = false;
@@ -764,12 +768,7 @@ mod tests {
         while let Some(next) = it.next() {
             let Ok(entry) = next else { continue };
             let is_dir = entry.file_type().is_dir();
-            if entry.depth() > 0
-                && entry
-                    .file_name()
-                    .to_str()
-                    .is_some_and(|n| n.starts_with('.'))
-            {
+            if entry.depth() > 0 && is_hidden_name(entry.file_name()) {
                 stack.record_hidden(is_dir);
                 if is_dir {
                     it.skip_current_dir();
@@ -1098,6 +1097,47 @@ mod tests {
                 .any(|l| l.contains("(3 non-hidden files inside them)")),
             "{lines:?}"
         );
+    }
+
+    /// After the walker started treating a non-UTF-8 `.\x80` name as hidden,
+    /// `count_inside` still used `to_str().starts_with('.')` and counted those
+    /// files (and descended those directories). APFS rejects the name; Linux
+    /// does not.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn count_inside_skips_hidden_non_utf8_names() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        write(root, ".xerjignore", "pruned/\n");
+        write(root, "keep.md", "x");
+        write(root, "pruned/visible1.txt", "x");
+        write(root, "pruned/.hiddenutf8", "x");
+        fs::write(
+            root.join("pruned").join(OsStr::from_bytes(b".\x80hidden")),
+            "x",
+        )
+        .unwrap();
+        fs::create_dir(root.join("pruned").join(OsStr::from_bytes(b".\x80dir"))).unwrap();
+        fs::write(
+            root.join("pruned")
+                .join(OsStr::from_bytes(b".\x80dir"))
+                .join("inside.txt"),
+            "x",
+        )
+        .unwrap();
+
+        let (kept, deep) = survivors(root, IgnoreOptions::default().with_deep_count(true));
+        assert_eq!(kept, vec!["keep.md".to_string()], "{kept:?}");
+        assert_eq!(
+            deep.files_inside_pruned_dirs, 1,
+            "only pruned/visible1.txt is a non-hidden file inside the pruned \
+             tree; .hiddenutf8, .\\x80hidden, and .\\x80dir/inside.txt are \
+             hidden: {deep:?}"
+        );
+        assert!(deep.files_inside_pruned_dirs_is_exact());
     }
 
     /// #279. The claim the reporting makes about its own number, checked as

--- a/engine/crates/xerj-autoindex/src/walk.rs
+++ b/engine/crates/xerj-autoindex/src/walk.rs
@@ -9,7 +9,15 @@
 
 use crate::ignore_rules::{IgnoreOptions, IgnoreReport, IgnoreStack};
 use anyhow::{Context, Result};
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+
+/// Hidden names start with `.` even when they are not valid UTF-8.
+/// `OsStr::to_str()` is `None` for those, so a UTF-8 `starts_with('.')`
+/// would walk them.
+fn is_hidden_name(name: &OsStr) -> bool {
+    name.as_encoded_bytes().first() == Some(&b'.')
+}
 
 #[derive(Debug, Clone)]
 pub struct FileEntry {
@@ -139,12 +147,7 @@ pub fn walk_reporting(
         // itself (depth 0) is exempt so a brain over a dot-named folder still
         // works. `--no-ignore` does NOT turn this off: it is not one of the
         // ignore rules, it is the reason secrets stay out.
-        if entry.depth() > 0
-            && entry
-                .file_name()
-                .to_str()
-                .is_some_and(|n| n.starts_with('.'))
-        {
+        if entry.depth() > 0 && is_hidden_name(entry.file_name()) {
             stack.record_hidden(is_dir);
             if is_dir {
                 it.skip_current_dir();
@@ -267,6 +270,58 @@ mod hidden_skip_tests {
         assert!(
             !rels.iter().any(|r| r.ends_with(".secret")),
             "indexed a nested dotfile: {rels:?}"
+        );
+    }
+
+    /// A name whose first byte is '.' but is not valid UTF-8 must still be
+    /// treated as hidden. `file_name().to_str()` is `None` for that name, so
+    /// the UTF-8 `starts_with('.')` check misses it.
+    #[cfg(unix)]
+    #[test]
+    fn hidden_non_utf8_dot_name_is_detected() {
+        use super::is_hidden_name;
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let hidden = OsStr::from_bytes(b".\x80");
+        assert!(
+            hidden.to_str().is_none(),
+            "fixture must be non-UTF-8 so to_str() cannot save us"
+        );
+        assert!(
+            is_hidden_name(hidden),
+            "first byte is '.', even when to_str() is None"
+        );
+        assert!(is_hidden_name(OsStr::from_bytes(b".env")));
+        assert!(!is_hidden_name(OsStr::from_bytes(b"README.md")));
+        assert!(!is_hidden_name(OsStr::from_bytes(b"\x80env")));
+    }
+
+    /// Same name on disk. APFS/HFS reject non-UTF-8 names; Linux does not.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn hidden_non_utf8_dotfile_is_never_indexed() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        fs::write(root.join("README.md"), "hello").unwrap();
+        fs::write(root.join(OsStr::from_bytes(b".\x80")), "SECRET=pat-abc123").unwrap();
+
+        let files = walk(root, false).unwrap();
+        let rels: Vec<String> = files.iter().map(|e| e.rel.clone()).collect();
+        assert!(
+            rels.contains(&"README.md".to_string()),
+            "visible file must still be indexed: {rels:?}"
+        );
+        assert!(
+            !files.iter().any(|e| {
+                e.path
+                    .file_name()
+                    .is_some_and(|n| n.as_encoded_bytes().first() == Some(&b'.'))
+            }),
+            "indexed a hidden non-UTF-8 name: {rels:?}"
         );
     }
 

--- a/engine/crates/xerj-autoindex/src/walk.rs
+++ b/engine/crates/xerj-autoindex/src/walk.rs
@@ -7,17 +7,9 @@
 //! descended, so its contents cost nothing — no stat, no hash, no bulk body.
 //! The matching itself lives in [`crate::ignore_rules`].
 
-use crate::ignore_rules::{IgnoreOptions, IgnoreReport, IgnoreStack};
+use crate::ignore_rules::{is_hidden_name, IgnoreOptions, IgnoreReport, IgnoreStack};
 use anyhow::{Context, Result};
-use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-
-/// Hidden names start with `.` even when they are not valid UTF-8.
-/// `OsStr::to_str()` is `None` for those, so a UTF-8 `starts_with('.')`
-/// would walk them.
-fn is_hidden_name(name: &OsStr) -> bool {
-    name.as_encoded_bytes().first() == Some(&b'.')
-}
 
 #[derive(Debug, Clone)]
 pub struct FileEntry {
@@ -279,7 +271,7 @@ mod hidden_skip_tests {
     #[cfg(unix)]
     #[test]
     fn hidden_non_utf8_dot_name_is_detected() {
-        use super::is_hidden_name;
+        use crate::ignore_rules::is_hidden_name;
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 


### PR DESCRIPTION
## What this changes, and why

`xerj autoindex <folder>` claims it never indexes hidden files (`.env`, `.ssh`, `.git`). The check was `file_name().to_str().is_some_and(|n| n.starts_with('.'))`.

On Unix, `OsStr::to_str()` is `None` when the name is not valid UTF-8. A name whose first byte is `.` then fails the `is_some_and` check and is walked like a visible file.

Typical UTF-8 secrets are already skipped. This closes the remaining Unix case. It is not a GHSA.

The skip now compares the first byte of `file_name().as_encoded_bytes()` to `b'.'`. UTF-8 `.env` / `.ssh` / `.git` are unchanged. `--dry-run`'s `ignored_files_in_pruned_dirs` count uses the same `is_hidden_name` predicate.

This bug was introduced with the hidden-file skip in [#287](https://github.com/xerj-org/xerj/pull/287) ([`5c7b3696`](https://github.com/xerj-org/xerj/commit/5c7b3696), 2026-08-10). Related: [#279](https://github.com/xerj-org/xerj/pull/279), [#79](https://github.com/xerj-org/xerj/issues/79) (UTF-8 skip already landed).

## Upgrade (graph-enabled corpora)

A corpus indexed by a pre-fix binary that contains a hidden non-UTF-8 name looks like a file removal to the resume-plan path. That path is the default, and it is what `xerj brain` uses.

Until [#439](https://github.com/xerj-org/xerj/issues/439) lands, the first rerun exits 1 with `unsupported_content_group_removal`, writes nothing, and the already-indexed documents stay live. Every subsequent rerun reproduces that abort.

Do **not** follow the refusal's first recovery route (`restore_removed_files`). The file is still on disk; the walker just no longer yields it. `--fresh` is refused on that state directory.

Recovery that works:

1. Delete the published indices and the state directory.
2. Re-index the folder with the new binary.

An isolated rebuild with a new `--state-dir` / `--prefix` also exits 0, but leaves the old target's documents live until those indices are deleted by hand.

`--no-graph` can delete the data documents on the upgrade run. Catalog residue can remain; the purge above is the operator procedure this PR documents.

This PR does not change `UnsupportedInventoryDelta`. That is [#439](https://github.com/xerj-org/xerj/issues/439).

Ref #439

## Evidence

Red (helper, before the byte check; APFS cannot create `.\x80`, so local red is on `OsStr::from_bytes`):

```
$ cargo test -p xerj-autoindex -- hidden_non_utf8
test walk::hidden_skip_tests::hidden_non_utf8_dot_name_is_detected ... FAILED
first byte is '.', even when to_str() is None
```

Green (existing UTF-8 hidden skip plus the new tests):

```
$ cargo test -p xerj-autoindex -- hidden_
test result: ok. 6 passed; 0 failed
$ cargo test -p xerj-autoindex -- ignore_rules
test result: ok. 16 passed; 0 failed
```

Linux CI also runs `hidden_non_utf8_dotfile_is_never_indexed` and `count_inside_skips_hidden_non_utf8_names`, which create `.\x80` names on disk.

## Checks

- [x] `cargo fmt --all` (from `engine/`)
- [x] Scoped release build: `cd engine && cargo build --release -j 32 -p xerj-autoindex`
- [x] `cargo test -p xerj-autoindex -- hidden_` (6 passed)
- [x] `cargo test -p xerj-autoindex -- ignore_rules` (16 passed on macOS; Linux adds `count_inside_skips_hidden_non_utf8_names`)
- [x] `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`
- [ ] ES-YAML conformance suite: not run
- [ ] New ES-compatible behaviour YAML case: not applicable
- [x] CHANGELOG `[Unreleased]` Fixed bullet, including the upgrade abort and purge procedure
- [x] Contribution review: public path, fail-closed only on the unsafe name. Durable resume-plan state is affected on upgrade; documented above. Reconciler exemption is #439, not this PR.

**Not run:** ES-YAML (walk / ignore only; no query or index-engine change). `cargo-audit` and fuzz (not a wire parser). Linux on-disk `.\x80` tests (APFS rejects that name; CI Linux will run them).

## Provenance

- Written by: AI coding agent, run by @SebTardif who has reviewed it
- **Verified** (commands run, output observed):
  - `gh pr view 419 --repo xerj-org/xerj --json state,mergedAt` → MERGED 2026-08-16
  - Red: `cargo test -p xerj-autoindex -- hidden_non_utf8` failed on `is_hidden_name(OsStr::from_bytes(b".\\x80"))` while the check still used `to_str()`
  - Green: `cargo test -p xerj-autoindex -- hidden_` → 6 passed; `cargo test -p xerj-autoindex -- ignore_rules` → 16 passed
  - `cargo fmt --all` from `engine/`
  - `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`
  - `cd engine && cargo build --release -j 32 -p xerj-autoindex` → Finished release
- **Assumed** (not tested, and what would falsify it):
  - Linux ext4 will create `.\x80` and both `walk()` and `count_inside` will see it. Falsified if the Linux CI tests cannot create the file or if walkdir skips it before our check.
  - Windows WTF-8 still starts `.env` with `b'.'`. Falsified if a Windows hidden name we care about no longer starts with that byte.
