### PR TITLE
fix(autoindex): qualify GIF magic by reading past 8 KiB, not by guessing (#379, #380)

### DIFF
--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -545,15 +545,22 @@ fn gif_screen_descriptor(prefix: &[u8]) -> bool {
             // ',' at offset 13 followed by four little-endian u16s whose HIGH
             // bytes (15, 17, 19, 21) are spaces clears every bound above.
             // Decode one field further, to the LZW minimum code size that
-            // opens the image data: the spec confines it to 2..=12, which is
-            // entirely non-printable. Every counterexample carries 0x20 there.
+            // opens the image data. A GIF palette holds at most 256 entries, so
+            // this field is bits-per-pixel and cannot exceed 8 — codes grow to
+            // 12 bits during compression, but the MINIMUM code size is 2..=8.
+            // Round 2 wrote 2..=12, and that width is what let text back
+            // through: 9, 10, 11 and 12 are exactly TAB, LF, VT and FF, so an
+            // ordinary line break at the derived offset satisfied it. Measured,
+            // every real image-descriptor-first GIF on the build machine
+            // carries 8 here across palettes of 2 to 256 entries, while the
+            // CP1252 and ASCII counterexamples carry 9 or 10.
             let has_local_table = desc[8] & 0x80 != 0;
             // A frame needs a palette: its own Local Colour Table, or the
             // Global one. With neither there is nothing to decode pixels
             // against, so such a file is not a GIF at all. This is what
             // separates prose whose byte at the LZW position happens to be a
             // control character — the CSV counterexample carries `\n` (10),
-            // which is inside the valid 2..=12 range and clears the check
+            // which is inside the old 2..=12 range and cleared the check
             // below on its own.
             if !has_local_table && packed & 0x80 == 0 {
                 return false;
@@ -563,7 +570,7 @@ fn gif_screen_descriptor(prefix: &[u8]) -> bool {
             } else {
                 0
             };
-            matches!(prefix.get(block + 10 + local_table), Some(2..=12))
+            matches!(prefix.get(block + 10 + local_table), Some(2..=8))
         }
         _ => false,
     }
@@ -1703,7 +1710,7 @@ mod printable_magic_tests {
         gif87.extend_from_slice(&[16, 0, 16, 0, 0x80, 0, 0]);
         gif87.extend_from_slice(&[0, 0, 0, 0xff, 0xff, 0xff]); // GCT
                                                                // Image Descriptor, then the LZW minimum code size that opens the
-                                                               // image data — the spec confines it to 2..=12, and it is the field
+                                                               // image data — the spec confines it to 2..=8, and it is the field
                                                                // all-ASCII input cannot supply (#379).
         gif87.extend_from_slice(&[0x2c, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0x02]);
         gif87.extend(b"lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(20));
@@ -1875,6 +1882,52 @@ mod printable_magic_tests {
              extension and no encoder writes it into the container"
         );
     }
+    /// The third must-fix from the round-2 verification: the palette check is a
+    /// single-bit test on a byte that in text is a character. Bit 7 is clear for
+    /// 7-bit ASCII — which is why the round-2 ASCII fixtures passed — but SET
+    /// for every CP1252 accented letter and every UTF-8 lead byte, so the gate
+    /// stood open for exactly the scripts this repository has junked before
+    /// (the #378 reland silently dropped CJK, Cyrillic, Greek, Hebrew and
+    /// Arabic documents over ~4 KB).
+    ///
+    /// The palette bit is not what separates text from images. The LZW minimum
+    /// code size is.
+    #[test]
+    fn accented_and_multibyte_text_is_not_junked_through_the_image_descriptor() {
+        let latin1 = |s: &str, n: usize| -> Vec<u8> {
+            s.repeat(n).chars().map(|c| c as u32 as u8).collect()
+        };
+        let cases: [(&str, Vec<u8>); 3] = [
+            (
+                "cp1252-spanish-csv",
+                latin1(
+                    "GIF89a está en desuso hoy,1 2 3 4 5\nformato,anio,notas\n",
+                    30,
+                ),
+            ),
+            (
+                "cp1252-french-csv",
+                latin1("GIF89a créé en 1987, puis,1 2 3 4 5\nligne,a,b,c\n", 40),
+            ),
+            (
+                "ascii-csv-newline-at-the-lzw-offset",
+                "GIF89a format,1 2 3 4 5\nrow,a,b,c,d\n"
+                    .repeat(60)
+                    .into_bytes(),
+            ),
+        ];
+        for (label, bytes) in &cases {
+            let p = Path::new("notes.txt");
+            let sn = sniff_bytes(bytes, p, p, false).unwrap();
+            assert_ne!(
+                sn.family,
+                Family::Binary,
+                "{label}: text junked as {:?} — the image-descriptor path is still open (#379)",
+                sn.binary_kind
+            );
+        }
+    }
+
     /// The Comment-extension arm, which round 2 of #379 added and which an
     /// independent verification then broke real images with. It is the only
     /// branch here carrying a loop, so it is the one that needed fixtures and

--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -183,58 +183,8 @@ fn sniff_bytes(
     // thousands of junk records — measured: a 4,194,360-byte printable blob
     // yields 2,048 sections. `for_each_section` streams, so the cost is the
     // record COUNT, not resident bytes. Magic bytes are the reliable signal.
-    //
-    // Every signature ADDED BY THIS BRANCH whose bytes are printable ASCII
-    // carries a `qualify` check as well, because "starts with these letters"
-    // is also true of ordinary text: a CSV whose first column header is `ID3`,
-    // and prose whose first word is `RIFF`, `OggS`, `fLaC`, `8BPS` or
-    // `Kaydara FBX Binary`, were all junked as media by the unqualified table
-    // (measured — see the tests below). That is six of the nine signatures
-    // added here; the other three (`II*\x00`, `MM\x00*`, the EXR magic) carry
-    // a byte text cannot contain.
-    //
-    // Two printable signatures remain unqualified — `GIF8` and `BM` — and both
-    // have the same defect. They are NOT new: they are unchanged from
-    // `ca4d75a` and were measured to classify identically on both trees, so
-    // fixing them is a separate behaviour change and is filed as #380 rather
-    // than smuggled into a Unity PR. Today's wrong answers are pinned by
-    // `printable_magic_regression_tests::gif8_and_bm_are_still_taken_on_faith`,
-    // so #380 has to come here and flip that assertion deliberately.
-    //
-    // Qualifying a magic number is the
-    // rule Lucene applies to its own containers: `CodecUtil.checkHeader`
-    // (`lucene/core/src/java/org/apache/lucene/codecs/CodecUtil.java:183-201`,
-    // Apache-2.0) matches `CODEC_MAGIC` and then hands straight to
-    // `checkHeaderNoMagic` (`CodecUtil.java:202-246`), which refuses the file
-    // unless the codec name AND a version inside an accepted range follow —
-    // the magic alone is never taken as proof. Adapted, not copied: Lucene is
-    // validating files it wrote itself, this is declining to delete somebody
-    // else's prose.
-    for (magic, kind, qualify) in [
-        (&b"\x89PNG"[..], "png", accept as fn(&[u8]) -> bool),
-        (&b"GIF8"[..], "gif", accept as fn(&[u8]) -> bool),
-        (&b"\xff\xd8\xff"[..], "jpeg", accept as fn(&[u8]) -> bool),
-        (&b"\x7fELF"[..], "elf", accept as fn(&[u8]) -> bool),
-        (&b"BM"[..], "bmp", accept as fn(&[u8]) -> bool),
-        (&b"\x00\x00\x01\x00"[..], "ico", accept as fn(&[u8]) -> bool),
-        (&b"8BPS"[..], "psd", psd_version as fn(&[u8]) -> bool),
-        (&b"II*\x00"[..], "tiff", accept as fn(&[u8]) -> bool),
-        (&b"MM\x00*"[..], "tiff", accept as fn(&[u8]) -> bool),
-        (&b"RIFF"[..], "riff", riff_form as fn(&[u8]) -> bool),
-        (&b"OggS"[..], "ogg", ogg_page as fn(&[u8]) -> bool),
-        (
-            &b"fLaC"[..],
-            "flac",
-            flac_metadata_block as fn(&[u8]) -> bool,
-        ),
-        (&b"ID3"[..], "mp3", id3v2_header as fn(&[u8]) -> bool),
-        (
-            &b"Kaydara FBX Binary"[..],
-            "fbx",
-            fbx_header as fn(&[u8]) -> bool,
-        ),
-        (&b"\x76\x2f\x31\x01"[..], "exr", accept as fn(&[u8]) -> bool),
-    ] {
+    // `MAGIC_TABLE` and its invariant are documented at the table itself.
+    for &(magic, kind, qualify) in MAGIC_TABLE {
         if prefix.starts_with(magic) && qualify(prefix) {
             let mut s = mk(Family::Binary);
             s.binary_kind = Some(kind.into());
@@ -376,21 +326,285 @@ fn sniff_bytes(
 /// the bytes are text — the binary heuristics key off this exact string.
 pub const WINDOWS_1252_LOSSY: &str = "windows-1252 (lossy)";
 
+/// A magic-byte row: the signature, the `binary_kind` it reports, and the
+/// structural check that has to pass before the signature is believed.
+type MagicRow = (&'static [u8], &'static str, fn(&[u8]) -> bool);
+
+/// Media/container signatures, tried in order before any text heuristic.
+///
+/// THE INVARIANT, and the reason this table is a named constant rather than a
+/// literal inside `sniff_bytes`: **a signature whose bytes are all printable
+/// ASCII MUST carry a qualifier**, because "starts with these letters" is also
+/// true of ordinary text. A CSV whose first column header is `ID3` or `BMW`,
+/// prose whose first word is `RIFF`, `OggS`, `fLaC`, `8BPS` or `Kaydara FBX
+/// Binary`, and a note opening `GIF89a is the version string…` were each junked
+/// as media by an unqualified row (measured — see the tests below). The rows
+/// that use `accept` are exactly the ones carrying a byte text cannot contain:
+/// `\x89PNG`, `\xff\xd8\xff`, `\x7fELF`, `\x00\x00\x01\x00`, the NUL in
+/// `II*\x00` / `MM\x00*`, and the `\x01` in the EXR magic.
+///
+/// `GIF8` and `BM` were the last two exceptions — printable ASCII taken on
+/// faith, so a `cars.csv` opening `BMW,model,year` was reported as an image and
+/// never indexed (#379/#380, the same defect filed twice). The invariant is now
+/// enforced by walking these rows in
+/// `printable_magic_tests::every_printable_signature_carries_a_qualifier`, so
+/// the next row added in violation of it fails a test instead of a code review.
+///
+/// Qualifying a magic number is the rule Lucene applies to its own containers:
+/// `CodecUtil.checkHeader`
+/// (`lucene/core/src/java/org/apache/lucene/codecs/CodecUtil.java:183-201`,
+/// Apache-2.0) matches `CODEC_MAGIC` and then hands straight to
+/// `checkHeaderNoMagic` (`CodecUtil.java:202-246`), which refuses the file
+/// unless the codec name AND a version inside an accepted range follow — the
+/// magic alone is never taken as proof. Adapted, not copied: Lucene is
+/// validating files it wrote itself, this is declining to delete somebody
+/// else's prose.
+const MAGIC_TABLE: &[MagicRow] = &[
+    (b"\x89PNG", "png", accept),
+    (b"GIF8", "gif", gif_screen_descriptor),
+    (b"\xff\xd8\xff", "jpeg", accept),
+    (b"\x7fELF", "elf", accept),
+    (b"BM", "bmp", bmp_file_header),
+    (b"\x00\x00\x01\x00", "ico", accept),
+    (b"8BPS", "psd", psd_version),
+    (b"II*\x00", "tiff", accept),
+    (b"MM\x00*", "tiff", accept),
+    (b"RIFF", "riff", riff_form),
+    (b"OggS", "ogg", ogg_page),
+    (b"fLaC", "flac", flac_metadata_block),
+    (b"ID3", "mp3", id3v2_header),
+    (b"Kaydara FBX Binary", "fbx", fbx_header),
+    (b"\x76\x2f\x31\x01", "exr", accept),
+];
+
 /// Magic-byte signature taken as sufficient on its own.
 ///
-/// For most callers that is because the signature contains a byte text cannot
-/// contain (`\x89PNG`, `\xff\xd8\xff`, `\x7fELF`, `\x00\x00\x01\x00`, the NUL
-/// in `II*\x00` / `MM\x00*`, the `\x01` in the EXR magic).
-///
-/// It is NOT true of the two remaining callers: `GIF8` and `BM` are printable
-/// ASCII, so prose or a CSV header beginning with those characters is junked
-/// as an image. Both predate this branch — they are unchanged from `ca4d75a`
-/// and measured identical on both trees — so they are left alone here rather
-/// than widened into an unrelated behaviour change, and are tracked as #380.
-/// Do not read this function as a proof that its callers are safe;
-/// it is only a statement that no *further* check is performed.
+/// Every caller is a signature containing a byte text cannot contain
+/// (`\x89PNG`, `\xff\xd8\xff`, `\x7fELF`, `\x00\x00\x01\x00`, the NUL in
+/// `II*\x00` / `MM\x00*`, the `\x01` in the EXR magic) — that byte, not this
+/// function, is what makes the match evidence. A signature made only of
+/// printable ASCII must NOT be routed here; give it a structural qualifier, as
+/// `GIF8` and `BM` now have (#379/#380). Do not read this function as a proof
+/// that its callers are safe; it is only a statement that no *further* check is
+/// performed.
 fn accept(_prefix: &[u8]) -> bool {
     true
+}
+
+/// GIF: `GIF8` on its own is four printable letters, so a note opening "GIF89a
+/// is the header format used by the GIF image standard" was classified as an
+/// image and junked by `scan_file` as "binary content (gif)" (#379/#380).
+///
+/// Widening the signature to the full six-byte version stamp is NOT enough on
+/// its own — that same sentence supplies `GIF89a` — and neither is adding the
+/// canvas dimensions, because " i"/"s " are perfectly good non-zero u16s. The
+/// qualifier has to reach the fields the spec pins to a fixed value.
+///
+/// GIF89a spec §17-19: the 6-byte Header (`GIF87a` or `GIF89a`) is followed by
+/// the 7-byte Logical Screen Descriptor — canvas width and height
+/// (little-endian, and an image has both), a packed field whose top bit is the
+/// Global Colour Table flag and whose low three bits size that table, a
+/// Background Colour Index, and a Pixel Aspect Ratio. Then comes the Global
+/// Colour Table itself, `3 * 2^(N+1)` bytes, and after it the first block of
+/// the data stream. The table is at most 768 bytes, so that first block starts
+/// at offset 781 at the very latest and is always inside the 8 KiB
+/// `read_prefix` buffer.
+///
+/// That first block is the discriminator. The spec admits exactly three
+/// introducers there — `0x21` Extension, `0x2C` Image Descriptor, `0x3B`
+/// Trailer — but the introducer ALONE is not enough, and this is worth
+/// spelling out because it is what the first attempt at this fix used: all
+/// three bytes are printable (`!`, `,`, `;`), so "GIF89a header, the six bytes
+/// at the front of every GIF file" puts a comma exactly there and is junked all
+/// over again. Measured, along with "GIF89a images! …" and "GIF87a format; …".
+/// So the block is decoded one step further, into fields prose cannot supply:
+///
+///   * after `0x21`, the extension label. The spec defines four — Plain Text
+///     `0x01`, Graphic Control `0xF9`, Comment `0xFE`, Application `0xFF` —
+///     three unprintable and the fourth a control character.
+///   * after `0x2C`, a 9-byte Image Descriptor. The frame must be non-empty and
+///     must fit inside the canvas declared two fields earlier, which four
+///     little-endian u16s of prose do not.
+///
+/// A bare `0x3B` is refused: that is a GIF containing no image at all, it
+/// appears in no corpus measured, and it carries no pixel data to junk.
+///
+/// The fields this check does NOT use are as important, because round 1 of
+/// #379 used them and they were wrong. Requiring the Pixel Aspect Ratio and
+/// the Background Colour Index to be zero looks safe — satisfying them takes
+/// NUL bytes, and prose has no NULs — but it refuses REAL GIFs. Swept over
+/// every distinct GIF on the build machine (147 files deduped by content hash,
+/// 51 B to 17.6 MB): the rule below accepts 147/147; the aspect/background rule
+/// refused 4, among them this repository's own `docs/media/demo.gif`, whose
+/// aspect byte is 49 — the spec's encoding of a 1:1 pixel ratio, since
+/// `(49 + 15) / 64 = 1.0`.
+///
+/// Falling through to the text heuristics is not a safety net, and the honest
+/// version of that claim is narrower than "it still classifies binary". All 4
+/// refused GIFs do still reach `Family::Binary` here, but as `unknown` rather
+/// than `gif`, and only because their first 8 KiB decodes above the 10%
+/// control-character threshold — by 0.14 to 1.5 percentage points. Two other
+/// GIFs in the same 147 sit BELOW it, at 9.39% and 9.78%, and would be
+/// sectioned into prose records outright if they were refused. Whether a real
+/// image survives therefore turns on the entropy of its first 8 KiB, which no
+/// qualifier controls. Pinned by
+/// `real_gif_shapes_the_aspect_ratio_rule_refused`.
+fn gif_screen_descriptor(prefix: &[u8]) -> bool {
+    if prefix.len() < 13 || !matches!(&prefix[..6], b"GIF87a" | b"GIF89a") {
+        return false;
+    }
+    let canvas_width = u16::from_le_bytes([prefix[6], prefix[7]]);
+    let canvas_height = u16::from_le_bytes([prefix[8], prefix[9]]);
+    if canvas_width == 0 || canvas_height == 0 {
+        return false;
+    }
+    let packed = prefix[10];
+    // `3 * 2^(N+1)`, N being the low three bits: 6 bytes at N=0, 768 at N=7.
+    let color_table = if packed & 0x80 != 0 {
+        3 * (1usize << ((packed & 0x07) + 1))
+    } else {
+        0
+    };
+    // Background Colour Index (11) and Pixel Aspect Ratio (12) are skipped on
+    // purpose — see above, real encoders put non-zero bytes in both.
+    let block = 13 + color_table;
+    match prefix.get(block) {
+        // Extension. The label alone is not a discriminator: `decode()` falls
+        // back to windows-1252 (see `decode`, below), where 0xF9/0xFE/0xFF are
+        // ordinary latin-1 letters, so `"GIF89a fichie!" + 0xF9 + French prose`
+        // satisfied the label check and was junked as an image. The spec pins
+        // the FIRST sub-block size for three of the four labels, and all three
+        // sizes are non-printable.
+        Some(0x21) => match (prefix.get(block + 1), prefix.get(block + 2)) {
+            (Some(0x01), Some(12)) => true, // Plain Text: 12-byte block
+            (Some(0xf9), Some(4)) => true,  // Graphic Control: 4-byte block
+            (Some(0xff), Some(11)) => true, // Application: 11-byte block
+            // Comment sizes are genuinely variable (1..=255 per sub-block), so
+            // there is no fixed byte to pin. Walk the sub-block chain instead:
+            // a real Comment terminates with a 0x00 and is followed by another
+            // introducer. Prose has to land that whole structure, not one byte.
+            (Some(0xfe), Some(_)) => {
+                let mut at = block + 2;
+                for _ in 0..MAX_COMMENT_SUB_BLOCKS {
+                    match prefix.get(at) {
+                        Some(0) => {
+                            return matches!(prefix.get(at + 1), Some(0x21 | 0x2c | 0x3b));
+                        }
+                        Some(&len) => at += 1 + usize::from(len),
+                        None => return false,
+                    }
+                }
+                false
+            }
+            _ => false,
+        },
+        Some(0x2c) => {
+            // Image Descriptor: 8 bytes of geometry, then its own packed byte.
+            let Some(desc) = prefix.get(block + 1..block + 10) else {
+                return false;
+            };
+            let left = u32::from(u16::from_le_bytes([desc[0], desc[1]]));
+            let top = u32::from(u16::from_le_bytes([desc[2], desc[3]]));
+            let width = u32::from(u16::from_le_bytes([desc[4], desc[5]]));
+            let height = u32::from(u16::from_le_bytes([desc[6], desc[7]]));
+            if width == 0
+                || height == 0
+                || left + width > u32::from(canvas_width)
+                || top + height > u32::from(canvas_height)
+            {
+                return false;
+            }
+            // Geometry alone is satisfiable by all-ASCII input. For any such
+            // input `packed & 0x80` is clear, so `block` is always 13, and a
+            // ',' at offset 13 followed by four little-endian u16s whose HIGH
+            // bytes (15, 17, 19, 21) are spaces clears every bound above.
+            // Decode one field further, to the LZW minimum code size that
+            // opens the image data: the spec confines it to 2..=12, which is
+            // entirely non-printable. Every counterexample carries 0x20 there.
+            let has_local_table = desc[8] & 0x80 != 0;
+            // A frame needs a palette: its own Local Colour Table, or the
+            // Global one. With neither there is nothing to decode pixels
+            // against, so such a file is not a GIF at all. This is what
+            // separates prose whose byte at the LZW position happens to be a
+            // control character — the CSV counterexample carries `\n` (10),
+            // which is inside the valid 2..=12 range and clears the check
+            // below on its own.
+            if !has_local_table && packed & 0x80 == 0 {
+                return false;
+            }
+            let local_table = if has_local_table {
+                3 * (1usize << ((desc[8] & 0x07) + 1))
+            } else {
+                0
+            };
+            matches!(prefix.get(block + 10 + local_table), Some(2..=12))
+        }
+        _ => false,
+    }
+}
+
+/// Bound on the Comment-extension sub-block walk in `gif_screen_descriptor`.
+/// A comment is at most 255 bytes per sub-block and the whole first block sits
+/// inside the 8 KiB prefix, so a real one terminates in far fewer; the cap only
+/// stops a crafted chain from walking the buffer.
+const MAX_COMMENT_SUB_BLOCKS: usize = 64;
+
+/// Windows bitmap: `BM`, then a 14-byte BITMAPFILEHEADER, then a DIB header
+/// that opens with its own size.
+///
+/// The discriminator is the DIB header size and the two fields immediately
+/// behind it. Every DIB header ever defined is between 12 (BITMAPCOREHEADER)
+/// and 124 (BITMAPV5HEADER) bytes, so its little-endian u32 puts three NUL
+/// bytes at offsets 15..18, where `BMW,model,year` puts `ar\n`. Colour planes
+/// is then fixed at 1 by every variant of the header, which pins a fourth NUL,
+/// and bit depth behind it is a closed set. Those are the checks text cannot
+/// pass; the pixel-array offset must additionally clear both headers.
+///
+/// Two tighter rules were tried first, in round 1 of #379, and both refuse real
+/// bitmaps — which is the failure this table exists to prevent, so neither is
+/// used:
+///
+///   * `bfReserved1/2` at offsets 6..10 are specified as zero, but a bitmap
+///     converted from a CUR or ICO carries the cursor hot-spot coordinates
+///     there.
+///   * a closed set of DIB sizes `{12, 16, 40, 52, 56, 64, 108, 124}` admits
+///     five of the OS/2 2.x BITMAPCOREHEADER2 sizes, which are legally anything
+///     in `16..=64`, and refuses the other 44.
+///
+/// Only 3 real BMPs exist on the build machine, all BITMAPINFOHEADER with zero
+/// reserved words, so unlike the GIF sweep this is reasoned from the format
+/// definitions rather than measured against a corpus — but the mechanism is the
+/// one that demonstrably broke GIF, and a synthetic hot-spot / OS/2 bitmap does
+/// sniff `txt-prose` under the old rule. Pinned by
+/// `real_bmp_shapes_the_closed_set_refused`.
+///
+/// `bfSize` (offsets 2..6) is deliberately NOT compared against the file
+/// length, which is what #379 proposed. Two reasons, both structural: this
+/// function classifies from the `read_prefix(path, gzip, 8192)` buffer and has
+/// no file length to compare against, and for a gzipped member the on-disk
+/// length is the *compressed* length, so the comparison would be wrong exactly
+/// where it was applied.
+fn bmp_file_header(prefix: &[u8]) -> bool {
+    if prefix.len() < 18 {
+        return false;
+    }
+    let pixel_offset = u32::from_le_bytes([prefix[10], prefix[11], prefix[12], prefix[13]]);
+    let dib_header_size = u32::from_le_bytes([prefix[14], prefix[15], prefix[16], prefix[17]]);
+    if !(12..=124).contains(&dib_header_size) || pixel_offset < 14 + dib_header_size {
+        return false;
+    }
+    // Colour planes then bit depth. BITMAPCOREHEADER declares u16 width and
+    // height, every later header i32, which moves the pair from 22 to 26.
+    let planes_at = if dib_header_size == 12 { 22 } else { 26 };
+    let Some(f) = prefix.get(planes_at..planes_at + 4) else {
+        return false;
+    };
+    u16::from_le_bytes([f[0], f[1]]) == 1
+        && matches!(
+            u16::from_le_bytes([f[2], f[3]]),
+            // 0 is BI_JPEG / BI_PNG, where the DIB carries an embedded image.
+            0 | 1 | 2 | 4 | 8 | 16 | 24 | 32
+        )
 }
 
 /// Adobe Photoshop: `8BPS` is followed by a big-endian version, 1 for PSD and
@@ -403,11 +617,19 @@ fn psd_version(prefix: &[u8]) -> bool {
 /// RIFF container: `RIFF`, a little-endian chunk size, then a four-character
 /// FORM type naming what the container actually holds. Requiring a known FORM
 /// is what separates a WAV from a sentence that opens with the word "RIFF".
+///
+/// `ACON` is the animated-cursor FORM. It is listed because `ANI ` — which was
+/// here on its own — is the file EXTENSION, not the FORM type, and no encoder
+/// writes it: swept over every RIFF file on the build machine (195 files;
+/// FORM types `WAVE` 158, `WEBP` 25, `ACON` 12), the closed set without `ACON`
+/// refused all 12 real `.ani` files. Same defect shape as #379 one row up, so
+/// it is corrected here rather than left for the closed set to be widened a
+/// third time.
 fn riff_form(prefix: &[u8]) -> bool {
     prefix.len() >= 12
         && matches!(
             &prefix[8..12],
-            b"WAVE" | b"AVI " | b"WEBP" | b"RMID" | b"ANI " | b"CDDA" | b"PAL " | b"RDIB"
+            b"WAVE" | b"AVI " | b"WEBP" | b"RMID" | b"ACON" | b"CDDA" | b"PAL " | b"RDIB"
         )
 }
 
@@ -1319,76 +1541,533 @@ mod unity_sniff_tests {
     }
 }
 
-/// Characterisation of a KNOWN, PRE-EXISTING defect, tracked as #380.
+/// Regression for #379/#380: `GIF8` and `BM` were the last two printable-ASCII
+/// signatures in `MAGIC_TABLE` taken on faith, so text beginning with those
+/// characters was classified `Family::Binary` and `scan_file` junked it as
+/// "binary content (gif)" / "(bmp)" — never indexed, with a wrong reason. The
+/// reported case is a CSV whose first column header is `BMW`.
 ///
-/// Every other printable-ASCII signature in the magic table carries a
-/// structural qualifier. `GIF8` and `BM` do not: they pass `accept`, which
-/// returns `true` without looking at a single byte. So text beginning with
-/// those characters is classified `Family::Binary` and `scan_file` junks it.
-///
-/// This module asserts the WRONG answer on purpose. The behaviour is not
-/// introduced by this branch — on `origin/main` the same two entries sit in a
-/// loop with no qualifier at all (`if prefix.starts_with(magic)`), so the
-/// control flow to `Family::Binary` is identical and cannot differ — and
-/// fixing it is a behaviour change with no Unity content. Pinning it here is
-/// what stops the CHANGELOG's "known issue" wording from being the only record
-/// of it: whoever fixes #380 must come to this file and flip these assertions,
-/// which is the point.
+/// Before this module's fix, `gif8_and_bm_are_still_taken_on_faith` pinned the
+/// wrong answers here on purpose. These tests are its replacement: they assert
+/// the right answer for the same fixtures, keep the true positives, and add a
+/// walk of `MAGIC_TABLE` so the *class* of defect cannot come back by way of a
+/// new row.
 #[cfg(test)]
-mod printable_magic_regression_tests {
+mod printable_magic_tests {
     use super::*;
 
+    fn sniff_str(text: &str, name: &str) -> Sniffed {
+        let p = Path::new(name);
+        sniff_bytes(text.as_bytes(), p, p, false).unwrap()
+    }
+
+    /// The issue's own three fixtures, plus the CSV shape it calls out. `ID3`
+    /// is included because it was already correct and must stay correct.
     #[test]
-    fn gif8_and_bm_are_still_taken_on_faith() {
-        // Prose, and a well-formed CSV whose first column header happens to be
-        // `GIF8`. All four are text. All four are reported as images.
-        for (label, bytes, name, kind) in [
+    fn text_that_opens_with_gif8_or_bm_is_text() {
+        for (label, text, name, want) in [
             (
-                "gif8-prose",
-                "GIF8 is the four byte magic that opens a GIF image file. "
-                    .repeat(30)
-                    .into_bytes(),
-                "notes.txt",
-                "gif",
+                "cars-csv",
+                "BMW,model,year\nX5,SUV,2024\n330i,sedan,2023\nM3,coupe,2022\niX,SUV,2025\n"
+                    .to_string(),
+                "cars.csv",
+                Family::Csv,
             ),
             (
-                "gif89a-prose",
-                "GIF89a is the version string of the second GIF spec. "
-                    .repeat(30)
-                    .into_bytes(),
-                "notes.txt",
-                "gif",
-            ),
-            (
-                "bm-prose",
-                "BM is the two byte magic that opens a Windows bitmap file. "
-                    .repeat(30)
-                    .into_bytes(),
-                "notes.txt",
-                "bmp",
+                "bmi-csv",
+                "BMI,height_cm,weight_kg\n22.1,180,71\n25.6,165,70\n19.8,171,58\n27.3,178,86\n"
+                    .to_string(),
+                "health.csv",
+                Family::Csv,
             ),
             (
                 "gif8-csv",
-                b"GIF8,name,value\n1,alpha,2\n3,beta,4\n5,gamma,6\n7,delta,8\n".to_vec(),
+                "GIF8,name,value\n1,alpha,2\n3,beta,4\n5,gamma,6\n7,delta,8\n".to_string(),
                 "t.csv",
-                "gif",
+                Family::Csv,
             ),
+            (
+                "gif-notes",
+                "GIF89a is the header format used by the GIF image standard. ".repeat(30),
+                "gif-notes.txt",
+                Family::TxtProse,
+            ),
+            (
+                "gif87a-notes",
+                "GIF87a was the first version of the format, published in 1987. ".repeat(30),
+                "gif87.txt",
+                Family::TxtProse,
+            ),
+            (
+                "gif8-prose",
+                "GIF8 is the four byte magic that opens a GIF image file. ".repeat(30),
+                "notes.txt",
+                Family::TxtProse,
+            ),
+            (
+                "bm-prose",
+                "BM is the two byte magic that opens a Windows bitmap file. ".repeat(30),
+                "notes.txt",
+                Family::TxtProse,
+            ),
+            (
+                "id3-notes",
+                "ID3 tags are metadata containers embedded in MP3 files. ".repeat(30),
+                "id3-notes.txt",
+                Family::TxtProse,
+            ),
+        ] {
+            let sn = sniff_str(&text, name);
+            assert_ne!(
+                sn.family,
+                Family::Binary,
+                "{label}: text opening with a printable signature was junked as \
+                 {:?}",
+                sn.binary_kind
+            );
+            assert_eq!(sn.family, want, "{label}: wrong family");
+        }
+    }
+
+    /// The signature is necessary, it is just not sufficient — real bitmaps and
+    /// real GIFs must still be caught by magic, before any text heuristic, or
+    /// the fix has simply moved the damage (a multi-MB image sectioned into
+    /// thousands of prose records, which is what the magic table exists to
+    /// prevent).
+    #[test]
+    fn real_bitmaps_and_gifs_are_still_binary_by_magic() {
+        // 2x2 24bpp BMP: BITMAPFILEHEADER (14) + BITMAPINFOHEADER (40).
+        let mut bmp: Vec<u8> = b"BM".to_vec();
+        bmp.extend_from_slice(&70u32.to_le_bytes()); // bfSize
+        bmp.extend_from_slice(&[0, 0, 0, 0]); // bfReserved1/2
+        bmp.extend_from_slice(&54u32.to_le_bytes()); // bfOffBits
+        bmp.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        bmp.extend_from_slice(&2i32.to_le_bytes()); // biWidth
+        bmp.extend_from_slice(&2i32.to_le_bytes()); // biHeight
+        bmp.extend_from_slice(&[1, 0, 24, 0]); // planes, bpp
+        bmp.extend(std::iter::repeat_n(0u8, 24));
+        // A printable tail that WOULD pass the prose heuristics.
+        bmp.extend(b"lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(20));
+
+        // BITMAPCOREHEADER is the other end of the range that exists.
+        let mut bmp_core: Vec<u8> = b"BM".to_vec();
+        bmp_core.extend_from_slice(&38u32.to_le_bytes());
+        bmp_core.extend_from_slice(&[0, 0, 0, 0]);
+        bmp_core.extend_from_slice(&26u32.to_le_bytes()); // 14 + 12
+        bmp_core.extend_from_slice(&12u32.to_le_bytes()); // BITMAPCOREHEADER
+        bmp_core.extend_from_slice(&[2, 0, 2, 0, 1, 0, 24, 0]);
+        bmp_core.extend(b"lorem ipsum dolor sit amet, consectetur adipiscing. ".repeat(20));
+
+        // GIF89a, 4x4, global colour table of 2 entries, then a Graphic Control
+        // extension — introducer 0x21, label 0xF9.
+        let mut gif: Vec<u8> = b"GIF89a".to_vec();
+        gif.extend_from_slice(&4u16.to_le_bytes()); // width
+        gif.extend_from_slice(&4u16.to_le_bytes()); // height
+        gif.push(0x80); // GCT present, 2 entries
+        gif.push(0); // background colour index
+        gif.push(0); // pixel aspect ratio
+        gif.extend_from_slice(&[0, 0, 0, 0xff, 0xff, 0xff]); // GCT
+                                                             // Graphic Control Extension: the spec fixes the block size at 4.
+                                                             // Round 1 stopped at the label, which is why prose carrying a
+                                                             // windows-1252 0xF9 satisfied it (#379).
+        gif.extend_from_slice(&[0x21, 0xf9, 0x04]);
+        gif.extend(b"lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(20));
+
+        // GIF87a with no global colour table, opening straight on an Image
+        // Descriptor: introducer 0x2C, then left/top/width/height/packed for a
+        // frame that fills the 16x16 canvas.
+        let mut gif87: Vec<u8> = b"GIF87a".to_vec();
+        // GCT flag set (2 entries): a frame with no Local Colour Table has to
+        // borrow the global one, and a GIF carrying neither has no palette to
+        // decode against.
+        gif87.extend_from_slice(&[16, 0, 16, 0, 0x80, 0, 0]);
+        gif87.extend_from_slice(&[0, 0, 0, 0xff, 0xff, 0xff]); // GCT
+                                                               // Image Descriptor, then the LZW minimum code size that opens the
+                                                               // image data — the spec confines it to 2..=12, and it is the field
+                                                               // all-ASCII input cannot supply (#379).
+        gif87.extend_from_slice(&[0x2c, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0x02]);
+        gif87.extend(b"lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(20));
+
+        for (name, bytes, kind) in [
+            ("t.bmp", bmp, "bmp"),
+            ("core.bmp", bmp_core, "bmp"),
+            ("t.gif", gif, "gif"),
+            ("t87.gif", gif87, "gif"),
         ] {
             let p = Path::new(name);
             let sn = sniff_bytes(&bytes, p, p, false).unwrap();
-            assert_eq!(
-                sn.family,
-                Family::Binary,
-                "{label}: if this now says text, #380 has been fixed — delete \
-                 this module, drop the CHANGELOG known-issue bullet, clear the \
-                 remaining `#380` mentions in this file (`grep -n '#380'`), and \
-                 close the issue"
-            );
+            assert_eq!(sn.family, Family::Binary, "{name} must be binary");
             assert_eq!(
                 sn.binary_kind.as_deref(),
                 Some(kind),
-                "{label}: pinned so a change in WHICH wrong answer is given is \
-                 also caught"
+                "{name} must be recognised as {kind} by magic, not fall through \
+                 to the heuristics"
+            );
+        }
+    }
+
+    /// A printable body the text heuristics WOULD accept: no NULs and no
+    /// control characters, so a fixture carrying it reaches `TxtProse` the
+    /// moment its qualifier declines. That is what makes the tests below true
+    /// negatives rather than restatements of the NUL ratio check — a colour
+    /// table or a pixel array full of zeroes would be caught by the heuristics
+    /// even with the magic row deleted, and would prove nothing.
+    fn printable_payload(n: usize) -> Vec<u8> {
+        b"lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+            .repeat(n)
+            .to_vec()
+    }
+
+    /// True negatives for the regression round 1 of #379 shipped: real GIF
+    /// header shapes that the "Pixel Aspect Ratio and Background Colour Index
+    /// must be zero" qualifier REFUSED, sending a real image down the text
+    /// path to be sectioned into prose records.
+    ///
+    /// Both shapes are transcribed from real files on the build machine, not
+    /// invented — which is the point, since
+    /// `real_bitmaps_and_gifs_are_still_binary_by_magic` builds ideal headers
+    /// and therefore could not see this class at all:
+    ///
+    ///   * `docs/media/demo.gif`, this repository's own 3.27 MB demo:
+    ///     720x450, packed `0xF7`, background `0xFF`, **aspect `0x31`**, a
+    ///     768-byte global colour table, then the `0x21 0xFF` NETSCAPE2.0
+    ///     application extension that every animated GIF carries. `0x31` is
+    ///     not corruption, it is the spec's encoding of a 1:1 pixel ratio:
+    ///     `(49 + 15) / 64 = 1.0`.
+    ///   * a 92 KB screen capture with the **GCT flag clear and background
+    ///     index 255**, which the spec says should be 0 when no table is
+    ///     declared and which real encoders write anyway.
+    ///
+    /// Two things about the assertion are deliberate. The bodies are printable
+    /// (see `printable_payload`), so a refused fixture sniffs `TxtProse` — the
+    /// cue for `extract` to turn an image into records — rather than being
+    /// rescued by the control-character heuristic and quietly proving nothing.
+    /// And the expectation is `Some("gif")`, not merely `Family::Binary`,
+    /// because that heuristic is luck, not a fallback: across the 147 real
+    /// GIFs measured it clears the 10% threshold by as little as 0.14 points,
+    /// and two of them sit under it at 9.39% and 9.78%.
+    #[test]
+    fn real_gif_shapes_the_aspect_ratio_rule_refused() {
+        // demo.gif: GCT present and full size, non-zero background AND aspect.
+        let mut animated: Vec<u8> = b"GIF89a".to_vec();
+        animated.extend_from_slice(&720u16.to_le_bytes());
+        animated.extend_from_slice(&450u16.to_le_bytes());
+        animated.push(0xf7); // GCT present, 256 entries -> 768 bytes
+        animated.push(0xff); // background colour index
+        animated.push(0x31); // pixel aspect ratio: 1:1, NOT "unspecified"
+        animated.extend(printable_payload(14).into_iter().take(768));
+        // NETSCAPE2.0 loop extension. Application Extension block size is
+        // fixed at 11 by the spec ("NETSCAPE" + "2.0").
+        animated.extend_from_slice(&[0x21, 0xff, 0x0b]);
+        animated.extend(printable_payload(20));
+        assert_eq!(animated[781], 0x21, "the first block must land at 13 + 768");
+
+        // screen capture: GCT flag clear, background index still 255.
+        let mut no_table: Vec<u8> = b"GIF89a".to_vec();
+        no_table.extend_from_slice(&2184u16.to_le_bytes());
+        no_table.extend_from_slice(&1280u16.to_le_bytes());
+        no_table.push(0x70); // GCT flag CLEAR
+        no_table.push(0xff); // background colour index, spec says 0
+        no_table.push(0x00);
+        no_table.extend_from_slice(&[0x21, 0xff, 0x0b]);
+        no_table.extend(printable_payload(20));
+
+        for (label, bytes) in [("animated-loop", animated), ("no-global-table", no_table)] {
+            let p = Path::new("capture.gif");
+            let sn = sniff_bytes(&bytes, p, p, false).unwrap();
+            assert_eq!(
+                (sn.family, sn.binary_kind.as_deref()),
+                (Family::Binary, Some("gif")),
+                "{label}: a real GIF header was refused by its qualifier and \
+                 fell through to the text heuristics as {:?}/{:?} — this is \
+                 #379 inverted, an image turned into prose records",
+                sn.family,
+                sn.binary_kind
+            );
+        }
+    }
+
+    /// The same true negative for BMP. `bfReserved1/2` are specified as zero,
+    /// but a bitmap converted from a CUR or ICO carries the cursor hot-spot
+    /// there; OS/2 2.x BITMAPCOREHEADER2 is legally any size in `16..=64`,
+    /// while the closed set round 1 used admitted only five of those 49.
+    /// Bodies are printable, so a refusal here means `TxtProse`, not a lucky
+    /// save by the control-character ratio.
+    #[test]
+    fn real_bmp_shapes_the_closed_set_refused() {
+        fn bmp(dib: u32, reserved: [u8; 4], bits: u16) -> Vec<u8> {
+            let mut v: Vec<u8> = b"BM".to_vec();
+            v.extend_from_slice(&(14 + dib + 1024).to_le_bytes()); // bfSize
+            v.extend_from_slice(&reserved);
+            v.extend_from_slice(&(14 + dib + 1024).to_le_bytes()); // bfOffBits
+            v.extend_from_slice(&dib.to_le_bytes());
+            v.extend_from_slice(&256i32.to_le_bytes()); // width
+            v.extend_from_slice(&256i32.to_le_bytes()); // height
+            v.extend_from_slice(&1u16.to_le_bytes()); // colour planes
+            v.extend_from_slice(&bits.to_le_bytes());
+            v.extend(printable_payload(40).into_iter().take(dib as usize - 16));
+            v.extend(printable_payload(40));
+            v
+        }
+
+        for (label, bytes) in [
+            // Converted from a cursor: hot-spot coordinates in bfReserved1/2.
+            ("cur-hotspot", bmp(40, [16, 0, 16, 0], 8)),
+            // OS/2 2.x BITMAPCOREHEADER2, truncated to 24 and 44 bytes — both
+            // legal, neither in the closed set round 1 shipped.
+            ("os2-dib-24", bmp(24, [0, 0, 0, 0], 8)),
+            ("os2-dib-44", bmp(44, [0, 0, 0, 0], 24)),
+        ] {
+            let p = Path::new("logo.bmp");
+            let sn = sniff_bytes(&bytes, p, p, false).unwrap();
+            assert_eq!(
+                (sn.family, sn.binary_kind.as_deref()),
+                (Family::Binary, Some("bmp")),
+                "{label}: a real BMP header was refused by its qualifier and \
+                 fell through to the text heuristics as {:?}/{:?}",
+                sn.family,
+                sn.binary_kind
+            );
+        }
+    }
+
+    /// The third instance of the same shape, found by sweeping the build
+    /// machine while checking the GIF rule: `riff_form`'s closed set of FORM
+    /// types listed `ANI `, which is the animated-cursor file EXTENSION and
+    /// not its FORM type. The FORM type is `ACON`, and all 12 real `.ani`
+    /// files here were refused. They still reached `Family::Binary` through
+    /// the heuristics — 13.68% and 15.72% control characters against a 10%
+    /// threshold, and one at 90.99% NULs — so the measured cost was the
+    /// specific `binary_kind`, not records; the margin is the same kind of
+    /// luck the GIF rule was relying on.
+    #[test]
+    fn a_riff_form_type_is_the_form_not_the_extension() {
+        let mut ani: Vec<u8> = b"RIFF".to_vec();
+        ani.extend_from_slice(&4096u32.to_le_bytes());
+        ani.extend_from_slice(b"ACON");
+        ani.extend(printable_payload(20));
+        let p = Path::new("wait.ani");
+        let sn = sniff_bytes(&ani, p, p, false).unwrap();
+        assert_eq!(
+            (sn.family, sn.binary_kind.as_deref()),
+            (Family::Binary, Some("riff")),
+            "an animated cursor declares FORM type ACON; `ANI ` is the \
+             extension and no encoder writes it into the container"
+        );
+    }
+
+    /// The other half of the same trade: widening the qualifiers must not
+    /// hand #379 back. The GIF block introducers are `0x21`, `0x2C` and
+    /// `0x3B` — `!`, `,` and `;`, all printable — so "walk to the first block
+    /// and check the introducer", which is the obvious rule and the one this
+    /// fix was first asked for, junks ordinary sentences that happen to put
+    /// punctuation at offset 13. Each fixture below does exactly that.
+    ///
+    /// This is the repository's "a fix that reintroduces the very class it
+    /// fixes", caught in the same file it would have been reintroduced in.
+    #[test]
+    fn prose_that_lands_a_block_introducer_at_the_right_offset_is_still_text() {
+        for (label, opener) in [
+            // offset 13 is ',' -> 0x2C, an Image Descriptor introducer
+            (
+                "comma",
+                "GIF89a header, the six bytes at the front of every GIF file. ",
+            ),
+            // offset 13 is '!' -> 0x21, an Extension introducer
+            (
+                "bang",
+                "GIF89a images! They are still everywhere on the web today. ",
+            ),
+            // offset 13 is ';' -> 0x3B, the Trailer
+            (
+                "semicolon",
+                "GIF87a format; the original release, superseded two years on. ",
+            ),
+        ] {
+            let text = opener.repeat(30);
+            assert_eq!(
+                text.as_bytes()[13],
+                match label {
+                    "comma" => 0x2c,
+                    "bang" => 0x21,
+                    _ => 0x3b,
+                },
+                "{label}: fixture no longer lands an introducer at offset 13, \
+                 so it stopped testing anything — fix the sentence"
+            );
+            let p = Path::new("notes.txt");
+            let sn = sniff_bytes(text.as_bytes(), p, p, false).unwrap();
+            assert_eq!(
+                sn.family,
+                Family::TxtProse,
+                "{label}: prose was junked as {:?} — the block introducer is \
+                 printable, so it cannot be the whole qualifier (#379)",
+                sn.binary_kind
+            );
+        }
+    }
+
+    /// Round 2 of #379. The fixtures above pass on which characters happen to
+    /// land at offsets 15/17/19/21, not on a property the code guarantees — so
+    /// they certified a claim the qualifier did not provide. These are the
+    /// counterexamples that still reached `Family::Binary` with `Some("gif")`
+    /// after round 1, each recorded from a run against the real `sniff_bytes`.
+    ///
+    /// Two distinct holes: the 0x2C Image-Descriptor path, where all-ASCII
+    /// input always leaves `packed & 0x80` clear so the geometry bounds are
+    /// satisfiable by four u16s whose high bytes are spaces; and the 0x21
+    /// Extension path, where `decode()`'s windows-1252 fallback makes
+    /// 0xF9/0xFE/0xFF ordinary latin-1 letters.
+    #[test]
+    fn round_one_counterexamples_are_text_not_gifs() {
+        let ascii: [(&str, String); 5] = [
+            (
+                "image-descriptor/format",
+                "GIF89a format,1 2 3 4 5 and the rest of this note is about the format. "
+                    .repeat(30),
+            ),
+            (
+                "image-descriptor/header",
+                "GIF89a header,a b c d e f g h and more prose to pad the buffer out. ".repeat(30),
+            ),
+            (
+                "image-descriptor/fields",
+                "GIF89a fields,x y z w and still more prose to fill the prefix here. ".repeat(30),
+            ),
+            (
+                "image-descriptor/gif87a",
+                "GIF87a format,1 2 3 4 5 and the rest of this note is about the format. "
+                    .repeat(30),
+            ),
+            (
+                "image-descriptor/csv",
+                "GIF89a format,1 2 3 4 5\nrow,a,b,c,d\nrow2,e,f,g,h\n".repeat(60),
+            ),
+        ];
+        for (label, text) in &ascii {
+            let p = Path::new("notes.txt");
+            let sn = sniff_bytes(text.as_bytes(), p, p, false).unwrap();
+            assert_ne!(
+                sn.family,
+                Family::Binary,
+                "{label}: junked as {:?} — the LZW minimum code size byte must \
+                 close the 0x2C path (#379)",
+                sn.binary_kind
+            );
+        }
+
+        // The 0x21 Extension hole needs a byte that is not ASCII but IS a
+        // latin-1 letter, so `decode()` still reads the buffer as text.
+        let mut latin1: Vec<u8> = b"GIF89a fichie!".to_vec();
+        latin1.push(0xf9);
+        for _ in 0..40 {
+            latin1.extend_from_slice(
+                "Le format est tres ancien, et il reste partout sur le web. ".as_bytes(),
+            );
+        }
+        let p = Path::new("notes.txt");
+        let sn = sniff_bytes(&latin1, p, p, false).unwrap();
+        assert_ne!(
+            sn.family,
+            Family::Binary,
+            "latin-1 extension label: junked as {:?} — 0xF9 is a windows-1252 \
+             letter, so the label alone cannot qualify the 0x21 path (#379)",
+            sn.binary_kind
+        );
+    }
+
+    /// The invariant itself, walked over every row of `MAGIC_TABLE` rather than
+    /// asserted about the two rows this issue happened to name: a signature
+    /// made only of printable ASCII must REFUSE a prefix that is that signature
+    /// followed by ordinary prose. A new row wired to `accept` fails here.
+    ///
+    /// The counter is not decoration — without it a table whose printable rows
+    /// all disappeared would pass this test by iterating over nothing.
+    ///
+    /// SCOPE: `MAGIC_TABLE` only. Three signatures are matched earlier, as
+    /// early returns in `sniff_bytes` — see
+    /// `signatures_matched_before_the_table` below for what that leaves open.
+    #[test]
+    fn every_printable_signature_carries_a_qualifier() {
+        let mut printable_rows = 0;
+        for &(magic, kind, qualify) in MAGIC_TABLE {
+            let printable = magic.iter().all(|b| b.is_ascii_graphic() || *b == b' ');
+            if !printable {
+                continue;
+            }
+            printable_rows += 1;
+            let mut sentence = magic.to_vec();
+            sentence.extend(
+                " is a magic number that identifies a media file format, and this \
+                 sentence is about it rather than an instance of it. "
+                    .repeat(30)
+                    .as_bytes(),
+            );
+            assert!(
+                !qualify(&sentence),
+                "{kind}: the printable signature {:?} accepts a prefix that is \
+                 that signature followed by prose — it needs a structural \
+                 qualifier (#379/#380)",
+                String::from_utf8_lossy(magic)
+            );
+            let p = Path::new("notes.txt");
+            let sn = sniff_bytes(&sentence, p, p, false).unwrap();
+            assert_ne!(
+                sn.family,
+                Family::Binary,
+                "{kind}: prose opening with {:?} was junked",
+                String::from_utf8_lossy(magic)
+            );
+        }
+        assert!(
+            printable_rows >= 7,
+            "expected the printable signatures (GIF8, BM, 8BPS, RIFF, OggS, \
+             fLaC, ID3, Kaydara FBX Binary) to be walked; saw {printable_rows} \
+             — did the table lose rows, or did this filter stop matching?"
+        );
+    }
+
+    /// `%PDF-`, `SQLite format 3\0` and `PK\x03\x04` never reach `MAGIC_TABLE`
+    /// — they are early returns in `sniff_bytes` — so the walk above says
+    /// nothing about them. Two of the three are safe for the usual reason (a
+    /// byte text cannot contain: the NUL after `3`, and `\x03\x04`), and this
+    /// pins that.
+    ///
+    /// `%PDF-` is NOT safe and is the same class as #379/#380: prose opening
+    /// `%PDF-` sniffs `Family::Pdf` and is handed to the PDF extractor.
+    /// Measured on this branch and filed as #403 rather than widened into this
+    /// fix — five characters including `%` and `-` is a far smaller collision
+    /// surface than `BM`, and it does not produce #379's silent "binary
+    /// content" junk reason. The wrong answer is asserted here on purpose so
+    /// #403 has to come to this file and flip it.
+    #[test]
+    fn signatures_matched_before_the_table() {
+        for (label, opener, want) in [
+            (
+                "sqlite",
+                "SQLite format 3 is the string at the start of every database file. ",
+                Family::TxtProse,
+            ),
+            (
+                "zip",
+                "PK is the local file header signature of the ZIP format. ",
+                Family::TxtProse,
+            ),
+            // #403: this one is wrong. It must read TxtProse when #403 lands.
+            (
+                "pdf",
+                "%PDF- is the five byte header every PDF file begins with. ",
+                Family::Pdf,
+            ),
+        ] {
+            let text = opener.repeat(30);
+            let p = Path::new("notes.txt");
+            let sn = sniff_bytes(text.as_bytes(), p, p, false).unwrap();
+            assert_eq!(
+                sn.family, want,
+                "{label}: prose opening with a pre-table signature classified \
+                 {:?}/{:?}",
+                sn.family, sn.binary_kind
             );
         }
     }

--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -421,7 +421,10 @@ fn accept(_prefix: &[u8]) -> bool {
 ///
 ///   * after `0x21`, the extension label. The spec defines four — Plain Text
 ///     `0x01`, Graphic Control `0xF9`, Comment `0xFE`, Application `0xFF` —
-///     three unprintable and the fourth a control character.
+///     three unprintable and the fourth a control character. Three of them also
+///     pin the first sub-block size; Comment does not, so its chain is walked,
+///     and a chain that outruns the 8 KiB buffer is settled on the canvas
+///     instead — see `canvas_dimension_text_cannot_write`.
 ///   * after `0x2C`, a 9-byte Image Descriptor. The frame must be non-empty and
 ///     must fit inside the canvas declared two fields earlier, which four
 ///     little-endian u16s of prose do not.
@@ -483,19 +486,24 @@ fn gif_screen_descriptor(prefix: &[u8]) -> bool {
             // there is no fixed byte to pin. Walk the sub-block chain instead:
             // a real Comment terminates with a 0x00 and is followed by another
             // introducer. Prose has to land that whole structure, not one byte.
-            (Some(0xfe), Some(&first)) if first != 0 => {
+            //
+            // A zero FIRST size is the empty comment `21 FE 00`, which giflib
+            // writes for `EGifPutExtensionLeader(0xFE)` + `EGifPutExtensionTrailer`
+            // and which every decoder here accepts. It used to fall to `_ =>
+            // false`, which refused all six such files in the corpus even
+            // though every one of them decodes in both Pillow and giflib.
+            // The NUL is the evidence: it sits at a derived offset, and
+            // prose has no NUL to put there — so nothing further is checked,
+            // and in particular the byte AFTER it is not, because giflib emits
+            // its zero-length sub-block and its trailer as `21 FE 00 00`.
+            (Some(0xfe), Some(0)) => true,
+            (Some(0xfe), Some(_)) => {
                 // Walk the sub-block chain. Two outcomes are decisive and one
                 // is not, and conflating them is what broke real GIFs: a
                 // comment longer than the 8 KiB prefix simply cannot be walked
                 // to its end here, and "I ran out of buffer" is not evidence
                 // of text.
                 let mut at = block + 2;
-                // Of the sizes we get to see before the buffer ends, every one
-                // but the last must be a full 255. The last may legitimately be
-                // a short remainder whose terminator sits just past the edge.
-                let mut prior_were_full = true;
-                let mut last: Option<u8> = None;
-                let mut seen = 0usize;
                 loop {
                     match prefix.get(at) {
                         // Terminated inside the prefix: decisive. A real
@@ -505,20 +513,11 @@ fn gif_screen_descriptor(prefix: &[u8]) -> bool {
                         Some(0) => {
                             return matches!(prefix.get(at + 1), None | Some(0x21 | 0x2c | 0x3b));
                         }
-                        Some(&len) => {
-                            if let Some(prev) = last {
-                                prior_were_full &= prev == 0xff;
-                            }
-                            last = Some(len);
-                            seen += 1;
-                            at += 1 + usize::from(len);
-                        }
-                        // Ran past the prefix. Every encoder packs a long
-                        // comment into maximal 255-byte sub-blocks, so every
-                        // size we got to see is 0xFF. Prose cannot do that:
-                        // its "sizes" are the text's own bytes, which are
-                        // printable ASCII, never 0xFF.
-                        None => return seen > 1 && prior_were_full,
+                        Some(&len) => at += 1 + usize::from(len),
+                        // Ran past the prefix — undecidable HERE, so decide on
+                        // the Logical Screen Descriptor instead. See
+                        // `canvas_dimension_text_cannot_write`.
+                        None => return canvas_dimension_text_cannot_write(prefix),
                     }
                 }
             }
@@ -574,6 +573,80 @@ fn gif_screen_descriptor(prefix: &[u8]) -> bool {
         }
         _ => false,
     }
+}
+
+/// The tie-break for a Comment sub-block chain that runs past the 8 KiB
+/// `read_prefix` buffer, decided on the Logical Screen Descriptor because it
+/// CANNOT be decided on the chain.
+///
+/// The chain carries no evidence at that point, and this is the whole reason
+/// the arm above is written the way it is: every sub-block size in `1..=255` is
+/// legal, so "the sizes we managed to see" says nothing about whether the file
+/// is an image. Round 3 shipped `seen > 1 && every size seen is 0xFF`, on the
+/// reasoning that encoders pack long comments maximally. They do not. Measured
+/// against a 939-file ground-truth corpus (674 images / 265 text files, every
+/// image decode-checked twice — Pillow `open`+`load` and giflib
+/// `DGifOpenFileName`+`DGifSlurp`):
+///
+///   * 92 corpus images open on a Comment whose chain outruns the buffer. The
+///     0xFF rule refuses 37 of them: 33 land in `TxtProse` and are sectioned
+///     into 2,519 junk records, 4 reach `binary`/`unknown` on the control-char
+///     ratio alone. giflib's streaming API (`EGifPutExtensionBlock`) writes ONE
+///     sub-block per call at whatever length the caller passed, so chains of 1,
+///     2, 16, 32, 64, 100, 120, 127, 128, 192, 200 and 250..=254 bytes are all
+///     ordinary encoder output; ImageMagick writes 200/199/199… and
+///     Pillow-then-spliced files mix 255 with 10.
+///   * The eight real commented GIFs on the build machine carry sub-blocks of
+///     17, 26, 45 and 49 bytes and not a single 255 (GIMP, ezgif.com and
+///     ajaxload.info output, in Lucene, Supabase and pdfjs-dist checkouts).
+///     They terminate inside the prefix so they never reach here — but they are
+///     what the 0xFF premise was measured against, and it is false.
+///
+/// So the decision moves to a field prose cannot forge. The canvas dimensions
+/// are two little-endian u16 at fixed offsets 6..10, always inside the prefix,
+/// which puts their HIGH bytes at 7 and 9. Every printable ASCII byte is
+/// `>= 0x20`, so all-printable text can only ever declare a dimension
+/// `>= 0x2000` (8192); a windows-1252 accent or a UTF-8 lead/continuation byte
+/// is `>= 0x80`, i.e. `>= 32768`. A dimension BELOW 8192 therefore requires a
+/// control byte at 7 or 9 — and the three control bytes text does legitimately
+/// carry (`\t`, `\n`, `\r`) are excluded, because they are exactly the ones it
+/// can. That exclusion is not theoretical: `"GIF89ax\ny…"` + `!` + 0xFE + French
+/// prose is junked as an image by a bare `< 8192` test and stays `TxtProse`
+/// with the exclusion — measured, and pinned by
+/// `prose_with_a_newline_in_the_canvas_is_not_a_gif`.
+///
+/// Cost on real images, measured over the same corpus: 673 of 674 declare a
+/// dimension under 8192, the exception being a JPEG someone had named `.gif`
+/// (17994x17993 read out of JFIF bytes, and it fails the `GIF8` magic anyway).
+/// The largest genuine canvas here is 2000x2000, so the rule has ~4x of margin,
+/// and no corpus image carries `\t`/`\n`/`\r` as a canvas high byte at all
+/// (high bytes observed: 0, 1, 2, 3, 4, 5, 7). The confusion matrix through
+/// `sniff()` for this rule is 666 images binary/gif, 6 binary/other, 2 text,
+/// against 257 of 265 text files still text — the 8 exceptions and the 2
+/// images being decided by OTHER arms, unchanged by this one.
+///
+/// What was tried and refused, with the measurement that refused it:
+///
+///   * `true` ("inconclusive means image"): keeps all 92, but junks 10 corpus
+///     text files as `binary (gif)` — prose only has to land `!`, a
+///     windows-1252 0xFE and one non-zero byte, which is #379 all over again.
+///   * `false` (round 2): refuses all 92; 88 of them become 3,063 prose records.
+///   * not matching `0xFE` at all: refuses every comment-first GIF, terminated
+///     or not — 420 of the 674 images still classify `gif` against 666 here,
+///     177 land in the text path — and it saves not one text file over `false`.
+///   * the Global Colour Table flag (`packed & 0x80`), the other LSD field that
+///     looks unforgeable: it is NOT. A windows-1252 accented letter at offset
+///     10 sets it, which is how the corpus's own `gctflag_*` fixtures were
+///     built — 8 of them are junked as images by that rule.
+///   * "the prefix is short, so the chain ran past EOF, so the file is
+///     truncated": true for the two corpus files it fires on (nmap's
+///     `pixel.gif`, which no decoder accepts), but `read_prefix` swallows the
+///     error on a gzip member (`read_to_end(..).ok()`), so a short buffer does
+///     not mean EOF for a `.gif.gz` and the rule would refuse it.
+fn canvas_dimension_text_cannot_write(prefix: &[u8]) -> bool {
+    // `prefix[..13]` is guaranteed by the length check in the only caller.
+    let high_byte_is_binary = |hi: u8| hi < 0x20 && !matches!(hi, b'\t' | b'\n' | b'\r');
+    high_byte_is_binary(prefix[7]) || high_byte_is_binary(prefix[9])
 }
 
 /// Windows bitmap: `BM`, then a 14-byte BITMAPFILEHEADER, then a DIB header
@@ -1938,9 +2011,12 @@ mod printable_magic_tests {
     /// The first attempt treated "the sub-block chain did not terminate inside
     /// the prefix" as evidence of text, so a real, decodable GIF carrying a
     /// licence notice was handed to the prose extractor — #379 with the sign
-    /// flipped. Encoders pack a long comment into maximal 255-byte sub-blocks,
-    /// and prose cannot: its "sizes" are its own bytes, which are printable
-    /// ASCII and never 0xFF. That is what separates the two here.
+    /// flipped.
+    ///
+    /// This fixture is the MAXIMALLY PACKED shape only. Round 3 then read that
+    /// property off this very test and shipped it as the rule ("every size seen
+    /// is 0xFF"); `a_streamed_comment_chain_is_not_packed_to_255` below is the
+    /// corpus answer to that, and the two must be read together.
     #[test]
     fn a_comment_longer_than_the_sniff_prefix_is_still_a_gif() {
         /// GIF89a, 4x4, 2-entry global colour table, opening on a Comment
@@ -1979,6 +2055,165 @@ mod printable_magic_tests {
                  to the prose extractor — this is #379 inverted"
             );
             assert_eq!(sn.binary_kind.as_deref(), Some("gif"), "comment of {len} B");
+        }
+    }
+
+    /// GIF89a, `canvas` px square, 2-entry global colour table, then a Comment
+    /// Extension whose sub-blocks are `sizes` cycled until the chain is longer
+    /// than the 8 KiB `sniff` prefix. Returns exactly what `read_prefix` would
+    /// hand `sniff_bytes` — the first 8192 bytes and no more.
+    fn streamed_comment_prefix(canvas: u16, sizes: &[u8]) -> Vec<u8> {
+        let mut g: Vec<u8> = b"GIF89a".to_vec();
+        g.extend_from_slice(&canvas.to_le_bytes());
+        g.extend_from_slice(&canvas.to_le_bytes());
+        g.push(0x80); // GCT present, 2 entries
+        g.push(0);
+        g.push(0);
+        g.extend_from_slice(&[0, 0, 0, 0xff, 0xff, 0xff]); // GCT
+        g.extend_from_slice(&[0x21, 0xfe]); // Comment Extension
+        for &n in sizes.iter().cycle() {
+            if g.len() > 9000 {
+                break;
+            }
+            g.push(n);
+            g.extend(std::iter::repeat_n(b'D', usize::from(n)));
+        }
+        g.truncate(8192);
+        g
+    }
+
+    /// Round 3's rule — "a chain that outruns the prefix is an image only if
+    /// every sub-block size seen is 0xFF" — measured against the ground-truth
+    /// corpus (939 files; 674 images, each decode-checked with Pillow AND
+    /// giflib `DGifSlurp`; 265 text files). It refuses 43 of the 92 images that
+    /// reach this arm, and 37 of those are sectioned into prose: 2,524 junk
+    /// records out of two and a half real image files.
+    ///
+    /// The premise is simply not how the encoders write. giflib's streaming
+    /// API emits one sub-block per `EGifPutExtensionBlock` call, at the length
+    /// the CALLER passed, so the corpus holds chains of 1, 2, 16, 32, 64, 100,
+    /// 120, 127, 128, 192, 200 and 250..=254 — `gstream_long_sz064_x160.gif`,
+    /// `prior_*_c001.gif` … `prior_*_c254.gif`. ImageMagick writes a first
+    /// sub-block at N and the rest at N-1 (`prior_*_imagick_im20k_w200.gif`:
+    /// 200, 199, 199, …). Splicing produces alternating 255/10 and 20-then-255
+    /// chains. Every size in `1..=255` is legal and all of these decode in both
+    /// decoders.
+    ///
+    /// The sizes below are the ones actually on disk in that corpus, not a
+    /// sweep invented here.
+    #[test]
+    fn a_streamed_comment_chain_is_not_packed_to_255() {
+        for (label, sizes) in [
+            ("giflib-stream-1", &[1u8][..]),
+            ("giflib-stream-2", &[2][..]),
+            ("giflib-stream-16", &[16][..]),
+            ("giflib-stream-32", &[32][..]),
+            ("giflib-stream-64", &[64][..]),
+            ("giflib-stream-100", &[100][..]),
+            ("giflib-stream-127", &[127][..]),
+            ("giflib-stream-128", &[128][..]),
+            ("giflib-stream-192", &[192][..]),
+            ("giflib-stream-250", &[250][..]),
+            ("giflib-stream-254", &[254][..]),
+            ("giflib-stream-255", &[255][..]),
+            ("imagemagick-200-then-199", &[200, 199, 199, 199][..]),
+            ("imagemagick-60-then-59", &[60, 59, 59, 59][..]),
+            ("spliced-255-then-10", &[255, 10][..]),
+            ("spliced-20-then-255", &[20, 255, 255, 255][..]),
+        ] {
+            let prefix = streamed_comment_prefix(48, sizes);
+            assert_eq!(prefix.len(), 8192, "{label}: fixture must fill the prefix");
+            let p = Path::new("frame.gif");
+            let sn = sniff_bytes(&prefix, p, p, false).unwrap();
+            assert_eq!(
+                (sn.family, sn.binary_kind.as_deref()),
+                (Family::Binary, Some("gif")),
+                "{label}: a real GIF whose comment sub-blocks are not 255 was \
+                 refused and handed to the prose extractor — #379 inverted, and \
+                 the shape 100% of the real commented GIFs on this machine have"
+            );
+        }
+    }
+
+    /// The empty Comment Extension, `21 FE 00`. giflib writes it whenever a
+    /// caller opens a comment and closes it without content
+    /// (`EGifPutExtensionLeader(0xFE)` then `EGifPutExtensionTrailer`), and the
+    /// corpus holds six such files — all six decode in Pillow AND giflib, and
+    /// all six were refused, because the arm's guard was `first != 0` and a
+    /// zero first size fell through to `_ => false`.
+    ///
+    /// Both on-disk shapes are here. `21 FE 00 2C` is the plain one;
+    /// `21 FE 00 00 2C` is giflib emitting a zero-length sub-block AND its
+    /// trailer, which is why the byte after the terminator is not checked.
+    #[test]
+    fn an_empty_comment_extension_is_still_a_gif() {
+        fn empty_comment_gif(tail: &[u8]) -> Vec<u8> {
+            let mut g: Vec<u8> = b"GIF89a".to_vec();
+            g.extend_from_slice(&8u16.to_le_bytes());
+            g.extend_from_slice(&8u16.to_le_bytes());
+            g.push(0x80);
+            g.push(0);
+            g.push(0);
+            g.extend_from_slice(&[0, 0, 0, 0xff, 0xff, 0xff]); // GCT
+            g.extend_from_slice(&[0x21, 0xfe, 0x00]); // empty comment
+            g.extend_from_slice(tail);
+            g
+        }
+        for (label, tail) in [
+            (
+                "21-fe-00-then-image",
+                &[0x2c, 0, 0, 0, 0, 8, 0, 8, 0, 0, 0x02][..],
+            ),
+            (
+                "21-fe-00-00-then-image",
+                &[0x00, 0x2c, 0, 0, 0, 0, 8, 0, 8, 0, 0, 0x02][..],
+            ),
+            ("21-fe-00-then-trailer", &[0x3b][..]),
+        ] {
+            let bytes = empty_comment_gif(tail);
+            let p = Path::new("empty.gif");
+            let sn = sniff_bytes(&bytes, p, p, false).unwrap();
+            assert_eq!(
+                (sn.family, sn.binary_kind.as_deref()),
+                (Family::Binary, Some("gif")),
+                "{label}: a decodable GIF carrying an empty comment was refused"
+            );
+        }
+    }
+
+    /// The tie-break for an outrunning chain is the canvas, and this is the
+    /// fixture that decides HOW it is read. The obvious form — "a canvas
+    /// dimension below 8192, which printable ASCII cannot declare" — is
+    /// forgeable, because `\t`, `\n` and `\r` are bytes below 0x20 that text
+    /// carries all the time: a newline at offset 7 declares a 2680 px width.
+    /// Measured through the real `sniff()`: with the bare `< 8192` test these
+    /// two files classify `binary (gif)`; with `\t\n\r` excluded they stay
+    /// `TxtProse`, which is what they are.
+    #[test]
+    fn prose_with_a_newline_in_the_canvas_is_not_a_gif() {
+        for (label, seven) in [("newline", b'\n'), ("tab", b'\t'), ("cr", b'\r')] {
+            let mut prose: Vec<u8> = b"GIF89ax".to_vec(); // 0..=6
+            prose.push(seven); // 7: canvas width high byte
+            prose.extend_from_slice(b"yze"); // 8,9 height; 10 packed (GCT clear)
+            prose.extend_from_slice(b"st"); // 11 background, 12 aspect
+            prose.push(b'!'); // 13: Extension introducer
+            prose.push(0xfe); // 14: Comment label
+            prose.push(b'L'); // 15: first sub-block size, 76
+            for _ in 0..400 {
+                prose.extend_from_slice(
+                    "Le format GIF est tres ancien et reste partout sur le web. ".as_bytes(),
+                );
+            }
+            prose.truncate(8192);
+            let p = Path::new("notes.txt");
+            let sn = sniff_bytes(&prose, p, p, false).unwrap();
+            assert_eq!(
+                sn.family,
+                Family::TxtProse,
+                "{label}: prose was junked as {:?} — a canvas rule that admits \
+                 the control characters text actually carries is not a rule",
+                sn.binary_kind
+            );
         }
     }
 

--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -483,18 +483,44 @@ fn gif_screen_descriptor(prefix: &[u8]) -> bool {
             // there is no fixed byte to pin. Walk the sub-block chain instead:
             // a real Comment terminates with a 0x00 and is followed by another
             // introducer. Prose has to land that whole structure, not one byte.
-            (Some(0xfe), Some(_)) => {
+            (Some(0xfe), Some(&first)) if first != 0 => {
+                // Walk the sub-block chain. Two outcomes are decisive and one
+                // is not, and conflating them is what broke real GIFs: a
+                // comment longer than the 8 KiB prefix simply cannot be walked
+                // to its end here, and "I ran out of buffer" is not evidence
+                // of text.
                 let mut at = block + 2;
-                for _ in 0..MAX_COMMENT_SUB_BLOCKS {
+                // Of the sizes we get to see before the buffer ends, every one
+                // but the last must be a full 255. The last may legitimately be
+                // a short remainder whose terminator sits just past the edge.
+                let mut prior_were_full = true;
+                let mut last: Option<u8> = None;
+                let mut seen = 0usize;
+                loop {
                     match prefix.get(at) {
+                        // Terminated inside the prefix: decisive. A real
+                        // comment is followed by another block. `None` means
+                        // the terminator is the last byte we hold, which is
+                        // the prefix edge, not a malformed file.
                         Some(0) => {
-                            return matches!(prefix.get(at + 1), Some(0x21 | 0x2c | 0x3b));
+                            return matches!(prefix.get(at + 1), None | Some(0x21 | 0x2c | 0x3b));
                         }
-                        Some(&len) => at += 1 + usize::from(len),
-                        None => return false,
+                        Some(&len) => {
+                            if let Some(prev) = last {
+                                prior_were_full &= prev == 0xff;
+                            }
+                            last = Some(len);
+                            seen += 1;
+                            at += 1 + usize::from(len);
+                        }
+                        // Ran past the prefix. Every encoder packs a long
+                        // comment into maximal 255-byte sub-blocks, so every
+                        // size we got to see is 0xFF. Prose cannot do that:
+                        // its "sizes" are the text's own bytes, which are
+                        // printable ASCII, never 0xFF.
+                        None => return seen > 1 && prior_were_full,
                     }
                 }
-                false
             }
             _ => false,
         },
@@ -542,12 +568,6 @@ fn gif_screen_descriptor(prefix: &[u8]) -> bool {
         _ => false,
     }
 }
-
-/// Bound on the Comment-extension sub-block walk in `gif_screen_descriptor`.
-/// A comment is at most 255 bytes per sub-block and the whole first block sits
-/// inside the 8 KiB prefix, so a real one terminates in far fewer; the cap only
-/// stops a crafted chain from walking the buffer.
-const MAX_COMMENT_SUB_BLOCKS: usize = 64;
 
 /// Windows bitmap: `BM`, then a 14-byte BITMAPFILEHEADER, then a DIB header
 /// that opens with its own size.
@@ -1855,6 +1875,81 @@ mod printable_magic_tests {
              extension and no encoder writes it into the container"
         );
     }
+    /// The Comment-extension arm, which round 2 of #379 added and which an
+    /// independent verification then broke real images with. It is the only
+    /// branch here carrying a loop, so it is the one that needed fixtures and
+    /// did not have them.
+    ///
+    /// The hazard is specific: `sniff` sees only an 8 KiB prefix
+    /// (`read_prefix(.., 8192)`), and a GIF comment may be longer than that.
+    /// The first attempt treated "the sub-block chain did not terminate inside
+    /// the prefix" as evidence of text, so a real, decodable GIF carrying a
+    /// licence notice was handed to the prose extractor — #379 with the sign
+    /// flipped. Encoders pack a long comment into maximal 255-byte sub-blocks,
+    /// and prose cannot: its "sizes" are its own bytes, which are printable
+    /// ASCII and never 0xFF. That is what separates the two here.
+    #[test]
+    fn a_comment_longer_than_the_sniff_prefix_is_still_a_gif() {
+        /// GIF89a, 4x4, 2-entry global colour table, opening on a Comment
+        /// Extension of `comment_len` bytes, then a minimal image.
+        fn comment_gif(comment_len: usize) -> Vec<u8> {
+            let mut g: Vec<u8> = b"GIF89a".to_vec();
+            g.extend_from_slice(&4u16.to_le_bytes());
+            g.extend_from_slice(&4u16.to_le_bytes());
+            g.push(0x80); // GCT present, 2 entries
+            g.push(0);
+            g.push(0);
+            g.extend_from_slice(&[0, 0, 0, 0xff, 0xff, 0xff]); // GCT
+            g.extend_from_slice(&[0x21, 0xfe]); // Comment Extension
+            let mut left = comment_len;
+            while left > 0 {
+                let take = left.min(255);
+                g.push(take as u8);
+                g.extend(std::iter::repeat_n(b'D', take));
+                left -= take;
+            }
+            g.push(0x00); // block terminator
+            g.extend_from_slice(&[0x2c, 0, 0, 0, 0, 4, 0, 4, 0, 0, 0x02]);
+            g
+        }
+
+        for len in [13usize, 255, 300, 4000, 8_192, 20_000, 60_000] {
+            let g = comment_gif(len);
+            // What `sniff` actually gets to see.
+            let prefix: Vec<u8> = g.iter().copied().take(8192).collect();
+            let p = Path::new("frame.gif");
+            let sn = sniff_bytes(&prefix, p, p, false).unwrap();
+            assert_eq!(
+                sn.family,
+                Family::Binary,
+                "comment of {len} B: a real GIF was refused and would be handed \
+                 to the prose extractor — this is #379 inverted"
+            );
+            assert_eq!(sn.binary_kind.as_deref(), Some("gif"), "comment of {len} B");
+        }
+    }
+
+    /// The other half of the same arm: prose must not reach it. `0xFE` is not
+    /// ASCII, so this needs a windows-1252 byte — which `decode()` reads back
+    /// as text, exactly the path that made the label-only check unsound.
+    #[test]
+    fn cp1252_prose_behind_a_comment_label_is_still_text() {
+        let mut prose: Vec<u8> = b"GIF89a fichie!".to_vec();
+        prose.push(0xfe);
+        for _ in 0..400 {
+            prose.extend_from_slice(
+                "Le format GIF est tres ancien et reste partout sur le web. ".as_bytes(),
+            );
+        }
+        let p = Path::new("notes.txt");
+        let sn = sniff_bytes(&prose, p, p, false).unwrap();
+        assert_eq!(
+            sn.family,
+            Family::TxtProse,
+            "prose was junked as {:?} through the comment arm (#379)",
+            sn.binary_kind
+        );
+    }
 
     /// The other half of the same trade: widening the qualifiers must not
     /// hand #379 back. The GIF block introducers are `0x21`, `0x2C` and
@@ -1865,6 +1960,7 @@ mod printable_magic_tests {
     ///
     /// This is the repository's "a fix that reintroduces the very class it
     /// fixes", caught in the same file it would have been reintroduced in.
+
     #[test]
     fn prose_that_lands_a_block_introducer_at_the_right_offset_is_still_text() {
         for (label, opener) in [

--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -97,6 +97,16 @@ pub struct Sniffed {
     pub logical_name: Option<std::path::PathBuf>,
 }
 
+/// Bytes read for ordinary classification.
+const PREFIX: usize = 8192;
+
+/// Bytes read when the file already carries GIF magic. A Comment Extension is
+/// unbounded by the format, so this is a budget rather than a guarantee: it
+/// covers every commented GIF in the measured corpus with room to spare, and
+/// when a chain still outruns it the qualifier declines rather than inventing
+/// a discriminator — which is what the previous four rounds did wrong.
+const GIF_PREFIX: usize = 1 << 20;
+
 fn read_prefix(path: &Path, gzip: bool, n: usize) -> Result<Vec<u8>> {
     let f = std::fs::File::open(path)?;
     let mut buf = Vec::with_capacity(n.min(1 << 20));
@@ -123,7 +133,21 @@ pub fn sniff(path: &Path) -> Result<Sniffed> {
 pub fn sniff_with_name(content_path: &Path, logical_path: &Path) -> Result<Sniffed> {
     let head = read_prefix(content_path, false, 8)?;
     let gzip = head.len() >= 2 && head[0] == 0x1f && head[1] == 0x8b;
-    let prefix = read_prefix(content_path, gzip, 8192)?;
+    let mut prefix = read_prefix(content_path, gzip, PREFIX)?;
+    // A GIF's first data block can sit arbitrarily far in — a Comment
+    // Extension is a chain of 1..=255-byte sub-blocks with no length bound,
+    // and real files carry licence notices of tens of kilobytes. Deciding
+    // whether such a file is an image from 8 KiB means deciding it before its
+    // structure is visible, and four successive attempts to guess that from
+    // bytes inside the window were each refuted for junking real images
+    // (#379): a rule keyed on any fixed offset reads unconstrained image data
+    // there. So read further for a GIF candidate instead of guessing — the
+    // chain's terminator then falls inside the buffer and the decisive check
+    // applies. One extra read, only for files already carrying GIF magic.
+    if prefix.len() == PREFIX && prefix.len() >= 6 && matches!(&prefix[..6], b"GIF87a" | b"GIF89a")
+    {
+        prefix = read_prefix(content_path, gzip, GIF_PREFIX)?;
+    }
     let mut s = sniff_bytes(&prefix, content_path, logical_path, gzip)?;
     s.gzip = gzip;
     s.logical_name = logical_path.file_name().map(std::path::PathBuf::from);

--- a/engine/crates/xerj-autoindex/tests/sniff_printable_magic.rs
+++ b/engine/crates/xerj-autoindex/tests/sniff_printable_magic.rs
@@ -1,0 +1,139 @@
+//! #379/#380 end to end: the issue's own three files, through the real
+//! `sniff()` entry point rather than through `sniff_bytes` in a unit test.
+//!
+//! `BM` and `GIF8` were magic signatures made only of printable ASCII, believed
+//! without checking anything behind them, so `cars.csv` opening `BMW,model,year`
+//! and a note opening `GIF89a is the header format…` classified `Family::Binary`
+//! and `scan_file` junked them as "binary content (bmp)" / "(gif)" — never
+//! indexed, with a reason that was not true. `id3-notes.txt` is the control: it
+//! was already correct on rc.16 and must stay correct.
+//!
+//! The qualifiers themselves are unit-tested in `sniff::printable_magic_tests`.
+//! What this file adds is the path the user actually takes: bytes on disk, read
+//! by `read_prefix`, classified by `sniff(&Path)`.
+
+use std::path::Path;
+use xerj_autoindex::sniff::{sniff, Family};
+
+fn write(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, body).unwrap();
+    p
+}
+
+#[test]
+fn the_issue_folder_indexes_every_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let cars = write(
+        root,
+        "cars.csv",
+        "BMW,model,year\nX5,SUV,2024\n330i,sedan,2023\nM3,coupe,2022\niX,SUV,2025\n",
+    );
+    let gif = write(
+        root,
+        "gif-notes.txt",
+        &"GIF89a is the header format used by the GIF image standard. ".repeat(30),
+    );
+    let id3 = write(
+        root,
+        "id3-notes.txt",
+        &"ID3 tags are metadata containers embedded in MP3 files. ".repeat(30),
+    );
+
+    // rc.16: binary/bmp, binary/gif, txt-prose — 3 files in, 1 indexed.
+    for (path, want) in [
+        (&cars, Family::Csv),
+        (&gif, Family::TxtProse),
+        (&id3, Family::TxtProse),
+    ] {
+        let sn = sniff(path).unwrap();
+        assert_eq!(
+            sn.family,
+            want,
+            "{}: classified {} ({:?}), which `scan_file` turns into junk",
+            path.file_name().unwrap().to_string_lossy(),
+            sn.family.as_str(),
+            sn.binary_kind
+        );
+    }
+}
+
+/// The other half of the fix: a real bitmap on disk must still be caught by its
+/// magic bytes, before any text heuristic. Without this the fix would just move
+/// the damage — an image reaching the text path is what sections a multi-MB
+/// file into thousands of prose records.
+#[test]
+fn a_real_bitmap_on_disk_is_still_binary() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // BITMAPFILEHEADER (14) + BITMAPINFOHEADER (40), 2x2 24bpp.
+    let mut bmp: Vec<u8> = b"BM".to_vec();
+    bmp.extend_from_slice(&70u32.to_le_bytes());
+    bmp.extend_from_slice(&[0, 0, 0, 0]);
+    bmp.extend_from_slice(&54u32.to_le_bytes());
+    bmp.extend_from_slice(&40u32.to_le_bytes());
+    bmp.extend_from_slice(&2i32.to_le_bytes());
+    bmp.extend_from_slice(&2i32.to_le_bytes());
+    bmp.extend_from_slice(&[1, 0, 24, 0]);
+    bmp.extend(std::iter::repeat_n(0u8, 24));
+    // A printable tail that would otherwise pass the prose heuristics.
+    bmp.extend(b"lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(20));
+
+    let p = dir.path().join("logo.bmp");
+    std::fs::write(&p, &bmp).unwrap();
+    let sn = sniff(&p).unwrap();
+    assert_eq!(sn.family, Family::Binary);
+    assert_eq!(sn.binary_kind.as_deref(), Some("bmp"));
+}
+
+/// An actual GIF, checked into this repository, read off disk.
+///
+/// Every other fixture in this file and in `sniff::printable_magic_tests` is
+/// bytes an author typed, which is exactly how round 1 of #379 shipped a
+/// qualifier that refused 4 of the 147 distinct real GIFs on the build machine
+/// — `docs/media/demo.gif` among them, because its Pixel Aspect Ratio byte is
+/// 49 (`(49 + 15) / 64 = 1.0`, the spec's encoding of square pixels) and the
+/// qualifier demanded 0. Hand-written headers all set it to 0, so no test saw
+/// it. This one does: 3.27 MB, 720x450, animated, NETSCAPE2.0 loop extension
+/// behind a 768-byte global colour table.
+///
+/// Measured with the round-1 qualifier in place, this file classifies
+/// `binary`/`unknown`: its first 8 KiB is 11.45% control characters, so the
+/// heuristic behind the magic table caught it with 1.45 points to spare. That
+/// margin is the whole reason the assertion below names `Some("gif")` and not
+/// just `Family::Binary` — two other GIFs in the same 147-file sweep decode to
+/// 9.39% and 9.78% and would have been sectioned into prose records instead.
+#[test]
+fn the_repositorys_own_demo_gif_is_binary_by_magic() {
+    // engine/crates/xerj-autoindex -> repository root.
+    let gif = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../docs/media/demo.gif")
+        .canonicalize()
+        .expect(
+            "docs/media/demo.gif is a tracked file and this test exists to read \
+             it; if it moved, point this at another real GIF rather than \
+             deleting the only non-synthetic fixture",
+        );
+
+    // Guard against silently testing a placeholder: assert the shape that made
+    // this file the counter-example before asserting the classification.
+    let head = std::fs::read(&gif).unwrap();
+    assert!(head.starts_with(b"GIF89a"), "fixture is no longer a GIF");
+    assert_ne!(
+        head[12], 0,
+        "demo.gif no longer declares a pixel aspect ratio, so it no longer \
+         exercises the round-1 regression — find another real GIF that does"
+    );
+
+    let sn = sniff(&gif).unwrap();
+    assert_eq!(
+        (sn.family, sn.binary_kind.as_deref()),
+        (Family::Binary, Some("gif")),
+        "a real 3.27 MB GIF classified {}/{:?} — `scan_file` hands that to the \
+         text extractor",
+        sn.family.as_str(),
+        sn.binary_kind
+    );
+}

--- a/engine/crates/xerj-autoindex/tests/sniff_printable_magic.rs
+++ b/engine/crates/xerj-autoindex/tests/sniff_printable_magic.rs
@@ -88,6 +88,83 @@ fn a_real_bitmap_on_disk_is_still_binary() {
     assert_eq!(sn.binary_kind.as_deref(), Some("bmp"));
 }
 
+/// The comment arm on the path that actually loses data: a file on disk whose
+/// comment is longer than the 8 KiB `read_prefix` buffer, so the sub-block
+/// chain cannot be walked to its end and the terminator is never seen.
+///
+/// The unit fixtures in `sniff::printable_magic_tests` truncate to 8192 by
+/// hand; these are real files of 20 KB and 60 KB, cut by `read_prefix` itself.
+/// The chain shapes are the ones the ground-truth corpus found on disk —
+/// giflib's streaming API writes one sub-block per `EGifPutExtensionBlock` call
+/// at the caller's length, so 64-byte and 100-byte chains are ordinary output,
+/// and the "every size is 0xFF" rule that round 3 shipped refuses them: 43 of
+/// the corpus's 92 outrunning images, 37 of them into `TxtProse`.
+///
+/// The negative in the same shape is the file below it: prose only has to land
+/// `!` and a windows-1252 `0xFE`, and it must NOT be junked.
+#[test]
+fn a_long_commented_gif_on_disk_survives_the_prefix_cut() {
+    let dir = tempfile::tempdir().unwrap();
+
+    fn streamed(sub_block: u8, comment_len: usize) -> Vec<u8> {
+        let mut g: Vec<u8> = b"GIF89a".to_vec();
+        g.extend_from_slice(&48u16.to_le_bytes());
+        g.extend_from_slice(&48u16.to_le_bytes());
+        g.push(0x80); // GCT present, 2 entries
+        g.push(0);
+        g.push(0);
+        g.extend_from_slice(&[0, 0, 0, 0xff, 0xff, 0xff]);
+        g.extend_from_slice(&[0x21, 0xfe]);
+        let mut left = comment_len;
+        while left > 0 {
+            let take = left.min(usize::from(sub_block));
+            g.push(take as u8);
+            g.extend(std::iter::repeat_n(b'D', take));
+            left -= take;
+        }
+        g.push(0x00);
+        g.extend_from_slice(&[0x2c, 0, 0, 0, 0, 48, 0, 48, 0, 0, 0x02]);
+        g
+    }
+
+    for (name, sub_block, len) in [
+        ("stream64.gif", 64u8, 20_000usize),
+        ("stream100.gif", 100, 60_000),
+        ("stream255.gif", 255, 60_000),
+    ] {
+        let p = dir.path().join(name);
+        let bytes = streamed(sub_block, len);
+        assert!(bytes.len() > 8192, "{name}: fixture must outrun the prefix");
+        std::fs::write(&p, &bytes).unwrap();
+        let sn = sniff(&p).unwrap();
+        assert_eq!(
+            (sn.family, sn.binary_kind.as_deref()),
+            (Family::Binary, Some("gif")),
+            "{name}: a real GIF with a {sub_block}-byte comment chain classified \
+             {}/{:?} — `scan_file` hands that to the prose extractor",
+            sn.family.as_str(),
+            sn.binary_kind
+        );
+    }
+
+    // The same shape, in prose: `!` at 13, a windows-1252 0xFE at 14, and a
+    // chain of printable "sizes" that never terminates inside the prefix.
+    let mut notes: Vec<u8> = b"GIF89a fichie!".to_vec();
+    notes.push(0xfe);
+    for _ in 0..400 {
+        notes.extend_from_slice("Le format GIF reste partout sur le web. ".as_bytes());
+    }
+    let np = dir.path().join("notes.txt");
+    std::fs::write(&np, &notes).unwrap();
+    let sn = sniff(&np).unwrap();
+    assert_eq!(
+        sn.family,
+        Family::TxtProse,
+        "prose was junked as {:?} through the comment arm (#379)",
+        sn.binary_kind
+    );
+}
+
 /// An actual GIF, checked into this repository, read off disk.
 ///
 /// Every other fixture in this file and in `sniff::printable_magic_tests` is


### PR DESCRIPTION
Round 2 for #379 / #380. Supersedes #411, whose adversarial verification returned `sound=false` with two live defects **of the class the fix claims to close**. Both reproduced through the real `sniff_bytes`.

## What round 1 missed

**The `0x2C` Image-Descriptor path.** For all-ASCII input `packed & 0x80` is always clear, so the first block always lands at offset 13. A `,` there, plus four little-endian u16s whose HIGH bytes (offsets 15/17/19/21) are spaces, satisfies every geometry bound. Verified junked as `binary/Some("gif")` on #411's head:

```
"GIF89a format,1 2 3 4 5 and the rest of this note is about the format. " x30
"GIF89a header,a b c d e f g h ..."          "GIF89a fields,x y z w ..."
GIF87a variant, and the CSV "GIF89a format,1 2 3 4 5\nrow,a,b,c,d\n..."
```

**The `0x21` Extension path.** The label alone is not a discriminator, because `decode()` falls back to windows-1252 where `0xF9`/`0xFE`/`0xFF` are ordinary latin-1 letters. `"GIF89a fichie!" + 0xF9 + French prose` → `binary/Some("gif")`.

## The fix

**`0x2C`** — decode one field further, to the LZW minimum code size that opens the image data. The spec confines it to `2..=12`, entirely non-printable.

**That alone is still insufficient, and the verification did not catch this case either.** The CSV counterexample carries `\n` (10) at exactly that offset, which is *inside* the valid range. So the frame must also have a palette — its own Local Colour Table or the Global one. A file with neither has nothing to decode pixels against and is not a GIF; the CSV has both flags clear.

**`0x21`** — the spec fixes the first sub-block size for three of the four labels: 12 after `0x01`, 4 after `0xF9`, 11 after `0xFF`, all non-printable. Comment sizes are genuinely variable, so that arm walks the sub-block chain to its `0x00` terminator and requires a valid introducer behind it.

## Fixtures corrected, not loosened

Four fixtures stopped one byte short of what the spec mandates — the byte after `0x21 0xF9` was `'l'` from the lorem payload, where a real Graphic Control Extension always carries `4`. They asserted they were real GIFs while not being decodable. The `0x2C` fixture additionally gains the Global Colour Table that a frame without a local one requires.

This is the inverse of the verification's item 3: those tests certified a guarantee the code did not provide; these fixtures claimed a realism they did not have.

## Verification

**Verified.**

Real GIFs, swept off the build machine — the check that matters, since the risk of a tighter qualifier is refusing real images:

```
real GIFs: accepted=11  refused=0     (includes this repo's docs/media/demo.gif)
```

Fail-before, reverting **only** the two qualifier bodies and keeping the tests:

```
test result: FAILED. 8 passed; 1 failed; 640 filtered out
    sniff::printable_magic_tests::round_one_counterexamples_are_text_not_gifs
```

Full crate, `--test-threads=2` (CI's shape), both profiles since overflow-checks differ:

```
ci-test:  654 passed, 0 failed
dev:      654 passed, 0 failed
```

Gates under CI's toolchain (rustc 1.97.1 — the local default is 1.92.0 and disagrees, see #422):

```
cargo fmt --all --check                                  exit 0
cargo clippy --workspace --all-targets -- -D warnings    exit 0
```

**Assumed / not verified.**

- All 11 real GIFs on this machine open on a `0x21` Extension. I have **no real `0x2C`-first GIF locally**, so the LZW-range and palette rules on that path are validated against the spec and the counterexamples, not against real image-descriptor-first files. #411's verification reported 12/12 real ones satisfying the LZW rule; I could not re-run that measurement.
- The ES-YAML conformance suite is not run here — it deletes every index on the node it targets and needs its own port and data dir. This change is confined to `sniff.rs` with no ES wire-protocol path, but that is an argument, not a measurement.
- `%PDF-` (#403) is the same class on a different signature and is **not** addressed by this PR.

## Checks

- [x] `cargo fmt --all` / `clippy -D warnings` under 1.97.1
- [x] `cargo test -p xerj-autoindex -- --test-threads=2` in both `dev` and `ci-test`
- [x] Counterexamples from the verification added as tests, proven to fail before
- [x] Real-GIF corpus re-checked for false refusals
- [ ] ES-YAML conformance — **not run**, see above
