### PR TITLE
fix(autoindex): isolate one-shot test failpoints by thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,15 +248,16 @@ jobs:
       #
       # Scoped to the one crate whose lib tests have been *measured* green at
       # default parallelism (10 dev-profile and 5 ci-test-profile clean runs at
-      # this commit, 20 cores). `--workspace --lib` is the destination, not this
-      # commit: at default parallelism it is currently red in xerj-autoindex
-      # (5 failures in 10 runs), where the `incremental_reconcile_http_tests`
-      # module reaches the global `SNAPSHOT_FAILPOINT` without holding the
-      # `SNAPSHOT_TEST_LOCK` that guards it and steals another test's injected
-      # failure -- the same defect class as #372, in a different crate. That is
-      # issue #385; widening this step past xerj-engine is #384. A gate is
-      # worth nothing if it is merged red, so it goes in at the width it
-      # passes at.
+      # this commit, 20 cores). `--workspace --lib` remains the destination,
+      # but the broader gate is tracked separately in #384.
+      #
+      # Historical context for this scope: before #385, xerj-autoindex was red
+      # at default parallelism because `incremental_reconcile_http_tests` could
+      # reach the global `SNAPSHOT_FAILPOINT` without holding the
+      # `SNAPSHOT_TEST_LOCK` and steal another test's injected failure. The
+      # thread-local failpoint fix in this commit removes that defect; widening
+      # this step past xerj-engine remains #384. A gate is worth nothing if it
+      # is merged red, so it goes in at the width it passes at.
       #
       # Reuses the binaries the step above already built: the added cost is test
       # runtime, not another compile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Autoindex snapshot and replay one-shot failpoints can no longer be stolen by unrelated parallel tests.** ([#385](https://github.com/xerj-org/xerj/issues/385)).
+  The two test-only failpoints are now owned by the thread that arms them, while
+  retaining their existing one-shot behavior and serialization locks.
+
 - **Console delete/upsert no longer reports success after a refused write.**
   `DELETE /_xerj-console/api/v1/views/{id}` swallowed `delete_document`
   errors and returned `204` while the view stayed on disk (the same class

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -21,15 +21,17 @@ use std::path::Path;
 const SNAPSHOT_VERSION: u32 = 2;
 
 #[cfg(test)]
-static SNAPSHOT_FAILPOINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+thread_local! {
+    // Test failpoints belong to the thread that arms them: an unrelated test
+    // running in parallel must not consume another test's one-shot failure.
+    static SNAPSHOT_FAILPOINT: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+    static REPLAY_FAIL_AFTER_APPLY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 #[cfg(test)]
 static SNAPSHOT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(test)]
 static POST_SEAL_SOURCE_REPLACEMENT: std::sync::Mutex<Option<(std::path::PathBuf, Vec<u8>)>> =
     std::sync::Mutex::new(None);
-#[cfg(test)]
-static REPLAY_FAIL_AFTER_APPLY: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
 #[cfg(test)]
 pub(crate) static REPLAY_FAILPOINT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(test)]
@@ -1744,18 +1746,20 @@ fn apply_post_seal_source_replacement(path: &Path) -> Result<()> {
 
 #[cfg(test)]
 fn fail_next_snapshot(boundary: u8) {
-    SNAPSHOT_FAILPOINT.store(boundary, std::sync::atomic::Ordering::SeqCst);
+    SNAPSHOT_FAILPOINT.with(|failpoint| failpoint.set(boundary));
 }
 
 #[cfg(test)]
 fn snapshot_failpoint(boundary: u8) -> Result<()> {
-    if SNAPSHOT_FAILPOINT.compare_exchange(
-        boundary,
-        0,
-        std::sync::atomic::Ordering::SeqCst,
-        std::sync::atomic::Ordering::SeqCst,
-    ) == Ok(boundary)
-    {
+    let armed = SNAPSHOT_FAILPOINT.with(|failpoint| {
+        if failpoint.get() == boundary {
+            failpoint.set(0);
+            true
+        } else {
+            false
+        }
+    });
+    if armed {
         anyhow::bail!("injected snapshot failure at boundary {boundary}");
     }
     Ok(())
@@ -1768,12 +1772,12 @@ fn snapshot_failpoint(_boundary: u8) -> Result<()> {
 
 #[cfg(test)]
 fn fail_replay_after_next_apply() {
-    REPLAY_FAIL_AFTER_APPLY.store(true, std::sync::atomic::Ordering::SeqCst);
+    REPLAY_FAIL_AFTER_APPLY.with(|failpoint| failpoint.set(true));
 }
 
 #[cfg(test)]
 fn replay_fail_after_apply() -> Result<()> {
-    if REPLAY_FAIL_AFTER_APPLY.swap(false, std::sync::atomic::Ordering::SeqCst) {
+    if REPLAY_FAIL_AFTER_APPLY.with(|failpoint| failpoint.replace(false)) {
         anyhow::bail!("injected crash after accepted operation");
     }
     Ok(())
@@ -2482,6 +2486,80 @@ mod tests {
                 recovered
             );
         }
+    }
+
+    #[test]
+    fn snapshot_failpoint_cannot_be_stolen_by_an_unrelated_thread() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let (armed_tx, armed_rx) = std::sync::mpsc::channel();
+        let (thief_done_tx, thief_done_rx) = std::sync::mpsc::channel();
+
+        let owner = std::thread::spawn(move || {
+            fail_next_snapshot(2);
+            armed_tx.send(()).unwrap();
+            thief_done_rx.recv().unwrap();
+            (
+                snapshot_failpoint(2).is_err(),
+                snapshot_failpoint(2).is_ok(),
+            )
+        });
+
+        armed_rx.recv().unwrap();
+        let thief_result = snapshot_failpoint(2);
+        thief_done_tx.send(()).unwrap();
+        let (owner_consumed_once, owner_second_probe_succeeded) = owner.join().unwrap();
+
+        assert!(
+            thief_result.is_ok(),
+            "a thread that did not arm the snapshot failpoint consumed it"
+        );
+        assert!(
+            owner_consumed_once,
+            "the thread that armed the snapshot failpoint did not consume it"
+        );
+        assert!(
+            owner_second_probe_succeeded,
+            "the snapshot failpoint must retain one-shot semantics"
+        );
+    }
+
+    #[test]
+    fn replay_failpoint_cannot_be_stolen_by_an_unrelated_thread() {
+        let _guard = REPLAY_FAILPOINT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let (armed_tx, armed_rx) = std::sync::mpsc::channel();
+        let (thief_done_tx, thief_done_rx) = std::sync::mpsc::channel();
+
+        let owner = std::thread::spawn(move || {
+            fail_replay_after_next_apply();
+            armed_tx.send(()).unwrap();
+            thief_done_rx.recv().unwrap();
+            (
+                replay_fail_after_apply().is_err(),
+                replay_fail_after_apply().is_ok(),
+            )
+        });
+
+        armed_rx.recv().unwrap();
+        let thief_result = replay_fail_after_apply();
+        thief_done_tx.send(()).unwrap();
+        let (owner_consumed_once, owner_second_probe_succeeded) = owner.join().unwrap();
+
+        assert!(
+            thief_result.is_ok(),
+            "a thread that did not arm the replay failpoint consumed it"
+        );
+        assert!(
+            owner_consumed_once,
+            "the thread that armed the replay failpoint did not consume it"
+        );
+        assert!(
+            owner_second_probe_succeeded,
+            "the replay failpoint must retain one-shot semantics"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Written by an AI coding agent (OpenAI Codex), run by @buger, who has reviewed this change.

## What this changes, and why

At parallel test execution, an unrelated autoindex test could consume a crash failure armed by another test. The snapshot failure hook was a process-global `AtomicU8`, and the replay-after-apply hook was a process-global `AtomicBool`. Both were one-shot values, so whichever test thread reached the hook first owned the failure, regardless of which thread armed it.

That produced a symmetric failure: the unrelated test received an injected crash, while the owner test unexpectedly succeeded. The original issue #385 measured the snapshot case in 5 of 10 default-parallelism runs on its 20-core host. Issue #404 independently reproduced the replay case and was closed as a duplicate of #385.

This change stores those two test-only failpoints in thread-local `Cell`s. The thread that arms a hook is now the only thread that can observe and consume it. The existing one-shot behavior and serialization locks are retained.

Snapshot and replay are bundled because they are the same ownership defect in the same module, use the same synchronous arm-then-run pattern, and each has its own deterministic owner/thief negative control. Splitting them would knowingly leave the independently reproduced replay form unfixed.

The workflow edit changes comments only. It records #385 as historical context; the executable CI commands are unchanged, and widening the default-parallelism gate remains tracked by #384.

## Evidence

Commands below omit only the machine-local `CARGO_TARGET_DIR` cache location unless the cache path is relevant. All test profile, package, filter, thread-count, and LTO arguments are shown.

### Fail before: deterministic causal controls

With the regression tests present and only the implementation hunk restored to the original process-global atomics:

```console
$ cargo test --profile ci-test -p xerj-autoindex \
    sync_executor::tests::snapshot_failpoint_cannot_be_stolen_by_an_unrelated_thread \
    -- --exact --nocapture
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 642 filtered out
a thread that did not arm the snapshot failpoint consumed it

$ cargo test --profile ci-test -p xerj-autoindex \
    sync_executor::tests::replay_failpoint_cannot_be_stolen_by_an_unrelated_thread \
    -- --exact --nocapture
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 642 filtered out
a thread that did not arm the replay failpoint consumed it
```

The two owner/thief tests use channels to force this order: owner arms, unrelated thread probes, owner probes twice. They therefore assert both isolation and exactly one consumption without relying on scheduler timing.

### Fail before: current-main repeated-suite reproduction

The current-main audit was run at `abc614ee72768fc2c5ff85926f87c589d9ab9bb7`, the exact parent of this branch. At the machine's default 16 test threads, ten consecutive `cargo test --profile ci-test -p xerj-autoindex --lib` runs passed 10/10. With `--test-threads=20`, 2 of 10 runs failed: one run showed the snapshot owner/thief pair and one showed the sibling replay owner/thief pair. This corrected reproduction matters because it shows that the defect remains real on current main but is scheduling-sensitive; a green ten-run sample at 16 threads does not disprove it.

```console
$ for run in $(seq 1 10); do
    cargo test --profile ci-test -p xerj-autoindex --lib
  done
10/10 runs passed at the machine's default 16 test threads

$ for run in $(seq 1 10); do
    cargo test --profile ci-test -p xerj-autoindex --lib -- --test-threads=20
  done
8/10 runs passed; 2/10 failed
failure 1: snapshot failpoint was consumed by an unrelated test
failure 2: replay-after-apply failpoint was consumed by an unrelated test
```

This current-main result is separate from the original issue's historical measurement. Issue #385 ran the then-633-test library suite ten times at default parallelism on a different 20-core host: five runs passed 633/633 and five failed with 631 passed / 2 failed. The failure pair was always the snapshot crash owner plus whichever unrelated HTTP test reached snapshot creation first.

Replay was also observed before this branch outside the deterministic negative control. The #404 reproduction failed with 638 passed / 2 failed on a clean checkout and 641 passed / 2 failed on an unrelated `sniff.rs` branch; the replay owner unexpectedly succeeded while an HTTP test received `injected crash after accepted operation`.

### Pass after

The same two focused commands on the final implementation each passed 1/1 with 642 tests filtered out.

```console
$ cargo test --profile ci-test -p xerj-autoindex --lib
test result: ok. 643 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.64s

$ cargo test --profile ci-test -p xerj-autoindex --lib -- --test-threads=2
test result: ok. 643 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.01s

$ for run in $(seq 1 10); do
    cargo test --profile ci-test -p xerj-autoindex --lib -- --test-threads=20
  done
10/10 runs passed; every run was 643 passed / 0 failed; wall times were 5.67s-6.49s

$ cargo test --profile ci-test -p xerj-autoindex
library: 643 passed / 0 failed
journal_lock_inheritance: 1 passed / 0 failed
scan_pool_width: 1 passed / 0 failed
doc tests: 0 tests / 0 failed

$ cargo fmt --all --check
# exit 0, no output

$ cargo clippy -p xerj-autoindex --all-targets --profile ci-test -- -D warnings
Finished `ci-test` profile [optimized] target(s) in 38.32s
```

### Release builds and ES-YAML hard gate

Development validation explicitly disabled fat LTO while retaining the optimized release profile. The touched crate's scoped release build completed successfully, then the server needed for the wire-conformance gate was also built successfully.

```console
$ CARGO_PROFILE_RELEASE_LTO=off cargo build --release -j 32 -p xerj-autoindex
Finished `release` profile [optimized] target(s) in 4m 30s
exit 0

$ CARGO_PROFILE_RELEASE_LTO=off cargo build --release -j 32 -p xerj-server
Finished `release` profile [optimized] target(s) in 8m 22s
exit 0
```

The prescribed ES-YAML runner was executed against that server on a private port and private data directory. The server reported green health before the run.

```console
$ CARGO_PROFILE_RELEASE_LTO=off cargo run --release -p es-yaml-runner -- \
    --dir tests/es-compat-yaml/yaml --url http://127.0.0.1:19286
ES-COMPAT YAML RUNNER · 200 files · http://127.0.0.1:19286
1366 passed · 0 failed · 3 skipped · 1369 total
exit 0
```

All validation servers were stopped with SIGINT. Process probes confirmed the server processes absent and private ports 19285 and 19286 free after shutdown.

The behavioral runs preceded the final comment/CHANGELOG-only amend. The `sync_executor.rs` blob is byte-identical before and after that amend; formatting, ancestry, effective-diff, and workflow-command checks were repeated on the final commit `07cc2870edf21f6a9a44985e58e5d523e99bfb56`.

## Scope and non-goals

- This is test-only behavior under `cfg(test)`; runtime indexing, durable state, HTTP/CLI contracts, telemetry, and performance are unchanged.
- The arm and consume sites are synchronous and remain on the same OS thread. No async task or worker migration exists between them.
- `GC_FAIL_AFTER_RENAME` and `POST_SEAL_SOURCE_REPLACEMENT` are deliberately unchanged. Neither was established by this issue's reproductions or negative controls; speculative changes do not belong in this fix.
- CI widening is not included. That work remains #384.
- Persistent-state, legacy-mapping, recovery, migration, feature-gate, and performance sections of the contribution audit are not applicable because no production path or stored format changes.

## Checks

- [x] `cargo fmt --all --check`
- [x] Scoped non-LTO release build: `CARGO_PROFILE_RELEASE_LTO=off cargo build --release -j 32 -p xerj-autoindex`
- [x] Scoped non-LTO server build for conformance: `CARGO_PROFILE_RELEASE_LTO=off cargo build --release -j 32 -p xerj-server`
- [x] `cargo test --profile ci-test -p xerj-autoindex`
- [x] ES-YAML conformance suite: 1366 passed / 0 failed / 3 skipped / 1369 total
- [x] New ES-compatible behavior: not applicable; this changes test-only hooks
- [x] CHANGELOG updated; no runtime user documentation changes apply
- [x] Applicable `docs/CONTRIBUTION_REVIEW.md` audit completed against current `main`; the branch is one independent commit with no prerequisite
- [x] Scoped strict Clippy in the CI test profile
- [x] Validation servers stopped cleanly; private ports confirmed free

## Provenance

- Written by: OpenAI Codex, run by @buger, who has reviewed the final change.
- **Verified:** both targeted fail-before mutations; the current-main repeated-suite matrix at default 16-thread and explicit 20-thread parallelism; both focused pass-after tests; the 643-test library suite at default, 2-thread, and 20-thread parallelism; ten consecutive fixed 20-thread runs; the full xerj-autoindex crate test; formatting; scoped strict Clippy; scoped non-LTO release builds of xerj-autoindex and xerj-server; ES-YAML at 1366 passed / 0 failed / 3 skipped; clean server shutdown and free private ports; final ancestry and effective diff; unchanged executable CI workflow commands. Behavioral tests ran before the final comment/CHANGELOG-only amend; the Rust source blob is unchanged.
- **Assumed:** no behavior on non-Linux test hosts was exercised. A future refactor that moves an arm and its hook onto different worker threads would need an explicitly propagated failpoint context instead of thread-local ownership.

Closes #385.
