### PR TITLE
docs: document the verified air-gapped deployment boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ your PATH if needed): `xerj --insecure --data-dir ./data &`, wait until
 `http://localhost:9200` responds, then `xerj autoindex ~/my-project` — see
 [Index a folder](#index-a-folder).
 
+For a host with no runtime internet access, follow the
+[air-gapped deployment recipe](./docs/recipes/air-gapped-deployment.md). The
+default lexical embedder is offline; neural mode needs the three model files
+staged locally before the first semantic operation.
+
 ## Index a folder
 
 Start the server, then point `autoindex` at anything:

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -21,6 +21,7 @@ These are practical "how do I actually do X" recipes, not an API reference (that
 | [Continuous anomaly datafeeds](./continuous-anomaly-datafeeds.md) | A live `_ml` datafeed that re-scores an index on a timer and stores new anomaly records you poll | [`datafeed_demo.py`](../examples/continuous-anomaly-datafeeds/datafeed_demo.py) |
 | [Migrate from Elasticsearch](./migrate-from-elasticsearch.md) | Point your existing ES client at XERJ — same wire, change the URL | [`migrate_demo.sh`](../examples/migrate-from-elasticsearch/migrate_demo.sh) |
 | [Production deployment](./production-deployment.md) | The hardened posture: in-process TLS + API-key auth, health-probe & gRPC posture, air-gapped neural-model staging, and copying data out of a live Elasticsearch (scroll + bulk) | inline `curl` + `bash` |
+| [Air-gapped deployment](./air-gapped-deployment.md) | Stage a release and optional neural model on a connected machine, then run XERJ offline with explicit network and persistence boundaries | inline `curl` + `bash` |
 | [Diagnose CPU and memory with pprof](./debug-profiling.md) | A private, bounded, symbolized CPU/heap capture with reproducibility manifest, artifact validation, and AI analysis prompts | [`debug-profiling/`](../../demo/playbooks/debug-profiling/) |
 
 Every example is stdlib-only Python 3, plain `curl`, or the `xerj` binary itself — no dependencies to install. Start XERJ (`./target/release/xerj --data-dir ./data --insecure`), then run any example.

--- a/docs/recipes/air-gapped-deployment.md
+++ b/docs/recipes/air-gapped-deployment.md
@@ -1,0 +1,291 @@
+# Air-gapped deployment: run XERJ without runtime internet
+
+This is a short, Linux x86_64-musl procedure. It stages one operator-approved
+release, installs the service as an unprivileged account, and keeps the node on
+loopback. The base path is lexical and needs no model files. Neural embedding is
+an optional, separately staged path.
+
+## Runtime boundary
+
+- The default embedding mode is **lexical feature hashing**. It needs no model,
+  no embedding service, and no network connection.
+- Neural mode is optional. Without `embedding.local_model_dir`, the first
+  operation that needs an embedding downloads `config.json`, `tokenizer.json`,
+  and `model.safetensors` for `sentence-transformers/all-MiniLM-L6-v2` from the
+  Hugging Face Hub. With that directory set, XERJ reads those files locally.
+- `proxy` calls only the configured OpenAI-compatible
+  `embedding.default_endpoint`. The experimental `onnx-experimental` backend
+  needs an ONNX-enabled build and explicit local assets; neither is the base
+  release path.
+
+The running node makes no telemetry, update-check, or license-activation call.
+Release-download analytics are a property of the connected website/GitHub
+staging surface, not of a running XERJ process. The installer also downloads a
+release archive and its checksum from GitHub; an offline operator must stage
+those files before entering the enclave.
+
+## Defaults and boundaries
+
+| Component | Default | Air-gapped meaning |
+|---|---|---|
+| Embedding | `auto`: lexical unless an endpoint is configured | No model or network for lexical mode |
+| Neural model | Off | Set `local_model_dir` before selecting `neural` |
+| External proxy | Disabled (`default_endpoint = ""`) | Only the configured endpoint is contacted |
+| ONNX | Experimental and not in the standard release | Build the feature and provide local assets explicitly |
+| WAL tap | Disabled | It remains inert unless enabled with a target URL; see the durable overlay note below |
+| Cluster | Disabled | Single-node startup does not initialize the Raft transport |
+| REST / ES-compatible listeners | `127.0.0.1` | The default is loopback-only |
+| `autoindex` and MCP clients | Localhost defaults | They connect to `localhost`; they do not create a public listener |
+| Runtime telemetry/update/license activation | None | No outbound call is made by the running binary for these purposes |
+
+This is a statement of defaults, not a claim that every browser UI request is
+offline. **The bundled Console has three external Google Fonts link elements
+(two preconnects and one stylesheet; stylesheet may fetch additional font files).**
+Blocked requests fall back to system fonts. The engine and APIs
+continue to work.
+
+This procedure does not claim that egress was measured here. If your policy
+requires that boundary, apply an egress-deny rule and inspect firewall/log
+counters during the acceptance checks.
+
+## 1. Stage an approved release on a connected machine
+
+Do this on a machine that is allowed to reach GitHub. Set `TAG` to the
+operator-approved `vX.Y.Z` release tag before running; there is no moving
+release alias in this procedure. The release workflow names each archive from
+the version without the `v` prefix, target triple, and extension. The matching
+`.sha256` is a separate per-archive asset.
+
+The following stages the Linux x86_64 musl archive only.
+
+```bash
+set -eu
+
+: "${TAG:?set TAG to an operator-approved vX.Y.Z release tag}"
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "TAG must match vX.Y.Z with optional prerelease/build metadata: $TAG" >&2
+  exit 2
+fi
+VERSION="${TAG#v}"
+TARGET="x86_64-unknown-linux-musl"
+EXT="tar.gz"
+STAGE="xerj-${VERSION}-${TARGET}"
+ASSET="${STAGE}.${EXT}"
+BASE="https://github.com/xerj-org/xerj/releases/download/${TAG}"
+OUT="${OUT:-$PWD/xerj-airgap-${VERSION}-${TARGET}}"
+
+mkdir -p "$OUT/release"
+curl -fL --retry 3 -o "$OUT/release/$ASSET" "$BASE/$ASSET"
+curl -fL --retry 3 -o "$OUT/release/$ASSET.sha256" "$BASE/$ASSET.sha256"
+
+(
+  cd "$OUT/release"
+  sha256sum -c "$ASSET.sha256"
+  tar -xzf "$ASSET"
+  test -x "$STAGE/xerj"
+  "$STAGE/xerj" --version
+)
+```
+
+The checksum proves that the archive matches the digest published beside that
+archive in the same GitHub release. It is an integrity check, not an
+independent signature, provenance statement, or attestation. If your policy
+requires signed releases or an external attestation, obtain and verify that
+evidence separately; `.sha256` alone does not provide it.
+
+After transfer, set the same approved `TAG` in the enclave and verify before
+extracting:
+
+```bash
+: "${TAG:?set TAG to the same operator-approved release tag}"
+VERSION="${TAG#v}"
+ASSET="xerj-${VERSION}-x86_64-unknown-linux-musl.tar.gz"
+cd /opt/xerj-staging/release
+sha256sum -c "$ASSET.sha256"
+tar -xzf "$ASSET"
+test -x "xerj-${VERSION}-x86_64-unknown-linux-musl/xerj"
+```
+
+## 2. Install the base lexical node
+
+The account and directories below are an example of the required ownership;
+use the equivalent account-management command on the target Linux image. No
+model directory is created for the lexical deployment.
+
+```bash
+if ! getent passwd xerj >/dev/null; then
+  sudo useradd --system --user-group --home-dir /var/lib/xerj --shell /sbin/nologin xerj
+fi
+sudo install -d -m 0755 /opt/xerj/bin /etc/xerj
+sudo install -d -o xerj -g xerj -m 0750 /var/lib/xerj
+sudo install -m 0755 \
+  "/opt/xerj-staging/release/xerj-${VERSION}-x86_64-unknown-linux-musl/xerj" \
+  /opt/xerj/bin/xerj
+```
+
+Create `/etc/xerj/xerj.toml` with the complete base configuration. Explicitly
+selecting lexical mode and an empty endpoint prevents an accidental proxy or
+neural dependency:
+
+```toml
+[server]
+bind_address = "127.0.0.1"
+data_dir = "/var/lib/xerj"
+es_compat_port = 9200
+
+[auth]
+enabled = true
+
+[embedding]
+mode = "lexical"
+default_endpoint = ""
+default_model = ""
+```
+
+Start it as the service user. On first start, the authenticated admin key is
+written to `/var/lib/xerj/admin.key` with restrictive permissions.
+
+```bash
+sudo -u xerj /opt/xerj/bin/xerj --config /etc/xerj/xerj.toml
+```
+
+Keep the listener on loopback. A network-facing listener requires the separate
+production TLS/auth procedure; this recipe does not teach a cleartext opt-out.
+
+## 3. Optional neural model
+
+Do this only when the enclave needs neural semantics. On the connected staging
+machine, download the three files consumed by the built-in loader and checksum
+them for the transfer:
+
+```bash
+MODEL="$OUT/model/all-MiniLM-L6-v2"
+mkdir -p "$MODEL"
+for FILE in config.json tokenizer.json model.safetensors; do
+  curl -fL --retry 3 -o "$MODEL/$FILE" \
+    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/$FILE"
+done
+(
+  cd "$MODEL"
+  sha256sum config.json tokenizer.json model.safetensors > ../model.sha256
+)
+```
+
+Transfer `OUT/model` with the release and verify `model.sha256` inside the
+enclave. Then install the files and change only the embedding block:
+
+```bash
+sudo install -d -o xerj -g xerj -m 0750 /opt/xerj/models/all-MiniLM-L6-v2
+sudo install -o xerj -g xerj -m 0640 \
+  /opt/xerj-staging/model/all-MiniLM-L6-v2/{config.json,tokenizer.json,model.safetensors} \
+  /opt/xerj/models/all-MiniLM-L6-v2/
+```
+
+```toml
+[embedding]
+mode = "neural"
+local_model_dir = "/opt/xerj/models/all-MiniLM-L6-v2"
+```
+
+XERJ does not independently pin or verify model checksums; the transferred
+digest is an operator supply-chain check, not a XERJ signature. If you only
+need lexical search, omit this section and all model assets.
+
+## 4. Authenticate local clients and verify
+
+These checks are intentionally operator-run checks, not a claim that this
+documentation was live-tested against a disconnected firewall. They verify the
+actual binary and local files in your enclave.
+
+```bash
+XERJ=/opt/xerj/bin/xerj
+DATA=/var/lib/xerj
+KEY="$(sudo cat "$DATA/admin.key")"
+export XERJ_API_KEY="$KEY"
+
+"$XERJ" --version
+curl -fsS -H "Authorization: ApiKey $KEY" \
+  http://127.0.0.1:9200/_cluster/health
+```
+
+With the lexical node running, index a small semantic document and query it
+through the authenticated ES-compatible surface. This semantic query uses the
+local lexical embedder and needs zero model files; assert that it returns
+`_id` `1`.
+
+```bash
+curl -fsS -X PUT "http://127.0.0.1:9200/offline-demo" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{"mappings":{"properties":{"body":{"type":"semantic_text"}}}}'
+curl -fsS -X POST "http://127.0.0.1:9200/offline-demo/_doc/1?refresh=true" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{"body":"A local lexical node can answer this without a network service."}'
+curl -fsS -X POST "http://127.0.0.1:9200/offline-demo/_search" \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{"query":{"semantic":{"field":"body","query":"local lexical"}}}'
+```
+
+Repeat the health and semantic query after restarting the same data directory.
+For the stronger boundary check, run the sequence with host egress disabled
+and inspect the firewall/log counters; this recipe does not claim that test was
+run here.
+
+For MCP, `XERJ_AUTH` and `--auth` are complete Authorization-header values,
+including the scheme:
+
+```bash
+XERJ_URL=http://127.0.0.1:9200 XERJ_AUTH="ApiKey $KEY" "$XERJ" mcp
+"$XERJ" mcp --url http://127.0.0.1:9200 --auth "ApiKey $KEY"
+```
+
+For `xerj autoindex`, `XERJ_API_KEY` and `--api-key` take the raw key; the
+client adds `Authorization: ApiKey` itself:
+
+```bash
+XERJ_API_KEY="$KEY" "$XERJ" autoindex /path/to/folder --url http://127.0.0.1:9200
+"$XERJ" autoindex /path/to/folder --url http://127.0.0.1:9200 --api-key "$KEY"
+```
+
+## Existing data directories and local clients
+
+The WAL tap and cluster are disabled by default. A runtime `PUT
+/_xerj/wal_tap` persists an overlay and can re-enable a tap on restart when a
+data directory is reused. Inspect and remove that overlay before an offline run
+if the directory is not fresh:
+
+```bash
+curl -fsS -H "Authorization: ApiKey $KEY" \
+  http://127.0.0.1:9200/_xerj/wal_tap
+curl -fsS -X DELETE -H "Authorization: ApiKey $KEY" \
+  http://127.0.0.1:9200/_xerj/wal_tap
+```
+
+Cluster mode stays off unless explicitly enabled with peers and a shared
+`cluster.auth_secret`. `xerj mcp` is a local stdio client that proxies
+`XERJ_URL`; `xerj autoindex` walks files visible to the invoking machine. Neither
+creates an external listener or silently uploads corpus data.
+
+## What this page does not promise
+
+- An offline release is not a signed or attested software supply chain. Verify
+  the archive checksum and apply your organization's release-signing process.
+- XERJ does not independently checksum the Hugging Face model files today.
+  Stage and verify them according to your organization's model-supply-chain
+  policy.
+- The bundled Console falls back to system fonts, but its three external Google
+  Fonts link elements remain browser egress attempts unless your deployment
+  removes or rewrites that HTML; stylesheet may fetch additional font files.
+- This page does not claim a live disconnected-firewall run or measured browser
+  egress. The procedure is traced to the config, neural loader, installer, and
+  release workflow; execute those checks in your target environment.
+
+Related references:
+
+- [Production deployment](./production-deployment.md) — TLS, API-key auth,
+  listener boundaries, health probes, and the broader air-gapped model recipe.
+- [Configuration reference](../../landing/docs/config.html) — all TOML keys and
+  defaults.
+- [Experimental ONNX backend](../EXPERIMENTAL_ONNX.md) — explicit feature/build
+  and local asset requirements; not the standard release path.
+- [Metrics privacy posture](../../metrics/README.md) — connected distribution
+  analytics and what they do not measure.

--- a/landing/architecture/index.html
+++ b/landing/architecture/index.html
@@ -188,28 +188,28 @@
       <text x="40" y="44" class="label mute">SEALED ENCLAVE · NO INTERNET · TARGET: GOV · DEFENSE · FIN</text>
 
       <g class="node accent"><rect x="60" y="80" width="500" height="140"/>
-        <text x="76" y="104" class="label">XERJ CLUSTER · 3-NODE HA · AIRGAP=1</text>
-        <text x="76" y="128" class="small">FTS · VECTOR · COLUMNS · AGENT MEMORY</text>
-        <text x="76" y="150" class="small">encrypted segments · AES-256-GCM · BYOK</text>
-        <text x="76" y="176" class="small mute">RTO &lt; 30 s · RPO 0 (sync) · 99.95 % availability</text>
-        <text x="76" y="204" class="small mute">no outbound · no telemetry · no license ping</text>
+        <text x="76" y="104" class="label">XERJ NODE · STANDARD BINARY · LEXICAL BASELINE</text>
+        <text x="76" y="128" class="small">loopback listener · authenticated API</text>
+        <text x="76" y="150" class="small">optional local model staged by operator</text>
+        <text x="76" y="176" class="small mute">archive + adjacent .sha256 integrity check</text>
+        <text x="76" y="204" class="small mute">no runtime telemetry · update · license calls</text>
       </g>
 
       <g class="node mute"><rect x="600" y="80" width="320" height="140" class="dashed"/>
-        <text x="616" y="104" class="label">OFFLINE UPDATE CHANNEL</text>
-        <text x="616" y="128" class="small">signed bundle via data-diode</text>
-        <text x="616" y="148" class="small">manifest verified before install</text>
-        <text x="616" y="168" class="small">SBOM + SLSA provenance</text>
+        <text x="616" y="104" class="label">OPERATOR-STAGED RELEASE</text>
+        <text x="616" y="128" class="small">archive + adjacent .sha256</text>
+        <text x="616" y="148" class="small">verify before transfer</text>
+        <text x="616" y="168" class="small">optional local model files</text>
         <text x="616" y="196" class="small mute">inbound only</text>
       </g>
 
       <line x1="598" y1="150" x2="566" y2="150" class="mute"/>
       <polygon class="mute" points="570,146 570,154 562,150"/>
     </svg>
-    <div class="row"><div class="k">NODES</div><div class="v">1–N · offline</div></div>
-    <div class="row"><div class="k">RTO / RPO</div><div class="v">Same as HA cluster</div></div>
-    <div class="row"><div class="k">EGRESS</div><div class="v">Zero telemetry · zero update probe · zero license ping</div></div>
-    <div class="row"><div class="k">UPDATES</div><div class="v">Signed offline bundle · SBOM verified before install · reproducible-build manifest</div></div>
+    <div class="row"><div class="k">NODES</div><div class="v">1 · loopback by default</div></div>
+    <div class="row"><div class="k">RTO / RPO</div><div class="v">Operator-defined</div></div>
+    <div class="row"><div class="k">EGRESS</div><div class="v">No runtime telemetry · update · license calls; Console may attempt external Google Fonts</div></div>
+    <div class="row"><div class="k">UPDATES</div><div class="v">Operator-staged archive · adjacent .sha256 integrity only</div></div>
     <div class="row"><div class="k">USE WHEN</div><div class="v">Classified enclaves · SCIFs · regulated on-prem with no internet · sovereign cloud</div></div>
   </div>
 

--- a/landing/docs/install.html
+++ b/landing/docs/install.html
@@ -150,6 +150,7 @@ $ sha256sum -c xerj-${ver}-x86_64-unknown-linux-musl.tar.gz.sha256
 $ tar xzf xerj-${ver}-x86_64-unknown-linux-musl.tar.gz
 $ sudo install -m 0755 xerj-${ver}-x86_64-unknown-linux-musl/xerj /usr/local/bin/xerj
 $ xerj --version</pre>
+  <p>Deploying to a host with no runtime internet access? Follow the <a href="/docs/recipes/air-gapped-deployment.html">air-gapped deployment recipe</a> for release checksums, optional local neural model files, and the loopback/auth defaults.</p>
   <p><strong>macOS Gatekeeper:</strong> the release binaries are not code-signed or notarized. A tarball fetched with <code class="inline">curl</code> (both the one-liner and the commands above) is not quarantined and runs as-is. A tarball downloaded through a <em>browser</em> is: macOS attaches <code class="inline">com.apple.quarantine</code> and the first launch is blocked with <em>"cannot be opened because the developer cannot be verified"</em>. Clear it once, then run normally:</p>
 <pre class="code">$ xattr -d com.apple.quarantine ./xerj</pre>
 

--- a/landing/docs/recipes/air-gapped-deployment.html
+++ b/landing/docs/recipes/air-gapped-deployment.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="night">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>XERJ · Docs · Recipe · Air-gapped deployment</title>
+<meta name="description" content="Stage a XERJ release and optional neural model on a connected machine, then run the node without runtime internet access.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap">
+<link rel="stylesheet" href="/style.css?v=90f643e">
+</head>
+<body>
+<nav class="nav" aria-label="Primary">
+  <a href="/index.html" class="brand">XERJ.AI</a>
+  <a href="/index.html">HOME</a><a href="/product.html">PRODUCT</a>
+  <span class="spacer"></span>
+  <a href="/for-agents.html">FOR AGENTS</a><a href="/docs/index.html">DOCS</a>
+  <a href="/docs/recipes/index.html" class="active">RECIPES</a>
+  <a href="https://github.com/xerj-org/xerj" rel="external">GITHUB</a>
+  <span class="spacer"></span>
+  <span class="theme"><button type="button" data-theme="day">DAY</button><span class="dash">·</span><button type="button" data-theme="night" class="active">NIGHT</button></span>
+</nav>
+
+<div class="docs-search" id="docsSearch">
+  <input type="text" id="docsSearchInput" placeholder="Search docs · keys, flags, endpoints, playbooks…" aria-label="Search docs" autocomplete="off" spellcheck="false">
+  <span class="hint">⌘ K</span><div class="results" id="docsSearchResults" aria-live="polite"></div>
+</div>
+
+<div class="docs-shell">
+<nav class="docs-nav" aria-label="Docs">
+  <div class="group"><span class="label">START</span>
+    <a href="/docs/index.html"><span class="eyebrow">01</span>Overview</a>
+    <a href="/docs/install.html"><span class="eyebrow">02</span>Install</a>
+  </div>
+  <div class="group"><span class="label">OPERATIONS</span>
+    <a href="/docs/operations.html"><span class="eyebrow">01</span>Running in production</a>
+    <a href="/docs/config.html"><span class="eyebrow">02</span>Config TOML</a>
+  </div>
+  <div class="group"><span class="label">RECIPES</span>
+    <a href="/docs/recipes/index.html"><span class="eyebrow">00</span>All recipes</a>
+    <a href="/docs/recipes/air-gapped-deployment.html" class="active"><span class="eyebrow">13</span>Air-gapped deployment</a>
+  </div>
+</nav>
+
+<main class="docs-content">
+  <div class="breadcrumb"><a href="/docs/index.html">DOCS</a><span class="sep">·</span><a href="/docs/recipes/index.html">RECIPES</a><span class="sep">·</span>AIR-GAPPED DEPLOYMENT
+    <button class="pdf-btn" onclick="window.print()" title="Save this page as PDF"><svg viewBox="0 0 24 24"><path d="M12 3v12M12 15l-4-4M12 15l4-4"/><path d="M4 17v2a2 2 0 002 2h12a2 2 0 002-2v-2"/></svg>PDF</button>
+  </div>
+  <div class="kicker"><span>RECIPE · 13 · OPERATIONS</span></div>
+  <h1>Run XERJ fully offline — air-gapped deployment</h1>
+  <p><strong>Goal:</strong> follow this short Linux x86_64-musl procedure: stage one operator-approved release, install it as an unprivileged service, and keep the node on loopback. The base path is lexical and needs no model files; neural embedding is optional.</p>
+
+  <blockquote><p>This recipe is traced to the release workflow, installer, embedding loader, and configuration defaults. It is not a claim that an egress-disabled enclave run was live-tested. Execute the final firewall and operational checks in your own target environment.</p></blockquote>
+
+  <h2>Runtime boundary</h2>
+  <ul>
+    <li>The default embedding mode is <strong>lexical feature hashing</strong>: no model, embedding service, or network connection is required.</li>
+    <li>Neural mode is optional. Without <code class="inline">embedding.local_model_dir</code>, its first embedding operation downloads <code class="inline">config.json</code>, <code class="inline">tokenizer.json</code>, and <code class="inline">model.safetensors</code> for <code class="inline">sentence-transformers/all-MiniLM-L6-v2</code> from Hugging Face; with that directory set, XERJ reads them locally.</li>
+    <li><code class="inline">proxy</code> calls only the configured OpenAI-compatible <code class="inline">embedding.default_endpoint</code>. The experimental <code class="inline">onnx-experimental</code> backend needs an ONNX-enabled build and explicit local assets; neither is the base release path.</li>
+  </ul>
+
+  <h2>Defaults and boundaries</h2>
+  <table><thead><tr><th>Component</th><th>Default</th><th>Offline meaning</th></tr></thead><tbody>
+    <tr><td>Embedding</td><td><code class="inline">auto</code></td><td>Lexical unless an endpoint is configured; no model/network for lexical mode.</td></tr>
+    <tr><td>WAL tap</td><td>Disabled</td><td>A persisted runtime overlay can override TOML on a reused data directory.</td></tr>
+    <tr><td>Cluster</td><td>Disabled</td><td>Single-node startup does not initialize the Raft transport.</td></tr>
+    <tr><td>REST / ES-compatible listeners</td><td><code class="inline">127.0.0.1</code></td><td>Loopback-only by default; keep it there unless the production auth/TLS procedure is followed.</td></tr>
+    <tr><td>autoindex / MCP</td><td>Localhost defaults</td><td>Local clients; they do not create a public listener or silently upload corpus data.</td></tr>
+    <tr><td>Runtime telemetry, updates, license activation</td><td>None</td><td>The running binary makes no calls for these purposes.</td></tr>
+  </tbody></table>
+  <p>The bundled Console has three external Google Fonts link elements (two preconnects and one stylesheet; stylesheet may fetch additional font files). Blocked requests fall back to system fonts.</p>
+  <p>This procedure does not claim that egress was measured here. If policy requires that boundary, apply an egress-deny rule and inspect firewall/log counters during acceptance.</p>
+
+  <h2>1. Stage an approved release</h2>
+  <p>Run this on a connected staging machine. Set <code class="inline">TAG</code> to the operator-approved <code class="inline">vX.Y.Z</code> release tag before running; there is no moving release alias here. This procedure stages the Linux x86_64 musl archive only. The matching <code class="inline">.sha256</code> is a separate per-archive asset.</p>
+<pre class="code">set -eu
+
+: "${TAG:?set TAG to an operator-approved vX.Y.Z release tag}"
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "TAG must match vX.Y.Z with optional prerelease/build metadata: $TAG" &gt;&amp;2
+  exit 2
+fi
+VERSION="${TAG#v}"
+TARGET="x86_64-unknown-linux-musl"
+EXT="tar.gz"
+STAGE="xerj-${VERSION}-${TARGET}"
+ASSET="${STAGE}.${EXT}"
+BASE="https://github.com/xerj-org/xerj/releases/download/${TAG}"
+OUT="${OUT:-$PWD/xerj-airgap-${VERSION}-${TARGET}}"
+
+mkdir -p "$OUT/release"
+curl -fL --retry 3 -o "$OUT/release/$ASSET" "$BASE/$ASSET"
+curl -fL --retry 3 -o "$OUT/release/$ASSET.sha256" "$BASE/$ASSET.sha256"
+(
+  cd "$OUT/release"
+  sha256sum -c "$ASSET.sha256"
+  tar -xzf "$ASSET"
+  test -x "$STAGE/xerj"
+  "$STAGE/xerj" --version
+)</pre>
+  <p>The checksum proves archive integrity against the digest published beside it in the same release; it is not a signature, provenance statement, or attestation. After transfer, set the same approved <code class="inline">TAG</code> and verify before extracting:</p>
+<pre class="code">: "${TAG:?set TAG to the same operator-approved release tag}"
+VERSION="${TAG#v}"
+ASSET="xerj-${VERSION}-x86_64-unknown-linux-musl.tar.gz"
+cd /opt/xerj-staging/release
+sha256sum -c "$ASSET.sha256"
+tar -xzf "$ASSET"
+test -x "xerj-${VERSION}-x86_64-unknown-linux-musl/xerj"</pre>
+
+  <h2>2. Install the base lexical node</h2>
+  <p>Create the service account first, then install only the staged binary. No model directory is needed for lexical mode:</p>
+<pre class="code">if ! getent passwd xerj &gt;/dev/null; then
+  sudo useradd --system --user-group --home-dir /var/lib/xerj --shell /sbin/nologin xerj
+fi
+sudo install -d -m 0755 /opt/xerj/bin /etc/xerj
+sudo install -d -o xerj -g xerj -m 0750 /var/lib/xerj
+sudo install -m 0755 \
+  "/opt/xerj-staging/release/xerj-${VERSION}-x86_64-unknown-linux-musl/xerj" \
+  /opt/xerj/bin/xerj</pre>
+  <p>Create <code class="inline">/etc/xerj/xerj.toml</code> with the complete base configuration. Explicit lexical mode and an empty endpoint keep this path model-free:</p>
+<pre class="code">[server]
+bind_address = "127.0.0.1"
+data_dir = "/var/lib/xerj"
+es_compat_port = 9200
+
+[auth]
+enabled = true
+
+[embedding]
+mode = "lexical"
+default_endpoint = ""
+default_model = ""</pre>
+<pre class="code">sudo -u xerj /opt/xerj/bin/xerj --config /etc/xerj/xerj.toml</pre>
+  <p>Start it as <code class="inline">xerj</code>. On first start the authenticated admin key is written to <code class="inline">/var/lib/xerj/admin.key</code>. Keep the listener on loopback; a network-facing listener needs the production TLS/auth procedure.</p>
+
+  <h2>3. Optional neural model</h2>
+  <p>Only when neural semantics are needed, stage the three loader files on the connected machine:</p>
+<pre class="code">MODEL="$OUT/model/all-MiniLM-L6-v2"
+mkdir -p "$MODEL"
+for FILE in config.json tokenizer.json model.safetensors; do
+  curl -fL --retry 3 -o "$MODEL/$FILE" \
+    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/$FILE"
+done
+( cd "$MODEL" &amp;&amp; sha256sum config.json tokenizer.json model.safetensors &gt; ../model.sha256 )</pre>
+  <p>Transfer and verify <code class="inline">model.sha256</code>, then install the files:</p>
+<pre class="code">sudo install -d -o xerj -g xerj -m 0750 /opt/xerj/models/all-MiniLM-L6-v2
+sudo install -o xerj -g xerj -m 0640 \
+  /opt/xerj-staging/model/all-MiniLM-L6-v2/{config.json,tokenizer.json,model.safetensors} \
+  /opt/xerj/models/all-MiniLM-L6-v2/</pre>
+  <p>Replace only the embedding block with:</p>
+<pre class="code">[embedding]
+mode = "neural"
+local_model_dir = "/opt/xerj/models/all-MiniLM-L6-v2"</pre>
+  <p>XERJ does not independently verify model checksums; the transferred digest is an operator check, not a XERJ signature. Omit this section and all model assets for lexical search.</p>
+
+  <h2>4. Authenticate local clients and verify</h2>
+<pre class="code">XERJ=/opt/xerj/bin/xerj
+DATA=/var/lib/xerj
+KEY="$(sudo cat "$DATA/admin.key")"
+export XERJ_API_KEY="$KEY"
+"$XERJ" --version
+curl -fsS -H "Authorization: ApiKey $KEY" \
+  http://127.0.0.1:9200/_cluster/health</pre>
+  <p>With the lexical node running, this semantic query uses the local lexical embedder and needs zero model files. Assert that it returns <code class="inline">_id</code> <code class="inline">1</code>:</p>
+<pre class="code">curl -fsS -X PUT http://127.0.0.1:9200/offline-demo \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{"mappings":{"properties":{"body":{"type":"semantic_text"}}}}'
+curl -fsS -X POST 'http://127.0.0.1:9200/offline-demo/_doc/1?refresh=true' \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{"body":"A local lexical node can answer this without a network service."}'
+curl -fsS -X POST http://127.0.0.1:9200/offline-demo/_search \
+  -H "Authorization: ApiKey $KEY" -H 'Content-Type: application/json' \
+  -d '{"query":{"semantic":{"field":"body","query":"local lexical"}}}'</pre>
+  <p>Repeat health and query after restarting the same data directory. For the stronger boundary check, run the sequence with host egress disabled and inspect firewall/log counters; this recipe does not claim that test was run here.</p>
+  <p>For MCP, <code class="inline">XERJ_AUTH</code> and <code class="inline">--auth</code> are complete Authorization-header values, including the scheme:</p>
+<pre class="code">XERJ_URL=http://127.0.0.1:9200 XERJ_AUTH="ApiKey $KEY" "$XERJ" mcp
+"$XERJ" mcp --url http://127.0.0.1:9200 --auth "ApiKey $KEY"</pre>
+  <p>For <code class="inline">xerj autoindex</code>, <code class="inline">XERJ_API_KEY</code> and <code class="inline">--api-key</code> take the raw key; the client adds the <code class="inline">ApiKey</code> scheme:</p>
+<pre class="code">XERJ_API_KEY="$KEY" "$XERJ" autoindex /path/to/folder --url http://127.0.0.1:9200
+"$XERJ" autoindex /path/to/folder --url http://127.0.0.1:9200 --api-key "$KEY"</pre>
+
+  <h2>Existing data directories and local clients</h2>
+  <p>WAL tap is disabled by default, but <code class="inline">PUT /_xerj/wal_tap</code> persists a runtime overlay and reapplies it over TOML on restart. Inspect and remove an old overlay before reusing a data directory:</p>
+<pre class="code">curl -fsS -H "Authorization: ApiKey $KEY" http://127.0.0.1:9200/_xerj/wal_tap
+curl -fsS -X DELETE -H "Authorization: ApiKey $KEY" http://127.0.0.1:9200/_xerj/wal_tap</pre>
+  <p>Cluster mode remains disabled unless explicitly enabled and supplied a shared <code class="inline">cluster.auth_secret</code>. <code class="inline">xerj mcp</code> is a local stdio client to <code class="inline">XERJ_URL</code>; <code class="inline">xerj autoindex</code> also defaults to the local ES-compatible endpoint. Neither creates an external listener or silently uploads corpus data.</p>
+
+  <h2>What this recipe does not promise</h2>
+  <ul>
+    <li>Release <code class="inline">.sha256</code> files provide integrity, not signing or attestation.</li>
+    <li>XERJ does not independently checksum the Hugging Face model files.</li>
+    <li>The Console falls back to system fonts, but its three external Google Fonts link elements remain browser egress attempts unless deployment removes or rewrites that HTML; stylesheet may fetch additional font files.</li>
+    <li>This is a traced procedure, not a live disconnected-firewall run or measured browser-egress claim.</li>
+  </ul>
+  <p>Related: <a href="/docs/operations.html">production operations</a>, <a href="/docs/config.html">configuration reference</a>, <a href="https://github.com/xerj-org/xerj/blob/main/docs/EXPERIMENTAL_ONNX.md">experimental ONNX backend</a>, and <a href="https://github.com/xerj-org/xerj/blob/main/metrics/README.md">metrics privacy posture</a>.</p>
+</main>
+</div>
+
+<footer class="footer"><span>XERJ.AI · DOCS</span><span>READ THE SOURCE</span><span><a href="/index.html">HOME</a> · <a href="/llms.txt">LLMS.TXT</a></span></footer>
+
+<script type="application/json" id="docs-index">[{"title":"Overview","slug":"/docs/index.html","kicker":"START","snip":""},{"title":"Quickstart","slug":"/docs/quickstart.html","kicker":"START","snip":""},{"title":"Install","slug":"/docs/install.html","kicker":"START","snip":""},{"title":"Migrate from ES","slug":"/docs/migration-from-es.html","kicker":"START","snip":""},{"title":"CLI","slug":"/docs/cli.html","kicker":"REFERENCE","snip":""},{"title":"Config TOML","slug":"/docs/config.html","kicker":"REFERENCE","snip":""},{"title":"Environment","slug":"/docs/env.html","kicker":"REFERENCE","snip":""},{"title":"Native REST API","slug":"/docs/api-native.html","kicker":"REFERENCE","snip":""},{"title":"ES-compat API","slug":"/docs/api-es-compat.html","kicker":"REFERENCE","snip":""},{"title":"Query types","slug":"/docs/queries.html","kicker":"DATA MODEL","snip":""},{"title":"Aggregations","slug":"/docs/aggregations.html","kicker":"DATA MODEL","snip":""},{"title":"Analyzers","slug":"/docs/analyzers.html","kicker":"DATA MODEL","snip":""},{"title":"Vectors & kNN","slug":"/docs/vectors.html","kicker":"DATA MODEL","snip":""},{"title":"Ingest pipelines","slug":"/docs/ingest.html","kicker":"ENGINE","snip":""},{"title":"Storage & WAL","slug":"/docs/storage.html","kicker":"ENGINE","snip":""},{"title":"Compression","slug":"/docs/compression.html","kicker":"ENGINE","snip":""},{"title":"Clustering","slug":"/docs/clustering.html","kicker":"ENGINE","snip":""},{"title":"Metrics","slug":"/docs/metrics.html","kicker":"ENGINE","snip":""},{"title":"Auth & TLS","slug":"/docs/security.html","kicker":"ENGINE","snip":""},{"title":"Running in production","slug":"/docs/operations.html","kicker":"OPERATIONS","snip":""},{"title":"Backup & restore","slug":"/docs/backup-restore.html","kicker":"OPERATIONS","snip":""},{"title":"Upgrades","slug":"/docs/upgrades.html","kicker":"OPERATIONS","snip":""},{"title":"Troubleshooting","slug":"/docs/troubleshooting.html","kicker":"OPERATIONS","snip":""},{"title":"SIEM","slug":"/docs/playbooks/siem.html","kicker":"PLAYBOOKS","snip":""},{"title":"Log analytics","slug":"/docs/playbooks/log-analytics.html","kicker":"PLAYBOOKS","snip":""},{"title":"Vector · RAG","slug":"/docs/playbooks/vector-search.html","kicker":"PLAYBOOKS","snip":""},{"title":"Full-text search","slug":"/docs/playbooks/full-text.html","kicker":"PLAYBOOKS","snip":""},{"title":"Observability","slug":"/docs/playbooks/observability.html","kicker":"PLAYBOOKS","snip":""},{"title":"CLI · --config","slug":"/docs/cli.html#config-flag","kicker":"CLI","snip":"-c, --config <PATH>  Path to the TOML config file."},{"title":"CLI · --data-dir","slug":"/docs/cli.html#data-dir-flag","kicker":"CLI","snip":"-d, --data-dir <PATH>  Override [server] data_dir at the command line."},{"title":"CLI · --insecure","slug":"/docs/cli.html#insecure-flag","kicker":"CLI","snip":"-k, --insecure  Disable TLS and API-key auth. Dev only."},{"title":"[server] rest_port","slug":"/docs/config.html#server","kicker":"CONFIG","snip":"u16 · default 8080 · Native REST API listener port."},{"title":"[server] es_compat_port","slug":"/docs/config.html#server","kicker":"CONFIG","snip":"u16 · default 9200 · Elasticsearch-wire-format port. 0 to disable."},{"title":"[storage] wal_sync","slug":"/docs/config.html#storage","kicker":"CONFIG","snip":"enum · default batched · sync · batched · async. Durability knob."},{"title":"[vector] hnsw_ef_search","slug":"/docs/config.html#vector","kicker":"CONFIG","snip":"u32 · default 100 · Accepted but not wired — the beam width comes from the request num_candidates."},{"title":"[vector] default_quantization","slug":"/docs/config.html#vector","kicker":"CONFIG","snip":"enum · none (default) · scalar8. binary is refused at startup; scalar4 is not accepted."},{"title":"GET /v1/health","slug":"/docs/api-native.html#health","kicker":"NATIVE API","snip":"Liveness + readiness. {status, uptime_s, version}."},{"title":"GET /v1/metrics","slug":"/docs/api-native.html#metrics","kicker":"NATIVE API","snip":"Prometheus text format. Scrape-friendly."},{"title":"POST /v1/indices/:name/turbo-ingest","slug":"/docs/api-native.html#turbo-ingest","kicker":"NATIVE API","snip":"NDJSON bulk path with parallel tokenization."},{"title":"POST /v1/indices/:name/search","slug":"/docs/api-native.html#search","kicker":"NATIVE API","snip":"Unified query endpoint — full-text, term, range, KNN, hybrid."},{"title":"POST /:index/_bulk","slug":"/docs/api-es-compat.html#bulk","kicker":"ES API","snip":"NDJSON bulk. Actions: index, create, update, delete."},{"title":"POST /:index/_search","slug":"/docs/api-es-compat.html#search","kicker":"ES API","snip":"ES query DSL. Drop-in migration path."},{"title":"match_all","slug":"/docs/queries.html#match-all","kicker":"QUERY","snip":"Everything in the index."},{"title":"bool","slug":"/docs/queries.html#bool","kicker":"QUERY","snip":"must / should / must_not / filter clauses."},{"title":"knn","slug":"/docs/queries.html#knn","kicker":"QUERY","snip":"Vector kNN — HNSW-served when unfiltered (exact-rescored); filtered runs the exact scan."},{"title":"semantic","slug":"/docs/queries.html#semantic","kicker":"QUERY","snip":"Embed the query text at query time and search the vector field."},{"title":"hybrid","slug":"/docs/queries.html#hybrid","kicker":"QUERY","snip":"RRF / linear fusion of sub-queries."},{"title":"terms aggregation","slug":"/docs/aggregations.html#terms","kicker":"AGG","snip":"Exact, pre-computed terms histograms over keyword fields."},{"title":"date_histogram","slug":"/docs/aggregations.html#date-histogram","kicker":"AGG","snip":"Time-bucketed counts."},{"title":"kNN serving","slug":"/docs/vectors.html#knn-query","kicker":"VECTORS","snip":"Unfiltered kNN via persisted HNSW + exact rescore; filtered kNN exact scan."},{"title":"SQ8 quantization","slug":"/docs/vectors.html#quantization","kicker":"VECTORS","snip":"8-bit scalar quantization. int8 scoring precision, not a memory saving (#392)."},{"title":"turbo-ingest","slug":"/docs/ingest.html#turbo","kicker":"INGEST","snip":"NDJSON bulk path. Parallel tokenization across cores."},{"title":"delta-of-delta","slug":"/docs/compression.html#delta-of-delta","kicker":"COMPRESSION","snip":"Timestamp encoding. Apache/Nginx/ISO auto-detect."},{"title":"dictionary encoding","slug":"/docs/compression.html#dictionary","kicker":"COMPRESSION","snip":"Up to 256 unique strings per column."},{"title":"api_key","slug":"/docs/security.html#api-key","kicker":"SECURITY","snip":"Static admin key. Auto-generated on first run."},{"title":"SIEM playbook","slug":"/docs/playbooks/siem.html","kicker":"PLAYBOOK","snip":"Terms agg over source IPs for SIEM, with detection rules."},{"title":"RAG playbook","slug":"/docs/playbooks/vector-search.html","kicker":"PLAYBOOK","snip":"Embeddings, kNN, hybrid search, BM25 + kNN fusion."},{"title":"[cluster] enabled","slug":"/docs/config.html#cluster","kicker":"CONFIG","snip":"bool · default false · Enable multi-node Raft cluster mode."},{"title":"[cluster] peers","slug":"/docs/config.html#cluster","kicker":"CONFIG","snip":"array · \"node_id=host:port\" · At least one peer per node."},{"title":"[cluster] port","slug":"/docs/config.html#cluster","kicker":"CONFIG","snip":"u16 · default 9300 · Intra-cluster Raft + search port."},{"title":"[embedding] default_endpoint","slug":"/docs/config.html#embedding","kicker":"CONFIG","snip":"string · OpenAI-compatible embeddings URL for auto-embedding on ingest."},{"title":"[embedding] default_model","slug":"/docs/config.html#embedding","kicker":"CONFIG","snip":"string · Model name (e.g. text-embedding-3-small, nomic-embed-text)."},{"title":"Raft","slug":"/docs/clustering.html","kicker":"CLUSTER","snip":"Embedded Raft — leader election, log replication, metadata only."},{"title":"Node draining","slug":"/docs/clustering.html","kicker":"CLUSTER","snip":"POST /v1/cluster/nodes/:id/drain before maintenance."},{"title":"Region split/merge","slug":"/docs/clustering.html","kicker":"CLUSTER","snip":"Range partitions auto-split at byte threshold, merge back when small."},{"title":"Systemd unit","slug":"/docs/operations.html","kicker":"OPS","snip":"Production unit file with hardening directives."},{"title":"Readiness probe","slug":"/docs/operations.html","kicker":"OPS","snip":"GET /v1/health/ready — only 200 once WAL replay is complete."},{"title":"Config reload","slug":"/docs/operations.html","kicker":"OPS","snip":"SIGHUP reloads most keys without restart."},{"title":"Hot backup","slug":"/docs/backup-restore.html","kicker":"OPS","snip":"rsync the data dir after POST /v1/admin/flush."},{"title":"S3 backup","slug":"/docs/backup-restore.html","kicker":"OPS","snip":"POST /v1/admin/backup → any S3-compatible endpoint."},{"title":"Rolling upgrade","slug":"/docs/upgrades.html","kicker":"OPS","snip":"Drain → stop → upgrade → start → activate, per node."},{"title":"Merge pressure","slug":"/docs/troubleshooting.html","kicker":"OPS","snip":"Segment count climbing → raise merge.max_concurrent + io_rate."},{"title":"Cluster flapping","slug":"/docs/troubleshooting.html","kicker":"OPS","snip":"Leader changes every few seconds → raise cluster.tick_ms."},{"title":"WAL replay failed","slug":"/docs/troubleshooting.html","kicker":"OPS","snip":"xerj verify --repair-wal truncates at last valid entry."},{"title":"Recipes","slug":"/docs/recipes/index.html","kicker":"RECIPES","snip":"Task-oriented AI & search recipes, each verified end-to-end against a live XERJ."},{"title":"Semantic search & RAG","slug":"/docs/recipes/semantic-search-rag.html","kicker":"RECIPE","snip":"Retrieval by meaning with semantic_text — auto-embed on ingest, no separate vector DB."},{"title":"Agent memory","slug":"/docs/recipes/agentic-memory.html","kicker":"RECIPE","snip":"Long-term memory for agents via /_memory — store, recall, forget, per-agent isolation."},{"title":"Passage retrieval","slug":"/docs/recipes/passage-retrieval.html","kicker":"RECIPE","snip":"Auto-chunk long docs; best-passage (max-sim) scoring — 98% top-3."},{"title":"Vector search · kNN","slug":"/docs/recipes/vector-search-knn.html","kicker":"RECIPE","snip":"Nearest-neighbor over dense_vector — HNSW-served unfiltered, exact with filters."},{"title":"Vector quantization","slug":"/docs/recipes/vector-quantization.html","kicker":"RECIPE","snip":"scalar8 (accepts ES int8_hnsw; exact code scan) — int8 scoring at recall@10 = 0.998. Precision, not memory."},{"title":"Hybrid search","slug":"/docs/recipes/hybrid-search.html","kicker":"RECIPE","snip":"Keyword + vector in one query — RRF fusion."},{"title":"Log analytics","slug":"/docs/recipes/log-analytics.html","kicker":"RECIPE","snip":"Raw logs to dashboards — error rates, p95 latency, top services."},{"title":"Anomaly detection","slug":"/docs/recipes/anomaly-detection.html","kicker":"RECIPE","snip":"Statistical _ml detectors that flag spikes in metrics/logs."},{"title":"Anomaly datafeeds","slug":"/docs/recipes/continuous-anomaly-datafeeds.html","kicker":"RECIPE","snip":"Live _ml datafeed re-scores an index on a timer, stores anomaly records."},{"title":"Migrate from ES","slug":"/docs/recipes/migrate-from-elasticsearch.html","kicker":"RECIPE","snip":"Point your existing ES client at XERJ — same wire, change the URL."},{"title":"Index a folder of mixed docs","slug":"/docs/recipes/document-folder-index.html","kicker":"RECIPE","snip":"Walk a folder of PDF/DOCX/HTML/MD/TXT, extract + chunk + embed, then lexical/semantic/hybrid search — grep can't read a PDF."},{"title":"Zero-config autoindex","slug":"/docs/recipes/zero-config-autoindex.html","kicker":"RECIPE","snip":"xerj autoindex <folder> — one command, content-sniffed formats, inferred mappings, a self-describing data map. 80/81 ground-truth checks on a 518 MB corpus."},{"title":"Air-gapped deployment","slug":"/docs/recipes/air-gapped-deployment.html","kicker":"RECIPE","snip":"Linux x86_64-musl release staging and model-free lexical deployment; neural optional."}]</script>
+<script>
+(function () {
+  const root = document.documentElement;
+  for (const btn of document.querySelectorAll('[data-theme]')) btn.addEventListener('click', () => {
+    const theme = btn.getAttribute('data-theme'); root.setAttribute('data-theme', theme);
+    for (const b of document.querySelectorAll('[data-theme]')) b.classList.toggle('active', b.getAttribute('data-theme') === theme);
+  });
+  const search = document.getElementById('docsSearch'), input = document.getElementById('docsSearchInput'), results = document.getElementById('docsSearchResults'), data = document.getElementById('docs-index');
+  if (!search || !input || !results || !data) return;
+  const index = JSON.parse(data.textContent || '[]');
+  const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  input.addEventListener('input', () => {
+    const q = input.value.trim().toLowerCase();
+    if (!q) { search.classList.remove('active'); results.innerHTML = ''; return; }
+    const hits = index.filter((e) => (e.title + ' ' + e.kicker + ' ' + e.snip).toLowerCase().includes(q));
+    results.innerHTML = hits.length ? hits.map((e) => '<a href="' + e.slug + '"><span class="kicker">' + esc(e.kicker) + '</span><span class="title">' + esc(e.title) + '</span><span class="snip">' + esc(e.snip) + '</span></a>').join('') : '<div class="no-results">NO MATCHES</div>';
+    search.classList.add('active');
+  });
+  document.addEventListener('keydown', (e) => { if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); input.focus(); } });
+}());
+</script>
+</body>
+</html>

--- a/landing/docs/recipes/index.html
+++ b/landing/docs/recipes/index.html
@@ -104,6 +104,7 @@
     <a href="/docs/recipes/migrate-from-elasticsearch.html" class=""><span class="eyebrow">10</span>Migrate from ES</a>
     <a href="/docs/recipes/document-folder-index.html" class=""><span class="eyebrow">11</span>Doc folder index</a>
     <a href="/docs/recipes/zero-config-autoindex.html" class=""><span class="eyebrow">12</span>Zero-config autoindex</a>
+    <a href="/docs/recipes/air-gapped-deployment.html" class=""><span class="eyebrow">13</span>Air-gapped deployment</a>
   </div>
 </nav>
 
@@ -183,6 +184,11 @@
       <span class="num">11</span>
       <span class="title">Index a folder of PDFs, Word docs &amp; web pages</span>
       <p class="lead">One <code class="inline">xerj-index</code> pass walks a recursive folder of PDF/DOCX/HTML/MD/TXT, extracts + chunks + auto-embeds every file, then lexical, semantic &amp; hybrid search return ranked, cited passages — measured 21/22 vs a fair grep baseline's 14/22, with the decisive win on binary_only (6/7 vs 0/7) because grep can't read a PDF/DOCX.</p>
+    </a>
+    <a class="recipe" href="/docs/recipes/air-gapped-deployment.html">
+      <span class="num">13 · OPERATIONS</span>
+      <span class="title">Run XERJ fully offline — air-gapped deployment</span>
+      <p class="lead">Stage the release archive, checksum, and optional three-file neural model bundle on a connected machine, then run the standard binary without runtime internet access. Covers lexical defaults, local neural assets, proxy/ONNX boundaries, loopback/auth posture, WAL overlays, and the Console's system-font fallback.</p>
     </a>
   </div>
 

--- a/landing/industries/index.html
+++ b/landing/industries/index.html
@@ -82,13 +82,13 @@
       <span class="card-k">02 · PUBLIC SECTOR</span>
       <span class="card-t">GOVERNMENT ·<br>DEFENSE ·<br><span class="accent">INTELLIGENCE</span></span>
       <span class="card-b">
-        Air-gapped enclaves. Signed offline updates. ~36 MB binary
-        fits inside ATO envelopes that reject JVM stacks. FedRAMP +
-        IL5 on the roadmap · SBOM shipped per release today.
+        Air-gapped enclaves with an operator-staged standard binary in offline
+        lexical mode. Optional local model; adjacent SHA-256 integrity check.
+        FedRAMP + IL5 remain on the roadmap.
       </span>
       <span class="card-facts">
-        AIR-GAP MODE · NO TELEMETRY EGRESS<br>
-        SBOM + SLSA PROVENANCE (ROADMAP Q3)<br>
+        OFFLINE DEPLOYMENT · NO RUNTIME TELEMETRY/UPDATE/LICENSE CALLS<br>
+        OPTIONAL LOCAL MODEL · OPERATOR-STAGED RELEASE<br>
         NIST 800-53 / AI RMF CROSS-WALK
       </span>
       <span class="card-cta">EXPLORE PUBLIC SECTOR  →</span>
@@ -158,8 +158,8 @@
     <div class="v">Customer-managed keys via AWS KMS · GCP KMS · Azure Key Vault · HashiCorp Vault · Thales Luna HSM. No XERJ-side plaintext access.</div>
   </div>
   <div class="row">
-    <div class="k">AIR-GAP</div>
-    <div class="v"><span class="mono">XERJ_AIRGAP=1</span> disables all telemetry egress · offline bundle · signed release manifest. <strong>Deployable into a SCIF or a sealed rack.</strong></div>
+    <div class="k">OFFLINE DEPLOYMENT</div>
+    <div class="v">Standard binary · offline lexical mode · operator-staged archive + adjacent <span class="mono">.sha256</span> integrity only · optional local model · no runtime telemetry/update/license calls. <strong><a href="/docs/recipes/air-gapped-deployment.html">See the deployment recipe.</a></strong></div>
   </div>
 </section>
 

--- a/landing/industries/public-sector.html
+++ b/landing/industries/public-sector.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>XERJ.ai — Public Sector</title>
-<meta name="description" content="XERJ for government, defense, and intelligence. Air-gap-capable, FedRAMP/IL5 track, ~36 MB static binary, SBOM.">
+<meta name="description" content="XERJ for government, defense, and intelligence. Offline deployment, FedRAMP/IL5 track, ~36 MB static binary.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;800;900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
@@ -50,7 +50,7 @@
     Public-sector AI cannot depend on a retrieval vendor reachable
     over the commercial internet. XERJ is a ~36 MB static binary
     that runs inside a sealed rack, a SCIF, or a national-cloud
-    enclave — zero telemetry egress when air-gap mode is on.
+    enclave — the running node makes no telemetry, update-check, or license-activation call; browser/optional endpoints are separate.
   </p>
 </section>
 
@@ -68,7 +68,7 @@
   <div class="pane active" data-group="ps-mode" data-pane="airgap">
     <svg class="diagram" viewBox="0 0 960 440" role="img" aria-label="Air-gapped deployment">
       <rect x="20" y="20" width="920" height="400" class="dashed mute"/>
-      <text x="40" y="44" class="label mute">CLASSIFIED ENCLAVE · NO INTERNET · SIGNED MEDIA · PHYSICAL ACCESS CONTROL</text>
+      <text x="40" y="44" class="label mute">CLASSIFIED ENCLAVE · NO INTERNET · OPERATOR-STAGED MEDIA · PHYSICAL ACCESS CONTROL</text>
 
       <g class="node"><rect x="60" y="70" width="380" height="60"/>
         <text x="76" y="92" class="label">DATA SOURCES</text>
@@ -83,10 +83,10 @@
       <line x1="250" y1="220" x2="250" y2="246"/><polygon points="246,242 254,242 250,250"/>
 
       <g class="node accent"><rect x="60" y="250" width="380" height="96"/>
-        <text x="76" y="272" class="label">XERJ CLUSTER · 3-NODE HA · AIRGAP=1</text>
+        <text x="76" y="272" class="label">XERJ NODE · STANDARD BINARY · LEXICAL BASELINE</text>
         <text x="76" y="294" class="small">FTS · VECTOR · COLUMNAR · AGENT MEMORY</text>
-        <text x="76" y="312" class="small">AES-256-GCM at rest · BYOK · TLS 1.3 in transit</text>
-        <text x="76" y="332" class="small mute">no outbound · no telemetry · no license ping</text>
+        <text x="76" y="312" class="small">loopback listener · authenticated API</text>
+        <text x="76" y="332" class="small mute">no runtime telemetry · update · license calls</text>
       </g>
       <line x1="250" y1="346" x2="250" y2="372"/><polygon points="246,368 254,368 250,376"/>
 
@@ -96,11 +96,11 @@
 
       <g class="node mute"><rect x="500" y="160" width="420" height="186" class="dashed"/>
         <text x="516" y="184" class="label">OFFLINE UPDATE CHANNEL</text>
-        <text x="516" y="208" class="small">signed release bundle · delivered via data-diode</text>
-        <text x="516" y="228" class="small">SBOM + SLSA provenance per release</text>
-        <text x="516" y="248" class="small">manifest verified before install</text>
+        <text x="516" y="208" class="small">operator-staged release archive + adjacent .sha256 integrity</text>
+        <text x="516" y="228" class="small">verify before transfer and after receipt</text>
+        <text x="516" y="248" class="small">optional locally staged neural model</text>
         <text x="516" y="278" class="small">one-minor-version rollback window</text>
-        <text x="516" y="320" class="small mute">inbound only · no outbound update probe</text>
+        <text x="516" y="320" class="small mute">inbound only · no runtime update probe</text>
       </g>
       <line x1="498" y1="298" x2="446" y2="298" class="mute"/>
       <polygon class="mute" points="450,294 450,302 442,298"/>
@@ -220,7 +220,6 @@
   <div class="matrix-row"><span class="mk">NIST AI RMF</span><span class="mv">Per-query explain-plan + audit trail aligns with "measure" + "manage" functions</span><span class="mstatus ga">GA</span></div>
   <div class="matrix-row"><span class="mk">CJIS</span><span class="mv">Tenant isolation + audit trail + encryption at rest + access control</span><span class="mstatus yes">INHERITED</span></div>
   <div class="matrix-row"><span class="mk">CMMC Lvl 2</span><span class="mv">DFARS 252.204-7012 · self-hosted inherits organizational controls</span><span class="mstatus yes">INHERITED</span></div>
-  <div class="matrix-row"><span class="mk">SBOM · SLSA</span><span class="mv">Every release ships an SBOM · SLSA-compliant provenance roadmap · reproducible builds</span><span class="mstatus road">ROAD Q3</span></div>
   <div class="matrix-row"><span class="mk">FedRAMP MODERATE</span><span class="mv">Commercial SaaS offering track</span><span class="mstatus road">ROAD 2027</span></div>
   <div class="matrix-row"><span class="mk">FedRAMP HIGH</span><span class="mv">Higher-impact workloads · planning phase</span><span class="mstatus road">ROAD 2027+</span></div>
   <div class="matrix-row"><span class="mk">DoD IL5</span><span class="mv">BYOK + FIPS-validated crypto + air-gap · engineering scope ready · accreditation roadmap</span><span class="mstatus road">ROAD 2027</span></div>

--- a/landing/llms-full.txt
+++ b/landing/llms-full.txt
@@ -141,6 +141,8 @@ Content types:
       air-gapped or policy-constrained hosts, pre-download them and set
       `embedding.local_model_dir`; nothing is then fetched.
 
+For a complete disconnected deployment procedure, including current GitHub release asset names, per-archive `.sha256` verification, model staging, loopback/API-key defaults, persisted WAL-tap overlays, and the exact limits of the procedure, use the [air-gapped deployment recipe](https://xerj.org/docs/recipes/air-gapped-deployment.html). The running binary has no runtime telemetry, update check, or license activation call. The Console's HTML has three external Google Fonts link elements (two preconnects and one stylesheet; stylesheet may fetch additional font files) and may attempt them before falling back to system fonts; this is not a claim of zero browser egress attempts. Release `.sha256` files provide integrity only, not signing or attestation.
+
 - Scroll is a BOUNDED SNAPSHOT, not a cursor — the ceiling is
   <!-- generated:scroll-snapshot-cap -->10,000<!-- /generated:scroll-snapshot-cap --> documents.
   `_search?scroll=` materialises the entire result set into the scroll context up front,

--- a/landing/llms.txt
+++ b/landing/llms.txt
@@ -129,6 +129,8 @@ install -m 755 xerj-*/xerj ~/.local/bin/xerj
 
 `<target>` is `{x86_64,aarch64}-{unknown-linux-musl,unknown-linux-gnu,apple-darwin,pc-windows-msvc}` — e.g. `xerj-1.0.0-rc.16-x86_64-unknown-linux-musl.tar.gz`. Resolve `<tag>` from `https://api.github.com/repos/xerj-org/xerj/releases/latest`. Note what the checksum does and does not prove: it verifies the archive against the digest published beside it in the same release — integrity, not independent provenance.
 
+**Air-gapped deployment:** see the [air-gapped deployment recipe](https://xerj.org/docs/recipes/air-gapped-deployment.html) for exact release staging, checksum verification, optional local neural files, and the secure loopback/auth boundary. Lexical mode is offline by default; neural mode needs `config.json`, `tokenizer.json`, and `model.safetensors` staged locally. The running binary has no runtime telemetry, update check, or license activation call. The Console has three external Google Fonts link elements (two preconnects and one stylesheet; stylesheet may fetch additional font files) and may attempt them in a browser before falling back to system fonts.
+
 **If you cannot execute commands at all** (no shell, MCP/function-calling only), hand your operator this block and take over afterwards over HTTP:
 
 ```

--- a/landing/pricing/index.html
+++ b/landing/pricing/index.html
@@ -93,11 +93,11 @@
       <span class="tt">ENTERPRISE</span>
       <p class="body" style="color:var(--z-mute); margin-top:4px;">Multi-region · regulated · global enterprise</p>
       <ul>
-        <li>Multi-region · air-gapped · BYOK</li>
+        <li>Operator-staged air-gapped deployment</li>
         <li>24×7 support · 1 h response</li>
         <li>99.99 % availability SLA</li>
         <li>Dedicated CSM + solutions architect</li>
-        <li>HIPAA BAA · custom compliance · SBOM · provenance</li>
+        <li>HIPAA BAA · custom compliance</li>
         <li>Private roadmap input · early-access builds</li>
       </ul>
       <div class="kicker" style="margin-top:var(--sp-6);">
@@ -173,7 +173,7 @@
         <td class="cell-no">—</td><td class="cell-no">—</td><td class="cell-val">Q3 2026</td>
       </tr>
       <tr>
-        <td class="cell-feat">Air-gapped deployment <span class="desc">offline bundle · signed manifest · no telemetry</span></td>
+        <td class="cell-feat">Air-gapped deployment <span class="desc">offline lexical binary · adjacent .sha256 integrity · optional local model</span></td>
         <td class="cell-no">—</td><td class="cell-no">—</td><td class="cell-check">✓</td>
       </tr>
       <tr>
@@ -211,7 +211,7 @@
         <td class="cell-no">—</td><td class="cell-check">✓</td><td class="cell-check">✓</td>
       </tr>
       <tr>
-        <td class="cell-feat">SBOM + SLSA provenance <span class="desc">signed artifacts · reproducible builds</span></td>
+        <td class="cell-feat">Release integrity <span class="desc">per-archive .sha256 digest · operator verification</span></td>
         <td class="cell-check">✓</td><td class="cell-check">✓</td><td class="cell-check">✓</td>
       </tr>
       <tr>

--- a/landing/security/index.html
+++ b/landing/security/index.html
@@ -123,7 +123,7 @@
   <div class="matrix-row"><span class="mk">SCIM</span><span class="mv">SCIM 2.0 provisioning for tenant and user lifecycle</span><span class="mstatus road">ROAD Q3</span></div>
   <div class="matrix-row"><span class="mk">AUDIT TRAIL</span><span class="mv">Structured event log · queryable as index · replayable · exportable</span><span class="mstatus beta">BETA</span></div>
   <div class="matrix-row"><span class="mk">EXPLAIN-PLAN</span><span class="mv">First-class endpoint · per-node cost + rows · audit artifact for every retrieval</span><span class="mstatus ga">GA</span></div>
-  <div class="matrix-row"><span class="mk">AIR-GAP</span><span class="mv">Offline bundle · signed release manifest · <span class="mono">XERJ_AIRGAP=1</span> disables all telemetry</span><span class="mstatus ga">GA</span></div>
+  <div class="matrix-row"><span class="mk">AIR-GAP</span><span class="mv">Standard binary · offline lexical mode · operator-staged archive + adjacent <span class="mono">.sha256</span> integrity only · optional local model · no runtime telemetry/update/license calls · Console may attempt external Google Fonts</span><span class="mstatus">DOCS</span></div>
   <div class="matrix-row"><span class="mk">MULTI-TENANCY</span><span class="mv">Tenant-isolated indices + quotas + audit · physical isolation via separate clusters</span><span class="mstatus ga">GA</span></div>
   <div class="matrix-row"><span class="mk">CIRCUIT-BREAKERS</span><span class="mv">Per-request heap + time · per-tenant concurrency · per-index doc-scan ceiling</span><span class="mstatus ga">GA</span></div>
 </section>
@@ -143,26 +143,26 @@
   <div class="matrix-row"><span class="mk">PCI-DSS · CJIS · GDPR</span><span class="mv">Self-hosted deployments inherit customer controls</span><span class="mstatus yes">INHERITED</span></div>
 </section>
 
-<!-- SBOM · SUPPLY CHAIN -->
+<!-- RELEASE INTEGRITY · OPERATOR CONTROL -->
 <section class="scene-section">
-  <div class="kicker"><span>SUPPLY CHAIN</span><span class="dash">·</span><span>WHAT SHIPS WITH EACH RELEASE</span></div>
-  <h2 class="scene">SIGNED.<br><span class="accent">VERIFIABLE.</span></h2>
+  <div class="kicker"><span>RELEASE INTEGRITY</span><span class="dash">·</span><span>OPERATOR CONTROL</span></div>
+  <h2 class="scene">RELEASE.<br><span class="accent">INTEGRITY.</span></h2>
 
   <div class="row">
-    <div class="k">SBOM</div>
-    <div class="v">Every release ships a CycloneDX SBOM alongside the binary. Every Rust dependency, every transitive, every crate version. <strong>Auditors verify before deploy.</strong></div>
+    <div class="k">ARCHIVE CHECK</div>
+    <div class="v">Each release archive has an adjacent <span class="mono">.sha256</span> file. It verifies archive integrity against the published digest, not a signature or attestation.</div>
   </div>
   <div class="row">
-    <div class="k">SLSA PROVENANCE</div>
-    <div class="v">Build provenance attestations · reproducible builds · cryptographically-signed artifact manifests. SLSA Level 3 target. <strong>Roadmap Q3 2026.</strong></div>
+    <div class="k">OFFLINE BASELINE</div>
+    <div class="v">The standard binary runs in offline lexical mode without model files. An optional local model can be staged separately when neural embedding is required.</div>
   </div>
   <div class="row">
-    <div class="k">SIGNED ARTIFACTS</div>
-    <div class="v">Signed Git tags · signed release archives · cosign-compatible signatures. Offline verification works with <span class="mono">cosign verify-blob</span>.</div>
+    <div class="k">RUNTIME BOUNDARY</div>
+    <div class="v">The running binary makes no runtime telemetry, update, or license-activation calls. The Console may still attempt its external Google Fonts resources in a browser.</div>
   </div>
   <div class="row">
-    <div class="k">REPRODUCIBLE BUILDS</div>
-    <div class="v">Same source + same toolchain + same flags = byte-identical binary. <strong>Anyone can rebuild and verify.</strong></div>
+    <div class="k">PROCEDURE</div>
+    <div class="v">Stage the release and any model files on a connected machine, verify the adjacent digest, then transfer and verify again inside the enclave.</div>
   </div>
   <div class="row">
     <div class="k">MINIMAL DEPENDENCIES</div>


### PR DESCRIPTION
Written by an AI coding agent (OpenAI Codex), run by @buger, who has reviewed this change.

## What this changes, and why

XERJ had no single truthful answer for an operator evaluating an air-gapped deployment: the relevant runtime behavior was scattered across several documents, while public landing pages contradicted the source by advertising a nonexistent `XERJ_AIRGAP` mode, signed bundles and manifests, cosign verification, reproducible builds, per-release SBOM/SLSA provenance, and GA status.

This adds one Markdown recipe and its landing-page counterpart, links it from the main documentation surfaces, and narrows the contradictory security, architecture, industries, public-sector, and pricing copy to behavior the repository and a published binary support.

The documented runtime boundary is explicit:

- The default `auto` embedding mode uses the built-in lexical feature-hashing embedder when no external endpoint is configured; the copyable base deployment selects `mode = "lexical"`, an empty endpoint, and no model files.
- Neural embedding is optional. Without `embedding.local_model_dir`, first use downloads `config.json`, `tokenizer.json`, and `model.safetensors` for `sentence-transformers/all-MiniLM-L6-v2`; the air-gapped path stages those three files and points XERJ at the local directory.
- `proxy` contacts only the configured OpenAI-compatible `embedding.default_endpoint`.
- `onnx-experimental` is not the standard release path; it requires an ONNX-enabled build and explicit local model and tokenizer assets.
- The running binary has no runtime telemetry, update-check, or license-activation call. Browser behavior is separate: the bundled Console contains three external Google Fonts link elements—two preconnects and one stylesheet—and the stylesheet may fetch additional font files.

The operator flow is deliberately bounded to Linux x86_64-musl: provide an approved SemVer-shaped `TAG`, download the matching release archive and adjacent `.sha256`, verify and inspect it on the connected staging host, verify it again after transfer, install it under an unprivileged `xerj` user/group, and start an authenticated loopback lexical node. Neural assets are a separate optional section rather than a prerequisite.

Authentication examples now match the implementations: MCP's `XERJ_AUTH` and `--auth` take the complete `Authorization` value such as `ApiKey <key>`, while autoindex's `XERJ_API_KEY` and `--api-key` take the raw key and add the scheme themselves.

The marketing corrections retain only the source-backed boundary: operator-staged archive plus adjacent SHA-256 integrity check, standard lexical binary, optional local neural model, authenticated loopback API, no runtime telemetry/update/license calls, and explicit browser/optional-endpoint caveats. The checksum is described as integrity evidence, not signing, provenance, or attestation.

## Evidence

The current published artifact at validation time was exercised directly, not replaced with a local build:

- Tag and asset: `v1.0.0-rc.17`, `xerj-1.0.0-rc.17-x86_64-unknown-linux-musl.tar.gz`, downloaded from the tag's GitHub release URL with its adjacent `.sha256` asset.
- Published archive SHA-256: `432546bc10c38549c210a2f234b86ce0af20d185e25095889ac3e0266080f7c2`; `sha256sum -c` returned `OK`.
- Extracted binary SHA-256: `db525d42b677717222bc532f9f18b02b5f0a67c8cf10878a4b8ab89730572583`; `xerj --version` returned `xerj v1.0.0-rc.17`.
- Fresh configuration: lexical mode, empty endpoint/model, auth enabled, loopback ES-compatible port `19376`, and a new durable data directory.
- First process: user `nobody` (`uid 65534`), PID `1348376`; authenticated health was green, index creation was acknowledged, ingest created `_id` `1`, and the lexical semantic query returned `_id` `1`.
- Restarted process: user `nobody`, distinct PID `1348721`, same binary/config/data directory; authenticated health was green and the same semantic query again returned `_id` `1`.
- Model-file probes before and after restart found zero `config.json`, `tokenizer.json`, `model.safetensors`, or ONNX files in the data directory.
- Both processes logged receipt of SIGINT and a clean stop; both `wait` calls returned `0`, each process was absent afterward, and immediate `ss` probes found port `19376` free.

## Checks

- [x] `git diff --check`
- [x] All 11 Markdown and 11 HTML shell snippets passed `bash -n`.
- [x] Both Markdown TOML blocks and both HTML TOML blocks parsed successfully.
- [x] Changed landing pages parsed as HTML and their static local links resolved.
- [x] The recipe's docs-search JSON parsed with 88 unique records and one air-gapped recipe entry.
- [x] All 77 inline landing-page scripts parsed as JavaScript.
- [x] Positive and negative TAG cases verified the Bash regex accepts `v1.0.0-rc.17` and rejects malformed/path-bearing values.
- [x] MCP and autoindex authentication forms are aligned between Markdown, HTML, help text, and client source.
- [x] The broad landing stale-claim guard found no remaining `XERJ_AIRGAP`, `AIRGAP=1`, signed-media/release/bundle/archive/manifest, cosign, reproducible-build, SBOM/SLSA, provenance-package, or “air-gap mode” claims.
- [x] Installer lint passed its POSIX shell syntax and shellcheck gates.
- [x] Documentation and landing pages were updated; no engine or wire behavior changed.
- [x] ES-YAML conformance: not applicable because this is docs/landing-only.

The landing constants guard still reports two pre-existing failures: rc.15 footer-version drift and six-versus-seven canonical agent-operation wording. The effective diff does not introduce either failure.

## Limitations and not run

Browser/firewall egress was not measured. The recipe therefore does not claim a disconnected-firewall acceptance run or zero browser requests; it tells operators to enforce egress denial and inspect firewall/log counters in their target environment.

The optional neural-model path was traced to the loader and configuration but was not exercised in the published-artifact acceptance run. XERJ does not independently pin or verify those Hugging Face files; the documented transfer digest is an operator control.

PowerShell installer lint was not run because `pwsh` was unavailable.

`cargo fmt`, Cargo builds/tests, Clippy, and the ES-YAML suite were not run because the diff changes only documentation and landing content and does not modify engine code, Cargo files, test cases, or wire behavior.

## Provenance

- **Verified:** the commands and observed results listed under Evidence and Checks, including the published artifact run, restart, persistence, process ownership, clean shutdown, snippet/TOML/HTML/JavaScript validation, link checks, stale-claim search, and final diff/ownership review.
- **Assumed:** target-environment firewall/browser behavior and successful loading of operator-staged neural files; these would be falsified by measured unexpected egress or by a neural startup/embedding failure with the documented three-file local directory.

Closes #376
