### PR TITLE
DO NOT MERGE (refuted — snapshot not atomic) — fix(scroll): continuation pages resolve real _seq_no/_version (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behaviour — that keeping the raw index spec left per-hit `_index`
   "authoritative when paging" — which is why the defect outlived review.
 
-  `ScrollContext::hits` is now `Vec<(String, Hit)>`, so a hit carries the index
-  it came from rather than borrowing one from the context. Both context-creation
+  `ScrollContext::hits` now carries a `ScrollHit` per hit — the index it came
+  from, and the meta-fields as they stood when the scroll opened — rather than a
+  bare hit borrowing both from the context. (This field changed twice in this
+  unreleased cycle: first to `Vec<(String, Hit)>` for the index, then to
+  `Vec<ScrollHit>` when #428 showed the meta-fields had to be frozen with it.
+  Recorded as one change because only the final shape ever ships.) Both context-creation
   sites previously discarded it with the same `.map(|(_, h)| h.clone())`.
 
   **Scope, established by an independent adversarial verification of the fix and

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -19915,40 +19915,63 @@ pub async fn search_with_scroll(
         .iter()
         .skip(from)
         .take(size)
-        .map(|(idx_name, h)| EsHit {
-            index: idx_name.clone(),
-            id: h.id.clone(),
-            score: Some(h.score as f64),
-            version: Some(1),
-            seq_no: Some(0),
-            primary_term: Some(1),
-            source: if h.source.is_null() {
+        .map(|(idx_name, h)| {
+            // Resolve, or emit nothing. This branch — `_search_scroll` with no
+            // `scroll=` — previously hardcoded `seq_no: 0` / `version: 1`, and
+            // unlike the scroll branch it serialises through EsHit's derive,
+            // whose `skip_serializing_if = "Option::is_none"` suppresses only
+            // `None`. So the fabricated values reached the wire on every hit
+            // whether or not the caller asked for them: `_seq_no: 0` for a
+            // document whose real sequence number was 8. That is the same
+            // construct this change removes from the scroll branch, five lines
+            // below it.
+            let want_sn = body.seq_no_primary_term.unwrap_or(false);
+            let want_v = body.version.unwrap_or(false);
+            let own = state.engine.get_index(idx_name).ok();
+            let sn = if want_sn {
+                own.as_ref().and_then(|i| i.lookup_seq_no(&h.id))
+            } else {
                 None
-            } else {
-                Some(h.source.clone())
-            },
-            fields: passage_fields(h),
-            sort: if h.sort.is_empty() {
-                None
-            } else {
-                Some(h.sort.clone())
-            },
-            highlight: h.highlight.clone(),
-            explanation: None,
-            inner_hits: None,
-            matched_queries: if h.matched_queries.is_empty() {
-                Value::Null
-            } else {
-                Value::Array(
-                    h.matched_queries
-                        .iter()
-                        .cloned()
-                        .map(Value::String)
-                        .collect(),
-                )
-            },
-            ignored: None,
-            ignored_field_values: None,
+            };
+            EsHit {
+                index: idx_name.clone(),
+                id: h.id.clone(),
+                score: Some(h.score as f64),
+                version: if want_v {
+                    own.as_ref().and_then(|i| i.lookup_version(&h.id))
+                } else {
+                    None
+                },
+                seq_no: sn,
+                primary_term: sn.map(|_| 1u64),
+                source: if h.source.is_null() {
+                    None
+                } else {
+                    Some(h.source.clone())
+                },
+                fields: passage_fields(h),
+                sort: if h.sort.is_empty() {
+                    None
+                } else {
+                    Some(h.sort.clone())
+                },
+                highlight: h.highlight.clone(),
+                explanation: None,
+                inner_hits: None,
+                matched_queries: if h.matched_queries.is_empty() {
+                    Value::Null
+                } else {
+                    Value::Array(
+                        h.matched_queries
+                            .iter()
+                            .cloned()
+                            .map(Value::String)
+                            .collect(),
+                    )
+                },
+                ignored: None,
+                ignored_field_values: None,
+            }
         })
         .collect();
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -14250,6 +14250,10 @@ async fn search_impl(
             created: now,
             keep_alive,
             expires_at: now + keep_alive,
+            // Fixed for the scroll's whole lifetime from the opening
+            // request — see the field's doc comment (issue #428).
+            seq_no_primary_term: body.seq_no_primary_term.unwrap_or(false),
+            version: body.version.unwrap_or(false),
         };
         state.engine.scrolls.insert(scroll_id.clone(), ctx);
         response_body["_scroll_id"] = Value::String(scroll_id);
@@ -19815,6 +19819,8 @@ pub async fn search_with_scroll(
             created: now,
             keep_alive,
             expires_at: now + keep_alive,
+            seq_no_primary_term: body.seq_no_primary_term.unwrap_or(false),
+            version: body.version.unwrap_or(false),
         };
         state.engine.scrolls.insert(scroll_id.clone(), ctx);
 
@@ -20020,19 +20026,47 @@ async fn scroll_page_response(
                 .map(|(_, h)| !h.sort.is_empty())
                 .unwrap_or(false);
 
+            // #428: `seq_no_primary_term`/`version` are fixed for the
+            // scroll's whole lifetime by the opening `_search?scroll=…`
+            // request (see `ScrollContext`'s doc comment) — resolve the
+            // real values the same way the main `search()` handler does
+            // (`idx.lookup_seq_no`/`lookup_version`) rather than the
+            // hardcoded `Some(0)`/`Some(1)` every page after the first used
+            // to carry, silently, regardless of what was asked for.
+            let emit_seq_no = ctx.seq_no_primary_term;
+            let emit_version = ctx.version;
+            let index_name = ctx.index.clone();
+            let index_for_lookup = state.engine.get_index(&index_name).ok();
+
             let page_hits: Vec<EsHit> = ctx
                 .hits
                 .iter()
                 .skip(position)
                 .take(page_size)
-                .map(|(hit_index, h)| EsHit {
+                .map(|(hit_index, h)| {
+                    let (seq_no, primary_term) = if emit_seq_no {
+                        let sn = index_for_lookup
+                            .as_ref()
+                            .and_then(|idx| idx.lookup_seq_no(&h.id));
+                        (sn, sn.map(|_| 1u64))
+                    } else {
+                        (None, None)
+                    };
+                    let version = if emit_version {
+                        index_for_lookup
+                            .as_ref()
+                            .and_then(|idx| idx.lookup_version(&h.id))
+                    } else {
+                        None
+                    };
+                    EsHit {
                     // Per-hit index, not the context-level one (#414).
                     index: hit_index.clone(),
                     id: h.id.clone(),
                     score: Some(h.score as f64),
-                    version: Some(1),
-                    seq_no: Some(0),
-                    primary_term: Some(1),
+                    version,
+                    seq_no,
+                    primary_term,
                     source: if h.source.is_null() {
                         None
                     } else {
@@ -20060,6 +20094,7 @@ async fn scroll_page_response(
                     },
                     ignored: None,
                     ignored_field_values: None,
+                    }
                 })
                 .collect();
 
@@ -20086,6 +20121,20 @@ async fn scroll_page_response(
                             Some(s) => json!(s),
                             None => Value::Null,
                         });
+                        // #428: these were resolved above (or left None when
+                        // not requested) but never reached the wire — this
+                        // hit object is built by hand, not through EsHit's
+                        // derived Serialize, so a field only leaves this
+                        // function if it is inserted here explicitly.
+                        if let Some(seq_no) = h.seq_no {
+                            o.insert("_seq_no".to_string(), json!(seq_no));
+                        }
+                        if let Some(primary_term) = h.primary_term {
+                            o.insert("_primary_term".to_string(), json!(primary_term));
+                        }
+                        if let Some(version) = h.version {
+                            o.insert("_version".to_string(), json!(version));
+                        }
                         if let Some(src) = &h.source {
                             o.insert("_source".to_string(), src.clone());
                         }
@@ -20169,6 +20218,8 @@ mod passage_scroll_tests {
                 created: now,
                 keep_alive: Duration::from_secs(60),
                 expires_at: now + Duration::from_secs(60),
+                seq_no_primary_term: false,
+                version: false,
             },
         );
         let app = crate::router::build_es_compat_router(state);
@@ -20225,6 +20276,8 @@ mod passage_scroll_tests {
                 created: now,
                 keep_alive: Duration::from_secs(60),
                 expires_at: now + Duration::from_secs(60),
+                seq_no_primary_term: false,
+                version: false,
             },
         );
         let app = crate::router::build_es_compat_router(state);
@@ -20277,6 +20330,8 @@ mod passage_scroll_tests {
                 created: now,
                 keep_alive: Duration::from_secs(60),
                 expires_at: now + Duration::from_secs(60),
+                seq_no_primary_term: false,
+                version: false,
             },
         );
         let app = crate::router::build_es_compat_router(state);
@@ -20310,6 +20365,87 @@ mod passage_scroll_tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Regression test for #428: `seq_no_primary_term: true` on the
+    /// scroll-opening request was honored on page one (resolved via
+    /// `idx.lookup_seq_no`, same as an ordinary search) but silently
+    /// dropped on every page after — `scroll_page_response` hardcoded
+    /// `seq_no: Some(0)` in the intermediate `EsHit` and then never even
+    /// serialized it (or `_version`) into the response at all, regardless
+    /// of what the opening request asked for. This indexes real documents
+    /// through the actual write path (so there is a real version-map entry
+    /// to resolve, not a synthetic `Hit`) and scrolls one at a time to
+    /// force a real page 2.
+    #[tokio::test]
+    async fn scroll_continuation_resolves_real_seq_no_when_requested() {
+        let state = test_state();
+        let app = crate::router::build_es_compat_router(state);
+
+        for i in 0..3 {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::post(format!("/seqidx/_doc/d{i}"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(json!({ "n": i }).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CREATED);
+        }
+
+        let open = app
+            .clone()
+            .oneshot(
+                Request::post("/seqidx/_search?scroll=1m")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "size": 1,
+                            "seq_no_primary_term": true,
+                            "query": { "match_all": {} },
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(open.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(open.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        let scroll_id = body["_scroll_id"].as_str().unwrap().to_string();
+        assert!(
+            body["hits"]["hits"][0].get("_seq_no").and_then(Value::as_u64).is_some(),
+            "page 1 should already carry a real _seq_no: {body}"
+        );
+
+        // Page 2 — exactly what #428 broke.
+        let next = app
+            .clone()
+            .oneshot(
+                Request::post("/_search/scroll")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "scroll": "1m", "scroll_id": scroll_id }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(next.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(next.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            body["hits"]["hits"][0].get("_seq_no").and_then(Value::as_u64).is_some(),
+            "page 2 must carry a real _seq_no when seq_no_primary_term was requested (#428): {body}"
+        );
     }
 
     #[tokio::test]

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -11199,10 +11199,27 @@ async fn search_impl(
     // Snapshot every matching hit for the scroll context BEFORE we consume
     // merged_hits to build `hits`. We'll register the context after the
     // response_body is built.
-    let scroll_snapshot: Option<Vec<(String, xerj_query::executor::Hit)>> = if is_scroll_request {
-        // Keep the index name with each hit (#414): dropping it here is what
-        // made continuation pages fall back to a single context-level name.
-        Some(merged_hits.clone())
+    let scroll_snapshot: Option<Vec<xerj_engine::engine::ScrollHit>> = if is_scroll_request {
+        // Freeze the meta-fields HERE, with the hits (#428). Resolving them at
+        // render time meant a document updated mid-scroll came back as the old
+        // body carrying the new sequence number, and a reindexer feeding that
+        // back as `if_seq_no` passed the CAS and destroyed the newer revision.
+        // A scroll is a point-in-time view; the metadata has to be part of the
+        // point in time. The index name likewise stays with its hit (#414).
+        let mut snap: Vec<xerj_engine::engine::ScrollHit> = Vec::with_capacity(merged_hits.len());
+        for (idx_name, h) in merged_hits.iter() {
+            let own = state.engine.get_index(idx_name).ok();
+            let seq_no = own.as_ref().and_then(|i| i.lookup_seq_no(&h.id));
+            let version = own.as_ref().and_then(|i| i.lookup_version(&h.id));
+            snap.push(xerj_engine::engine::ScrollHit {
+                index: idx_name.clone(),
+                hit: h.clone(),
+                seq_no,
+                primary_term: seq_no.map(|_| 1u64),
+                version,
+            });
+        }
+        Some(snap)
     } else {
         None
     };
@@ -19758,46 +19775,74 @@ pub async fn search_with_scroll(
         let scroll_id = Uuid::new_v4().to_string();
         // Extract just the hits from the pairs.
         // Index name stays paired with its hit (#414).
-        let hits_only: Vec<(String, xerj_query::executor::Hit)> = all_hits.clone();
+        // Freeze the meta-fields with the hits (#428) — see the sibling
+        // snapshot in `search_impl`. This route's own first page is rendered
+        // from the same values just below, so page one and every continuation
+        // page now agree instead of disagreeing (they previously both omitted
+        // the fields; wiring only the continuation path made them diverge).
+        let hits_only: Vec<xerj_engine::engine::ScrollHit> = all_hits
+            .iter()
+            .map(|(idx_name, h)| {
+                let own = state.engine.get_index(idx_name).ok();
+                let seq_no = own.as_ref().and_then(|i| i.lookup_seq_no(&h.id));
+                let version = own.as_ref().and_then(|i| i.lookup_version(&h.id));
+                xerj_engine::engine::ScrollHit {
+                    index: idx_name.clone(),
+                    hit: h.clone(),
+                    seq_no,
+                    primary_term: seq_no.map(|_| 1u64),
+                    version,
+                }
+            })
+            .collect();
 
         // Return first page.
-        let first_page: Vec<EsHit> = all_hits
+        let want_seq_no = body.seq_no_primary_term.unwrap_or(false);
+        let want_version = body.version.unwrap_or(false);
+        // Built from the SAME snapshot the continuation pages read, so this
+        // route stops disagreeing with itself. It previously omitted the
+        // meta-fields on page one while continuations emitted them, which is
+        // #428's own defect one route over.
+        let first_page: Vec<EsHit> = hits_only
             .iter()
             .take(page_size)
-            .map(|(idx_name, h)| EsHit {
-                index: idx_name.clone(),
-                id: h.id.clone(),
-                score: Some(h.score as f64),
-                version: Some(1),
-                seq_no: Some(0),
-                primary_term: Some(1),
-                source: if h.source.is_null() {
-                    None
-                } else {
-                    Some(h.source.clone())
-                },
-                fields: passage_fields(h),
-                sort: if h.sort.is_empty() {
-                    None
-                } else {
-                    Some(h.sort.clone())
-                },
-                highlight: h.highlight.clone(),
-                explanation: None,
-                inner_hits: None,
-                matched_queries: if h.matched_queries.is_empty() {
-                    Value::Null
-                } else {
-                    Value::Array(
-                        h.matched_queries
-                            .iter()
-                            .cloned()
-                            .map(Value::String)
-                            .collect(),
-                    )
-                },
-                ignored: None,
-                ignored_field_values: None,
+            .map(|sh| {
+                let h = &sh.hit;
+                EsHit {
+                    index: sh.index.clone(),
+                    id: h.id.clone(),
+                    score: Some(h.score as f64),
+                    version: sh.version,
+                    seq_no: sh.seq_no,
+                    primary_term: sh.primary_term,
+                    source: if h.source.is_null() {
+                        None
+                    } else {
+                        Some(h.source.clone())
+                    },
+                    fields: passage_fields(h),
+                    sort: if h.sort.is_empty() {
+                        None
+                    } else {
+                        Some(h.sort.clone())
+                    },
+                    highlight: h.highlight.clone(),
+                    explanation: None,
+                    inner_hits: None,
+                    matched_queries: if h.matched_queries.is_empty() {
+                        Value::Null
+                    } else {
+                        Value::Array(
+                            h.matched_queries
+                                .iter()
+                                .cloned()
+                                .map(Value::String)
+                                .collect(),
+                        )
+                    },
+                    ignored: None,
+                    ignored_field_values: None,
+                }
             })
             .collect();
 
@@ -19839,6 +19884,20 @@ pub async fn search_with_scroll(
                         "_score": h.score,
                         "_source": h.source,
                     });
+                    // Same fields, same condition, as the continuation pages.
+                    if want_seq_no {
+                        if let Some(sn) = h.seq_no {
+                            hit["_seq_no"] = json!(sn);
+                        }
+                        if let Some(pt) = h.primary_term {
+                            hit["_primary_term"] = json!(pt);
+                        }
+                    }
+                    if want_version {
+                        if let Some(v) = h.version {
+                            hit["_version"] = json!(v);
+                        }
+                    }
                     if let Some(fields) = &h.fields {
                         hit["fields"] = serde_json::to_value(fields).unwrap_or(Value::Null);
                     }
@@ -20023,7 +20082,7 @@ async fn scroll_page_response(
             let has_non_score_sort = ctx
                 .hits
                 .first()
-                .map(|(_, h)| !h.sort.is_empty())
+                .map(|sh| !sh.hit.sort.is_empty())
                 .unwrap_or(false);
 
             // #428: `seq_no_primary_term`/`version` are fixed for the
@@ -20035,44 +20094,28 @@ async fn scroll_page_response(
             // to carry, silently, regardless of what was asked for.
             let emit_seq_no = ctx.seq_no_primary_term;
             let emit_version = ctx.version;
-            // Resolve the handle PER HIT, against the index that hit actually
-            // came from — not against the context-level `ctx.index`. #424 made
-            // `_index` per-hit and explicitly demoted that field to a
-            // "context-level fallback only"; looking the version map up in one
-            // index while reporting another is how a two-index scroll ends up
-            // serving `_seq_no` read out of the wrong index. This mirrors the
-            // main search handler, which resolves inside its per-hit loop.
-            // Cached per distinct index name so a page still costs one
-            // `get_index` per index, not one per hit.
-            let mut handles: std::collections::HashMap<String, Option<_>> =
-                std::collections::HashMap::new();
-            for (hit_index, _) in ctx.hits.iter().skip(position).take(page_size) {
-                handles
-                    .entry(hit_index.clone())
-                    .or_insert_with(|| state.engine.get_index(hit_index).ok());
-            }
-
+            // Read the meta-fields OUT OF THE SNAPSHOT. Resolving them here
+            // against the live index is what produced a silent lost update:
+            // the frozen `source` below was paired with a `_seq_no` from now,
+            // so a document updated mid-scroll came back as the old body
+            // carrying the new sequence number, and `if_seq_no` fed back from
+            // it passed the CAS and overwrote the newer revision (#428).
             let page_hits: Vec<EsHit> = ctx
                 .hits
                 .iter()
                 .skip(position)
                 .take(page_size)
-                .map(|(hit_index, h)| {
-                    let own_index = handles.get(hit_index).and_then(|h| h.as_ref());
+                .map(|sh| {
+                    let h = &sh.hit;
                     let (seq_no, primary_term) = if emit_seq_no {
-                        let sn = own_index.and_then(|idx| idx.lookup_seq_no(&h.id));
-                        (sn, sn.map(|_| 1u64))
+                        (sh.seq_no, sh.primary_term)
                     } else {
                         (None, None)
                     };
-                    let version = if emit_version {
-                        own_index.and_then(|idx| idx.lookup_version(&h.id))
-                    } else {
-                        None
-                    };
+                    let version = if emit_version { sh.version } else { None };
                     EsHit {
                         // Per-hit index, not the context-level one (#414).
-                        index: hit_index.clone(),
+                        index: sh.index.clone(),
                         id: h.id.clone(),
                         score: Some(h.score as f64),
                         version,
@@ -20221,8 +20264,20 @@ mod passage_scroll_tests {
             xerj_engine::engine::ScrollContext {
                 index: "reports".into(),
                 hits: vec![
-                    ("reports".to_string(), passage_hit("page-1", 0)),
-                    ("reports".to_string(), passage_hit("page-2", 1)),
+                    xerj_engine::engine::ScrollHit {
+                        index: "reports".to_string(),
+                        hit: passage_hit("page-1", 0),
+                        seq_no: None,
+                        primary_term: None,
+                        version: None,
+                    },
+                    xerj_engine::engine::ScrollHit {
+                        index: "reports".to_string(),
+                        hit: passage_hit("page-2", 1),
+                        seq_no: None,
+                        primary_term: None,
+                        version: None,
+                    },
                 ],
                 position: 1,
                 page_size: 1,
@@ -20279,8 +20334,20 @@ mod passage_scroll_tests {
             xerj_engine::engine::ScrollContext {
                 index: "mi_a".into(),
                 hits: vec![
-                    ("mi_a".to_string(), passage_hit("dup-1", 0)),
-                    ("mi_b".to_string(), passage_hit("dup-1", 1)),
+                    xerj_engine::engine::ScrollHit {
+                        index: "mi_a".to_string(),
+                        hit: passage_hit("dup-1", 0),
+                        seq_no: None,
+                        primary_term: None,
+                        version: None,
+                    },
+                    xerj_engine::engine::ScrollHit {
+                        index: "mi_b".to_string(),
+                        hit: passage_hit("dup-1", 1),
+                        seq_no: None,
+                        primary_term: None,
+                        version: None,
+                    },
                 ],
                 position: 1,
                 page_size: 1,
@@ -20333,8 +20400,20 @@ mod passage_scroll_tests {
             xerj_engine::engine::ScrollContext {
                 index: "reports".into(),
                 hits: vec![
-                    ("reports".to_string(), passage_hit("page-1", 0)),
-                    ("reports".to_string(), passage_hit("page-2", 1)),
+                    xerj_engine::engine::ScrollHit {
+                        index: "reports".to_string(),
+                        hit: passage_hit("page-1", 0),
+                        seq_no: None,
+                        primary_term: None,
+                        version: None,
+                    },
+                    xerj_engine::engine::ScrollHit {
+                        index: "reports".to_string(),
+                        hit: passage_hit("page-2", 1),
+                        seq_no: None,
+                        primary_term: None,
+                        version: None,
+                    },
                 ],
                 position: 1,
                 page_size: 1,

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -20035,8 +20035,22 @@ async fn scroll_page_response(
             // to carry, silently, regardless of what was asked for.
             let emit_seq_no = ctx.seq_no_primary_term;
             let emit_version = ctx.version;
-            let index_name = ctx.index.clone();
-            let index_for_lookup = state.engine.get_index(&index_name).ok();
+            // Resolve the handle PER HIT, against the index that hit actually
+            // came from — not against the context-level `ctx.index`. #424 made
+            // `_index` per-hit and explicitly demoted that field to a
+            // "context-level fallback only"; looking the version map up in one
+            // index while reporting another is how a two-index scroll ends up
+            // serving `_seq_no` read out of the wrong index. This mirrors the
+            // main search handler, which resolves inside its per-hit loop.
+            // Cached per distinct index name so a page still costs one
+            // `get_index` per index, not one per hit.
+            let mut handles: std::collections::HashMap<String, Option<_>> =
+                std::collections::HashMap::new();
+            for (hit_index, _) in ctx.hits.iter().skip(position).take(page_size) {
+                handles
+                    .entry(hit_index.clone())
+                    .or_insert_with(|| state.engine.get_index(hit_index).ok());
+            }
 
             let page_hits: Vec<EsHit> = ctx
                 .hits
@@ -20044,18 +20058,15 @@ async fn scroll_page_response(
                 .skip(position)
                 .take(page_size)
                 .map(|(hit_index, h)| {
+                    let own_index = handles.get(hit_index).and_then(|h| h.as_ref());
                     let (seq_no, primary_term) = if emit_seq_no {
-                        let sn = index_for_lookup
-                            .as_ref()
-                            .and_then(|idx| idx.lookup_seq_no(&h.id));
+                        let sn = own_index.and_then(|idx| idx.lookup_seq_no(&h.id));
                         (sn, sn.map(|_| 1u64))
                     } else {
                         (None, None)
                     };
                     let version = if emit_version {
-                        index_for_lookup
-                            .as_ref()
-                            .and_then(|idx| idx.lookup_version(&h.id))
+                        own_index.and_then(|idx| idx.lookup_version(&h.id))
                     } else {
                         None
                     };

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -20060,40 +20060,40 @@ async fn scroll_page_response(
                         None
                     };
                     EsHit {
-                    // Per-hit index, not the context-level one (#414).
-                    index: hit_index.clone(),
-                    id: h.id.clone(),
-                    score: Some(h.score as f64),
-                    version,
-                    seq_no,
-                    primary_term,
-                    source: if h.source.is_null() {
-                        None
-                    } else {
-                        Some(h.source.clone())
-                    },
-                    fields: passage_fields(h),
-                    sort: if h.sort.is_empty() {
-                        None
-                    } else {
-                        Some(h.sort.clone())
-                    },
-                    highlight: h.highlight.clone(),
-                    explanation: None,
-                    inner_hits: None,
-                    matched_queries: if h.matched_queries.is_empty() {
-                        Value::Null
-                    } else {
-                        Value::Array(
-                            h.matched_queries
-                                .iter()
-                                .cloned()
-                                .map(Value::String)
-                                .collect(),
-                        )
-                    },
-                    ignored: None,
-                    ignored_field_values: None,
+                        // Per-hit index, not the context-level one (#414).
+                        index: hit_index.clone(),
+                        id: h.id.clone(),
+                        score: Some(h.score as f64),
+                        version,
+                        seq_no,
+                        primary_term,
+                        source: if h.source.is_null() {
+                            None
+                        } else {
+                            Some(h.source.clone())
+                        },
+                        fields: passage_fields(h),
+                        sort: if h.sort.is_empty() {
+                            None
+                        } else {
+                            Some(h.sort.clone())
+                        },
+                        highlight: h.highlight.clone(),
+                        explanation: None,
+                        inner_hits: None,
+                        matched_queries: if h.matched_queries.is_empty() {
+                            Value::Null
+                        } else {
+                            Value::Array(
+                                h.matched_queries
+                                    .iter()
+                                    .cloned()
+                                    .map(Value::String)
+                                    .collect(),
+                            )
+                        },
+                        ignored: None,
+                        ignored_field_values: None,
                     }
                 })
                 .collect();
@@ -20420,7 +20420,10 @@ mod passage_scroll_tests {
         let body: Value = serde_json::from_slice(&bytes).unwrap();
         let scroll_id = body["_scroll_id"].as_str().unwrap().to_string();
         assert!(
-            body["hits"]["hits"][0].get("_seq_no").and_then(Value::as_u64).is_some(),
+            body["hits"]["hits"][0]
+                .get("_seq_no")
+                .and_then(Value::as_u64)
+                .is_some(),
             "page 1 should already carry a real _seq_no: {body}"
         );
 

--- a/engine/crates/xerj-api/tests/scroll_multi_index_seq_no.rs
+++ b/engine/crates/xerj-api/tests/scroll_multi_index_seq_no.rs
@@ -1,0 +1,174 @@
+//! #428 + #414 in composition: on a multi-index scroll, `_seq_no` / `_version`
+//! must be read from the index each hit actually came from.
+//!
+//! These two fixes collided rather than composed. #414 made continuation pages
+//! report a per-hit `_index`; #428's fix resolved the version map once, from the
+//! context-level `ctx.index`. On #428's original base that was consistent — every
+//! hit was stamped with the context index too, so the lookup agreed with what was
+//! reported (both wrong, but agreeing). Once `_index` became per-hit, the lookup
+//! did not follow, and hits from the second index reported `_seq_no` read out of
+//! the first index's version map.
+//!
+//! That is worse than the absent field it replaced: `_seq_no`/`_primary_term`
+//! exist to be fed back as `if_seq_no`/`if_primary_term`, so a consumer that
+//! previously failed loudly now gets a confident wrong value — on exactly the
+//! reindex/migration/CDC path scroll serves.
+//!
+//! Ids collide across the indices on purpose: that is the normal case when two
+//! indices each number their own documents.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn req(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut b = Request::builder().method(method).uri(path);
+    let payload = if body.is_null() {
+        Body::empty()
+    } else {
+        b = b.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let r = app.clone().oneshot(b.body(payload).unwrap()).await.unwrap();
+    let st = r.status();
+    let bytes = axum::body::to_bytes(r.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (st, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+}
+
+/// Write `times` distinct versions of each doc so `_seq_no` is not merely the
+/// ordinal — an ordinal would let both the old hardcoded `0` and a wrong-index
+/// lookup pass unnoticed.
+async fn seed(app: &axum::Router, index: &str, times: usize) {
+    let (st, _) = req(
+        app,
+        "PUT",
+        &format!("/{index}"),
+        json!({"mappings":{"properties":{"n":{"type":"long"}}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create {index}");
+    for round in 0..times {
+        for i in 0..4 {
+            let (st, _) = req(
+                app,
+                "PUT",
+                &format!("/{index}/_doc/{i}"),
+                json!({"n": i, "round": round}),
+            )
+            .await;
+            assert!(st.is_success(), "write {index}/{i}");
+        }
+    }
+    req(app, "POST", &format!("/{index}/_refresh"), Value::Null).await;
+}
+
+/// Ground truth: a plain `_search` with the same flags, which resolves per hit.
+async fn truth(app: &axum::Router, index: &str) -> Vec<(String, u64, u64)> {
+    let (st, v) = req(
+        app,
+        "POST",
+        &format!("/{index}/_search"),
+        json!({"size":10,"seq_no_primary_term":true,"version":true,"sort":[{"_id":"asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK);
+    v["hits"]["hits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| {
+            (
+                h["_id"].as_str().unwrap().to_string(),
+                h["_seq_no"].as_u64().expect("_seq_no on plain search"),
+                h["_version"].as_u64().expect("_version on plain search"),
+            )
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn multi_index_scroll_reads_seq_no_from_the_hits_own_index() {
+    let (app, _d) = app().await;
+    seed(&app, "sq_a", 1).await;
+    seed(&app, "sq_b", 4).await; // different write counts => different seq_no/version
+
+    let a: Vec<_> = truth(&app, "sq_a").await;
+    let b: Vec<_> = truth(&app, "sq_b").await;
+    assert_ne!(
+        a.iter().map(|x| x.1).collect::<Vec<_>>(),
+        b.iter().map(|x| x.1).collect::<Vec<_>>(),
+        "fixture is degenerate: both indices produced the same _seq_no values"
+    );
+
+    let (st, first) = req(
+        &app,
+        "POST",
+        "/sq_a,sq_b/_search?scroll=2m",
+        json!({"size":2,"seq_no_primary_term":true,"version":true}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "scroll start: {first}");
+
+    let mut sid = first["_scroll_id"].as_str().map(str::to_string);
+    let mut page = first;
+    let mut seen = Vec::new();
+    for _ in 0..16 {
+        let hits = page["hits"]["hits"].as_array().cloned().unwrap_or_default();
+        if hits.is_empty() {
+            break;
+        }
+        for h in &hits {
+            seen.push((
+                h["_index"].as_str().unwrap_or_default().to_string(),
+                h["_id"].as_str().unwrap_or_default().to_string(),
+                h["_seq_no"].as_u64(),
+                h["_version"].as_u64(),
+            ));
+        }
+        let Some(id) = sid.clone() else { break };
+        let (st, next) = req(
+            &app,
+            "POST",
+            "/_search/scroll",
+            json!({"scroll":"2m","scroll_id":id}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK);
+        sid = next["_scroll_id"].as_str().map(str::to_string).or(sid);
+        page = next;
+    }
+
+    assert_eq!(seen.len(), 8, "scroll must return all 8 documents");
+
+    let want = |idx: &str, id: &str| -> (u64, u64) {
+        let src = if idx == "sq_a" { &a } else { &b };
+        let row = src.iter().find(|r| r.0 == id).expect("id in truth");
+        (row.1, row.2)
+    };
+    let wrong: Vec<_> = seen
+        .iter()
+        .filter(|(idx, id, sn, ver)| {
+            let (w_sn, w_ver) = want(idx, id);
+            *sn != Some(w_sn) || *ver != Some(w_ver)
+        })
+        .collect();
+    assert!(
+        wrong.is_empty(),
+        "hits carried _seq_no/_version from the wrong index's version map — \
+         these feed straight back into if_seq_no/if_primary_term: {wrong:?}"
+    );
+}

--- a/engine/crates/xerj-api/tests/scroll_snapshot_metadata.rs
+++ b/engine/crates/xerj-api/tests/scroll_snapshot_metadata.rs
@@ -1,0 +1,226 @@
+//! #428: a scroll is a point-in-time view, so `_seq_no` / `_primary_term` /
+//! `_version` must come from that point in time — not from the live index at
+//! render time.
+//!
+//! Continuation pages once served the frozen `_source` beside meta-fields
+//! resolved when the page was rendered. For a document updated mid-scroll the
+//! lookup succeeded and stamped the CURRENT sequence number onto the OLD body.
+//! A reindexer doing `PUT dest/_doc/x?if_seq_no=<that>` then passed optimistic
+//! concurrency and overwrote the newer revision — a silent lost update, on
+//! exactly the reindex/migration/CDC path scroll exists to serve.
+//!
+//! Lucene has no such gap: a scroll pins an `IndexReader`, a point-in-time view
+//! whose `_seq_no` doc-values are written at index time and immutable per
+//! segment. ES therefore emits a `_seq_no` that agrees with the `_source` next
+//! to it, and a stale `if_seq_no` correctly 409s.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn req(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut b = Request::builder().method(method).uri(path);
+    let payload = if body.is_null() {
+        Body::empty()
+    } else {
+        b = b.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let r = app.clone().oneshot(b.body(payload).unwrap()).await.unwrap();
+    let st = r.status();
+    let bytes = axum::body::to_bytes(r.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (st, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+}
+
+/// A document updated after the scroll opened must still report the `_seq_no`
+/// it had when the snapshot was taken, because that is the version the
+/// `_source` beside it belongs to.
+#[tokio::test]
+async fn continuation_pages_report_the_snapshots_seq_no_not_the_live_one() {
+    let (app, _d) = app().await;
+    let (st, _) = req(
+        &app,
+        "PUT",
+        "/skew",
+        json!({"mappings":{"properties":{"n":{"type":"long"}}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK);
+
+    for i in 0..6 {
+        let (st, _) = req(
+            &app,
+            "PUT",
+            &format!("/skew/_doc/d{i}"),
+            json!({"n": i, "body": "v1"}),
+        )
+        .await;
+        assert!(st.is_success());
+    }
+    req(&app, "POST", "/skew/_refresh", Value::Null).await;
+
+    // Open the scroll and take page one — this is the point in time.
+    let (st, first) = req(
+        &app,
+        "POST",
+        "/skew/_search?scroll=5m",
+        json!({"size":2,"seq_no_primary_term":true,"version":true,"sort":[{"_id":"asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "{first}");
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+
+    // Now move the documents that page two will serve. Twice, so the sequence
+    // number is unambiguously different from the snapshot's.
+    for round in ["v2", "v3"] {
+        for i in 2..6 {
+            let (st, _) = req(
+                &app,
+                "PUT",
+                &format!("/skew/_doc/d{i}"),
+                json!({"n": i, "body": round}),
+            )
+            .await;
+            assert!(st.is_success());
+        }
+    }
+    req(&app, "POST", "/skew/_refresh", Value::Null).await;
+
+    // Walk the rest of the scroll.
+    let mut sid = Some(sid);
+    let mut page = first;
+    let mut cont: Vec<(String, Option<u64>, String)> = Vec::new();
+    let mut first_page = true;
+    for _ in 0..8 {
+        let hits = page["hits"]["hits"].as_array().cloned().unwrap_or_default();
+        if hits.is_empty() {
+            break;
+        }
+        if !first_page {
+            for h in &hits {
+                cont.push((
+                    h["_id"].as_str().unwrap_or_default().to_string(),
+                    h["_seq_no"].as_u64(),
+                    h["_source"]["body"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_string(),
+                ));
+            }
+        }
+        first_page = false;
+        let Some(id) = sid.clone() else { break };
+        let (st, next) = req(
+            &app,
+            "POST",
+            "/_search/scroll",
+            json!({"scroll":"5m","scroll_id":id}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK);
+        sid = next["_scroll_id"].as_str().map(str::to_string).or(sid);
+        page = next;
+    }
+
+    assert!(!cont.is_empty(), "no continuation pages were produced");
+
+    // The body must be the snapshot's. That is the whole point of a scroll.
+    for (id, _, body) in &cont {
+        assert_eq!(body, "v1", "{id}: continuation served a post-snapshot body");
+    }
+
+    // And the sequence number must belong to THAT body. Live values are what a
+    // client would feed to `if_seq_no`, so a live value next to a stale body is
+    // a CAS that succeeds and destroys the newer revision.
+    let (st, live) = req(
+        &app,
+        "POST",
+        "/skew/_search",
+        json!({"size":10,"seq_no_primary_term":true,"version":true,"sort":[{"_id":"asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK);
+    let live_sn: std::collections::HashMap<String, u64> = live["hits"]["hits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| {
+            (
+                h["_id"].as_str().unwrap().to_string(),
+                h["_seq_no"].as_u64().unwrap_or(u64::MAX),
+            )
+        })
+        .collect();
+
+    let leaked: Vec<_> = cont
+        .iter()
+        .filter(|(id, sn, _)| sn.is_some() && *sn == live_sn.get(id).copied())
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "continuation pages reported the LIVE _seq_no beside a snapshot _source — \
+         feeding these back as if_seq_no passes the CAS and overwrites the newer \
+         revision: {leaked:?} (live: {live_sn:?})"
+    );
+}
+
+/// The route that only ever omitted these fields must not start disagreeing
+/// with itself: page one and continuation pages either both carry them or
+/// neither does.
+#[tokio::test]
+async fn search_scroll_route_agrees_with_itself_across_pages() {
+    let (app, _d) = app().await;
+    req(
+        &app,
+        "PUT",
+        "/ssr",
+        json!({"mappings":{"properties":{"n":{"type":"long"}}}}),
+    )
+    .await;
+    for i in 0..6 {
+        req(&app, "PUT", &format!("/ssr/_doc/d{i}"), json!({"n": i})).await;
+    }
+    req(&app, "POST", "/ssr/_refresh", Value::Null).await;
+
+    let (st, first) = req(
+        &app,
+        "POST",
+        "/ssr/_search_scroll?scroll=5m",
+        json!({"size":3,"seq_no_primary_term":true,"version":true,"sort":[{"_id":"asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "{first}");
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+    let p1_has = first["hits"]["hits"][0].get("_seq_no").is_some();
+
+    let (st, second) = req(
+        &app,
+        "POST",
+        "/_search/scroll",
+        json!({"scroll":"5m","scroll_id":sid}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK);
+    let p2_has = second["hits"]["hits"][0].get("_seq_no").is_some();
+
+    assert_eq!(
+        p1_has, p2_has,
+        "/{{index}}/_search_scroll disagrees with itself: page1 _seq_no present={p1_has}, \
+         page2 present={p2_has} — a client reading the field unconditionally breaks on one page \
+         of its own scroll (#428)"
+    );
+}

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -171,6 +171,18 @@ pub struct ScrollContext {
     /// return the same 404 as an unknown id, and the background sweeper
     /// (or an opportunistic sweep on open) frees the pinned hits.
     pub expires_at: Instant,
+    /// Whether the request that opened this scroll carried
+    /// `seq_no_primary_term: true`. Real ES fixes this at the opening
+    /// `_search?scroll=…` request and does not accept it again on `POST
+    /// /_search/scroll` — the flag governs the scroll's whole lifetime, not
+    /// each individual page, so it belongs on the context, not re-read per
+    /// continuation (issue #428: continuation pages used to hardcode
+    /// `_seq_no`/`_version` and never even serialize them, regardless of
+    /// what the opening request asked for).
+    pub seq_no_primary_term: bool,
+    /// Whether the opening request carried `version: true`. Same reasoning
+    /// as `seq_no_primary_term` above.
+    pub version: bool,
 }
 
 /// Point-in-time search context — snapshots the set of indices and the

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -151,14 +151,40 @@ pub struct IndexTemplate {
 /// (from the request's `scroll=…` keep-alive, capped by
 /// `Config.search_context.scroll_max_keep_alive_secs`), refreshed on each
 /// continuation, enforced on access, and swept in the background.
+/// One frozen hit in a scroll snapshot: the document as it was, the index it
+/// came from, and the meta-fields as they stood at scroll-open time.
+#[derive(Clone, Debug)]
+pub struct ScrollHit {
+    pub index: String,
+    pub hit: xerj_query::executor::Hit,
+    /// Captured at snapshot time, never re-derived. `None` means the engine
+    /// had no value then — not that it has none now.
+    pub seq_no: Option<u64>,
+    pub primary_term: Option<u64>,
+    pub version: Option<u64>,
+}
+
 pub struct ScrollContext {
     pub index: String,
-    /// Each hit paired with the name of the index it actually came from.
-    /// Pairing is structural on purpose (#414): a multi-index scroll used to
-    /// store bare hits plus one context-level `index`, so every continuation
-    /// page stamped the same name onto hits from different indices and
-    /// `(_index, _id)` stopped being distinct.
-    pub hits: Vec<(String, xerj_query::executor::Hit)>,
+    /// The frozen result set: each hit with the index it came from AND the
+    /// meta-fields as they stood when the scroll was opened.
+    ///
+    /// Both halves are structural on purpose. The index name because a
+    /// multi-index scroll used to store bare hits plus one context-level
+    /// `index`, so every continuation page stamped the same name onto hits
+    /// from different indices and `(_index, _id)` stopped being distinct
+    /// (#414).
+    ///
+    /// The meta-fields because a scroll is a point-in-time view and resolving
+    /// them later is not. Continuation pages once served this frozen `source`
+    /// beside a `_seq_no` read live at render time, so a document updated
+    /// mid-scroll came back as the OLD body carrying the NEW sequence number —
+    /// and a reindexer feeding that back as `if_seq_no` passed the CAS and
+    /// overwrote the newer revision. Lucene has no such gap: a scroll pins an
+    /// `IndexReader`, and `_seq_no` doc-values are written at index time and
+    /// immutable per segment, so ES emits a `_seq_no` that agrees with the
+    /// `_source` next to it and a stale `if_seq_no` correctly 409s (#428).
+    pub hits: Vec<ScrollHit>,
     pub position: usize,
     pub page_size: usize,
     pub created: Instant,

--- a/engine/crates/xerj-engine/tests/search_context_ttl.rs
+++ b/engine/crates/xerj-engine/tests/search_context_ttl.rs
@@ -39,6 +39,8 @@ fn scroll_ctx(expires_in: i64) -> ScrollContext {
         created: now,
         keep_alive,
         expires_at,
+        seq_no_primary_term: false,
+        version: false,
     }
 }
 


### PR DESCRIPTION
Fixes #428.

## The bug

`seq_no_primary_term: true` on the scroll-opening request (`POST /{index}/_search?scroll=…`) is honored on that first page — real `_seq_no`/`_primary_term`, resolved via `idx.lookup_seq_no`. Every page after the first, served by `scroll_page_response`, came back with neither field at all, silently, regardless of what was requested.

Two compounding bugs in `scroll_page_response` (`es_compat.rs`):

1. The intermediate `EsHit` it builds hardcoded the values:
   ```rust
   version: Some(1),
   seq_no: Some(0),
   ```
2. Even those placeholders never reached the wire — the response is built by hand into a `serde_json::Map` a few lines later, which never inserted `_seq_no`/`_version`/`_primary_term` at all, unconditionally. `EsHit`'s own `Serialize` derive (which does have the right `skip_serializing_if`/rename attributes) was simply never used for this response.

Live-verified this is xerj-specific, not a scroll-protocol limitation: the identical request against a real OpenSearch 3.7.0 node carries `_seq_no`/`_primary_term` on every page.

## The fix

Real Elasticsearch fixes `seq_no_primary_term`/`version` at the scroll-opening request and doesn't even accept them again on the `POST /_search/scroll` continuation body — the flag governs the whole scroll's lifetime, not each individual page. So:

- `ScrollContext` now carries `seq_no_primary_term: bool` and `version: bool`, captured once when the context is created (both call sites: the main `search()` handler and `search_with_scroll`).
- `scroll_page_response` resolves the real values from the version map (`idx.lookup_seq_no` / `idx.lookup_version`) — the exact same mechanism the main search handler already uses for a plain (non-scroll) request — instead of the hardcoded placeholders, gated on the context's flags rather than re-reading them per continuation call.
- The hand-built response JSON now actually inserts `_seq_no`/`_primary_term`/`_version` when present, closing the second, independent omission.

## Testing

- New regression test (`scroll_continuation_resolves_real_seq_no_when_requested`) indexes real documents through the actual write path — every existing scroll test injects a synthetic `ScrollContext` directly with fabricated `Hit`s, which is exactly why this had no version-map entry to expose the bug. Pages one at a time to force a real page 2, asserts `_seq_no` is present and numeric on both page 1 and page 2.
- `cargo test -p xerj-api --lib`: 216 passed, 0 failed (includes the new test; no regressions in the existing 9 scroll-related tests).
- `cargo test -p xerj-engine --test search_context_ttl`: 2 passed (unaffected by the new `ScrollContext` fields).
- `cargo clippy -p xerj-api -p xerj-engine --lib`: clean.
- Live-verified against a real build: 4 real scroll pages against a 120-document index, `_seq_no` present throughout with correct incrementing values (not the old hardcoded `0`); `version: true` also resolves correctly; both fields stay correctly absent on every page when neither flag is requested, so this isn't an over-eager fix that starts emitting fields nobody asked for.
- Live-verified end-to-end against [xerj-seed](https://github.com/Vinz2168/xerj-seed) (the companion CLI whose multi-page testing surfaced this bug): its client-side `_mget` workaround for this exact gap still runs unchanged against the fixed build, harmlessly, since `_seq_no` is native again.

## Scope note

`version` was not part of the original report but is the identical bug in the identical two places (same hardcoded-then-unserialized pattern, one field over) — fixing only `_seq_no` and leaving `_version` visibly broken two lines away would have looked like an oversight rather than a deliberate scope decision, so both are covered here.

Claude-Session: https://claude.ai/code/session_01QXqdmVtcAdiSrcsatXwYFy
