### PR TITLE
docs(site): lead the reference-coding study with its measured result

### DIFF
--- a/landing/case-studies/reference-coding.html
+++ b/landing/case-studies/reference-coding.html
@@ -60,8 +60,8 @@
 
 <div class="uc-hero">
   <div class="uc-eyebrow">CASE STUDY · REFERENCE-CODING</div>
-  <h1>STOP RE-DERIVING APIs.<br><span class="accent">START LOOKING THEM UP.</span></h1>
-  <p class="uc-lead">When a coding agent meets an API it does not know, it guesses, fails, and guesses again — each lap burning the expensive kind of token. Reference-coding fixes that: clone the libraries that already solved your problem, index them with XERJ, and retrieve the real implementation before writing code. We measured it across <strong>13 purpose-built libraries in 5 languages</strong> against the <em>same</em> Claude Code. Below is the one prompt that turns it on — and every number behind it.</p>
+  <h1>REFERENCE CODING MAKES CLAUDE CODE<br><span class="accent">6.5× CHEAPER — MEASURED.</span></h1>
+  <p class="uc-lead">When a coding agent meets an API it does not know, it guesses, fails, and guesses again — each lap burning the expensive kind of token. Reference-coding fixes that: clone the libraries that already solved your problem, index them with XERJ, and retrieve the real implementation before writing code. Measured across <strong>13 purpose-built libraries in 5 languages</strong> against the <em>same</em> Claude Code: on code it has not memorised, plain Claude Code solved <strong>1 of 21</strong> tasks and burned <strong>$21.90</strong> doing it — with XERJ retrieval it solved <strong>21 of 21</strong> for <strong>$3.38</strong>. Same model, same tasks — only the retrieval differs. Paste the one line below to turn it on. Every number behind it is underneath, including where retrieval is worth nothing.</p>
 </div>
 
 <!-- OPENER PROMPT -->
@@ -74,7 +74,6 @@
         <button type="button" class="prompt-copy" data-copy="Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up reference coding: clone and index the open-source repos closest to what we're building, and search how they solved a problem before writing code.">COPY THE PROMPT</button>
       </div>
     </div>
-    <div class="hint">That is the current one-line setup, and the only one to paste — <a href="https://xerj.org/llms.txt" rel="external" style="color:var(--accent);">llms.txt</a> walks the agent through the whole loop with nothing else to install: start a node, <code class="inline">git clone --depth 1</code> each reference repo, <code class="inline">xerj autoindex</code> it, then query the <code class="inline">ax-*</code> indices before writing code.</div>
     <div class="lbl" style="margin-top:18px;">◆ HISTORICAL · the long-form prompt this study measured — kept verbatim for reproducibility, not current instructions</div>
     <pre>Set me up for reference-coding with XERJ and then use it automatically for the
 rest of our work, so I stop burning output tokens re-deriving APIs I could just


### PR DESCRIPTION
Updates the hero on `/case-studies/reference-coding` and removes the now-redundant setup note under the prompt card.

## Hero

**Before:** `STOP RE-DERIVING APIs. / START LOOKING THEM UP.` — a slogan, with the finding buried.

**After:** `REFERENCE CODING MAKES CLAUDE CODE 6.5× CHEAPER — MEASURED.` — plus the concrete result in the lead: the same Claude Code solves **1 of 21** unmemorised-contract tasks from memory at **$21.90**, and **21 of 21** with XERJ retrieval at **$3.38**.

## On the number

The request was for "x5". **There is no 5× result in the study.** The only `5×` in the corpus is Opus 5's output:input price ratio (`COSTS.md:9`) — a list price, not a measurement.

What is measured:

| comparison | figure | source |
|---|---|---|
| vs bare, cost | **6.5×** ($21.9 → $3.38) | `SUMMARY.md:28`, `CASE_STUDY.md:15` |
| vs bare, correctness | **1/21 → 21/21** | `CASE_STUDY.md:569` |
| vs native | 1.5× tokens, 1.2–1.3× cost | `CASE_STUDY.md:376` |

6.5× is both true and **larger** than the requested 5×, so nothing is lost by being accurate. It is also already the figure in this page's own `og:description`, which previously contradicted its hero.

`CASE_STUDY.md:620` states plainly that the native-vs-xerj gap "stays ~1.5×, not 10×". A fabricated 5× under the word **MEASURED** would be refuted by the very document the page links to, in the honesty section a skeptical reader opens first.

## One correction I made to my own draft

The first draft of the hero also claimed **24.9× fewer output tokens** alongside the other figures. That number is from the **sift track alone** (9 runs, `CASE_STUDY.md:224`), not the 21-run unmemorised set the $21.90/$3.38 figures come from. Quoting them in one sentence silently changes scope, so it is removed.

## Note removal

The `hint` div under the prompt card explained that the one-liner is current and the block below is historical. The one-liner is now the only prompt, and the historical block already carries its own `◆ HISTORICAL · kept verbatim for reproducibility` label — so the note was redundant.

## Verification

- `21.9 / 3.38 = 6.48` → 6.5× ✓
- every figure in the new hero grep-confirmed present in `docs/case-studies/reference-coding/*.md`
- structural: single `<h1>`, old hero gone, note gone, prompt card and historical block intact
- **Not verified:** no browser render check — this is a text-only change inside existing markup with no CSS or structural edits.