### PR TITLE
release: cut 1.0.0-rc.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`bool.filter` and `must_not` stopped contributing to `_score`, and `_score`
-  stopped depending on `size`** ([#361](https://github.com/xerj-org/xerj/issues/361),
+- **`bool.filter` stopped contributing to `_score` on the FTS path** ([#361](https://github.com/xerj-org/xerj/issues/361),
   [#387](https://github.com/xerj-org/xerj/pull/387)). This entry is written after
   the fact: #387 merged with no CHANGELOG entry at all, and an independent
   verification of the rc.18 cut caught it as a silent merge — 471 insertions of
@@ -37,9 +36,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   So `_score` stopped depending on `size` **on the BM25 path**. A `bool` carrying
   any second clause never reaches that path — it falls into the schema-less
-  `_source` scorer, where scores collapse toward `ln(2)+1` and still move with
-  `size`. That is the half of #361 that is still open, together with #399, and
-  #423 is the root cause.
+  `_source` scorer, where scores collapse toward `ln(2)+1`. That is the half of
+  #361 still open, together with #399, and #423 is the root cause.
+
+  **Two further corrections to this entry, both from independent verification.**
+  First, `must_not` never contributed to `_score` at all: the pre-change term
+  chain was `must.iter().chain(should.iter()).chain(filter.iter())`, with no
+  `must_not` in it, so #387 only removed it from the rescore *trigger* walk. The
+  headline said otherwise and has been narrowed.
+
+  Second, the size-independence above may be narrower than measured. The gate is
+  `exact_bm25_page = fts_scored_applied && !heuristic_scored_applied`, and
+  `heuristic_scored_applied` is set from `mem_doc_count > 0` — so by that reading
+  the rescore stays armed while any document is still buffered, which is the
+  normal state after ingest. **I could not reproduce it.** A 120-document index
+  queried with no `_refresh` at all (all 120 visible, so the probe was not
+  vacuous) was size-stable at 2/5/10/50, as was the flushed case. Recorded as an
+  unresolved discrepancy between a code reading and a measurement rather than
+  resolved in favour of whichever is more convenient.
 
   It also adds a `filter` field to the native `BoolQuery`, which is a new public
   request surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   separate non-scoring `filter` slot, matching `BooleanClause.isScoring()`. The
   IDF rescore heuristic no longer counts `filter` or `must_not` toward its
   trigger. And the page-local rescore is skipped when the whole page came from
-  the segment FTS path, so `_score` is no longer a function of the requested
-  `size` — the defect #361 was filed for.
+  the segment FTS path.
+
+  **That last claim needs its bounds stated, and the first draft of this entry
+  overstated it.** Measured on this cut across `size` 2/5/10/50:
+
+  ```text
+  bare match                    size-stable
+  bool.must[1]                  size-stable
+  bool.must + filter match_all  NOT size-stable
+  bool.must + must_not          NOT size-stable
+  ```
+
+  So `_score` stopped depending on `size` **on the BM25 path**. A `bool` carrying
+  any second clause never reaches that path — it falls into the schema-less
+  `_source` scorer, where scores collapse toward `ln(2)+1` and still move with
+  `size`. That is the half of #361 that is still open, together with #399, and
+  #423 is the root cause.
 
   It also adds a `filter` field to the native `BoolQuery`, which is a new public
   request surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.18] - 2026-08-16
+
 ### Fixed
 
 - **A multi-index `scroll` reported the wrong `_index` on every continuation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bool.filter` and `must_not` stopped contributing to `_score`, and `_score`
+  stopped depending on `size`** ([#361](https://github.com/xerj-org/xerj/issues/361),
+  [#387](https://github.com/xerj-org/xerj/pull/387)). This entry is written after
+  the fact: #387 merged with no CHANGELOG entry at all, and an independent
+  verification of the rc.18 cut caught it as a silent merge — 471 insertions of
+  production scoring code on the ES-compat `_search` path, documented nowhere.
+
+  Three behaviours changed. `bool.filter` was being projected onto the FTS `must`
+  slot, so a non-scoring clause summed its BM25 into `_score`; it now occupies a
+  separate non-scoring `filter` slot, matching `BooleanClause.isScoring()`. The
+  IDF rescore heuristic no longer counts `filter` or `must_not` toward its
+  trigger. And the page-local rescore is skipped when the whole page came from
+  the segment FTS path, so `_score` is no longer a function of the requested
+  `size` — the defect #361 was filed for.
+
+  It also adds a `filter` field to the native `BoolQuery`, which is a new public
+  request surface.
+
+  **Anyone upgrading rc.17 → rc.18 should expect different `_score` values and a
+  different hit order for `bool` queries carrying `filter` or `must_not`.** That
+  is the intended correction, but it is a visible change and it was undocumented
+  until now. #361 remains open: a `bool` carrying any second clause still
+  collapses `_score` into a near-constant, which is the other half of the same
+  family.
+
+### Fixed
+
 - **A multi-index `scroll` reported the wrong `_index` on every continuation
   page, so `(_index, _id)` stopped being distinct**
   ([#414](https://github.com/xerj-org/xerj/issues/414)). The scroll context

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Last reviewed: 2026-08-16 (against `v1.0.0-rc.18` and `main`). Statuses trace to
 ## Follow the roadmap
 
 - **This file** is authoritative. If any other surface disagrees with it, this file wins — and that disagreement is a bug worth an issue.
-- **[Milestones](https://github.com/xerj-org/xerj/milestones)** — release-by-release, where they exist. They are **not** a live view: at the rc.18 cut 36 of 38 open issues carried no milestone and the only two that did sat on already-shipped rc.17. The [rc.19 milestone](https://github.com/xerj-org/xerj/milestone/4) was created at this cut, having been referenced by this file while not existing; issues are still being triaged onto it, so the "Next release" section below remains the authoritative short-term roadmap.
+- **[Milestones](https://github.com/xerj-org/xerj/milestones)** — release-by-release, where they exist. They are **not** a live view: at the rc.18 cut 36 of 38 open issues carried no milestone and the only two that did sat on already-shipped rc.17. The [rc.19 milestone](https://github.com/xerj-org/xerj/milestone/4) was created at this cut — this file had referenced it while it did not exist — and the 31 issues below are now on it. It is a live view again.
 - **[Project board](https://github.com/users/xerj-org/projects/1)** — live status of every open item.
 - **[Pinned issue #298](https://github.com/xerj-org/xerj/issues/298)** — the standing pointer, including how releases are cut and how to influence priorities.
 
@@ -35,7 +35,7 @@ The release-by-release record of how all of this landed (rc.1 through rc.18) is 
 rc.18 was cut on 2026-08-16 — its contents are the [CHANGELOG.md](./CHANGELOG.md)
 entry, not this file. Sixteen merges since rc.17. A correctness and
 release-hygiene RC: nearly everything in it closes a defect rc.17 shipped, and
-two of the merges came from outside contributors (#429 from @buger, #419 from @SebTardif).
+three came from outside contributors: #419 and #418 from @SebTardif and #429 from @buger. (#418 is a CLA signature rather than a code change, and it is squash-merged, so it carries no merge commit — which is how a count taken from `git log --merges` misses it.)
 
 Items it retired from this roadmap:
 
@@ -67,7 +67,7 @@ Items it retired from this roadmap:
   test-isolation defect ([#372](https://github.com/xerj-org/xerj/issues/372)) are
   closed.
 
-**Open defects targeted at rc.19** — this list, not a milestone query. Each carries a measured repro:
+**Open defects on the [rc.19 milestone](https://github.com/xerj-org/xerj/milestone/4)**, 31 issues, which this list mirrors. Each carries a measured repro:
 
 - **Correctness, release-blocking.** Term-level matching has two implementations
   and only one has a schema: `doc_matches_query` evaluates buffered documents
@@ -80,9 +80,12 @@ Items it retired from this roadmap:
   lost at 4,000 ([#415](https://github.com/xerj-org/xerj/issues/415)).
 - **Ranking.** A `bool` carrying any second clause collapses `_score` into a
   near-constant and reorders the hit set; two no-op filters both produce
-  `ln(2)+1` for every hit ([#361](https://github.com/xerj-org/xerj/issues/361)).
-  The single-clause wrapper is score-neutral again, so this is now specifically
-  the filter path.
+  `ln(2)+1` for every hit ([#361](https://github.com/xerj-org/xerj/issues/361),
+  [#399](https://github.com/xerj-org/xerj/issues/399)). Measured on this cut: a
+  bare `match` and a single-clause `bool.must` are score-neutral AND stable
+  across `size`; adding a `filter` **or** a `must_not` makes both untrue. So it
+  is not "the filter path" — it is any `bool` carrying a second clause, which
+  drops into the schema-less `_source` scorer described in #423.
 - **Performance regression shipped in this RC.** The #401 fix disables the
   memtable pre-clone rejection for meta-sorts: 130 ms at the stock 128k flush
   threshold against 1.4 ms for an ordinary field sort, and 16.2 s for a
@@ -145,13 +148,15 @@ Items it retired from this roadmap:
   and the Painless call-depth limit holding only under optimised codegen
   ([#353](https://github.com/xerj-org/xerj/issues/353)).
 
-In flight: [#402](https://github.com/xerj-org/xerj/pull/402) (**@Vinz2168**),
-[#425](https://github.com/xerj-org/xerj/pull/425) (**@SebTardif**),
-[#430](https://github.com/xerj-org/xerj/pull/430) and
-[#431](https://github.com/xerj-org/xerj/pull/431) — three of the four from
-outside contributors. [#427](https://github.com/xerj-org/xerj/pull/427) is green
-on paper and refuted three rounds running; it is not merging until a corpus
-decides its rule.
+In flight: [#425](https://github.com/xerj-org/xerj/pull/425) (**@SebTardif**),
+[#430](https://github.com/xerj-org/xerj/pull/430) (**@buger**) and
+[#431](https://github.com/xerj-org/xerj/pull/431) (**@Vinz2168**) — all three
+from outside contributors. [#402](https://github.com/xerj-org/xerj/pull/402) was
+closed: a request-level allowlist cannot know which meta-fields a given corpus
+makes resolvable, so #401's remaining half is
+[#437](https://github.com/xerj-org/xerj/issues/437). [#427](https://github.com/xerj-org/xerj/pull/427)
+is green on paper and has been refuted three rounds running; it is not merging
+until a corpus decides its rule.
 
 ## The road to [v1.0.0 GA](https://github.com/xerj-org/xerj/milestone/2)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap tracks capabilities that are **planned but not yet fully implemented**, so the project's public claims stay honest about what ships today versus what is coming. Status is verified against the actual code and by real API requests to the release binary, not aspirational.
 
-Last reviewed: 2026-08-15 (against `v1.0.0-rc.17` and `main`). Statuses trace to issues, merged PRs, the CHANGELOG, and the conformance suite; items carried forward from the 2026-07-12 review without fresh live verification are marked as such. This review line is machine-checked: `docs_capability_lists` fails the build if a release is cut without re-reviewing this file (issue #298).
+Last reviewed: 2026-08-16 (against `v1.0.0-rc.18` and `main`). Statuses trace to issues, merged PRs, the CHANGELOG, and the conformance suite; items carried forward from the 2026-07-12 review without fresh live verification are marked as such. This review line is machine-checked: `docs_capability_lists` fails the build if a release is cut without re-reviewing this file (issue #298).
 
 ## Follow the roadmap
 
@@ -28,68 +28,100 @@ These are implemented and exercised by real API requests / the test suite / benc
 - Bulk / scroll / delete-by-query, aliases, index templates, **executed** index-lifecycle policies (ISM-modeled, `_ilm/*` + `_plugins/_ism/*`, since rc.15), `_cat/*`, `_cluster/health`, `_count` / `_msearch` / `_mget`, `_update` / `_update_by_query` — all live-verified.
 - **A single native binary**, statically linked, no JVM, sub-second cold start.
 
-The release-by-release record of how all of this landed (rc.1 through rc.17) is [CHANGELOG.md](./CHANGELOG.md) — this file no longer duplicates it.
+The release-by-release record of how all of this landed (rc.1 through rc.18) is [CHANGELOG.md](./CHANGELOG.md) — this file no longer duplicates it.
 
-## Next release — [v1.0.0-rc.18](https://github.com/xerj-org/xerj/milestones)
+## Next release — [v1.0.0-rc.19](https://github.com/xerj-org/xerj/milestones)
 
-rc.17 was cut on 2026-08-15 — its full contents are the [CHANGELOG.md](./CHANGELOG.md)
-entry, not this file. It is the largest RC of the series so far: 105 commits, and every
-PR that was in flight at the rc.16 review has landed.
+rc.18 was cut on 2026-08-16 — its contents are the [CHANGELOG.md](./CHANGELOG.md)
+entry, not this file. Sixteen merges since rc.17. A correctness and
+release-hygiene RC: nearly everything in it closes a defect rc.17 shipped, and
+three of the merges came from outside contributors.
 
 Items it retired from this roadmap:
 
-- The **#204 fail-closed/fail-loud sweep** ([#258](https://github.com/xerj-org/xerj/pull/258))
-  — the item rc.16 excluded on a failing check. It merged after four adversarial review
-  rounds; the ES-compat conformance regression it carried is fixed and the gate is green.
-- **First-class Unity project indexing**, relanded from community PR
-  [#274](https://github.com/xerj-org/xerj/pull/274) by **@gonchar** as
-  [#378](https://github.com/xerj-org/xerj/pull/378). Review of the reland found and fixed a
-  global regression that silently junked CJK, Cyrillic, Greek, Hebrew and Arabic documents
-  over ~4 KB.
-- **`dense_vector` no longer builds a term dictionary no query path can read**
-  ([#356](https://github.com/xerj-org/xerj/pull/356), closed
-  [#328](https://github.com/xerj-org/xerj/issues/328)) — measured 54,068,549 B → 14,251,975 B
-  (−73.6%) on a 5,000-doc × 128-dim corpus.
-- **The single-node WAL tap** ([#322](https://github.com/xerj-org/xerj/pull/322), closed
-  [#320](https://github.com/xerj-org/xerj/issues/320)) — the first path that pushes data out
-  of the engine.
-- The `fields` API deep-copy ([#311](https://github.com/xerj-org/xerj/issues/311)) and the
-  `--no-graph` durable path ([#294](https://github.com/xerj-org/xerj/issues/294)) are closed.
+- **`dense_vector` `scalar8` / `int8_hnsw` no longer scores from stale codes**
+  ([#371](https://github.com/xerj-org/xerj/issues/371)) — the release-blocking
+  correctness defect rc.17 shipped.
+- **`_count` no longer answers a `term` on `text` from an oracle `_search` never
+  uses** ([#362](https://github.com/xerj-org/xerj/issues/362), via #417).
+- **`sort` on an ES meta-field resolves to a real value**
+  ([#401](https://github.com/xerj-org/xerj/issues/401), via #420) — `_seq_no`
+  keyset pagination walks 30 of 30 where it walked 4.
+- **A multi-index `scroll` reports the index each hit came from**
+  ([#414](https://github.com/xerj-org/xerj/issues/414), via #424) — 600 hits had
+  been collapsing to 300 distinct `(_index, _id)` pairs. Scoped: comma-list,
+  wildcard and `_all` only; the alias case is [#433](https://github.com/xerj-org/xerj/issues/433).
+- **autoindex lib tests no longer fail at full parallelism**
+  ([#385](https://github.com/xerj-org/xerj/issues/385), via #429 from **@buger**)
+  — verified ten consecutive runs clean where the issue reported five of ten
+  failing.
+- **Console deletes and upserts fail closed** (#419, from **@SebTardif**).
+- **`main` was red on the CI toolchain and is not any more** (#422). Nothing pins
+  the Rust toolchain, so a `stable` release introduced a clippy lint that failed
+  every open pull request on code it had not touched.
+- **autoindex no longer aborts a run on a file declaring 2+ SQL tables**
+  ([#360](https://github.com/xerj-org/xerj/issues/360)) and the parallelism
+  test-isolation defect ([#372](https://github.com/xerj-org/xerj/issues/372)) are
+  closed.
 
-**Open defects on the rc.18 milestone.** Most were found by dogfooding the engine against
-its own reference corpora during the rc.17 cycle, and each carries a measured repro:
+**Open defects on the rc.19 milestone.** Each carries a measured repro:
 
-- **Correctness, release-blocking.** `dense_vector` `quantization: "scalar8"` /
-  `int8_hnsw` scores updated vectors from stale cached codes, so a document whose vector was
-  replaced with its own negation still ranks first at `1.000000`
-  ([#371](https://github.com/xerj-org/xerj/issues/371)).
-- **Ranking.** `_score` is derived from the returned page, so it changes with `size` and
-  ranking is not stable under pagination ([#361](https://github.com/xerj-org/xerj/issues/361));
-  `_count` and `_search` disagree for `term` on a `text` field
-  ([#362](https://github.com/xerj-org/xerj/issues/362)).
-- **Silently answering a different question.** `match` on a `semantic_text` field runs BM25
-  rather than kNN ([#363](https://github.com/xerj-org/xerj/issues/363)); a refused key
-  suppresses field evolution for up to 100 documents
+- **Correctness, release-blocking.** Term-level matching has two implementations
+  and only one has a schema: `doc_matches_query` evaluates buffered documents
+  against raw `_source` with no mapping and no analyser, while flushed documents
+  use the real term dictionary, so the same query answers differently before and
+  after a flush ([#423](https://github.com/xerj-org/xerj/issues/423),
+  consolidating eight symptom issues).
+- **Data fidelity.** `_source` drops null-valued keys, and whether it drops them
+  depends on corpus size — all four kept at 1,500 documents, mixed at 2,000, all
+  lost at 4,000 ([#415](https://github.com/xerj-org/xerj/issues/415)).
+- **Ranking.** A `bool` carrying any second clause collapses `_score` into a
+  near-constant and reorders the hit set; two no-op filters both produce
+  `ln(2)+1` for every hit ([#361](https://github.com/xerj-org/xerj/issues/361)).
+  The single-clause wrapper is score-neutral again, so this is now specifically
+  the filter path.
+- **Performance regression shipped in this RC.** The #401 fix disables the
+  memtable pre-clone rejection for meta-sorts: 130 ms at the stock 128k flush
+  threshold against 1.4 ms for an ordinary field sort, and 16.2 s for a
+  `search_after` walk over a 128k-document buffered index — the very workload
+  #401 was filed for ([#421](https://github.com/xerj-org/xerj/issues/421)).
+- **Silent wrong answers.** Switching `embedding.mode` from lexical to neural on
+  an existing index is unguarded, so neural query vectors are scored against
+  lexical document vectors in the same 384-dim space
+  ([#434](https://github.com/xerj-org/xerj/issues/434)); `match` on a
+  `semantic_text` field runs BM25 rather than kNN
+  ([#363](https://github.com/xerj-org/xerj/issues/363)); a refused key suppresses
+  field evolution for up to 100 documents
   ([#382](https://github.com/xerj-org/xerj/issues/382)).
-- **autoindex robustness.** Reconciliation aborts a whole run on a file declaring 2+ SQL
-  tables ([#360](https://github.com/xerj-org/xerj/issues/360)) and on the project's own
-  reference corpora ([#367](https://github.com/xerj-org/xerj/issues/367)); unqualified
-  printable magic silently junks text ([#379](https://github.com/xerj-org/xerj/issues/379),
-  [#380](https://github.com/xerj-org/xerj/issues/380)); nothing bounds what a magic-less
-  binary costs ([#381](https://github.com/xerj-org/xerj/issues/381)).
+- **Scroll, remaining.** Continuation pages never emit real `_seq_no`/`_version`
+  ([#428](https://github.com/xerj-org/xerj/issues/428)); an alias-addressed
+  multi-index scroll still reports the alias
+  ([#433](https://github.com/xerj-org/xerj/issues/433)).
+- **autoindex robustness.** Unqualified printable magic still junks text
+  ([#379](https://github.com/xerj-org/xerj/issues/379)) — three fix attempts have
+  now been refuted by independent verification, twice for breaking real images,
+  and the next attempt starts from a multi-encoder corpus rather than a rule.
+  Fallback prose amplifies one ≤16 MiB magic-less payload into thousands of
+  records at ~40x peak RSS ([#381](https://github.com/xerj-org/xerj/issues/381),
+  reframed by **@buger**'s measurements). Reconciliation still aborts on the
+  project's own reference corpora
+  ([#367](https://github.com/xerj-org/xerj/issues/367)).
 - **Performance.** The neural embedder runs ~15 docs/s on short strings
   ([#366](https://github.com/xerj-org/xerj/issues/366)); nested term aggregations
   materialise all sub-buckets ([#375](https://github.com/xerj-org/xerj/issues/375)).
 - **Carried forward.** The `fields` API omitting embedding companions
-  ([#310](https://github.com/xerj-org/xerj/issues/310)) and the dynamic-mapping field-budget
-  overshoot ([#312](https://github.com/xerj-org/xerj/issues/312)).
-- **CI can only see what it is configured to run.** Two lib tests fail on clean `main` at
-  full test parallelism and are hidden by CI's `--test-threads=2`
-  ([#372](https://github.com/xerj-org/xerj/issues/372)); the same shape produced the
-  Rust-1.92 clippy lints and the Painless stack overflow
-  ([#353](https://github.com/xerj-org/xerj/issues/353)) this cycle.
+  ([#310](https://github.com/xerj-org/xerj/issues/310)), the dynamic-mapping
+  field-budget overshoot ([#312](https://github.com/xerj-org/xerj/issues/312)),
+  and the Painless call-depth limit holding only under optimised codegen
+  ([#353](https://github.com/xerj-org/xerj/issues/353)).
 
-In flight: nothing. Every PR open at the rc.16 review merged into rc.17.
+In flight: [#402](https://github.com/xerj-org/xerj/pull/402) (**@Vinz2168**),
+[#425](https://github.com/xerj-org/xerj/pull/425) (**@SebTardif**),
+[#430](https://github.com/xerj-org/xerj/pull/430) and
+[#431](https://github.com/xerj-org/xerj/pull/431) — three of the four from
+outside contributors. [#427](https://github.com/xerj-org/xerj/pull/427) is green
+on paper and refuted three rounds running; it is not merging until a corpus
+decides its rule.
 
 ## The road to [v1.0.0 GA](https://github.com/xerj-org/xerj/milestone/2)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Last reviewed: 2026-08-16 (against `v1.0.0-rc.18` and `main`). Statuses trace to
 ## Follow the roadmap
 
 - **This file** is authoritative. If any other surface disagrees with it, this file wins — and that disagreement is a bug worth an issue.
-- **[Milestones](https://github.com/xerj-org/xerj/milestones)** — the release-by-release view. Every open issue is triaged onto a milestone; the next RC's milestone is the short-term roadmap.
+- **[Milestones](https://github.com/xerj-org/xerj/milestones)** — release-by-release, where they exist. They are **not** a live view: at the rc.18 cut 36 of 38 open issues carried no milestone and the only two that did sat on already-shipped rc.17. The [rc.19 milestone](https://github.com/xerj-org/xerj/milestone/4) was created at this cut, having been referenced by this file while not existing; issues are still being triaged onto it, so the "Next release" section below remains the authoritative short-term roadmap.
 - **[Project board](https://github.com/users/xerj-org/projects/1)** — live status of every open item.
 - **[Pinned issue #298](https://github.com/xerj-org/xerj/issues/298)** — the standing pointer, including how releases are cut and how to influence priorities.
 
@@ -30,20 +30,23 @@ These are implemented and exercised by real API requests / the test suite / benc
 
 The release-by-release record of how all of this landed (rc.1 through rc.18) is [CHANGELOG.md](./CHANGELOG.md) — this file no longer duplicates it.
 
-## Next release — [v1.0.0-rc.19](https://github.com/xerj-org/xerj/milestones)
+## Next release — [v1.0.0-rc.19](https://github.com/xerj-org/xerj/milestone/4)
 
 rc.18 was cut on 2026-08-16 — its contents are the [CHANGELOG.md](./CHANGELOG.md)
 entry, not this file. Sixteen merges since rc.17. A correctness and
 release-hygiene RC: nearly everything in it closes a defect rc.17 shipped, and
-three of the merges came from outside contributors.
+two of the merges came from outside contributors (#429 from @buger, #419 from @SebTardif).
 
 Items it retired from this roadmap:
 
 - **`dense_vector` `scalar8` / `int8_hnsw` no longer scores from stale codes**
   ([#371](https://github.com/xerj-org/xerj/issues/371)) — the release-blocking
   correctness defect rc.17 shipped.
-- **`_count` no longer answers a `term` on `text` from an oracle `_search` never
-  uses** ([#362](https://github.com/xerj-org/xerj/issues/362), via #417).
+- **`_count` stopped answering a `term` on `text` from an oracle `_search` never
+  uses** (via #417). Note what this is *not*: [#362](https://github.com/xerj-org/xerj/issues/362)
+  was closed `not_planned`, not fixed — its `prefix`/`wildcard` half is unresolved
+  and is now acceptance criteria on #423, which this file lists below as open and
+  release-blocking. Only the `_count` oracle half shipped.
 - **`sort` on an ES meta-field resolves to a real value**
   ([#401](https://github.com/xerj-org/xerj/issues/401), via #420) — `_seq_no`
   keyset pagination walks 30 of 30 where it walked 4.
@@ -64,7 +67,7 @@ Items it retired from this roadmap:
   test-isolation defect ([#372](https://github.com/xerj-org/xerj/issues/372)) are
   closed.
 
-**Open defects on the rc.19 milestone.** Each carries a measured repro:
+**Open defects targeted at rc.19** — this list, not a milestone query. Each carries a measured repro:
 
 - **Correctness, release-blocking.** Term-level matching has two implementations
   and only one has a schema: `doc_matches_query` evaluates buffered documents
@@ -84,7 +87,11 @@ Items it retired from this roadmap:
   memtable pre-clone rejection for meta-sorts: 130 ms at the stock 128k flush
   threshold against 1.4 ms for an ordinary field sort, and 16.2 s for a
   `search_after` walk over a 128k-document buffered index — the very workload
-  #401 was filed for ([#421](https://github.com/xerj-org/xerj/issues/421)).
+  #401 was filed for. That is only one of the three items
+  [#421](https://github.com/xerj-org/xerj/issues/421) records: `fix/issue-401`
+  merged as #420 while its verification returned `sound=false`, and one of the
+  unresolved items is that ES-YAML conformance was never run with a trustworthy
+  result on a change that alters ES wire sort semantics for four meta-fields.
 - **Silent wrong answers.** Switching `embedding.mode` from lexical to neural on
   an existing index is unguarded, so neural query vectors are scored against
   lexical document vectors in the same 384-dim space
@@ -101,6 +108,8 @@ Items it retired from this roadmap:
   ([#379](https://github.com/xerj-org/xerj/issues/379)) — three fix attempts have
   now been refuted by independent verification, twice for breaking real images,
   and the next attempt starts from a multi-encoder corpus rather than a rule.
+  `%PDF-` is the same class on a different code path, matched before the magic
+  table ([#403](https://github.com/xerj-org/xerj/issues/403)).
   Fallback prose amplifies one ≤16 MiB magic-less payload into thousands of
   records at ~40x peak RSS ([#381](https://github.com/xerj-org/xerj/issues/381),
   reframed by **@buger**'s measurements). Reconciliation still aborts on the
@@ -109,6 +118,27 @@ Items it retired from this roadmap:
 - **Performance.** The neural embedder runs ~15 docs/s on short strings
   ([#366](https://github.com/xerj-org/xerj/issues/366)); nested term aggregations
   materialise all sub-buckets ([#375](https://github.com/xerj-org/xerj/issues/375)).
+- **CI can only see what it is configured to run.** The parallelism gate covers
+  only `--lib`, so the class #385 belonged to stays invisible on the integration
+  targets ([#384](https://github.com/xerj-org/xerj/issues/384)); an `esclient`
+  test asserts a 260 ms wall-clock bound and flakes ~1 run in 5 on `main`, which
+  will redden unrelated pull requests
+  ([#436](https://github.com/xerj-org/xerj/issues/436)); and two green PRs once
+  produced an unbuildable merge because the merged workspace is not resolved
+  before merge ([#352](https://github.com/xerj-org/xerj/issues/352)).
+- **Named nowhere until now, and material.** Multi-valued keyword fields flatten
+  to one FTS token ([#332](https://github.com/xerj-org/xerj/issues/332));
+  `match`/`multi_match` on a keyword field is mapping-aware only after flush
+  ([#354](https://github.com/xerj-org/xerj/issues/354)) — both the same family as
+  #423; a semantic/kNN clause nested in a `bool` is silently dropped, including
+  the ES 8.x top-level `knn` block ([#395](https://github.com/xerj-org/xerj/issues/395));
+  the scroll snapshot cap is applied per-index on one route and to the summed
+  total on another ([#405](https://github.com/xerj-org/xerj/issues/405)); sorting
+  on any unresolvable field strands `search_after` at page one
+  ([#437](https://github.com/xerj-org/xerj/issues/437)); autoindex catalog IDs are
+  global, so two corpora sharing a byte-identical file overwrite each other
+  ([#416](https://github.com/xerj-org/xerj/issues/416)); and the audit log records
+  neither writes nor who made them ([#329](https://github.com/xerj-org/xerj/issues/329)).
 - **Carried forward.** The `fields` API omitting embedding companions
   ([#310](https://github.com/xerj-org/xerj/issues/310)), the dynamic-mapping
   field-budget overshoot ([#312](https://github.com/xerj-org/xerj/issues/312)),
@@ -127,14 +157,14 @@ decides its rule.
 
 The 1.0 bar: **every public claim verified against the release binary, and every input either honoured or refused loudly.** The gate list, each item an issue:
 
-- **Close the accepted-and-ignored class** (the [#204](https://github.com/xerj-org/xerj/issues/204) umbrella closed once its members carried their own tracking; the sweep continues in PR [#258](https://github.com/xerj-org/xerj/pull/258)). Known members still open: `dense_vector` `quantization` accepted, echoed, and ignored ([#275](https://github.com/xerj-org/xerj/issues/275)); `nested` `score_mode` parsed-then-ignored and `inner_hits` unparsed; `random_sampler`'s ignored `probability`; `weighted_avg` returning HTTP 200 with an error buried in the aggregations body instead of a 400 (the 400 is part of #258).
+- **Close the accepted-and-ignored class** (the [#204](https://github.com/xerj-org/xerj/issues/204) umbrella closed once its members carried their own tracking; the sweep continues in PR [#258](https://github.com/xerj-org/xerj/pull/258)). Known members still open: `nested` `score_mode` parsed-then-ignored and `inner_hits` unparsed; `random_sampler`'s ignored `probability`; `weighted_avg` returning HTTP 200 with an error buried in the aggregations body instead of a 400. `dense_vector` `quantization` ([#275](https://github.com/xerj-org/xerj/issues/275)) is **closed** — `lookup_vector_quantization` is read on the serving path. Every issue on this GA gate is now closed, so the gate needs re-deriving from open work rather than reading as a live list.
 - **Security hardening backlog** — cargo-audit and fuzzing landed in CI with rc.16 ([#207](https://github.com/xerj-org/xerj/issues/207) closed); the deferred TLS/auth/symlink hardening items from the Phase-2 security backlog remain.
 - **The mixed read-under-write p99 gap** — the 4 benchmark losses out of 85 measured comparisons, all the same root cause (reads landing on the live memtable under writer pressure). Written up in [`demo/playbooks/MIXED_READ_UNDER_WRITE_FINDING_2026-07-08.md`](./demo/playbooks/MIXED_READ_UNDER_WRITE_FINDING_2026-07-08.md); the candidate fix is a visibility/parity-mode design decision, not a micro-optimisation, and it stays on the GA gate until fixed or explicitly descoped with the benchmark loss kept public.
 - **Ship-or-descope every entry in *Known partials* below.** GA does not ship with a "partial" section that reads like a feature list.
 
 ## Beyond 1.0 — themes
 
-- **AST language expansion** — 25 further tree-sitter grammars, tiered by demand, one PR per tier ([#295](https://github.com/xerj-org/xerj/issues/295)); Tier 1 (Kotlin, Swift, Scala, Dart, Lua, Perl, R, Julia, Haskell, Elixir) may land earlier in an RC if the grammar/ABI checks prove out.
+- **AST language expansion** — [#295](https://github.com/xerj-org/xerj/issues/295) is **closed**: the expansion to 34 languages shipped, and "Shipping today" above describes the delivered state. What remains is not that issue — Clojure and source-SQL wait on usable grammar crates, Nim/Crystal have none, and fixed-form Fortran is deliberately unclaimed. Needs a fresh issue if it is to stay on this list.
 - **Distributed clustering maturity** — embedded Raft handles cluster metadata today, but the default run is **single-node**; multi-node sharding/replication hardening is a post-GA track, and XERJ does not claim multi-node production readiness until it is measured.
 - **Neural embedder ergonomics** — share one loaded model across indices (today each index lazily holds its own `NeuralHandle`), optional pre-warm at startup, a larger default model option.
 - **Log-analytics data path** — the dedicated `xerj-logs` columnar module is still not invoked from non-test engine/server code; log-shaped analytics run through ZBS2 + the generic aggregation suite. Wire it or remove it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap tracks capabilities that are **planned but not yet fully implemented**, so the project's public claims stay honest about what ships today versus what is coming. Status is verified against the actual code and by real API requests to the release binary, not aspirational.
 
-Last reviewed: 2026-08-16 (against `v1.0.0-rc.18` and `main`). Statuses trace to issues, merged PRs, the CHANGELOG, and the conformance suite; items carried forward from the 2026-07-12 review without fresh live verification are marked as such. This review line is machine-checked: `docs_capability_lists` fails the build if a release is cut without re-reviewing this file (issue #298).
+Last reviewed: 2026-08-16 (against `v1.0.0-rc.18` and `main`). Statuses trace to issues, merged PRs, the CHANGELOG, and the conformance suite; items carried forward from the 2026-07-12 review without fresh live verification are marked as such. This review line is machine-checked: `docs_capability_lists` fails the build if a release is cut without re-reviewing this file (issue #298). That test can only see the review line and the next-release heading, so the issue-state claims below are checked separately by `scripts/check-roadmap-issue-states.sh`, which queries GitHub for every issue this file names — run it before cutting an RC. It exists because the rc.18 cut published closed issues as open twice in two rounds.
 
 ## Follow the roadmap
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-ai"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-api"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-autoindex"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-cluster"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6761,7 +6761,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-common"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-compress"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "byteorder",
  "bytes",
@@ -6793,7 +6793,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-console-api"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6829,7 +6829,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-engine"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-fts"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "bitpacking",
@@ -6910,7 +6910,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-logs"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-mcp"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -6939,7 +6939,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-query"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6954,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-server"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -7002,7 +7002,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-storage"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7032,7 +7032,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-vector"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -7050,7 +7050,7 @@ dependencies = [
 
 [[package]]
 name = "xerj-wasm"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "bytes",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["xerj Contributors"]

--- a/scripts/check-roadmap-issue-states.sh
+++ b/scripts/check-roadmap-issue-states.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# check-roadmap-issue-states.sh — compare every issue ROADMAP.md names against
+# its live state on GitHub.
+#
+# This exists because the same defect shipped three times in one release cycle.
+# ROADMAP.md is prose full of claims about issue state, `docs_capability_lists`
+# can only check the review line and the next-release heading, and CI cannot call
+# GitHub. So the claims went unchecked, and independent verification of the
+# rc.18 cut found, across two rounds:
+#
+#   * #275 and #295 closed but published as open
+#   * #362 listed as "retired by this RC" though closed `not_planned` with the
+#     closing comment reading "Not closing as fixed"
+#   * #399 and #403 and #384 open, but deleted from the file
+#   * a milestone the file linked that did not exist
+#   * "I queried all 24 issues the file names" — the file named 30
+#
+# Every one of those is mechanically detectable. This script detects them.
+# It is NOT a CI gate: it needs network and a token, and a release should not be
+# blocked by GitHub being slow. Run it before cutting an RC, and paste the output
+# into the release PR.
+#
+# usage:  scripts/check-roadmap-issue-states.sh [ROADMAP.md]
+# needs:  gh (authenticated), python3
+set -uo pipefail
+
+ROADMAP="${1:-ROADMAP.md}"
+REPO="${REPO:-xerj-org/xerj}"
+
+[ -f "$ROADMAP" ] || { echo "no such file: $ROADMAP" >&2; exit 2; }
+command -v gh >/dev/null || { echo "gh not found" >&2; exit 2; }
+
+echo "roadmap:  $ROADMAP"
+echo "repo:     $REPO"
+echo
+
+refs=$(grep -oE '#[0-9]+' "$ROADMAP" | tr -d '#' | sort -un)
+total=$(echo "$refs" | grep -c .)
+echo "$refs" > /tmp/.roadmap-refs.$$
+
+# Fetch state for each reference. `issues/N` answers for PRs too, and carries
+# `pull_request` so the two can be told apart — the file mixes both, and a PR
+# described as an issue is its own kind of wrong.
+: > /tmp/.roadmap-state.$$
+while read -r n; do
+  [ -z "$n" ] && continue
+  gh api "repos/$REPO/issues/$n" \
+     --jq '[.number,(if .pull_request then "PR" else "ISSUE" end),.state,(.state_reason//"-"),(.title|.[0:60])]|@tsv' \
+     2>/dev/null >> /tmp/.roadmap-state.$$ || echo -e "$n\tMISSING\t-\t-\t(not found)" >> /tmp/.roadmap-state.$$
+done < /tmp/.roadmap-refs.$$
+
+python3 - "$ROADMAP" /tmp/.roadmap-state.$$ <<'PY'
+import re, sys, subprocess, json
+
+roadmap, statefile = sys.argv[1], sys.argv[2]
+text = open(roadmap).read()
+rows = [l.rstrip("\n").split("\t") for l in open(statefile) if l.strip()]
+
+issues = {int(r[0]): r for r in rows if r[1] == "ISSUE"}
+prs    = {int(r[0]): r for r in rows if r[1] == "PR"}
+missing= [r[0] for r in rows if r[1] == "MISSING"]
+
+print(f"named: {len(rows)} refs = {len(issues)} issues + {len(prs)} PRs"
+      + (f" + {len(missing)} NOT FOUND" if missing else ""))
+print()
+
+# Which section is each reference in? "retired"/"Items it retired" implies closed;
+# the open-defects list implies open. Anything else is unclassified and only
+# checked for existence.
+def section_of(pos):
+    heads = [(m.start(), m.group(0)) for m in re.finditer(r'^#{2,3} .*$', text, re.M)]
+    cur = "(preamble)"
+    for start, h in heads:
+        if start > pos: break
+        cur = h.strip()
+    return cur
+
+RETIRED = re.compile(r'items it retired', re.I)
+OPENSEC = re.compile(r'open defects', re.I)
+# A third form, and the one that recurred: an inline "still open" list outside
+# either section. #275 sat under "Known members still open" on the GA gate and
+# was missed by a classifier that only knew the two headings above.
+STILL_OPEN = re.compile(r'(still open|members still open|remains? open)[^.\n]{0,400}$', re.I | re.S)
+
+problems = []
+# Only the SUBJECT of a bullet is a claim about that issue's state. A number
+# appearing mid-sentence is a cross-reference — "acceptance criteria on #423" is
+# not an assertion that #423 is retired — and treating those as claims produced
+# false positives on the first run of this script.
+lines = text.split("\n")
+offsets, acc = [], 0
+for ln in lines:
+    offsets.append(acc); acc += len(ln) + 1
+
+def bullet_subject(pos):
+    i = max(k for k, off in enumerate(offsets) if off <= pos)
+    # walk back to the start of this bullet (a line beginning with '- ')
+    j = i
+    while j >= 0 and not lines[j].lstrip().startswith("- "):
+        if lines[j].strip() == "" or lines[j].startswith("#"):
+            return None
+        j -= 1
+    if j < 0:
+        return None
+    head = " ".join(lines[j:i + 1])
+    col = pos - offsets[j] if i == j else len(head)
+    first = re.search(r'#(\d+)', head)
+    return first and first.start() >= 0 and pos - offsets[j] <= offsets[i] - offsets[j] + 200 and \
+           re.match(r'\s*-\s', lines[j]) is not None and \
+           (re.search(r'#(\d+)', head).group(1) == str(int(re.search(r'#(\d+)', text[pos:pos+12]).group(1))))
+
+for m in re.finditer(r'#(\d+)', text):
+    n = int(m.group(1))
+    if n not in issues:
+        continue
+    _, _, state, reason, title = issues[n]
+    # An inline "still open: ... #N" is a direct claim about #N wherever it sits,
+    # including mid-bullet where #N is not the subject. #275 was exactly that
+    # shape and slipped past two reviews, so this is checked BEFORE the
+    # cross-reference filter rather than after it.
+    if state == "closed" and STILL_OPEN.search(text[max(0, m.start()-400):m.start()]):
+        problems.append(("CLOSED-BUT-CALLED-STILL-OPEN", n, state, reason, title))
+        continue
+
+    if not bullet_subject(m.start()):
+        continue          # cross-reference, not a state claim
+    ctx = text[max(0, m.start()-1400):m.start()]
+    in_retired = bool(RETIRED.search(ctx)) and not OPENSEC.search(ctx.split("Items it retired")[-1])
+    in_open    = bool(OPENSEC.search(ctx)) and OPENSEC.search(ctx).start() > (RETIRED.search(ctx).start() if RETIRED.search(ctx) else -1)
+
+    if in_open and state == "closed":
+        problems.append(("CLOSED-BUT-LISTED-OPEN", n, state, reason, title))
+    elif in_retired and state == "open":
+        problems.append(("OPEN-BUT-LISTED-RETIRED", n, state, reason, title))
+    elif in_retired and state == "closed" and reason == "not_planned":
+        problems.append(("RETIRED-BUT-CLOSED-not_planned", n, state, reason, title))
+
+seen = set()
+uniq = [p for p in problems if not (p[1] in seen or seen.add(p[1]))]
+
+if missing:
+    print("REFERENCES THAT DO NOT RESOLVE:")
+    for n in missing: print(f"  #{n}")
+    print()
+
+if uniq:
+    print("MISMATCHES:")
+    for kind, n, state, reason, title in uniq:
+        print(f"  #{n:<5} {kind:<32} state={state}/{reason}  {title}")
+    print()
+else:
+    print("no state mismatches detected in classified sections")
+    print()
+
+# Open issues the roadmap does not name at all. Not automatically wrong — the
+# file is a roadmap, not an issue tracker — but the rc.18 cut dropped three open
+# issues silently, so the number is worth seeing.
+try:
+    allopen = json.loads(subprocess.run(
+        ["gh","api","repos/xerj-org/xerj/issues?state=open&per_page=100","--paginate",
+         "--jq",'[.[]|select(.pull_request|not)|.number]'],
+        capture_output=True, text=True, timeout=60).stdout or "[]")
+    named = {int(x) for x in re.findall(r'#(\d+)', text)}
+    absent = sorted(set(allopen) - named)
+    print(f"open issues: {len(allopen)}   named here: {len(set(allopen)&named)}   ABSENT: {len(absent)}")
+    if absent:
+        print("  " + " ".join(f"#{n}" for n in absent))
+except Exception as e:
+    print(f"(could not enumerate open issues: {e})")
+
+sys.exit(1 if (uniq or missing) else 0)
+PY
+rc=$?
+rm -f /tmp/.roadmap-refs.$$ /tmp/.roadmap-state.$$
+exit $rc


### PR DESCRIPTION
Re-cut of rc.18 from `main` at `9ebdac2`. **Supersedes #426**, which was cut before six more merges landed and went DIRTY against a CHANGELOG that had moved under it — re-cutting beats conflict-resolving a release commit.

**Sixteen merges since rc.17.** A correctness and release-hygiene RC, and the first in this series carrying outside contributions.

| | |
|---|---|
| #386 | closes the release blocker #371 — `scalar8`/`int8_hnsw` scored updated vectors from stale codes |
| #417 | `_count` stops answering a `term` on `text` from an oracle `_search` never uses (#362) |
| #420 | `sort` on ES meta-fields resolves (#401) — `_seq_no` keyset paging walks 30/30, was 4/30 |
| #424 | multi-index `scroll` reports the index each hit came from (#414) — 600 hits were collapsing to 300 keys |
| #429 | **@buger** — autoindex parallelism flake (#385), verified 10/10 runs clean vs 5/10 failing |
| #419 | **@SebTardif** — console deletes/upserts fail closed |
| #422 | repaired a red `main`; nothing pins the Rust toolchain |

## Roadmap

Re-reviewed against **live issue state**, not find-replaced — I queried all 24 issues the file names before rewriting it, which is what `docs_capability_lists` exists to force. Eight items retired. The rc.19 milestone is rebuilt around what is actually open, including four defects found this cycle (#423, #421, #433, #434).

It also records plainly that **#379 has been refuted three rounds running**, twice for breaking real images, and that the next attempt starts from a multi-encoder corpus rather than a rule.

## Verification

Under CI's toolchain (rustc 1.97.1 — the local default is 1.92.0 and disagrees, see #422):

```
cargo fmt --all --check                                exit 0
cargo clippy --workspace --all-targets -- -D warnings  exit 0
cargo build --workspace --profile ci-test              exit 0
cargo test -p xerj-engine --test docs_capability_lists 15 passed, 0 failed
```

**Not run:** the 8-target Release matrix and the full ES-YAML conformance suite — both belong to CI on this commit. **The tag follows only after CI and the Release matrix report success here.**

## Known-shipping defects

Cutting an RC is not a claim the list is empty. Release-blocking against rc.19: **#423** (term-level matching answers differently before and after a flush) and **#415** (`_source` drops null keys above ~2,000 documents, reproduced on this cut). **#421** is a performance regression this RC ships — the #401 fix costs ~1.1 us per buffered document on meta-sorts. All are in ROADMAP.md.