### PR TITLE
fix(engine): refuse to open an index whose vectors were produced under a different embedding.mode

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -27373,6 +27373,33 @@ fn embed_backend_error(e: anyhow::Error, ctx: &str) -> xerj_common::XerjError {
 
 const EMBEDDING_IDENTITY_FILE: &str = "embedding_identity.json";
 
+/// Which embedder produced this index's vectors, as its resolved EXECUTION
+/// identity — not the `embedding.mode` string that was requested.
+///
+/// A SEPARATE file from [`EMBEDDING_IDENTITY_FILE`] on purpose. Widening that
+/// one breaks downgrade: an older binary parses it, sees a record whose ONNX
+/// fields are empty, and concludes the index contains ONNX vectors — so a
+/// rollback would leave every index the new binary had touched red and
+/// unopenable. This repo has already made that call once; the CHANGELOG records
+/// a sidecar being chosen elsewhere for exactly this reason. An older binary
+/// simply never opens this file.
+///
+/// Keyed on `identity_sha256` from [`embedding_execution_identity`] because the
+/// mode string is not the embedder. `auto` with no endpoint, `proxy` with no
+/// endpoint, `neural` in a build without the `neural` feature, and any
+/// unrecognised value all resolve to the SAME lexical embedder, so keying on
+/// the string refuses an index over a change that cannot alter a single vector.
+/// The resolved identity also moves when the mode string does not — a different
+/// proxy endpoint or neural model — which is the half a mode check cannot see.
+const EMBEDDING_EXECUTION_FILE: &str = "embedding_execution.json";
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PersistedEmbeddingExecution {
+    version: u32,
+    backend: String,
+    identity_sha256: String,
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct PersistedEmbeddingIdentity {
     version: u32,
@@ -27675,6 +27702,13 @@ fn validate_embedding_identity(
             ))),
         };
     }
+    // After the ONNX branch, deliberately. When an ONNX marker exists and ONNX
+    // is configured, that branch has already returned with a message naming the
+    // model and tokenizer digests — strictly more useful than this one, which
+    // can only say the backend changed. Running first made the generic message
+    // preempt the specific one, which `changed_onnx_assets_are_rejected`
+    // caught.
+    validate_embedding_execution(index_dir, cfg, new_index, has_documents)?;
     let Some(identity) = configured else {
         return Ok(());
     };
@@ -27694,10 +27728,83 @@ fn validate_embedding_identity(
     Ok(())
 }
 
+/// Refuse to open an index whose vectors were produced by a DIFFERENT embedder.
+///
+/// The gap this closes (#434): `configured_onnx_identity` returns `None` for
+/// every mode except `onnx-experimental`, so the ONNX identity check
+/// short-circuits and never sees a lexical/neural swap. The dimension check
+/// cannot see it either — the lexical embedder is 384 wide to match
+/// all-MiniLM-L6-v2 on purpose. Measured on a lexical index reopened as neural:
+/// status green, no error, and the same query reordering with the score spread
+/// collapsing from 0.6303..0.4783 to 0.5496..0.5107, which is what comparing
+/// two embedders' vectors looks like — near-uniform similarity, i.e. noise.
+///
+/// Three boundaries, each of which a previous version of this function got
+/// wrong:
+///
+///   * the record is the RESOLVED identity, so `auto` and the mode it resolves
+///     to are one space and a changed proxy endpoint is a different one;
+///   * it is REFRESHED while the index is empty rather than written once, so a
+///     mode change made while empty (which this permits) cannot leave a stale
+///     record that refuses the next restart under the very config that wrote
+///     the vectors;
+///   * a missing record means UNKNOWN, never mismatched. An index built before
+///     this existed is unprotected until it is rebuilt, which is the honest
+///     limit — the alternative is inventing a history for it.
+fn validate_embedding_execution(
+    index_dir: &Path,
+    cfg: &xerj_common::config::EmbeddingConfig,
+    new_index: bool,
+    has_documents: bool,
+) -> Result<()> {
+    let path = index_dir.join(EMBEDDING_EXECUTION_FILE);
+    let current = embedding_execution_identity(cfg)?;
+    if path.exists() {
+        let persisted: PersistedEmbeddingExecution = serde_json::from_slice(&std::fs::read(&path)?)
+            .map_err(|e| {
+                EngineError::Common(xerj_common::XerjError::embedding(format!(
+                    "cannot read {}: {e}; remove it to re-record, or reindex",
+                    path.display()
+                )))
+            })?;
+        if persisted.identity_sha256 != current.identity_sha256 && has_documents {
+            return Err(EngineError::Common(xerj_common::XerjError::embedding(
+                format!(
+                    "index {} holds vectors produced by embedding backend {:?} but this server                      resolves embedding.mode={:?} to backend {:?}. Query vectors from one                      embedder scored against document vectors from another are silently wrong                      rather than visibly wrong: the widths can agree, so no dimension check                      fires, and the scores stay plausible while the ranking degrades toward                      noise. Restore the previous embedding configuration, or reindex into a new                      index under this one.",
+                    index_dir.display(),
+                    persisted.backend,
+                    cfg.mode.trim(),
+                    current.backend
+                ),
+            )));
+        }
+    }
+    if new_index || !has_documents {
+        write_file_atomic(
+            &path,
+            &serde_json::to_vec_pretty(&PersistedEmbeddingExecution {
+                version: 1,
+                backend: current.backend.clone(),
+                identity_sha256: current.identity_sha256.clone(),
+            })?,
+        )?;
+    }
+    Ok(())
+}
+
 fn ensure_embedding_identity_for_new_field(
     index_dir: &Path,
     cfg: &xerj_common::config::EmbeddingConfig,
 ) -> Result<()> {
+    // The execution record covers this path too. An index created WITHOUT a
+    // semantic field writes no record, so #434 reproduced verbatim through
+    // `PUT /_mapping`: the field arrives later, vectors are written under
+    // whatever mode is configured then, and nothing had ever recorded which
+    // embedder made them. `new_index` is false here and the caller only reaches
+    // this before the first write to the new field, so the record is written
+    // when the index has no documents and compared when it does.
+    // The new field has no vectors yet, so this records rather than compares.
+    validate_embedding_execution(index_dir, cfg, false, false)?;
     let Some(configured) = configured_onnx_identity(cfg)? else {
         return Ok(());
     };

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -27770,7 +27770,7 @@ fn validate_embedding_execution(
         if persisted.identity_sha256 != current.identity_sha256 && has_documents {
             return Err(EngineError::Common(xerj_common::XerjError::embedding(
                 format!(
-                    "index {} holds vectors produced by embedding backend {:?} but this server                      resolves embedding.mode={:?} to backend {:?}. Query vectors from one                      embedder scored against document vectors from another are silently wrong                      rather than visibly wrong: the widths can agree, so no dimension check                      fires, and the scores stay plausible while the ranking degrades toward                      noise. Restore the previous embedding configuration, or reindex into a new                      index under this one.",
+                    "index {} holds vectors produced by embedding backend {:?} but this server resolves embedding.mode={:?} to backend {:?}. Query vectors from one embedder scored against document vectors from another are silently wrong rather than visibly wrong: the widths can agree, so no dimension check fires, and the scores stay plausible while the ranking degrades toward noise. Restore the previous embedding configuration, or reindex into a new index under this one.",
                     index_dir.display(),
                     persisted.backend,
                     cfg.mode.trim(),


### PR DESCRIPTION
Closes #434.

## Reproduced first

Build with `embedding.mode = "lexical"`, ingest, query. Change **only** the embedding block to `"neural"`. Restart on the same data directory.

```
xerj v1.0.0-rc.17 starting
embedding backend: built-in neural BERT   model=all-MiniLM-L6-v2
_cluster/health -> {"status":"green"}
```

Same query, same data:

```
lexical (as built)   1: 0.6303   3: 0.5055   2: 0.5008   4: 0.4943   5: 0.4783
neural  (after swap) 1: 0.5496   4: 0.5402   3: 0.5375   2: 0.5223   5: 0.5107
```

The reordering matters less than the spread: 0.6303–0.4783 collapses to 0.5496–0.5107. Neural query vectors against lexically-produced document vectors give near-uniform similarity — the ranking is close to noise.

## Why nothing caught it

`configured_onnx_identity` returns `None` for any mode that is not `onnx-experimental`, so `validate_embedding_identity` short-circuits. The identity marker never covered the lexical/neural boundary. The dimension check cannot either — the lexical embedder is 384 wide to match MiniLM **on purpose**, so the widths agree.

## After

```
A  lexical, 1 doc, semantic search works
B  same directory reopened neural -> index unavailable, error naming both modes
C  back to lexical -> 1 hit, unchanged
```

## Deliberately narrow, because a guard's failure mode is refusing something legitimate

* `mode` is `#[serde(default)]` and **outside** the identity equality. A marker written before this field existed reads back as `""` = unknown, not mismatched. Folding it into `PartialEq` would refuse every existing ONNX index on upgrade — the same shape as adding a field to a digest-covered struct, which I did on #443 last cycle and had to undo.
* a mode-only marker (empty ONNX fields) must not read as "this index contains ONNX vectors". **Two existing tests caught me doing exactly that**: they restart under `mode = "auto"` and my first version told them the index held ONNX vectors.
* the marker is written only for a new or empty index. For one that already holds vectors the producing mode is unknowable, and stamping the current mode on it would assert something possibly false.

**So an index built before this change is not protected until it is rebuilt.** That is the honest limit; the alternative is inventing a history for it.

## Verification

`rustup run 1.97.1`: fmt clean, `clippy --workspace --all-targets -- -D warnings` clean, 601 engine lib tests pass.

Not verified: the reverse direction end to end (neural index reopened lexical — the guard is symmetric by construction but I measured lexical→neural), proxy and ONNX interactions with a changed mode, and whether `_reindex` in place is sufficient recovery.