### PR TITLE
docs: require operational recipe verification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,10 +31,11 @@
 - [ ] New ES-compatible behaviour has a matching YAML case under `engine/tests/es-compat-yaml/yaml/`
 - [ ] Docs updated if user-visible behaviour changed
 - [ ] For non-trivial changes: the applicable audit in [`docs/CONTRIBUTION_REVIEW.md`](../docs/CONTRIBUTION_REVIEW.md)
-- [ ] Operational docs/recipe audit records ordered success and failure execution,
-  lifecycle/readiness/cleanup, persistent-data transitions/reindex,
-  generated-copy propagation, and the scoped verifier (or explicitly records it
-  as not applicable)
+- [ ] Operational docs/recipe audit is complete: it records ordered success and
+  failure execution, lifecycle/readiness/cleanup, persistent-data
+  transitions/reindex, generated-copy propagation, and the declared
+  inventory/completeness scope; each inapplicable item is marked `N/A` with a
+  reason.
 
 **Not run:** <!-- name any check above you skipped, and why. This is expected and fine; hiding it is not. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,10 @@
 - [ ] New ES-compatible behaviour has a matching YAML case under `engine/tests/es-compat-yaml/yaml/`
 - [ ] Docs updated if user-visible behaviour changed
 - [ ] For non-trivial changes: the applicable audit in [`docs/CONTRIBUTION_REVIEW.md`](../docs/CONTRIBUTION_REVIEW.md)
+- [ ] Operational docs/recipe audit records ordered success and failure execution,
+  lifecycle/readiness/cleanup, persistent-data transitions/reindex,
+  generated-copy propagation, and the scoped verifier (or explicitly records it
+  as not applicable)
 
 **Not run:** <!-- name any check above you skipped, and why. This is expected and fine; hiding it is not. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,11 +31,7 @@
 - [ ] New ES-compatible behaviour has a matching YAML case under `engine/tests/es-compat-yaml/yaml/`
 - [ ] Docs updated if user-visible behaviour changed
 - [ ] For non-trivial changes: the applicable audit in [`docs/CONTRIBUTION_REVIEW.md`](../docs/CONTRIBUTION_REVIEW.md)
-- [ ] Operational docs/recipe audit is complete: it records ordered success and
-  failure execution, lifecycle/readiness/cleanup, persistent-data
-  transitions/reindex, generated-copy propagation, and the declared
-  inventory/completeness scope; each inapplicable item is marked `N/A` with a
-  reason.
+- [ ] For non-trivial changes: if this PR changes an operational document or runnable recipe, complete the operational audit in [`docs/CONTRIBUTION_REVIEW.md`](../docs/CONTRIBUTION_REVIEW.md). Record a negative control that exits non-zero with no artifact extracted, installed, published, or served. Keep verification and its action in one block; rerun the control with the failing exit discarded and with the next documented block appended, and require that neither reaches an artifact or unsafe/privileged path. List tested variants and unsupported variants separately, and verify every publication copy. Otherwise mark this item `N/A` with a reason.
 
 **Not run:** <!-- name any check above you skipped, and why. This is expected and fine; hiding it is not. -->
 

--- a/docs/CONTRIBUTION_REVIEW.md
+++ b/docs/CONTRIBUTION_REVIEW.md
@@ -60,7 +60,7 @@ product does not implement.
 
 When a document is published through multiple paths, trace the publication
 topology from its source through generated pages, indexes, navigation, and
-agent-facing copies. Reuse the repository release verifier for shipped-artifact
+agent-facing copies. Reuse `scripts/verify-release.sh` for shipped-artifact
 claims rather than replacing it with a partial check. For docs-only changes,
 run the scoped documentation/link/render verifier and record Cargo and ES-YAML
 as not applicable; do not imply that an unrelated engine suite validated prose.

--- a/docs/CONTRIBUTION_REVIEW.md
+++ b/docs/CONTRIBUTION_REVIEW.md
@@ -34,36 +34,21 @@ If behavior must become fail-closed, refuse only the unsafe case. Name what was 
 
 ## Operational documentation and runnable recipes
 
-Treat every shell, TOML, systemd, configuration, and copy-paste command in a
-recipe as a program, not illustrative prose. Execute the ordered success path
-and a deliberate negative control (for example, a bad checksum, missing
-artifact, or disallowed egress) and verify that the unsafe path fails closed
-before extraction, publication, or service exposure. Record the observed exit
-status and recovery command.
+Treat every shell, TOML, systemd, configuration, and copy-paste command in a recipe as a program, not illustrative prose. Execute the ordered success path and a deliberate negative control, such as a bad checksum, missing artifact, or disallowed egress. A negative path fails closed only when the recipe exits non-zero and no artifact is extracted, installed, published, or served. Record the observed exit status, the state at refusal, and the recovery command, and prove that recovery succeeds.
 
-Exercise the process lifecycle: startup, readiness/health, the first real
-operation, graceful stop, cleanup, port release, and restart from the same
-state. For persistent configuration or data, test fresh state, an existing
-state, migration/reindex requirements, unchanged rerun, and the documented
-recovery or rollback transition; distinguish what is preserved from what is
-discarded.
+A runnable block that verifies an artifact must also be the block that acts on it. Do not hand off through a filesystem path between a verifying block and a privileged block.
 
-Make inventories honest. Separate shipped artifacts from source templates and
-generated copies, and state whether a count means files, pages, variants, link
-elements, requests, routes, or something else. For completeness claims, audit
-the declared universe (all, only, none, or no-egress variants), state the tested
-and unsupported feature, platform, transport, and fallback variants, list
-excluded targets, and verify every publication copy. Document mitigations that
-are executable in the stated environment—firewall policy, source rebuild,
-service hardening, or a verified release check—not a runtime workaround the
-product does not implement.
+Run each negative control in two additional compositions: one that discards the failing block's exit status, and one that appends the next documented block. In both compositions, require that no artifact is extracted, installed, published, or served and that no unsafe or privileged path is reached.
 
-When a document is published through multiple paths, trace the publication
-topology from its source through generated pages, indexes, navigation, and
-agent-facing copies. Reuse `scripts/verify-release.sh` for shipped-artifact
-claims rather than replacing it with a partial check. For docs-only changes,
-run the scoped documentation/link/render verifier and record Cargo and ES-YAML
-as not applicable; do not imply that an unrelated engine suite validated prose.
+For every directory or path a recipe reads or writes, name the trust boundary and who can write there. Treat an untrusted staging tree as attacker-controlled: assume an attacker can pre-create any path the recipe will use, including a path whose name is derived from a published digest. Create scratch space outside that tree, exercise the negative control with attacker-precreated paths already present, and verify the refusal state.
+
+Exercise the process lifecycle: startup, readiness/health, the first real operation, graceful stop, cleanup, port release, and restart from the same state. For persistent configuration or data, test fresh state, existing state, migration/reindex requirements, an unchanged rerun, and the documented recovery or rollback transition; distinguish what is preserved from what is discarded.
+
+Give every count an explicit unit, such as files, pages, variants, link elements, requests, or routes. If a claim says “all X”, “only X”, or “no X”, define X as a concrete set and enumerate its members. List exclusions. State which feature, platform, transport, and fallback variants were tested. Separately list every unsupported variant. Verify every publication copy.
+
+Document a concrete mitigation that is executable in the stated environment, such as a firewall rule paired with a negative egress probe, a source-rebuild command, or a service-hardening setting. Do not recommend a runtime switch or workaround that the product does not implement.
+
+When a document is published through multiple paths, trace the publication topology from its source through generated pages, indexes, navigation, and agent-facing copies. For claims about an already-published release, reuse `scripts/verify-release.sh`; it does not validate an unpublished pull request or an offline recipe.
 
 ## Durable state is not invocation state
 
@@ -247,6 +232,7 @@ Review this contribution against current upstream main, not only its tip commit.
 8. Reproduce performance/resource claims with matched builds, fixed inputs, repeated runs, correctness gates, raw evidence, and explicit workload boundaries.
 9. Inspect errors and help text for cause, state-change disclosure, exact recovery commands, related help, and agent-readable structure.
 10. Exercise ambiguous and equal-best durable-state/schema matches; prove incidental iteration or lexical order cannot silently choose the winner. List findings by severity, every section judged not applicable with a reason, explicit known gaps, and everything not verified. Do not infer completion from green unrelated tests.
+11. For every operational document or runnable recipe, execute the ordered success path and at least one negative control; require a non-zero exit with no artifact extracted, installed, published, or served; keep artifact verification and the action it authorizes in one runnable block with no filesystem handoff to a privileged block; rerun each negative control once with the failing block's exit status discarded and once with the next documented block appended, requiring that neither composition reaches an artifact or unsafe/privileged path; exercise lifecycle and recovery; identify path trust boundaries, attacker-precreated paths, and scratch space outside untrusted staging; enumerate completeness sets and exclusions; state which feature, platform, transport, and fallback variants were tested; separately list every unsupported variant; verify every publication copy and the documented mitigation.
 ```
 
 ## Evidence table
@@ -256,6 +242,7 @@ Include a table like this in the PR body or review record. Add or remove rows to
 | Claim or invariant | Authoritative source | Test or reproduction | Mutation / negative control | Result on final head | Evidence location | Known gap |
 |---|---|---|---|---|---|---|
 | Example: refusal happens before mutation | journal, snapshots, remote read-back | real HTTP refusal and recovery test | disable preflight guard | Pass: mutation is detected before writes | repository path or CI job | concurrent refusal not exercised |
+| Example: operational recipe fails closed at an untrusted staging boundary | recipe block boundaries, path ownership, publication topology | run the success path and confirm the verifying block also acts on the artifact | as the staging writer, pre-create a digest-derived destination; run the negative control once with the failing block's exit status discarded and once with the next documented block appended | Pass: neither composition extracts, installs, publishes, or serves an artifact or reaches an unsafe/privileged path; recovery succeeds | repository script or CI job | unsupported platforms are enumerated |
 |  |  |  |  |  |  |  |
 
 Evidence is useful only when another contributor can inspect or reproduce it. Prefer committed fixtures, scripts, CI jobs, and concise raw outputs over claims that depend on a private workstation path.

--- a/docs/CONTRIBUTION_REVIEW.md
+++ b/docs/CONTRIBUTION_REVIEW.md
@@ -32,6 +32,39 @@ At minimum, consider:
 
 If behavior must become fail-closed, refuse only the unsafe case. Name what was detected, state whether remote or durable state changed, and give an executable recovery route. Test that the recovery route actually works; an error that merely says “retry” or recommends a now-rejected flag is not a recovery contract.
 
+## Operational documentation and runnable recipes
+
+Treat every shell, TOML, systemd, configuration, and copy-paste command in a
+recipe as a program, not illustrative prose. Execute the ordered success path
+and a deliberate negative control (for example, a bad checksum, missing
+artifact, or disallowed egress) and verify that the unsafe path fails closed
+before extraction, publication, or service exposure. Record the observed exit
+status and recovery command.
+
+Exercise the process lifecycle: startup, readiness/health, the first real
+operation, graceful stop, cleanup, port release, and restart from the same
+state. For persistent configuration or data, test fresh state, an existing
+state, migration/reindex requirements, unchanged rerun, and the documented
+recovery or rollback transition; distinguish what is preserved from what is
+discarded.
+
+Make inventories honest. Separate shipped artifacts from source templates and
+generated copies, and state whether a count means files, pages, variants, link
+elements, requests, routes, or something else. For completeness claims, audit
+the declared universe (all, only, none, or no-egress variants), state the tested
+and unsupported feature, platform, transport, and fallback variants, list
+excluded targets, and verify every publication copy. Document mitigations that
+are executable in the stated environment—firewall policy, source rebuild,
+service hardening, or a verified release check—not a runtime workaround the
+product does not implement.
+
+When a document is published through multiple paths, trace the publication
+topology from its source through generated pages, indexes, navigation, and
+agent-facing copies. Reuse the repository release verifier for shipped-artifact
+claims rather than replacing it with a partial check. For docs-only changes,
+run the scoped documentation/link/render verifier and record Cargo and ES-YAML
+as not applicable; do not imply that an unrelated engine suite validated prose.
+
 ## Durable state is not invocation state
 
 Treat a resume journal, sealed snapshot, mapping, catalog document, index, or generation marker as authority. Treat counters, temporary files, process IDs, clocks, caches, and in-memory collections as invocation-local unless explicitly persisted.


### PR DESCRIPTION
Written by an AI coding agent (OpenAI Codex), run by @buger; human review of the follow-up commit is pending.

## What this changes, and why

Adds an operational-documentation and runnable-recipe audit to `docs/CONTRIBUTION_REVIEW.md` and a scoped checkbox to `.github/PULL_REQUEST_TEMPLATE.md`. The checkbox starts with `For non-trivial changes:` so typo-only and unrelated changes are exempt; applicable changes must satisfy the same fail-closed, tested-versus-unsupported, publication-copy, and explicit `N/A` criteria as the protocol.

PRs #430 and #441 showed that a plausible success path and an accidental-corruption test were not enough. A recipe also needs binary refusal criteria, explicit path trust boundaries, an adversarial pre-created-path test, lifecycle and recovery evidence, enumerable completeness claims, and verification of every published copy.

The guidance now requires:

- a negative path that exits non-zero and leaves no artifact extracted, installed, published, or served;
- artifact verification and the action it authorizes in the same runnable block, with no filesystem handoff to a privileged block;
- each negative control rerun once with the failing block's exit status discarded and once with the next documented block appended, with neither composition allowed to reach an artifact or unsafe/privileged path;
- trust boundaries and writers for every path, with attacker-precreated digest-derived paths and scratch space outside untrusted staging;
- startup, readiness, a real operation, stop, cleanup, port release, restart, persistent-state transitions, and recovery;
- an explicit unit for every count and an enumerated set for every “all”, “only”, or “no” claim, including exclusions and every publication copy;
- a statement of which feature, platform, transport, and fallback variants were tested, followed by a separate list of every unsupported variant;
- a concrete executable mitigation rather than a product capability that does not exist;
- `scripts/verify-release.sh` only for claims about an already-published release;
- an eleventh item in the copy-paste audit prompt and a matching operational evidence-table example.
- a readable, falsifiable operational checkbox scoped to non-trivial changes.

This contribution is independent and has no prerequisite or merge-order dependency.

Refs #430 and #441.

## Verified

- Final local head: `396afc69cde0dc63205f60e9b2aa57f10c1e223c` (`docs: make operational review criteria falsifiable`), on top of the two existing PR commits.
- Current `upstream/main` base and merge-base: `8d7fc764040a2473a0c99729c11a30215e7c5639`.
- The final effective diff contains exactly `.github/PULL_REQUEST_TEMPLATE.md` and `docs/CONTRIBUTION_REVIEW.md`.
- `git diff --check upstream/main...HEAD` passed.
- Relative links resolve, every evidence-table row has the expected column count, and the fenced audit prompt contains exactly items 1 through 11.
- The template contains eight standard GFM task-list items. The operational item begins with `For non-trivial changes:`, repeats the non-zero/no-extraction-or-exposure criterion, keeps verification and action in one block, requires both negative-control compositions to avoid artifact and unsafe/privileged paths, lists tested and unsupported variants separately, requires every publication copy, and provides an explicit `N/A` route.
- The operational section uses one physical line per paragraph, matching the surrounding file.
- Required-phrase checks passed for non-zero refusal with no artifact extracted, installed, published, or served; same-block verification and action; no filesystem handoff to a privileged block; discarded-exit and next-block-appended negative-control compositions; no artifact or unsafe/privileged path reached in either composition; attacker-controlled staging; digest-derived paths; scratch outside staging; explicit count units; enumerated completeness sets and exclusions; tested feature/platform/transport/fallback variants; a separate list of every unsupported variant; publication copies; concrete mitigations; and already-published release scope.
- Negative searches found no nonexistent scoped docs verifier instruction, “Make inventories honest” wording, ambiguous tested-versus-unsupported phrasing, stale fail-closed criterion, or unconditional operational checkbox.
- All three commits are authored as `buger <leonsbox@gmail.com>`, contain full commit bodies, and have no `Co-Authored-By` trailer.

## Assumed

- GitHub will render the standard Markdown headings, lists, fenced block, and table as inspected in source; no browser-renderer snapshot was available locally.

## Not run

- Cargo build, Cargo test, Clippy, and ES-YAML were not run because the final effective change is review guidance only and has no engine, wire-protocol, or runtime behavior.
- No product or release-artifact execution was run because this change does not modify a recipe or a shipped artifact.

## Review feedback addressed

The follow-up removes the unsatisfiable verifier instruction, scopes the release verifier correctly, defines fail-closed evidence, requires same-block verification and action, tests negative controls under discarded-exit and appended-next-block composition, adds the staging-path adversary model, replaces subjective inventory language with enumerable criteria, makes mitigations concrete, matches the file’s one-line paragraph style, exposes the operational audit through both the copy-paste prompt and evidence table, and restores the owner-requested checkbox with an explicit `For non-trivial changes:` scope.
