### PR TITLE
fix(es-compat): a multi-index alias answered as an alias over one member on every read path

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8605,7 +8605,17 @@ async fn search_impl(
         .map(|n| resolve_date_math_index(n.trim()))
         .collect();
     let raw_names: Vec<&str> = resolved_names_owned.iter().map(|s| s.as_str()).collect();
-    let needs_resolve = raw_names.iter().any(|n| *n == "_all" || n.contains('*'));
+    // An ALIAS also needs resolving, and used not to be counted here — which is
+    // why a multi-index alias behaved as an alias over one member on every read
+    // path (#433). `_count` and plain `_search` truncated the same way: three
+    // indices of 40 documents behind one alias answered 40, from the first
+    // member, with no error and a `_count` that agreed with the short result.
+    // The `_index`-stamping problem reported alongside it is downstream of this
+    // — the hits could not carry the right index because the other indices were
+    // never searched.
+    let needs_resolve = raw_names
+        .iter()
+        .any(|n| *n == "_all" || n.contains('*') || state.engine.aliases.contains_key(*n));
     let index_names: Vec<String> = if needs_resolve {
         let all = state.engine.list_indices().await;
         let all_names: Vec<String> = all.into_iter().map(|i| i.name).collect();
@@ -8620,6 +8630,16 @@ async fn search_impl(
             } else if pattern.contains('*') {
                 for name in &all_names {
                     if glob_match_simple(pattern, name) && !resolved.contains(name) {
+                        resolved.push(name.clone());
+                    }
+                }
+            } else if let Some(targets) = state.engine.aliases.get(*pattern) {
+                // Expand to the concrete members, exactly as
+                // `resolve_index_selector` already does for every other
+                // endpoint. An alias naming one index resolves to that one, so
+                // the single-member case is unchanged.
+                for name in targets.value() {
+                    if !resolved.contains(name) {
                         resolved.push(name.clone());
                     }
                 }
@@ -17951,7 +17971,24 @@ pub async fn count_docs(
     body: OptionalJson<Value>,
 ) -> impl IntoResponse {
     // Multi-index / all selector: sum counts from every participating index.
-    if index == "_all" || index == "*" || index.contains(',') || index.contains('*') {
+    //
+    // An ALIAS belongs in this branch too. It used not to, so a multi-index
+    // alias fell through to the single-index path and answered one member's
+    // count — three indices of 40 documents behind one alias reported 40, with
+    // no error (#433). This is a THIRD copy of the same resolution, alongside
+    // `resolve_index_selector` and the one inside `search_impl`; they disagreed
+    // about aliases in different ways, which is why `_search` and `_count`
+    // could give different answers for the same selector.
+    let alias_selector = index
+        .split(',')
+        .map(str::trim)
+        .any(|n| state.engine.aliases.contains_key(n));
+    if index == "_all"
+        || index == "*"
+        || index.contains(',')
+        || index.contains('*')
+        || alias_selector
+    {
         let all = state.engine.list_indices().await;
         let all_names: Vec<String> = all.into_iter().map(|i| i.name).collect();
         let wanted: Vec<String> = if index == "_all" || index == "*" {
@@ -17963,6 +18000,12 @@ pub async fn count_docs(
                 if pat.contains('*') {
                     for n in &all_names {
                         if glob_match_simple(pat, n) && !out.contains(n) {
+                            out.push(n.clone());
+                        }
+                    }
+                } else if let Some(targets) = state.engine.aliases.get(pat) {
+                    for n in targets.value() {
+                        if !out.contains(n) {
                             out.push(n.clone());
                         }
                     }

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -18023,11 +18023,35 @@ pub async fn count_docs(
             }
             out
         };
-        let has_query = body
-            .as_ref()
-            .and_then(|b| b.get("query"))
-            .map(|q| !q.is_null())
-            .unwrap_or(false);
+        // Alias filters, collected from the selector AS WRITTEN. Expanding an
+        // alias to its members and summing their raw document counts answers
+        // the unfiltered corpus — for a filtered alias that is not a smaller
+        // wrong answer than before, it is a LARGER one, and it made `_count`
+        // disagree with `_search` in the opposite direction. A filtered alias
+        // is the usual poor-man's document boundary, so the count has to be of
+        // what the alias exposes.
+        let mut alias_filters: Vec<Value> = Vec::new();
+        for part in index.split(',').map(str::trim) {
+            for entry in state.engine.aliases.iter() {
+                if entry.key() != part {
+                    continue;
+                }
+                for backing in entry.value().iter() {
+                    if let Some(meta) = state.engine.index_alias_metadata.get(backing) {
+                        if let Some(filter) = meta.get(part).and_then(|v| v.get("filter")).cloned()
+                        {
+                            alias_filters.push(filter);
+                        }
+                    }
+                }
+            }
+        }
+        let has_query = !alias_filters.is_empty()
+            || body
+                .as_ref()
+                .and_then(|b| b.get("query"))
+                .map(|q| !q.is_null())
+                .unwrap_or(false);
         // A refused query is not a zero. This loop used to run the search under
         // `if let Ok(..)` with no else, so an index whose mapping refuses the
         // query — a `match` on an `"index": false` field, say — contributed
@@ -18060,6 +18084,14 @@ pub async fn count_docs(
                     .and_then(|b| b.get("query"))
                     .cloned()
                     .unwrap_or(json!({ "match_all": {} }));
+                if !alias_filters.is_empty() {
+                    query_val = json!({
+                        "bool": {
+                            "must": [query_val],
+                            "filter": alias_filters.clone(),
+                        }
+                    });
+                }
                 // Resolve `terms` lookups exactly as `_search` does — without
                 // this, `_count` silently returned 0 for a filter that
                 // `_search` counts correctly (the parser sees the raw lookup

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -9180,15 +9180,23 @@ async fn search_impl(
     // filter. The combined filter is also handed to run_aggs via the
     // background corpus (covered by the query's filter path already).
     {
+        // Built from the names as WRITTEN, not from `index_names`. Expanding
+        // an alias to its concrete members (#433) removes the alias name from
+        // that list, and this lookup matches on the alias name — so reading it
+        // from the expanded list silently dropped every filtered alias's
+        // filter. `global_with_aliases.yml` caught exactly that.
         let mut alias_filters: Vec<Value> = Vec::new();
-        for name in &index_names {
+        for name in &resolved_names_owned {
             for entry in state.engine.aliases.iter() {
                 if entry.key() != name {
                     continue;
                 }
                 for backing in entry.value().iter() {
                     if let Some(meta) = state.engine.index_alias_metadata.get(backing) {
-                        if let Some(filter) = meta.get(*name).and_then(|v| v.get("filter")).cloned()
+                        if let Some(filter) = meta
+                            .get(name.as_str())
+                            .and_then(|v| v.get("filter"))
+                            .cloned()
                         {
                             alias_filters.push(filter);
                         }

--- a/engine/crates/xerj-api/tests/alias_multi_index_reads.rs
+++ b/engine/crates/xerj-api/tests/alias_multi_index_reads.rs
@@ -44,7 +44,10 @@ async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (Sta
     let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
-    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
 }
 
 const PER_INDEX: usize = 40;
@@ -163,7 +166,10 @@ async fn a_scroll_through_an_alias_walks_every_member_and_labels_each_hit() {
             hits.push((
                 h["_index"].as_str().unwrap_or_default().to_string(),
                 h["_id"].as_str().unwrap_or_default().to_string(),
-                h["_source"]["home"].as_str().unwrap_or_default().to_string(),
+                h["_source"]["home"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
             ));
         }
         let Some(id) = sid.clone() else { break };

--- a/engine/crates/xerj-api/tests/alias_multi_index_reads.rs
+++ b/engine/crates/xerj-api/tests/alias_multi_index_reads.rs
@@ -1,0 +1,203 @@
+//! Issue #433: a multi-index alias answered as an alias over ONE member on
+//! every read path.
+//!
+//! Three indices behind one alias, 40 documents each. `GET /_alias/kb` listed
+//! all three, and `_count`, `_search` and a scroll through the alias all
+//! answered 40 — from the first member, with no error and a count that agreed
+//! with the short result. Not a keyed consumer silently keeping a fraction:
+//! every consumer got a fraction.
+//!
+//! The cause was three independent copies of index-selector resolution.
+//! `resolve_index_selector` expanded aliases; `search_impl`'s own resolver only
+//! looked for `_all` and `*`; `count_docs` gated its whole multi-index branch on
+//! the same two plus a comma or a star. A plain alias fell through both.
+//!
+//! These go through the real HTTP routes because that is the only place the
+//! three resolvers meet.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+}
+
+const PER_INDEX: usize = 40;
+
+async fn seed(app: &axum::Router) {
+    for member in ["kb-a", "kb-b", "kb-c"] {
+        let (st, _) = call(
+            app,
+            "PUT",
+            &format!("/{member}"),
+            json!({"mappings": {"properties": {"v": {"type": "long"}, "home": {"type": "keyword"}}}}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "create {member}");
+
+        let mut bulk = String::new();
+        for i in 0..PER_INDEX {
+            bulk.push_str(&format!("{}\n", json!({"index": {"_id": i.to_string()}})));
+            bulk.push_str(&format!("{}\n", json!({"v": i, "home": member})));
+        }
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/{member}/_bulk"))
+                    .header("content-type", "application/x-ndjson")
+                    .body(Body::from(bulk))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "bulk {member}");
+        let (st, _) = call(app, "POST", &format!("/{member}/_refresh"), Value::Null).await;
+        assert_eq!(st, StatusCode::OK);
+    }
+    let (st, _) = call(
+        app,
+        "POST",
+        "/_aliases",
+        json!({"actions": [
+            {"add": {"index": "kb-a", "alias": "kb"}},
+            {"add": {"index": "kb-b", "alias": "kb"}},
+            {"add": {"index": "kb-c", "alias": "kb"}},
+            {"add": {"index": "kb-a", "alias": "solo"}}
+        ]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create aliases");
+}
+
+/// `_count` and `_search` must see every member, and a one-member alias must
+/// keep answering for exactly that member.
+#[tokio::test]
+async fn every_read_path_through_a_multi_index_alias_sees_every_member() {
+    let (app, _dir) = app().await;
+    seed(&app).await;
+    let all = (PER_INDEX * 3) as u64;
+
+    let (_, count) = call(&app, "GET", "/kb/_count", Value::Null).await;
+    assert_eq!(
+        count["count"].as_u64(),
+        Some(all),
+        "_count through the alias must cover all three members: {count}"
+    );
+
+    let (_, search) = call(
+        &app,
+        "POST",
+        "/kb/_search",
+        json!({"query": {"match_all": {}}, "size": 0}),
+    )
+    .await;
+    assert_eq!(
+        search["hits"]["total"]["value"].as_u64(),
+        Some(all),
+        "_search through the alias must cover all three members: {search}"
+    );
+
+    // The single-member case is the one a narrowing fix would break.
+    let (_, solo) = call(&app, "GET", "/solo/_count", Value::Null).await;
+    assert_eq!(
+        solo["count"].as_u64(),
+        Some(PER_INDEX as u64),
+        "an alias over one index still answers for that index: {solo}"
+    );
+    let (_, concrete) = call(&app, "GET", "/kb-a/_count", Value::Null).await;
+    assert_eq!(concrete["count"].as_u64(), Some(PER_INDEX as u64));
+}
+
+/// A scroll through the alias must walk every document AND report the index
+/// each hit truly came from — `(_index, _id)` is the key reindex, migration,
+/// backup and CDC consumers use, and ids collide across the members.
+#[tokio::test]
+async fn a_scroll_through_an_alias_walks_every_member_and_labels_each_hit() {
+    let (app, _dir) = app().await;
+    seed(&app).await;
+
+    let (st, mut page) = call(
+        &app,
+        "POST",
+        "/kb/_search?scroll=2m",
+        json!({"query": {"match_all": {}}, "size": 50}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "scroll start: {page}");
+    let mut sid = page["_scroll_id"].as_str().map(str::to_string);
+    let mut hits: Vec<(String, String, String)> = Vec::new();
+
+    for _ in 0..16 {
+        let page_hits = page["hits"]["hits"].as_array().cloned().unwrap_or_default();
+        if page_hits.is_empty() {
+            break;
+        }
+        for h in &page_hits {
+            hits.push((
+                h["_index"].as_str().unwrap_or_default().to_string(),
+                h["_id"].as_str().unwrap_or_default().to_string(),
+                h["_source"]["home"].as_str().unwrap_or_default().to_string(),
+            ));
+        }
+        let Some(id) = sid.clone() else { break };
+        let (st, next) = call(
+            &app,
+            "POST",
+            "/_search/scroll",
+            json!({"scroll": "2m", "scroll_id": id}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "continuation: {next}");
+        sid = next["_scroll_id"].as_str().map(str::to_string).or(sid);
+        page = next;
+    }
+
+    assert_eq!(hits.len(), PER_INDEX * 3, "every member must be walked");
+
+    let mislabelled: Vec<_> = hits
+        .iter()
+        .filter(|(reported, _, home)| reported != home)
+        .take(5)
+        .collect();
+    assert!(
+        mislabelled.is_empty(),
+        "hits must report the index they came from, not the alias: {mislabelled:?}"
+    );
+
+    let distinct: std::collections::HashSet<(&str, &str)> = hits
+        .iter()
+        .map(|(i, id, _)| (i.as_str(), id.as_str()))
+        .collect();
+    assert_eq!(
+        distinct.len(),
+        PER_INDEX * 3,
+        "(_index, _id) must be distinct — ids collide across the members"
+    );
+}


### PR DESCRIPTION
Closes #433.

## Reproduced first, and it is wider than the issue says

Three indices of 40 docs behind one alias; `GET /_alias/kb` lists all three.

```
                    alias   comma-list   wildcard
_count               40        120          120
_search  total       40        120          120
scroll   hits        40        120          120
```

**It is not a scroll bug** — `_count` and plain `_search` truncate identically, returning only `kb-a`'s documents.

**And the `(_index, _id)` framing describes the wrong failure.** On the alias scroll the pairs *are* distinct, 40 of 40, exactly because two-thirds of the corpus was never searched. It is not a keyed consumer silently keeping a fraction; it is every consumer getting a fraction, with a `_count` that agrees with the short result and no error anywhere.

## Cause: three copies of the same resolution, disagreeing

| resolver | aliases |
|---|---|
| `resolve_index_selector` | expanded |
| `search_impl`'s own (`es_compat.rs:8608`) | only `_all` and `*` |
| `count_docs`' branch gate | only `_all`, `*`, comma, star |

A plain alias fell through the last two — which is also why `_search` and `_count` could answer differently for the same selector. Both now expand aliases the way the first always did.

## After

```
_count  alias (3 members)            120
_count  alias (1 member)              40
_count  concrete index                40
_search alias total                  120
scroll  hits / distinct / mislabelled  120 / 120 / 0
```

Mislabelling drops to zero without touching scroll code: #424's per-hit plumbing was already correct and had no other indices to report.

## Fail-before

Reverting **only** the two source hunks, keeping the tests:

```
_count through the alias must cover all three members
  left: Some(40)  right: Some(120)
every member must be walked
  left: 40  right: 120
```

The single-member alias and concrete-index cases are asserted too — they are what a narrowing fix would break.

## Verification

`rustup run 1.97.1`: fmt clean, `clippy --workspace --all-targets -- -D warnings` clean, `xerj-api` green on both dev and ci-test.

**Not verified:** `_msearch`, aggregations and `_mget` — they reach a resolver too and may carry a fourth copy. I measured `_count`, `_search` and scroll only, and I am not claiming the rest.