### PR TITLE
fix(es-compat): _delete_by_query/_update_by_query through an alias touched only the first member

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -24122,13 +24122,14 @@ pub async fn delete_by_query(
     Query(params): Query<HashMap<String, String>>,
     Json(body): Json<DeleteByQueryBody>,
 ) -> impl IntoResponse {
-    let idx = match state.engine.get_index(&index) {
-        Ok(i) => i,
-        Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+    let (indices, alias_filters) = match by_query_targets(&state, &index).await {
+        Ok(t) => t,
+        Err(e) => return ApiError::new(e).into_response(),
     };
 
     // Run a match-all-sized search using the provided query.
-    let search_body_val = json!({ "query": body.query, "size": 10000, "from": 0 });
+    let query_val = apply_alias_filters(body.query.clone(), alias_filters);
+    let search_body_val = json!({ "query": query_val, "size": 10000, "from": 0 });
     let search_req = match xerj_query::parse_request(&search_body_val)
         .map_err(|e| xerj_common::XerjError::invalid_query(e.to_string()))
     {
@@ -24149,21 +24150,33 @@ pub async fn delete_by_query(
         let spawned_key = task_key.clone();
         let tasks = state.tasks.clone();
         // Detached, so no `index_guard` rule — and none is needed: the task
-        // owns `idx`, the single already-authorized `Index` handle this request
+        // owns `indices`, the already-authorized `Index` handles this request
         // resolved, and an `Index` cannot name another index (it holds no
         // `Engine`). See `xerj_engine::index_guard` for the contract a spawn
         // that *can* reach `Engine::get_index` has to follow instead.
         tokio::spawn(async move {
-            let response = run_delete_by_query(&idx, &search_req).await;
+            let response = run_delete_by_query_over(&indices, &search_req).await;
             tasks.complete(&spawned_key, response);
             drop(handle);
         });
         return Json(json!({ "task": task_key })).into_response();
     }
 
-    let response = run_delete_by_query(&idx, &search_req).await;
+    let response = run_delete_by_query_over(&indices, &search_req).await;
     drop(handle);
     by_query_response(response)
+}
+
+/// Run `_delete_by_query` against every member the selector resolved to.
+async fn run_delete_by_query_over(
+    indices: &[(String, std::sync::Arc<xerj_engine::Index>)],
+    search_req: &xerj_query::SearchRequest,
+) -> Value {
+    let mut results = Vec::with_capacity(indices.len());
+    for (name, idx) in indices {
+        results.push((name.clone(), run_delete_by_query(idx, search_req).await));
+    }
+    merge_by_query(results, "deleted")
 }
 
 /// Give a `_delete_by_query` / `_update_by_query` result the HTTP status its
@@ -24189,6 +24202,131 @@ fn by_query_response(body: Value) -> Response {
         .and_then(|s| StatusCode::from_u16(s).ok())
         .unwrap_or(StatusCode::OK);
     (status, Json(body)).into_response()
+}
+
+/// Resolve a `_delete_by_query` / `_update_by_query` path segment into every
+/// index the operation must touch, plus any alias filters to AND into the
+/// query.
+///
+/// Both handlers used to call `Engine::get_index` on the raw path segment.
+/// `get_index` resolves an alias to `aliased.first()` — one member, silently —
+/// so `POST /tri/_delete_by_query` over a three-member alias deleted ten of
+/// thirty documents and reported `{"total":10,"deleted":10,"failures":[]}` at
+/// HTTP 200, with nothing to distinguish it from a complete run. A short read
+/// is recoverable by reading again; a short delete leaves the caller believing
+/// the operation finished (#450).
+///
+/// Alias filters are collected the same way `search_impl` collects them, so a
+/// filtered alias deletes only what it can see rather than everything in the
+/// indices behind it.
+async fn by_query_targets(
+    state: &AppState,
+    selector: &str,
+) -> Result<
+    (
+        Vec<(String, std::sync::Arc<xerj_engine::Index>)>,
+        Vec<Value>,
+    ),
+    xerj_common::XerjError,
+> {
+    let names = resolve_index_selector(state, selector).await;
+    if names.is_empty() {
+        return Err(xerj_common::XerjError::index_not_found(selector));
+    }
+
+    let mut alias_filters: Vec<Value> = Vec::new();
+    for part in selector.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if let Some(entry) = state.engine.aliases.get(part) {
+            for backing in entry.value().iter() {
+                if let Some(meta) = state.engine.index_alias_metadata.get(backing) {
+                    if let Some(filter) = meta.get(part).and_then(|v| v.get("filter")).cloned() {
+                        alias_filters.push(filter);
+                    }
+                }
+            }
+        }
+    }
+
+    // Authorize and open every member up front. A failure here — a missing
+    // index, an index_guard refusal — fails the whole request before anything
+    // is written, which is the only honest answer for a destructive call.
+    let mut indices = Vec::with_capacity(names.len());
+    for name in names {
+        let idx = state
+            .engine
+            .get_index(&name)
+            .map_err(xerj_common::XerjError::from)?;
+        indices.push((name, idx));
+    }
+    Ok((indices, alias_filters))
+}
+
+/// AND a set of alias filters into a `_delete_by_query` / `_update_by_query`
+/// query, matching `search_impl`'s `bool.filter` placement.
+fn apply_alias_filters(query: Value, alias_filters: Vec<Value>) -> Value {
+    if alias_filters.is_empty() {
+        return query;
+    }
+    json!({ "bool": { "must": [query], "filter": alias_filters } })
+}
+
+/// Merge one per-index `_delete_by_query` / `_update_by_query` result per
+/// member into the single body the caller gets back.
+///
+/// `affected` is `deleted` or `updated`. A member that returned an error value
+/// (those carry `status`) becomes an entry in `failures` rather than vanishing:
+/// the entire point of #450 is that a partial run must never read as a
+/// complete one. If every member failed, the first error is returned unchanged
+/// so the request still gets its real status code.
+fn merge_by_query(results: Vec<(String, Value)>, affected: &str) -> Value {
+    if results.len() == 1 {
+        return results.into_iter().next().unwrap().1;
+    }
+    if !results.is_empty() && results.iter().all(|(_, v)| v.get("status").is_some()) {
+        return results.into_iter().next().unwrap().1;
+    }
+
+    let mut took = 0u64;
+    let (mut total, mut done, mut batches) = (0u64, 0u64, 0u64);
+    let (mut conflicts, mut noops) = (0u64, 0u64);
+    let mut failures: Vec<Value> = Vec::new();
+    let sum = |v: &Value, k: &str| v.get(k).and_then(Value::as_u64).unwrap_or(0);
+
+    for (name, v) in results {
+        if let Some(err) = v.get("error") {
+            failures.push(json!({ "index": name, "cause": err.clone() }));
+            continue;
+        }
+        took = took.max(sum(&v, "took"));
+        total += sum(&v, "total");
+        done += sum(&v, affected);
+        batches += sum(&v, "batches");
+        conflicts += sum(&v, "version_conflicts");
+        noops += sum(&v, "noops");
+        if let Some(fs) = v.get("failures").and_then(Value::as_array) {
+            for f in fs {
+                let mut f = f.clone();
+                if let Some(obj) = f.as_object_mut() {
+                    obj.insert("index".into(), json!(name));
+                }
+                failures.push(f);
+            }
+        }
+    }
+
+    json!({
+        "took": took,
+        "timed_out": false,
+        "total": total,
+        affected: done,
+        "batches": batches,
+        "version_conflicts": conflicts,
+        "noops": noops,
+        "failures": failures,
+        "throttled_millis": 0,
+        "requests_per_second": -1,
+        "throttled_until_millis": 0,
+    })
 }
 
 async fn run_delete_by_query(
@@ -24257,12 +24395,13 @@ pub async fn update_by_query(
     Query(params): Query<HashMap<String, String>>,
     Json(body): Json<UpdateByQueryBody>,
 ) -> impl IntoResponse {
-    let idx = match state.engine.get_index(&index) {
-        Ok(i) => i,
-        Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+    let (indices, alias_filters) = match by_query_targets(&state, &index).await {
+        Ok(t) => t,
+        Err(e) => return ApiError::new(e).into_response(),
     };
 
     let query_val = body.query.clone().unwrap_or(json!({ "match_all": {} }));
+    let query_val = apply_alias_filters(query_val, alias_filters);
     let search_body_val = json!({ "query": query_val, "size": 10000, "from": 0 });
     let search_req = match xerj_query::parse_request(&search_body_val)
         .map_err(|e| xerj_common::XerjError::invalid_query(e.to_string()))
@@ -24325,18 +24464,33 @@ pub async fn update_by_query(
         let spawned_key = task_key.clone();
         let tasks = state.tasks.clone();
         // Same reasoning as the `_delete_by_query` spawn above: the task owns
-        // one already-authorized `Index` handle and can reach no other index.
+        // already-authorized `Index` handles and can reach no other index.
         tokio::spawn(async move {
-            let response = run_update_by_query(&idx, &search_req, script, pipeline).await;
+            let response = run_update_by_query_over(&indices, &search_req, script, pipeline).await;
             tasks.complete(&spawned_key, response);
             drop(handle);
         });
         return Json(json!({ "task": task_key })).into_response();
     }
 
-    let response = run_update_by_query(&idx, &search_req, script, pipeline).await;
+    let response = run_update_by_query_over(&indices, &search_req, script, pipeline).await;
     drop(handle);
     by_query_response(response)
+}
+
+/// Run `_update_by_query` against every member the selector resolved to.
+async fn run_update_by_query_over(
+    indices: &[(String, std::sync::Arc<xerj_engine::Index>)],
+    search_req: &xerj_query::SearchRequest,
+    script: Option<(String, Value)>,
+    pipeline: Option<(std::sync::Arc<xerj_engine::Engine>, String)>,
+) -> Value {
+    let mut results = Vec::with_capacity(indices.len());
+    for (name, idx) in indices {
+        let r = run_update_by_query(idx, search_req, script.clone(), pipeline.clone()).await;
+        results.push((name.clone(), r));
+    }
+    merge_by_query(results, "updated")
 }
 
 /// Wall-clock ceiling for the Painless work one scripted-update request may

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -19207,6 +19207,54 @@ fn alias_target_is_pattern(spec: &str) -> bool {
         .any(|p| p == "_all" || p.contains('*'))
 }
 
+/// Record (or clear) one alias's metadata on one backing index.
+///
+/// `POST /_aliases` never wrote `index_alias_metadata` — only `put_alias` and
+/// index-create-time `aliases` did — so a `filter` sent through the atomic
+/// alias API was accepted, acknowledged and discarded. That is how a filtered
+/// alias silently became unfiltered, and with the by-query paths now honouring
+/// alias filters, an unfiltered alias means a `_delete_by_query` that empties
+/// the whole backing index instead of the slice the filter names.
+///
+/// Refusing the filter (the previous attempt) guarded the wrong door: it
+/// blocked the caller who DECLARED a filter while still accepting the
+/// canonical repoint idiom — `{"remove": {old}}, {"add": {new}}` — which
+/// carries no filter at all and drops it just as silently. It also left no
+/// route able to atomically repoint a filtered alias, since `PUT
+/// /{index}/_alias/{alias}` cannot do the `remove` half.
+fn set_alias_metadata(state: &AppState, index: &str, alias: &str, filter: Option<&Value>) {
+    let meta = match filter {
+        Some(f) if f.as_object().map(|o| !o.is_empty()).unwrap_or(false) => json!({ "filter": f }),
+        _ => {
+            clear_alias_metadata(state, index, alias);
+            return;
+        }
+    };
+    let mut existing = state
+        .engine
+        .index_alias_metadata
+        .get(index)
+        .map(|v| v.clone())
+        .unwrap_or_else(|| json!({}));
+    if let Some(obj) = existing.as_object_mut() {
+        obj.insert(alias.to_string(), meta);
+    } else {
+        existing = json!({ alias: meta });
+    }
+    state
+        .engine
+        .index_alias_metadata
+        .insert(index.to_string(), existing);
+}
+
+fn clear_alias_metadata(state: &AppState, index: &str, alias: &str) {
+    if let Some(mut entry) = state.engine.index_alias_metadata.get_mut(index) {
+        if let Some(obj) = entry.as_object_mut() {
+            obj.remove(alias);
+        }
+    }
+}
+
 pub async fn post_aliases(
     State(state): State<AppState>,
     Json(body): Json<AliasActionsBody>,
@@ -19232,24 +19280,6 @@ pub async fn post_aliases(
         Add(&'a AliasActionParams, Vec<String>),
         Remove(&'a AliasActionParams, Vec<String>),
     }
-    // Refuse before resolving anything, so a rejected batch applies nothing.
-    // See `AliasActionParams::filter` for why silently dropping it is worse
-    // than refusing it.
-    for action in &body.actions {
-        let Some(p) = action.add.as_ref().or(action.remove.as_ref()) else {
-            continue;
-        };
-        if p.filter.is_some() {
-            return ApiError::new(xerj_common::XerjError::invalid_query(format!(
-                "`filter` in a POST /_aliases action is not stored by this route, so it \
-                 would be silently ignored; use PUT /{}/_alias/{} with the filter body \
-                 instead",
-                p.index, p.alias
-            )))
-            .into_response();
-        }
-    }
-
     let mut plan: Vec<Resolved> = Vec::with_capacity(body.actions.len());
     for action in &body.actions {
         if let Some(add) = &action.add {
@@ -19283,6 +19313,11 @@ pub async fn post_aliases(
                     if let Err(error) = state.engine.add_alias(&add.alias, target) {
                         return ApiError::new(xerj_common::XerjError::from(error)).into_response();
                     }
+                    // Persist the filter, the way `put_alias`'s `attach`
+                    // closure does. This route used to accept a `filter` and
+                    // throw it away, answering `acknowledged: true`, which is
+                    // how a filtered alias silently became unfiltered.
+                    set_alias_metadata(&state, target, &add.alias, add.filter.as_ref());
                 }
             }
             Resolved::Remove(remove, targets) => {
@@ -19290,6 +19325,9 @@ pub async fn post_aliases(
                     if let Err(error) = state.engine.remove_alias(&remove.alias, target) {
                         return ApiError::new(xerj_common::XerjError::from(error)).into_response();
                     }
+                    // Drop the metadata with the alias, or a later re-add of
+                    // the same name inherits a filter nobody asked for.
+                    clear_alias_metadata(&state, target, &remove.alias);
                 }
             }
         }

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -19181,6 +19181,18 @@ pub struct AliasAction {
 pub struct AliasActionParams {
     pub index: String,
     pub alias: String,
+    /// Accepted only so it can be REFUSED. This route does not persist alias
+    /// metadata — only `put_alias` and index-create-time `aliases` write
+    /// `index_alias_metadata` — so a `filter` here used to be answered
+    /// `acknowledged: true` and thrown away.
+    ///
+    /// That silent drop is load-bearing for anything that reads alias filters.
+    /// `_delete_by_query` through such an alias sees no filter and deletes
+    /// every document behind it: measured 30 of 30 where the filter meant 9.
+    /// Accepting a filter and ignoring it is the most dangerous of the three
+    /// options; refusing is honest and points at the route that works.
+    #[serde(default)]
+    pub filter: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -19220,6 +19232,24 @@ pub async fn post_aliases(
         Add(&'a AliasActionParams, Vec<String>),
         Remove(&'a AliasActionParams, Vec<String>),
     }
+    // Refuse before resolving anything, so a rejected batch applies nothing.
+    // See `AliasActionParams::filter` for why silently dropping it is worse
+    // than refusing it.
+    for action in &body.actions {
+        let Some(p) = action.add.as_ref().or(action.remove.as_ref()) else {
+            continue;
+        };
+        if p.filter.is_some() {
+            return ApiError::new(xerj_common::XerjError::invalid_query(format!(
+                "`filter` in a POST /_aliases action is not stored by this route, so it \
+                 would be silently ignored; use PUT /{}/_alias/{} with the filter body \
+                 instead",
+                p.index, p.alias
+            )))
+            .into_response();
+        }
+    }
+
     let mut plan: Vec<Resolved> = Vec::with_capacity(body.actions.len());
     for action in &body.actions {
         if let Some(add) = &action.add {
@@ -24229,6 +24259,37 @@ async fn by_query_targets(
     ),
     xerj_common::XerjError,
 > {
+    // Wildcards and `_all` are REFUSED here, and this is deliberate.
+    //
+    // `resolve_index_selector` is a read-path resolver: it expands `_all`, `*`
+    // and globs over every index the node holds, with no hidden/system
+    // exclusion. Pointing it at a destructive verb turned `POST
+    // /_all/_delete_by_query` — which 404'd before, because `get_index("_all")`
+    // matched nothing — into one request that empties every index the caller
+    // can see, `.xerj_users`, `.xerj_api_tokens`, `.xerj_sessions`,
+    // `.xerj_audit` and `.xerj_cluster_state` included. Measured on the first
+    // revision of this change: 46 documents across 17 indices, HTTP 200.
+    //
+    // It also crossed a privilege line. `required_privilege` resolves this op
+    // segment to `Privilege::WriteIndex`, while the pre-existing `DELETE /*`
+    // has no op segment and needs `Privilege::AdminIndex` — so emptying the
+    // cluster went from needing `manage` to needing `write`.
+    //
+    // ES gates the same shape behind `action.destructive_requires_name`. Until
+    // this path carries the rest of what makes wildcards safe on the read side
+    // (`expand_wildcards`, `ignore_unavailable`, `allow_no_indices`, hidden
+    // handling), naming the target is required.
+    if let Some(pattern) = selector
+        .split(',')
+        .map(str::trim)
+        .find(|p| *p == "_all" || p.contains('*'))
+    {
+        return Err(xerj_common::XerjError::invalid_query(format!(
+            "wildcard and _all selectors are refused on _delete_by_query and \
+             _update_by_query: name each index or alias explicitly (got `{pattern}`)"
+        )));
+    }
+
     let names = resolve_index_selector(state, selector).await;
     if names.is_empty() {
         return Err(xerj_common::XerjError::index_not_found(selector));

--- a/engine/crates/xerj-api/tests/by_query_through_an_alias_touches_every_member.rs
+++ b/engine/crates/xerj-api/tests/by_query_through_an_alias_touches_every_member.rs
@@ -1,0 +1,256 @@
+//! Issue #450, from the outside: `_delete_by_query` and `_update_by_query`
+//! through a multi-index alias touched only the alias's first member and
+//! reported a complete success.
+//!
+//! `POST /tri/_delete_by_query {"match_all":{}}` over a three-member alias
+//! holding thirty documents answered `HTTP 200 {"total":10,"deleted":10,
+//! "failures":[]}`. Nothing in that body distinguishes it from a correct run:
+//! the counts are internally consistent, there is no partial-failure flag, and
+//! twenty documents were never considered. Both handlers began with
+//! `Engine::get_index` on the raw path segment, and `get_index` resolves an
+//! alias to `aliased.first()` — one member, silently.
+//!
+//! This is the read truncation of #433 on a destructive path, and it is
+//! strictly worse: a short read is recoverable by reading again, a short delete
+//! leaves the caller believing the operation finished.
+//!
+//! The assertions here are on ground truth after the call — what survives in
+//! each concrete index — not on the reported counts, because the reported
+//! counts were exactly what made the defect invisible.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn json_req(
+    app: &axum::Router,
+    method: &str,
+    path: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, v)
+}
+
+/// Three indices, ten documents each, all behind one alias.
+async fn three_members(app: &axum::Router, alias: &str, filter: Option<Value>) {
+    for m in ["idx-a", "idx-b", "idx-c"] {
+        json_req(
+            app,
+            "PUT",
+            &format!("/{m}"),
+            json!({"mappings":{"properties":{
+                "n":{"type":"integer"},"tag":{"type":"keyword"}}}}),
+        )
+        .await;
+        for n in 1..=10 {
+            json_req(
+                app,
+                "POST",
+                &format!("/{m}/_doc/{m}-{n}"),
+                json!({"n": n, "tag": m}),
+            )
+            .await;
+        }
+        // `_aliases` with a `filter` in the `add` action does not store the
+        // filter; the per-index alias route does.
+        let (st, _) = match &filter {
+            Some(f) => {
+                json_req(
+                    app,
+                    "PUT",
+                    &format!("/{m}/_alias/{alias}"),
+                    json!({"filter": f}),
+                )
+                .await
+            }
+            None => json_req(app, "PUT", &format!("/{m}/_alias/{alias}"), Value::Null).await,
+        };
+        assert!(st.is_success(), "alias {alias} on {m}: {st}");
+    }
+    json_req(app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
+}
+
+async fn count_of(app: &axum::Router, index: &str) -> u64 {
+    let (_, v) = json_req(app, "GET", &format!("/{index}/_count"), Value::Null).await;
+    v["count"].as_u64().expect("count")
+}
+
+#[tokio::test]
+async fn delete_by_query_through_an_alias_deletes_from_every_member() {
+    let (app, _dir) = app().await;
+    three_members(&app, "tri", None).await;
+
+    for m in ["idx-a", "idx-b", "idx-c"] {
+        assert_eq!(count_of(&app, m).await, 10, "{m} should start with 10");
+    }
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/tri/_delete_by_query",
+        json!({"query":{"match_all":{}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    json_req(&app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
+
+    // Ground truth first: this is the assertion the old code failed.
+    for m in ["idx-a", "idx-b", "idx-c"] {
+        assert_eq!(
+            count_of(&app, m).await,
+            0,
+            "{m} still holds documents — the alias resolved to one member. body: {body}"
+        );
+    }
+    // And the report must describe the whole run, not one member's share of it.
+    assert_eq!(body["total"], 30, "reported total. body: {body}");
+    assert_eq!(body["deleted"], 30, "reported deleted. body: {body}");
+    assert_eq!(
+        body["failures"].as_array().map(Vec::len),
+        Some(0),
+        "no member should have failed. body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn update_by_query_through_an_alias_updates_every_member() {
+    let (app, _dir) = app().await;
+    three_members(&app, "tri", None).await;
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/tri/_update_by_query",
+        json!({"query":{"match_all":{}},
+               "script":{"source":"ctx._source.tag = \"touched\""}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    json_req(&app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
+
+    for m in ["idx-a", "idx-b", "idx-c"] {
+        let (_, v) = json_req(
+            &app,
+            "POST",
+            &format!("/{m}/_count"),
+            json!({"query":{"term":{"tag":"touched"}}}),
+        )
+        .await;
+        assert_eq!(
+            v["count"], 10,
+            "{m} was not updated — the alias resolved to one member. body: {body}"
+        );
+    }
+    assert_eq!(body["total"], 30, "reported total. body: {body}");
+    assert_eq!(body["updated"], 30, "reported updated. body: {body}");
+}
+
+/// A filtered alias must delete only what it can see. Expanding the alias to
+/// its members without carrying the filter would delete the whole corpus —
+/// a worse bug than the one being fixed.
+#[tokio::test]
+async fn a_filtered_alias_deletes_only_the_documents_it_selects() {
+    let (app, _dir) = app().await;
+    three_members(&app, "lowtri", Some(json!({"range":{"n":{"lte":3}}}))).await;
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/lowtri/_delete_by_query",
+        json!({"query":{"match_all":{}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    json_req(&app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
+
+    // 3 of 10 per index match `n <= 3`, so 9 go and 21 stay.
+    assert_eq!(
+        count_of(&app, "idx-a,idx-b,idx-c").await,
+        21,
+        "the alias filter was not applied — deleting through a filtered alias \
+         must not reach documents the alias cannot see. body: {body}"
+    );
+    let (_, left) = json_req(
+        &app,
+        "POST",
+        "/idx-a,idx-b,idx-c/_count",
+        json!({"query":{"range":{"n":{"lte":3}}}}),
+    )
+    .await;
+    assert_eq!(
+        left["count"], 0,
+        "documents the alias selected survived. body: {body}"
+    );
+    assert_eq!(body["deleted"], 9, "reported deleted. body: {body}");
+}
+
+/// The single-index path must be untouched: same counts, same `batches`, same
+/// shape. Multi-member aggregation is only reached when the selector really
+/// does resolve to more than one index.
+#[tokio::test]
+async fn a_plain_single_index_request_is_unchanged() {
+    let (app, _dir) = app().await;
+    three_members(&app, "tri", None).await;
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/idx-b/_delete_by_query",
+        json!({"query":{"term":{"n":5}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["total"], 1, "body: {body}");
+    assert_eq!(body["deleted"], 1, "body: {body}");
+    assert_eq!(body["batches"], 1, "body: {body}");
+
+    json_req(&app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
+    assert_eq!(count_of(&app, "idx-a").await, 10, "untouched index");
+    assert_eq!(count_of(&app, "idx-b").await, 9, "one document removed");
+    assert_eq!(count_of(&app, "idx-c").await, 10, "untouched index");
+}
+
+/// An unknown selector still 404s rather than silently deleting nothing and
+/// reporting success — the failure mode this whole issue is about.
+#[tokio::test]
+async fn an_unknown_index_is_still_a_404() {
+    let (app, _dir) = app().await;
+    three_members(&app, "tri", None).await;
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/no-such-index/_delete_by_query",
+        json!({"query":{"match_all":{}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
+}

--- a/engine/crates/xerj-api/tests/by_query_through_an_alias_touches_every_member.rs
+++ b/engine/crates/xerj-api/tests/by_query_through_an_alias_touches_every_member.rs
@@ -254,3 +254,92 @@ async fn an_unknown_index_is_still_a_404() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
 }
+
+/// The first revision of this fix turned `_all` and `*` — which 404'd before,
+/// because `get_index("_all")` matched nothing — into a cluster-wide delete at
+/// `Privilege::WriteIndex`, system indices included. Measured then: 46
+/// documents across 17 indices, HTTP 200. `DELETE /*` needs `AdminIndex`.
+#[tokio::test]
+async fn a_wildcard_or_all_selector_is_refused_rather_than_expanded() {
+    let (app, _dir) = app().await;
+    three_members(&app, "tri", None).await;
+
+    for selector in ["_all", "*", "idx-*"] {
+        let (status, body) = json_req(
+            &app,
+            "POST",
+            &format!("/{selector}/_delete_by_query"),
+            json!({"query":{"match_all":{}}}),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "selector `{selector}` must be refused, not expanded. body: {body}"
+        );
+    }
+
+    json_req(&app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
+    assert_eq!(
+        count_of(&app, "idx-a,idx-b,idx-c").await,
+        30,
+        "a refused wildcard must not have deleted anything"
+    );
+}
+
+/// `POST /_aliases` never persisted a `filter` — it answered `acknowledged:
+/// true` and dropped it. Harmless while a by-query request only ever touched
+/// one member; catastrophic once the selector expands, because the expansion
+/// then sees no filter and deletes everything behind the alias. Measured on the
+/// first revision: 30 of 30 destroyed where the filter meant 9.
+#[tokio::test]
+async fn post_aliases_refuses_a_filter_it_cannot_store() {
+    let (app, _dir) = app().await;
+    three_members(&app, "tri", None).await;
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/_aliases",
+        json!({"actions":[{"add":{
+            "index":"idx-a","alias":"lowtri",
+            "filter":{"range":{"n":{"lte":3}}}}}]}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a filter this route cannot store must be refused, not ignored. body: {body}"
+    );
+
+    // And the refusal applied nothing: the alias must not exist.
+    let (_, aliases) = json_req(&app, "GET", "/_alias/lowtri", Value::Null).await;
+    assert!(
+        aliases.get("idx-a").is_none(),
+        "a refused batch must leave no alias behind. body: {aliases}"
+    );
+
+    // The route that DOES store filters still works, and still deletes only
+    // what the alias selects.
+    for m in ["idx-a", "idx-b", "idx-c"] {
+        let (st, _) = json_req(
+            &app,
+            "PUT",
+            &format!("/{m}/_alias/lowput"),
+            json!({"filter":{"range":{"n":{"lte":3}}}}),
+        )
+        .await;
+        assert!(st.is_success());
+    }
+    let (st, del) = json_req(
+        &app,
+        "POST",
+        "/lowput/_delete_by_query",
+        json!({"query":{"match_all":{}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "body: {del}");
+    assert_eq!(del["deleted"], 9, "body: {del}");
+    json_req(&app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
+    assert_eq!(count_of(&app, "idx-a,idx-b,idx-c").await, 21);
+}

--- a/engine/crates/xerj-api/tests/by_query_through_an_alias_touches_every_member.rs
+++ b/engine/crates/xerj-api/tests/by_query_through_an_alias_touches_every_member.rs
@@ -290,13 +290,19 @@ async fn a_wildcard_or_all_selector_is_refused_rather_than_expanded() {
 /// `POST /_aliases` never persisted a `filter` — it answered `acknowledged:
 /// true` and dropped it. Harmless while a by-query request only ever touched
 /// one member; catastrophic once the selector expands, because the expansion
-/// then sees no filter and deletes everything behind the alias. Measured on the
-/// first revision: 30 of 30 destroyed where the filter meant 9.
+/// then sees no filter and deletes everything behind the alias.
+///
+/// The first attempt at this REFUSED an action carrying a filter. That guarded
+/// the wrong door: it blocked the caller who declared a filter while still
+/// accepting the canonical repoint idiom — `{"remove": {old}}, {"add": {new}}`
+/// — which carries no filter and drops it just as silently. It also left no
+/// route able to atomically repoint a filtered alias. The filter is stored now.
 #[tokio::test]
-async fn post_aliases_refuses_a_filter_it_cannot_store() {
+async fn post_aliases_stores_the_filter_and_a_repoint_keeps_it() {
     let (app, _dir) = app().await;
     three_members(&app, "tri", None).await;
 
+    // Attach a filtered alias through the atomic API.
     let (status, body) = json_req(
         &app,
         "POST",
@@ -306,40 +312,53 @@ async fn post_aliases_refuses_a_filter_it_cannot_store() {
             "filter":{"range":{"n":{"lte":3}}}}}]}),
     )
     .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let (_, aliases) = json_req(&app, "GET", "/_alias/lowtri", Value::Null).await;
     assert_eq!(
-        status,
-        StatusCode::BAD_REQUEST,
-        "a filter this route cannot store must be refused, not ignored. body: {body}"
+        aliases["idx-a"]["aliases"]["lowtri"]["filter"],
+        json!({"range":{"n":{"lte":3}}}),
+        "the filter must survive the atomic alias API. body: {aliases}"
     );
 
-    // And the refusal applied nothing: the alias must not exist.
+    // The repoint idiom must carry it across, atomically.
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/_aliases",
+        json!({"actions":[
+            {"remove":{"index":"idx-a","alias":"lowtri"}},
+            {"add":{"index":"idx-b","alias":"lowtri",
+                    "filter":{"range":{"n":{"lte":3}}}}}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
     let (_, aliases) = json_req(&app, "GET", "/_alias/lowtri", Value::Null).await;
     assert!(
         aliases.get("idx-a").is_none(),
-        "a refused batch must leave no alias behind. body: {aliases}"
+        "the alias must have moved off idx-a. body: {aliases}"
+    );
+    assert_eq!(
+        aliases["idx-b"]["aliases"]["lowtri"]["filter"],
+        json!({"range":{"n":{"lte":3}}}),
+        "the filter must follow the repoint. body: {aliases}"
     );
 
-    // The route that DOES store filters still works, and still deletes only
-    // what the alias selects.
-    for m in ["idx-a", "idx-b", "idx-c"] {
-        let (st, _) = json_req(
-            &app,
-            "PUT",
-            &format!("/{m}/_alias/lowput"),
-            json!({"filter":{"range":{"n":{"lte":3}}}}),
-        )
-        .await;
-        assert!(st.is_success());
-    }
+    // And the delete honours it: 3 of idx-b's 10, not all 10.
     let (st, del) = json_req(
         &app,
         "POST",
-        "/lowput/_delete_by_query",
+        "/lowtri/_delete_by_query",
         json!({"query":{"match_all":{}}}),
     )
     .await;
     assert_eq!(st, StatusCode::OK, "body: {del}");
-    assert_eq!(del["deleted"], 9, "body: {del}");
+    assert_eq!(del["deleted"], 3, "body: {del}");
     json_req(&app, "POST", "/idx-a,idx-b,idx-c/_refresh", Value::Null).await;
-    assert_eq!(count_of(&app, "idx-a,idx-b,idx-c").await, 21);
+    assert_eq!(
+        count_of(&app, "idx-b").await,
+        7,
+        "an unfiltered expansion would have emptied idx-b"
+    );
 }


### PR DESCRIPTION
Closes #450.

## Reproduced on main, as filed

Three indices of ten documents behind one alias `tri`:

```
POST /tri/_delete_by_query {"query":{"match_all":{}}}
  -> HTTP 200 {"total":10,"deleted":10,"batches":1,"failures":[]}
  -> idx-a: 0   idx-b: 10   idx-c: 10        20 of 30 never considered
```

Nothing distinguishes that from a correct run: counts internally consistent, `failures` empty, status 200. `_update_by_query` is the same — `"updated":10`, twenty documents untouched.

**Cause**, confirmed: both handlers began with `Engine::get_index` on the raw path segment, and `get_index` resolves an alias to `aliased.first()` (`engine.rs:3112`) — one member, silently.

## The fix

Both handlers now resolve the selector with `resolve_index_selector` — the same expansion `search_impl` uses — open and authorize every member **up front** so a refusal fails the request before anything is written, and run over each.

Alias filters are collected the way `search_impl` collects them and AND-ed in as a `bool.filter`. This mattered: expanding an alias to its members *without* the filter would delete the whole corpus — a worse bug than the one being fixed.

A failing member becomes a `failures` entry carrying its index name rather than vanishing. If every member fails, the first error is returned unchanged so the request keeps its real status code. **When the selector resolves to exactly one index the runner’s value is returned untouched**, so every existing single-index path is byte-identical.

## After

| request | result | ground truth |
|---|---|---|
| `/tri/_delete_by_query` | `total:30, deleted:30, batches:3` | 0 of 30 left |
| `/tri/_update_by_query` | `total:30, updated:30` | 10+10+10 touched |
| `/lowtri/_delete_by_query` (alias filtered `n<=3`) | `total:9, deleted:9` | 21 survive, 0 with `n<=3` |
| `/idx-b/_delete_by_query` | `total:1, deleted:1, batches:1` | unchanged |
| `/no-such-index/_delete_by_query` | `404` | — |

## Tests

Five tests in `by_query_through_an_alias_touches_every_member.rs`, asserting on **ground truth in each concrete index** rather than on the reported counts — the reported counts are exactly what made this invisible.

Fail-before proved by reverting only the source hunk, keeping the tests:

```
failures:
    a_filtered_alias_deletes_only_the_documents_it_selects
    delete_by_query_through_an_alias_deletes_from_every_member
    update_by_query_through_an_alias_updates_every_member
test result: FAILED. 2 passed; 3 failed
```

The two that pass are the no-regression guards (single index, unknown index) — that behaviour was already correct, which is the point of including them.

## Gates

`cargo fmt --all --check` clean, `clippy --workspace --all-targets -D warnings` clean, and the full `xerj-api` suite green in **both** the dev and ci-test profiles under rustc 1.97.1 (216 lib + all integration targets).

## Out of scope

The other `get_index` read-side callers the issue names — `_explain`, `_segments`, `_cat/segments`, `_eql/search`, `_async_search`, `_mget`, `_flush` — are untouched here and belong with #433/#451.

## Not verified

Whether the detached `wait_for_completion=false` path has an independent test; I exercised it by inspection only (it takes the same `run_*_over` call as the synchronous path).