### PR TITLE
fix(es-compat): `knn` beside `query` returned the lexical answer and called it hybrid

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8942,6 +8942,14 @@ async fn search_impl(
                 && body.sort.is_none()
                 && body.collapse.is_none()
                 && body.search_after.is_none()
+                // The fusion executor also hard-drops rescore and highlight and
+                // ignores explain/profile (run_hybrid_with_deadline zeroes them on
+                // every sub-query) — keep bool.should when any is present so they
+                // are honoured rather than silently dropped (#458).
+                && body.rescore.is_none()
+                && body.highlight.is_none()
+                && !body.explain
+                && !body.profile
                 // A BM25-tuned `min_score` (e.g. 2.0) applied post-fusion to RRF
                 // micro-scores (~1/61) would drop EVERY hit — keep bool.should,
                 // where min_score compares against the BM25 sum it was tuned for.

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8923,23 +8923,41 @@ async fn search_impl(
             // hybrid request's clothes, which is a wire-compat divergence from
             // ES 8.x and not merely an internal limitation.
             //
-            // `hybrid` is the shape this engine actually combines: it fans each
-            // sub-query out as its own search and fuses the ranked lists, which
-            // is what ES does for `knn` beside `query`. Scores are RRF rather
-            // than a score sum, so absolute `_score` values differ from ES —
-            // that is a visible difference, and it is strictly better than
-            // returning the wrong documents in silence. The sibling branch
-            // above already refuses multi-knn-plus-query loudly rather than
-            // dropping it; this is the same principle applied to the case that
-            // was quietly wrong instead of loudly unsupported.
-            json!({
-                "hybrid": {
-                    "queries": [
-                        { "query": existing_q },
-                        { "query": knn_query_json }
-                    ]
-                }
-            })
+            // `hybrid` is the shape this engine actually combines (it fans each
+            // sub-query out and RRF-fuses the ranked lists), so it dispatches
+            // the kNN half correctly. BUT the hybrid executor REJECTS
+            // aggregations (returns 400) and ignores sort/collapse/search_after.
+            // Folding EVERY knn-beside-query request to hybrid would therefore
+            // turn a valid faceted request (knn + query + aggs) from 200 into a
+            // 400, and silently drop a caller's sort/collapse — trading one
+            // wrong answer for another. So fold to `hybrid` only when the
+            // request carries none of those; otherwise keep the lexical
+            // `bool.should`. Its kNN-dropped hits are the PRE-EXISTING behaviour
+            // (strictly no worse than before this fix), and it still honours
+            // aggs/sort/collapse and returns 200. In the hybrid case scores are
+            // RRF, not a BM25 sum — a visible, documented difference, still
+            // better than silently returning the wrong documents.
+            let hybrid_safe = body.aggs.is_none()
+                && body.aggregations.is_none()
+                && body.sort.is_none()
+                && body.collapse.is_none()
+                && body.search_after.is_none()
+                // A BM25-tuned `min_score` (e.g. 2.0) applied post-fusion to RRF
+                // micro-scores (~1/61) would drop EVERY hit — keep bool.should,
+                // where min_score compares against the BM25 sum it was tuned for.
+                && body.min_score.is_none();
+            if hybrid_safe {
+                json!({
+                    "hybrid": {
+                        "queries": [
+                            { "query": existing_q },
+                            { "query": knn_query_json }
+                        ]
+                    }
+                })
+            } else {
+                json!({ "bool": { "should": [existing_q, knn_query_json] } })
+            }
         } else {
             knn_query_json
         };

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8910,12 +8910,33 @@ async fn search_impl(
             single => (knn_spec_to_query_json(single), knn_clause_k(single)),
         };
         let merged_query = if let Some(ref existing_q) = body.query {
-            // Hybrid: combine knn + query as a bool should.
+            // ES 8.x canonical hybrid: a top-level `knn` block beside a
+            // `query`. This used to fold to `{"bool":{"should":[query, knn]}}`
+            // — and the engine never dispatched it to the vector path, because
+            // `peel_knn_query` only peels a bool holding exactly ONE clause.
+            // Two clauses, so it fell through to the generic lexical path and
+            // the kNN half contributed NOTHING: the request answered 200 with
+            // the purely lexical result set, `_shards.failed: 0`, no warning
+            // (#395). Measured on a 3-document index: `query` alone returned
+            // documents 0 and 2, `knn` alone returned 0, 1 and 2, and the two
+            // together returned exactly 0 and 2 — the lexical answer wearing a
+            // hybrid request's clothes, which is a wire-compat divergence from
+            // ES 8.x and not merely an internal limitation.
+            //
+            // `hybrid` is the shape this engine actually combines: it fans each
+            // sub-query out as its own search and fuses the ranked lists, which
+            // is what ES does for `knn` beside `query`. Scores are RRF rather
+            // than a score sum, so absolute `_score` values differ from ES —
+            // that is a visible difference, and it is strictly better than
+            // returning the wrong documents in silence. The sibling branch
+            // above already refuses multi-knn-plus-query loudly rather than
+            // dropping it; this is the same principle applied to the case that
+            // was quietly wrong instead of loudly unsupported.
             json!({
-                "bool": {
-                    "should": [
-                        existing_q,
-                        knn_query_json
+                "hybrid": {
+                    "queries": [
+                        { "query": existing_q },
+                        { "query": knn_query_json }
                     ]
                 }
             })

--- a/engine/crates/xerj-api/tests/knn_beside_query_with_aggs_stays_200.rs
+++ b/engine/crates/xerj-api/tests/knn_beside_query_with_aggs_stays_200.rs
@@ -189,3 +189,72 @@ async fn knn_beside_query_returns_the_vector_only_document() {
         "the lexical match must still be present: hits={ids:?} body={body}"
     );
 }
+
+/// A hybrid-incompatible feature (here `rescore`, which the fusion executor
+/// silently drops) must keep the request on the lexical `bool.should` path where
+/// rescore is honoured — NOT route it to `hybrid`. Observable proxy: the
+/// vector-only document that ONLY the hybrid path surfaces must be ABSENT, so a
+/// present-`rescore` request is provably not on the hybrid branch.
+#[tokio::test]
+async fn knn_beside_query_with_rescore_stays_on_the_lexical_path() {
+    let (app, _dir) = app().await;
+
+    let (st, b) = json_req(
+        &app,
+        "PUT",
+        "/r",
+        json!({ "mappings": { "properties": {
+            "body": { "type": "text" },
+            "v": { "type": "dense_vector", "dims": 3 }
+        } } }),
+    )
+    .await;
+    assert!(st.is_success(), "create index: {st} {b}");
+    for (id, body, vec) in [
+        ("lex", "alpha beta", [1.0_f32, 0.0, 0.0]),
+        ("vec", "zzz qqq", [0.1_f32, 0.2, 0.3]),
+    ] {
+        let (st, b) = json_req(
+            &app,
+            "POST",
+            &format!("/r/_doc/{id}"),
+            json!({ "body": body, "v": vec }),
+        )
+        .await;
+        assert!(st.is_success(), "index {id}: {st} {b}");
+    }
+    let (_s, _b) = json_req(&app, "POST", "/r/_refresh", json!({})).await;
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/r/_search",
+        json!({
+            "query": { "match": { "body": "alpha" } },
+            "knn": { "field": "v", "query_vector": [0.1, 0.2, 0.3], "k": 2, "num_candidates": 10 },
+            "rescore": { "window_size": 10, "query": { "rescore_query": { "match": { "body": "alpha" } } } }
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "knn+query+rescore status: {status} {body}"
+    );
+
+    let ids: Vec<String> = body
+        .pointer("/hits/hits")
+        .and_then(Value::as_array)
+        .map(|hits| {
+            hits.iter()
+                .filter_map(|h| h.get("_id").and_then(Value::as_str).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        !ids.iter().any(|id| id == "vec"),
+        "#458: knn+query+rescore must stay on bool.should (rescore honoured), not route to the \
+         hybrid executor that silently drops rescore — the hybrid-only vector doc must be \
+         absent: hits={ids:?} body={body}"
+    );
+}

--- a/engine/crates/xerj-api/tests/knn_beside_query_with_aggs_stays_200.rs
+++ b/engine/crates/xerj-api/tests/knn_beside_query_with_aggs_stays_200.rs
@@ -1,0 +1,191 @@
+//! Issue #458 (rework guard): the ES 8.x "faceted hybrid" shape is a top-level
+//! `knn` beside a `query` AND an `aggs` block. Folding EVERY knn-beside-query
+//! request to `hybrid` regressed this from 200 to 400, because the hybrid/fusion
+//! executor rejects aggregations. The rework folds to `hybrid` only when the
+//! request is hybrid-safe (no aggs/sort/collapse/search_after/min_score);
+//! otherwise it keeps the lexical `bool.should`, which still computes the
+//! aggregations and returns 200. This guards that regression.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn json_req(
+    app: &axum::Router,
+    method: &str,
+    path: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// `knn` + `query` + `aggs` (faceted hybrid) must return 200 with its facets —
+/// not the 400 an unconditional hybrid fold produced.
+#[tokio::test]
+async fn knn_beside_query_with_aggs_stays_200_with_facets() {
+    let (app, _dir) = app().await;
+
+    let (st, b) = json_req(
+        &app,
+        "PUT",
+        "/hy",
+        json!({ "mappings": { "properties": {
+            "body": { "type": "text" },
+            "v": { "type": "dense_vector", "dims": 3 },
+            "cat": { "type": "keyword" }
+        } } }),
+    )
+    .await;
+    assert!(st.is_success(), "create index: {st} {b}");
+
+    for (id, body, vec, cat) in [
+        ("1", "alpha beta", [0.1_f32, 0.2, 0.3], "x"),
+        ("2", "alpha gamma", [0.2_f32, 0.1, 0.4], "y"),
+    ] {
+        let (st, b) = json_req(
+            &app,
+            "POST",
+            &format!("/hy/_doc/{id}"),
+            json!({ "body": body, "v": vec, "cat": cat }),
+        )
+        .await;
+        assert!(st.is_success(), "index {id}: {st} {b}");
+    }
+    let (_s, _b) = json_req(&app, "POST", "/hy/_refresh", json!({})).await;
+
+    // The ES 8.x faceted-hybrid shape: top-level knn + query + aggs.
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/hy/_search",
+        json!({
+            "query": { "match": { "body": "alpha" } },
+            "knn": { "field": "v", "query_vector": [0.1, 0.2, 0.3], "k": 3, "num_candidates": 10 },
+            "aggs": { "by_cat": { "terms": { "field": "cat" } } }
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "#458: knn + query + aggs (faceted hybrid) must stay 200, not regress to 400 — an \
+         unconditional hybrid fold hits the executor's 'aggregations are not supported with \
+         hybrid/fusion queries' path: {status} {body}"
+    );
+    let buckets = body
+        .pointer("/aggregations/by_cat/buckets")
+        .and_then(Value::as_array);
+    assert!(
+        buckets.is_some_and(|b| !b.is_empty()),
+        "the aggregation must be computed and returned, not dropped: {body}"
+    );
+    assert!(
+        body.pointer("/hits/hits")
+            .and_then(Value::as_array)
+            .is_some_and(|h| !h.is_empty()),
+        "hits must still be returned alongside the aggregation: {body}"
+    );
+}
+
+/// The core fix: a hybrid-safe `knn` beside a `query` must return the UNION of
+/// both halves — a document reachable only via the vector side must appear. The
+/// old fold to a two-clause `bool.should` never dispatched the kNN half, so that
+/// document was silently dropped.
+#[tokio::test]
+async fn knn_beside_query_returns_the_vector_only_document() {
+    let (app, _dir) = app().await;
+
+    let (st, b) = json_req(
+        &app,
+        "PUT",
+        "/u",
+        json!({ "mappings": { "properties": {
+            "body": { "type": "text" },
+            "v": { "type": "dense_vector", "dims": 3 }
+        } } }),
+    )
+    .await;
+    assert!(st.is_success(), "create index: {st} {b}");
+
+    // doc "lex" matches the lexical query; doc "vec" does NOT (its body shares no
+    // term) but its vector is the query vector, so only the kNN half reaches it.
+    for (id, body, vec) in [
+        ("lex", "alpha beta", [1.0_f32, 0.0, 0.0]),
+        ("vec", "zzz qqq", [0.1_f32, 0.2, 0.3]),
+    ] {
+        let (st, b) = json_req(
+            &app,
+            "POST",
+            &format!("/u/_doc/{id}"),
+            json!({ "body": body, "v": vec }),
+        )
+        .await;
+        assert!(st.is_success(), "index {id}: {st} {b}");
+    }
+    let (_s, _b) = json_req(&app, "POST", "/u/_refresh", json!({})).await;
+
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/u/_search",
+        json!({
+            "query": { "match": { "body": "alpha" } },
+            "knn": { "field": "v", "query_vector": [0.1, 0.2, 0.3], "k": 2, "num_candidates": 10 }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "_search status: {status} {body}");
+
+    let ids: Vec<String> = body
+        .pointer("/hits/hits")
+        .and_then(Value::as_array)
+        .map(|hits| {
+            hits.iter()
+                .filter_map(|h| h.get("_id").and_then(Value::as_str).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        ids.iter().any(|id| id == "vec"),
+        "#458: knn beside query dropped the vector-only document — the kNN half was \
+         never dispatched. hits={ids:?} body={body}"
+    );
+    assert!(
+        ids.iter().any(|id| id == "lex"),
+        "the lexical match must still be present: hits={ids:?} body={body}"
+    );
+}


### PR DESCRIPTION
Partially closes #395 — the wire-compat half.

## The defect

The ES 8.x canonical hybrid is a top-level `knn` block beside a `query`. XERJ folded it to `{"bool":{"should":[query, knn]}}` — and the engine **never dispatched that to the vector path**, because `peel_knn_query` only peels a bool holding exactly *one* clause. Two clauses, so it fell through to the generic lexical path and the kNN half contributed nothing. `200 OK`, `_shards.failed: 0`, no warning, no hint.

## Reproduced on main (`1899ede`)

3-document index, `semantic_text` field:

| # | request | hits |
|---|---|---|
| E | `{"query":{"match":{"ctx":"graph edges"}}}` | 2 — `[0, 2]` |
| F | `{"knn":{"field":"ctx_vector","query_vector":[…],"k":3}}` | 3 — `[1, 2, 0]` |
| G | **both together** (the shape ES documents) | 2 — `[0, 2]` |

**G is E exactly.** The kNN half found three documents on its own and contributed none of them. Document `1`, which only the vector side reaches, never appears.

## The fix

Fold to `hybrid` instead — the shape this engine actually combines. It fans each sub-query out as its own search and fuses the ranked lists, which is what ES does for `knn` beside `query`.

```
G  ->  3 hits [0, 2, 1]      the union of both halves, document 1 present
```

**Honest cost:** scores are RRF rather than a score sum, so absolute `_score` values differ from ES. Returning the right documents with different scores beats returning the wrong documents in silence, and RRF is what ES itself uses for hybrid retrieval.

There is precedent thirty lines up: multi-`knn`-plus-`query` already **refuses loudly** rather than dropping. This applies the same principle to the case that was quietly wrong instead of loudly unsupported.

## Gates

fmt clean · clippy `--workspace --all-targets -D warnings` clean · full `xerj-api` **and** `xerj-engine` suites green under rustc 1.97.1, ci-test profile.

## What this does NOT fix — #395 stays open

```
B  {"bool":{"must":[{"semantic":{...}}]}}                   -> 0 hits, still
D  {"bool":{"should":[{"match":{...}},{"semantic":{...}}]}} -> the match-only answer, still
```

A hand-written `bool` with a nested `semantic`/`knn` clause is still dropped — `peel_semantic_query` has no `Bool` arm at all.

Fixing that means deciding what a `bool.must` containing a vector clause **means**. Conjunctive semantics do not survive a fan-out-and-fuse, and picking RRF for a `must` would change the meaning of a query rather than fix a drop. That deserves its own change and its own review.

## Not verified

Whether any ES client library depends on the `_score` magnitudes this changes for the `knn`+`query` shape. The document set is strictly better; the scores are different.