### PR TITLE
fix(es-compat): an alias 404ed on _refresh, _forcemerge, _cache/clear and _terms_enum

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -19391,15 +19391,37 @@ async fn resolve_indices_for_op(
                 }
             }
         } else {
-            // Concrete name inside a comma list: ES's default
-            // `ignore_unavailable=false` 404s the whole request on a
-            // missing name instead of silently dropping it —
-            // `POST /real,typo/_refresh` must not report success.
-            if !all.iter().any(|n| n == part) {
+            // A concrete name may be a real index OR an alias. An index of
+            // that name wins, matching ES, where an alias may not share a
+            // name with an index.
+            if all.iter().any(|n| n == part) {
+                if !names.iter().any(|n| n == part) {
+                    names.push(part.to_string());
+                }
+            } else if let Some(members) = state.engine.aliases.get(part) {
+                // This branch did not exist, so an alias was simply "not an
+                // index" and the whole request 404'd. `POST /tri/_refresh`
+                // over a three-member alias returned index_not_found while
+                // `POST /idx-a/_refresh` worked — measured on _refresh,
+                // _forcemerge, _cache/clear and _terms_enum. An alias is a
+                // valid index selector for every one of these in ES.
+                //
+                // Expanding to ALL members, not `aliased.first()`: a
+                // maintenance op that silently addressed one member of a
+                // multi-index alias is the same defect class as #450 on the
+                // read side, and `_refresh` reaching only one member makes a
+                // subsequent search non-deterministic in a way nothing in the
+                // response admits.
+                for m in members.value() {
+                    if !names.iter().any(|n| n == m) {
+                        names.push(m.clone());
+                    }
+                }
+            } else {
+                // ES's default `ignore_unavailable=false` 404s the whole
+                // request on a missing name instead of silently dropping it —
+                // `POST /real,typo/_refresh` must not report success.
                 return Err(xerj_common::XerjError::index_not_found(part));
-            }
-            if !names.iter().any(|n| n == part) {
-                names.push(part.to_string());
             }
         }
     }

--- a/engine/crates/xerj-api/tests/alias_is_a_valid_selector_for_maintenance_ops.rs
+++ b/engine/crates/xerj-api/tests/alias_is_a_valid_selector_for_maintenance_ops.rs
@@ -1,0 +1,121 @@
+//! An alias is a valid index selector in Elasticsearch for every maintenance
+//! endpoint. Here it was not: `resolve_indices_for_op` had no alias branch at
+//! all, so an alias was simply "not an index" and the whole request 404'd.
+//!
+//! Measured before the fix, on a three-member alias `tri`:
+//!
+//!   POST /tri/_refresh       -> 404      POST /idx-a/_refresh       -> 200
+//!   POST /tri/_forcemerge    -> 404      POST /idx-a/_forcemerge    -> 200
+//!   POST /tri/_cache/clear   -> 404      POST /idx-a/_cache/clear   -> 200
+//!   POST /tri/_terms_enum    -> 404      POST /idx-a/_terms_enum    -> 200
+//!
+//! The alias expands to EVERY member rather than `aliased.first()`. A
+//! maintenance op that silently addressed one member of a multi-index alias is
+//! the same defect class as #450 on the destructive side — and a `_refresh`
+//! that reaches one of three members makes the next search non-deterministic
+//! in a way nothing in the response admits.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn req(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut b = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        b = b.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let res = app.clone().oneshot(b.body(body).unwrap()).await.unwrap();
+    let status = res.status();
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn three_members(app: &axum::Router) {
+    for m in ["idx-a", "idx-b", "idx-c"] {
+        req(
+            app,
+            "PUT",
+            &format!("/{m}"),
+            json!({"mappings":{"properties":{"n":{"type":"integer"}}}}),
+        )
+        .await;
+        for n in 1..=3 {
+            req(app, "POST", &format!("/{m}/_doc/{m}{n}"), json!({"n": n})).await;
+        }
+        let (st, _) = req(app, "PUT", &format!("/{m}/_alias/tri"), Value::Null).await;
+        assert!(st.is_success(), "alias on {m}: {st}");
+    }
+}
+
+#[tokio::test]
+async fn maintenance_endpoints_accept_an_alias_and_reach_every_member() {
+    let (app, _d) = app().await;
+    three_members(&app).await;
+
+    for (method, path, body) in [
+        ("POST", "/tri/_refresh", Value::Null),
+        ("POST", "/tri/_forcemerge", Value::Null),
+        ("POST", "/tri/_cache/clear", Value::Null),
+        ("POST", "/tri/_terms_enum", json!({"field": "n"})),
+    ] {
+        let (st, b) = req(&app, method, path, body).await;
+        assert_eq!(st, StatusCode::OK, "{path} must accept an alias. body: {b}");
+    }
+
+    // Not just accepted — every member must be reached. One-member behaviour
+    // would still return 200 and would still be wrong.
+    let (st, b) = req(&app, "POST", "/tri/_refresh", Value::Null).await;
+    assert_eq!(st, StatusCode::OK);
+    assert_eq!(
+        b["_shards"]["total"], 3,
+        "an alias over three indices must refresh all three, not aliased.first(). body: {b}"
+    );
+    assert_eq!(b["_shards"]["failed"], 0, "body: {b}");
+}
+
+/// The alias branch must not weaken the missing-name rule: ES defaults
+/// `ignore_unavailable=false`, so a typo in a comma list fails the whole
+/// request rather than silently doing less than asked.
+#[tokio::test]
+async fn an_unknown_name_still_fails_the_whole_request() {
+    let (app, _d) = app().await;
+    three_members(&app).await;
+
+    let (st, _) = req(&app, "POST", "/no-such-thing/_refresh", Value::Null).await;
+    assert_eq!(st, StatusCode::NOT_FOUND);
+
+    let (st, _) = req(&app, "POST", "/idx-a,typo/_refresh", Value::Null).await;
+    assert_eq!(
+        st,
+        StatusCode::NOT_FOUND,
+        "a typo beside a real name must 404"
+    );
+
+    // And an index of the same name as an alias wins, as in ES.
+    let (st, b) = req(&app, "POST", "/idx-a/_refresh", Value::Null).await;
+    assert_eq!(st, StatusCode::OK);
+    assert_eq!(
+        b["_shards"]["total"], 1,
+        "concrete name addresses one index. body: {b}"
+    );
+}


### PR DESCRIPTION
Part of #449's class A, split out because it is small, additive and provable on its own.

## The defect

`resolve_indices_for_op` had **no alias branch at all** — its concrete-name arm checked the name against the list of real indices and 404'd otherwise, so an alias was simply "not an index".

Measured on a three-member alias `tri` over `idx-a`/`idx-b`/`idx-c`:

| request | via alias | via concrete index |
|---|---|---|
| `POST /_refresh` | **404** | 200 |
| `POST /_forcemerge` | **404** | 200 |
| `POST /_cache/clear` | **404** | 200 |
| `POST /_terms_enum` | **404** | 200 |

An alias is a valid index selector for every one of these in Elasticsearch.

## The fix

The new branch expands to **every member**, not `aliased.first()`. That distinction is why this was worth doing carefully: a maintenance op that silently addressed one member of a multi-index alias is the same defect class as #450 on the destructive side, and a `_refresh` reaching one of three members makes the next search non-deterministic with nothing in the response admitting it.

```
POST /tri/_refresh -> 200, _shards {"total":3,"successful":3,"failed":0}
```

A concrete index name still wins over an alias of the same name, matching ES, where the two namespaces cannot collide.

## The missing-name rule is deliberately unchanged

ES defaults `ignore_unavailable=false`, so a typo must fail the whole request rather than silently doing less than asked:

```
POST /no-such-thing/_refresh -> 404
POST /idx-a,typo/_refresh    -> 404
POST /idx-*/_refresh         -> 200   (wildcard expansion, unchanged)
```

## Fail-before

Reverting **only** the source hunk, keeping both tests:

```
test maintenance_endpoints_accept_an_alias_and_reach_every_member ... FAILED
test an_unknown_name_still_fails_the_whole_request ... ok
```

The second passing is the point — it is the no-regression guard, and that behaviour was already correct.

## Gates

fmt clean · clippy `--workspace --all-targets -D warnings` clean · full `xerj-api` suite green under rustc 1.97.1 in **both** the dev and ci-test profiles.

## What this does NOT fix — #449 stays open

The other resolver class: `Engine::get_index` resolves an alias to `aliased.first()`, so `_explain`, `_segments`, `_cat/segments`, `_eql/search`, `_async_search`, `_mget` and `_flush` answer from **one member** instead of 404ing.

Those return 200 with a partial answer, which is a different and harder problem than returning 404 on a valid name — it needs the same "what does this operation mean across members" judgement that keeps #453 drafted. Returning a correct answer for a name that used to be rejected is safe; changing what an already-succeeding endpoint returns is not, and I would rather do that with its own reproduction and its own review.

## Not verified

Whether any client depends on an alias 404ing from these endpoints. That would be depending on a bug, but I have not searched for it.
