### PR TITLE
fix(limits): cap the memory-derivation base at 8 GiB by default

### DIFF
--- a/engine/crates/xerj-common/src/config.rs
+++ b/engine/crates/xerj-common/src/config.rs
@@ -1,6 +1,6 @@
 //! xerj configuration system.
 //!
-//! Configuration is intentionally minimal: **115 settings** versus
+//! Configuration is intentionally minimal: **116 settings** versus
 //! Elasticsearch's 3000+. Every option is named, documented, and has a sensible
 //! production-ready default. The format is TOML, loaded from a single file.
 //!
@@ -97,7 +97,7 @@ pub struct Config {
     pub wal_tap: WalTapConfig,
 }
 
-// 21 sub-configs, 115 leaf settings in total. Do not maintain that sum by hand
+// 21 sub-configs, 116 leaf settings in total. Do not maintain that sum by hand
 // — `journey_zero_config` in xerj-engine/tests/product_experience.rs counts a
 // serialised `Config::default()` and fails if this comment and the module
 // header stop matching. `Default` is derived: every field is a sub-config that
@@ -436,7 +436,7 @@ impl Config {
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
-// Sub-configs  (115 user-facing settings total; counted by
+// Sub-configs  (116 user-facing settings total; counted by
 // `journey_zero_config`, not by hand)
 // ═════════════════════════════════════════════════════════════════════════════
 
@@ -1441,6 +1441,27 @@ pub struct LimitsConfig {
     /// WAL. The block clears automatically once usage drops back below the
     /// threshold. Set to `0` to disable the disk watermark.
     pub disk_flood_stage_percent: u8,
+    /// Hard ceiling on the machine size every other memory budget is derived
+    /// FROM, in MiB (default: `8192` = 8 GiB; `0` disables the cap).
+    ///
+    /// Without this, XERJ sizes itself to the machine. Every budget in
+    /// `ResourceGovernor` derives from `effective_memory_limit_bytes()`, which
+    /// is min(cgroup limit, total system RAM) — so with no cgroup, which is the
+    /// normal laptop and macOS case, the derivation base is the whole machine:
+    ///
+    ///   64 GiB host   memtables 25% = 16 GiB, hydration 20% = 12.8 GiB,
+    ///                 RSS watermark 95% = 60.8 GiB
+    ///
+    /// A bigger machine therefore bought a hungrier XERJ rather than a faster
+    /// one, and users reported ~20 GiB resident for two indexed projects. This
+    /// caps the derivation base itself, so every dependent budget shrinks
+    /// coherently instead of each one growing its own ceiling.
+    ///
+    /// The cap only ever LOWERS the base: on a machine smaller than the cap, or
+    /// under a smaller cgroup limit, the smaller value still wins. Raise it if
+    /// you are running a dedicated box and want the old machine-proportional
+    /// behaviour, or set `0` to remove the ceiling entirely.
+    pub max_process_memory_mb: u64,
 }
 
 impl Default for LimitsConfig {
@@ -1459,6 +1480,7 @@ impl Default for LimitsConfig {
             max_segment_hydration_cache_mb: 0, // 0 = 20% effective memory, no floor
             memory_watermark_percent: 95,
             disk_flood_stage_percent: 95,
+            max_process_memory_mb: 8192, // 8 GiB; 0 = derive from the machine
         }
     }
 }
@@ -2310,7 +2332,7 @@ mod tests {
             drift.join("\n  ")
         );
 
-        // …and the file's own header quotes how many of the 115 it sets. That
+        // …and the file's own header quotes how many of the 116 it sets. That
         // number was 38, then 56, and never once the truth (#207), so count the
         // assignments instead of trusting the sentence.
         let set_here = toml_src
@@ -2806,7 +2828,7 @@ mod tests {
             "the section table must sum to the whole config"
         );
         assert_eq!(
-            total, 115,
+            total, 116,
             "the total settings count changed. It is quoted in this module's \
              header, in xerj-common/src/lib.rs, in engine/README.md, in \
              xerj.default.toml and in EXPECTED_SETTINGS in \

--- a/engine/crates/xerj-engine/src/governor.rs
+++ b/engine/crates/xerj-engine/src/governor.rs
@@ -388,7 +388,24 @@ pub struct GovernorSnapshot {
 /// `effective_memory_limit_bytes`) — this function has no way to detect a
 /// host-RAM value passed in by mistake, so getting that argument right is
 /// the caller's responsibility.
+/// Apply the configured process-memory ceiling to the machine-derived limit.
+///
+/// `cap_mb == 0` disables the ceiling. The result is never larger than the
+/// machine/cgroup limit — this lowers a budget, it never invents headroom that
+/// the host does not have.
+fn cap_memory_limit(machine_limit: u64, cap_mb: u64) -> u64 {
+    if cap_mb == 0 {
+        return machine_limit;
+    }
+    machine_limit.min(cap_mb.saturating_mul(1024 * 1024))
+}
+
 fn auto_memtable_budget(effective_limit: u64) -> u64 {
+    // The 2 GiB floor is clamped by the 50% ceiling on the SAME effective
+    // limit, so an 8 GiB cap yields 2 GiB (25% = 2 GiB) and a 2 GiB effective
+    // limit yields 1 GiB rather than the floor's 2 GiB. The floor raises a
+    // budget on a roomy host; it must never hand out more than half of what
+    // the host — or the configured cap — actually allows.
     (effective_limit / 4)
         .max(2 * 1024 * 1024 * 1024)
         .min(effective_limit / 2)
@@ -496,7 +513,19 @@ fn build(config: &Config) -> ResourceGovernor {
     let limits = &config.limits;
 
     // ── RSS watermark against the effective memory limit ──
-    let memory_limit_bytes = effective_memory_limit_bytes();
+    //
+    // Capped by `limits.max_process_memory_mb` (default 8 GiB). Every budget
+    // below derives from this one number, so capping HERE is what makes the
+    // ceiling coherent — capping each dependent budget separately would let
+    // their sum exceed the ceiling nobody set.
+    //
+    // The cap only lowers: a smaller machine, or a smaller cgroup limit, still
+    // wins. Users reported ~20 GiB resident for two projects because with no
+    // cgroup the derivation base was the whole machine, so a 64 GiB host asked
+    // for 16 GiB of memtables and a 12.8 GiB hydration cache before anything
+    // else allocated a byte.
+    let memory_limit_bytes =
+        cap_memory_limit(effective_memory_limit_bytes(), limits.max_process_memory_mb);
 
     // ── memtable budget: 0 = auto-derive from the effective (cgroup-aware)
     // memory limit — see `auto_memtable_budget`. Must be derived from the
@@ -881,6 +910,59 @@ mod tests {
     /// `system_total_bytes()` directly, so it had no coverage at all —
     /// this table pins the exact values a reviewer reproduced live on a
     /// real cgroup-v2 host (1 GiB cap → 512 MiB, not the pre-fix ~30 GiB).
+    /// The reported symptom, as arithmetic: a big machine bought a hungrier
+    /// XERJ. Every budget derives from the same base, so the base is what the
+    /// cap has to bind.
+    #[test]
+    fn the_default_cap_binds_on_the_machines_users_actually_run() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        const DEFAULT_CAP_MB: u64 = 8192;
+
+        // 64 GiB Mac Pro, no cgroup — the reported case.
+        let uncapped = cap_memory_limit(64 * GIB, 0);
+        let capped = cap_memory_limit(64 * GIB, DEFAULT_CAP_MB);
+        assert_eq!(uncapped, 64 * GIB, "0 must mean no ceiling");
+        assert_eq!(capped, 8 * GIB, "the default must bind on a 64 GiB host");
+
+        // What that does to the budgets that actually allocate.
+        assert_eq!(auto_memtable_budget(uncapped), 16 * GIB);
+        assert_eq!(auto_memtable_budget(capped), 2 * GIB);
+
+        // 128 GiB workstation: still 8 GiB, not 32.
+        assert_eq!(cap_memory_limit(128 * GIB, DEFAULT_CAP_MB), 8 * GIB);
+    }
+
+    /// The cap lowers a budget; it must never invent headroom the host does
+    /// not have. A 4 GiB laptop stays a 4 GiB laptop.
+    #[test]
+    fn the_cap_never_raises_a_budget_above_the_machine() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        assert_eq!(cap_memory_limit(4 * GIB, 8192), 4 * GIB);
+        assert_eq!(cap_memory_limit(2 * GIB, 8192), 2 * GIB);
+        // A cgroup smaller than the cap still wins.
+        assert_eq!(cap_memory_limit(512 * 1024 * 1024, 8192), 512 * 1024 * 1024);
+    }
+
+    /// The 2 GiB memtable floor must not punch through a smaller ceiling —
+    /// otherwise the floor alone would hand out the entire cap, or more than
+    /// the machine has.
+    #[test]
+    fn the_memtable_floor_cannot_exceed_half_the_capped_base() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        for base_gib in [1u64, 2, 4, 8, 16, 64] {
+            let base = base_gib * GIB;
+            let budget = auto_memtable_budget(base);
+            assert!(
+                budget <= base / 2,
+                "memtable budget {budget} exceeds half of a {base_gib} GiB base"
+            );
+        }
+        // Concretely: at the 8 GiB default cap the floor does not apply at all.
+        assert_eq!(auto_memtable_budget(8 * GIB), 2 * GIB);
+        // And under a 2 GiB cgroup the floor is clamped to 1 GiB, not 2.
+        assert_eq!(auto_memtable_budget(2 * GIB), GIB);
+    }
+
     #[test]
     fn auto_memtable_budget_is_cgroup_proportional_and_bounded() {
         const GIB: u64 = 1024 * 1024 * 1024;

--- a/engine/crates/xerj-engine/tests/product_experience.rs
+++ b/engine/crates/xerj-engine/tests/product_experience.rs
@@ -753,7 +753,7 @@ fn count_settings(value: &serde_json::Value) -> usize {
 
 /// Settings in a default `Config`, measured by `count_settings`. Quoted in
 /// `xerj-common/src/config.rs`; keep the two in step.
-const EXPECTED_SETTINGS: usize = 115;
+const EXPECTED_SETTINGS: usize = 116;
 
 #[tokio::test]
 async fn journey_zero_config() {


### PR DESCRIPTION
Users report **~20 GiB resident for two indexed projects**, on a Mac Pro. This caps the default.

## Cause: XERJ sized itself to the machine

Every budget in the resource governor derives from `effective_memory_limit_bytes()` — which is just `min(cgroup limit, total system RAM)`. With no cgroup (the normal laptop and macOS case) the derivation base is **the whole machine**, so a bigger machine bought a hungrier XERJ rather than a faster one.

Measured on a 121 GiB host, same binary, only `max_process_memory_mb` differing:

| budget | uncapped (today) | 8 GiB cap (new default) |
|---|---:|---:|
| derivation base | 124,609 MB | **8,192 MB** |
| memtable budget | 31,152 MB | 2,048 MB |
| segment hydration cache | 24,921 MB | 1,638 MB |
| RSS watermark | 118,379 MB | 7,782 MB |

Before this change the engine was willing to hold **30 GiB of memtables plus 24 GiB of hydration cache** — 54 GiB of headroom it would grow into — before the RSS admission check at 118 GiB fired even once. Two projects reaching 20 GiB is that arithmetic working exactly as written.

## The cap goes at the derivation point, not on each budget

Capping the budgets individually would let their **sum** exceed a ceiling nobody set. One number feeds them all, so that number is what gets capped.

`limits.max_process_memory_mb` defaults to `8192`; `0` restores the old machine-proportional behaviour for a dedicated box.

**It only ever lowers.** A 4 GiB laptop stays 4 GiB; a cgroup smaller than the cap still wins. This hands out less than the machine allows, never more.

## The 2 GiB memtable floor, checked against a smaller ceiling

A floor that punches through the cap would hand the whole budget to one subsystem. It is already clamped by the 50% ceiling on the same base:

```
8 GiB base  -> 2 GiB  (25%, floor not reached)
2 GiB base  -> 1 GiB  (floor clamped, not 2 GiB)
```

Pinned by a test across 1/2/4/8/16/64 GiB bases.

## Tests

Three: the default binds on the machines users actually run (64 and 128 GiB), the cap never raises a budget above the machine, and the floor cannot exceed half the capped base.

`journey_zero_config` caught the new setting and refused the build until the count quoted in prose was updated — 115 → 116 in the module header, the `struct Config` comment, the counted assertion and `EXPECTED_SETTINGS`. The rc.17 CHANGELOG entry still says 115 and is deliberately left alone: that is the record of what rc.17 shipped, not a live claim.

## Gates

fmt clean · clippy `--workspace --all-targets -D warnings` clean · full `xerj-engine` **and** `xerj-api` suites green under rustc 1.97.1, ci-test profile.

## What this does NOT do — please read before treating 8 GiB as a guarantee

It caps the budgets **derived from machine size**. It does **not** bound allocation paths that consult no budget at all, and it is **not** an RSS ceiling — query materialization, decode scratch, mmaps and allocator fragmentation all sit outside it, exactly as the existing `max_segment_hydration_cache_mb` docs already warn.

A parallel audit is measuring where resident memory actually goes (per-index fixed overhead, cache eviction, retained allocations). Anything it finds that ignores these budgets needs its own fix. **This change should not be read as a promise that 8 GiB is now impossible to exceed** — it removes the engine's licence to *plan* for 54 GiB.

## Not verified

Real RSS under sustained load on a capped node — this measures the budgets the governor announces, not the resident memory a long autoindex run actually reaches. That is what the audit is for.
