### PR TITLE
fix(config): main is red — the 8 GiB cap setting broke two more counted claims

### DIFF
--- a/engine/crates/xerj-common/src/config.rs
+++ b/engine/crates/xerj-common/src/config.rs
@@ -74,7 +74,7 @@ pub struct Config {
     pub logs: LogsConfig,
     /// External embedding service — 19 settings.
     pub embedding: EmbeddingConfig,
-    /// Resource limits — 13 settings.
+    /// Resource limits — 14 settings.
     pub limits: LimitsConfig,
     /// High-throughput turbo indexing — 3 settings.
     pub indexing: IndexingConfig,
@@ -2776,7 +2776,7 @@ mod tests {
         ("vector", 6),
         ("logs", 2),
         ("embedding", 19),
-        ("limits", 13),
+        ("limits", 14),
         ("indexing", 3),
         ("engine", 4),
         ("cluster", 5),

--- a/engine/xerj.default.toml
+++ b/engine/xerj.default.toml
@@ -1,6 +1,6 @@
 # xerj Default Configuration
 # ============================================================
-# This file sets 54 of XERJ's 115 user-facing settings to their
+# This file sets 54 of XERJ's 116 user-facing settings to their
 # production-ready defaults, and describes the rest in comments.
 # Every value here IS the default, so copying this file changes
 # nothing until you edit it (a test enforces that). The complete


### PR DESCRIPTION
Main is RED at `addbb3e`. This is the fix.

```
config::tests::count_user_facing_settings ... FAILED
  left:  [... ("limits", 14) ...]
  right: [... ("limits", 13) ...]
```

Adding `limits.max_process_memory_mb` in #461 moved the limits section from 13 settings to 14. I updated the **total** (115 → 116) in four places plus `EXPECTED_SETTINGS`, and missed two more claims that count the same thing a different way:

- `SETTINGS_BY_SECTION` and the doc comment above `LimitsConfig` ("Resource limits — 13 settings")
- `engine/xerj.default.toml`'s header, "sets 54 of XERJ's 115 user-facing settings", checked by `shipped_default_config_documents_the_real_defaults` against the summed section counts

Both now say 14 and 116.

## How I missed it

I ran the `xerj-engine` and `xerj-api` suites and **not `-p xerj-common`, the crate I actually edited**. `journey_zero_config` (in xerj-engine) caught the total, I fixed that, and that success convinced me the counting gates were satisfied — the two in xerj-common never ran locally. Running the workspace, or just the crate under the diff, would have caught it. That is the lesson, not the two-line edit.

It reached main because #461 merged with 2 checks still in flight and no independent verdict, so nothing stood between my gap and the branch.

## Verified

`cargo test -p xerj-common` 91 + 3 pass · `product_experience` 10 pass · fmt clean · rustc 1.97.1, ci-test profile. Full workspace run is in progress.