### PR TITLE
feat(cli): xerj feedback + CLA carve-out so agents can file field reports (#329-adjacent contribution loop)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,22 @@ jobs:
       - name: Co-author CLA check unit tests
         run: python3 scripts/test_cla_coauthors.py
 
+      # The narrow field-report carve-out lives here: pass the PR's changed
+      # files to the checker, which SKIPS the trailer gate iff every changed
+      # path is a markdown field report under user-feedback/16-agent-field-reports/
+      # (and nothing else). Any code/CI/other-docs change re-arms the full gate.
+      # The binding `verification/cla-signed` status for a field-report-only PR
+      # is provided separately (.github/workflows/cla-field-report-exempt.yml),
+      # because cla-bot cannot path-scope itself.
       - name: Co-authored-by trailers resolve to signed contributors
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: python3 scripts/check_cla_coauthors.py --pr "$PR_NUMBER"
+          REPO: ${{ github.repository }}
+        run: |
+          FILES="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          python3 scripts/check_cla_coauthors.py --pr "$PR_NUMBER" --changed-files "$FILES"
 
   reference-coding:
     name: Reference-coding toolkit

--- a/.github/workflows/cla-field-report-exempt.yml
+++ b/.github/workflows/cla-field-report-exempt.yml
@@ -1,0 +1,75 @@
+name: CLA field-report exemption
+
+# Provides the required `verification/cla-signed` status for a pull request whose
+# ENTIRE diff is agent field reports — markdown files under
+# user-feedback/16-agent-field-reports/ — and ONLY such a pull request.
+#
+# Why a separate job at all: `verification/cla-signed` is normally posted by the
+# external cla-bot GitHub App, which matches commit AUTHORS against .contributors
+# and CANNOT path-scope itself. The agent field-report loop exists so any agent
+# can file one short report; gating that behind a CLA signature is the friction
+# that kept the folder empty (see demo/playbooks/AGENT_CONTRIBUTION_LOOP_2026-08-18.md).
+# This job scopes the exemption: it fires only when EVERY changed path is a field
+# report, so a mixed pull request (a field report plus any code/CI/other change)
+# is left entirely to cla-bot and gets the full gate. The predicate is the same
+# one the internal trailer gate uses (scripts/check_cla_coauthors.py
+# --is-field-report-only), so the two cannot drift.
+#
+# Why pull_request_target, not pull_request: only that event's token can write a
+# commit status on a fork pull request, and field reports come from exactly those
+# forks. This job is safe under the elevated token because it NEVER checks out or
+# runs the pull request's code — it checks out the trusted base ref, reads the
+# changed FILE LIST from the API, and posts a status. Do not add a checkout of the
+# PR head here.
+#
+# Honest limitation (stated plainly, per the task): posting this status races
+# cla-bot's own status for the same context — GitHub keeps the last writer per
+# context. Because this job never fires on a mixed PR, cla-bot stays authoritative
+# everywhere it matters, but the fully robust fix for field-report-only PRs is an
+# admin-level branch-protection or .clabot change, which lives outside this repo.
+# The status post is non-fatal (`|| echo`) so a token that cannot write it never
+# reddens the PR; cla-bot simply remains authoritative in that case.
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: cla-fr-exempt-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  field-report-exempt:
+    name: Field-report CLA exemption
+    runs-on: ubuntu-latest
+    steps:
+      # Trusted base code ONLY — never the PR head. This runs under the elevated
+      # pull_request_target token and must not execute untrusted contributor code.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Provide verification/cla-signed for a field-report-only PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          FILES="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          if python3 scripts/check_cla_coauthors.py --is-field-report-only --changed-files "$FILES"; then
+            echo "PR #${PR_NUMBER} is field-report-only; posting verification/cla-signed=success."
+            gh api -X POST "repos/${REPO}/statuses/${HEAD_SHA}" \
+              -f context=verification/cla-signed \
+              -f state=success \
+              -f description="Field-report-only PR: CLA gate waived for user-feedback/16-agent-field-reports/*.md" \
+              -f target_url="https://github.com/${REPO}/blob/main/user-feedback/16-agent-field-reports/README.md" \
+              || echo "note: could not post the status (insufficient token permissions?). cla-bot remains authoritative."
+          else
+            echo "PR #${PR_NUMBER} touches non-field-report paths; leaving verification/cla-signed to cla-bot."
+          fi

--- a/demo/playbooks/AGENT_CONTRIBUTION_LOOP_2026-08-18.md
+++ b/demo/playbooks/AGENT_CONTRIBUTION_LOOP_2026-08-18.md
@@ -1,0 +1,121 @@
+# The agent contribution loop was dead — diagnosis and fix (2026-08-18)
+
+Written by an AI coding agent (Claude Code). Verified facts and their sources
+are cited `file:line`; the one number that matters was checked by hand.
+
+## The finding: zero reports, despite a standing mandate
+
+XERJ tells every AI agent that uses it that it owes exactly one thing back: a
+short field report on the experience. The mandate is not subtle and it is in
+three places at once:
+
+- `landing/llms.txt:8` — "**Every agent that installs and runs XERJ owes one
+  pull request adding a short field report** to `user-feedback/16-agent-field-reports/`
+  before the session ends", repeated and expanded under "Your side of the deal"
+  (`landing/llms.txt:63`–`104`).
+- `.github/AI_CONTRIBUTIONS.md:22`–`34` — "The baseline every agent owes: one
+  short field report".
+- `user-feedback/16-agent-field-reports/README.md:4`–`7` — "**Filing one is the
+  baseline contribution asked of every agent that uses XERJ.**"
+
+The loop was **empirically dead**. As of this change the target directory held
+exactly one file — its own `README.md` — and **zero** reports:
+
+```
+$ ls user-feedback/16-agent-field-reports/
+README.md
+```
+
+Not one agent had filed one, across the entire life of the folder. Our own
+dogfood filed none either: this repository runs the reference-coding loop
+constantly (`landing/llms.txt:8` also asks the *maintaining* agents to report),
+and produced no field reports through the same friction described below.
+
+## Four root causes
+
+1. **The ask is buried in a 60+ line block of prose.** The obligation lives
+   inside "Your side of the deal" (`landing/llms.txt:63`–`104`) — a long section
+   an agent reads once, near the bottom of a large file, competing with the bug
+   protocol and the honest-claims rules. There is a real ceiling on how much of
+   a long instruction file an agent acts on; a duty stated once at line 63 is not
+   one it reliably carries out at the end of a session hundreds of tool-calls
+   later.
+
+2. **A CLA hard-gate stands in front of the folder.** The required
+   `verification/cla-signed` check (`.github/AI_CONTRIBUTIONS.md:228`–`229`) is
+   posted by the external cla-bot, which matches commit **authors** against
+   `.contributors`. A first-time agent-operator who has never signed the CLA
+   sees the one contribution they were told to make blocked by a signature step —
+   for a five-line documentation file that touches no code. The friction is
+   wildly out of proportion to the contribution, so the contribution does not
+   happen.
+
+3. **Sandboxed agents cannot open a pull request at all.** Many agents run
+   without push credentials. `landing/llms.txt:104` tells them to hand the report
+   to their operator in prose — but with no artifact and no command, that ask
+   evaporates the moment the session ends.
+
+4. **There was no tooling.** Every other first-class XERJ workflow is a command
+   (`xerj autoindex`, `xerj brain`, `xerj mcp`). The field report — the one thing
+   asked of *every* agent — was the only workflow with no command behind it: the
+   agent had to hand-write the markdown, look up the template, derive a filename,
+   craft the branch/commit/PR, and disclose its own authorship, all from memory.
+
+## The fix shipped here
+
+- **`xerj feedback` — the missing command.**
+  `engine/crates/xerj-autoindex/src/feedback.rs` (new module; dispatched from
+  `engine/crates/xerj-server/src/main.rs` alongside `autoindex`/`brain`). It
+  drafts the report to stdout or `-o <path>`, auto-filling only observable facts
+  — `xerj --version`, OS + arch, and "what was indexed" read from a running
+  node's `autoindex-catalog` via the reused
+  `xerj_autoindex::fetch_catalog_summary` (`engine/crates/xerj-autoindex/src/lib.rs`).
+  Every *opinion* is a flag (`--verdict`, `--used-for`, `--pointed-at`,
+  `--numbers`); an omitted flag emits the template placeholder rather than an
+  invented opinion, and the catalog auto-fill degrades to a placeholder when no
+  node answers — it never fabricates a corpus. The rendered report's first line
+  states an AI agent wrote it (the provenance rule at `landing/llms.txt:102`).
+  `--open-pr` commits only the one file and runs `gh pr create`; if `gh` is
+  missing or unauthenticated it fails loudly and prints the exact git+gh commands
+  — the honest sandboxed-agent path for root cause 3. `--dry-run` prints the
+  report and the commands and does nothing.
+
+- **A narrow, safe CLA carve-out** for root cause 2.
+  `scripts/check_cla_coauthors.py` gains `is_field_report_only()` and a
+  `--changed-files` guard: a pull request whose entire diff is markdown field
+  reports under `user-feedback/16-agent-field-reports/` (and nothing else —
+  not the folder README, not any code or CI) is exempt; any other changed path
+  re-arms the full gate, so a code change can never ride in under a field report.
+  `.github/workflows/ci.yml` (the `cla-config` job) now computes the PR's changed
+  files and passes them to the internal trailer check. Because cla-bot cannot
+  path-scope itself, the binding `verification/cla-signed` status for a strictly
+  field-report-only PR is provided by a separate, same-predicate job
+  (`.github/workflows/cla-field-report-exempt.yml`) — stated plainly there,
+  including its honest limitation (it races cla-bot last-writer-wins, so it is
+  scoped never to fire on a mixed PR, and the fully robust fix is an admin-level
+  branch-protection / `.clabot` change out of this repo). Tests:
+  `scripts/test_cla_coauthors.py` asserts field-report-only ⇒ exempt and every
+  mixed/README/nested/non-md case ⇒ NOT exempt.
+
+- **The reference-coding nudge** for root cause 4, closing the loop where the
+  maintaining agents actually work. `tools/xerj-code/SKILL.md` gains an "After
+  the session: file the field report" step, and `tools/xerj-code/scripts/xc.py`
+  prints a one-line, stderr-only, once-per-day, `XERJ_CODE_NO_NUDGE`-silenceable
+  reminder — never touching the stdout retrieval passages a caller parses. Note:
+  the *runtime* skill directory `.claude/skills/xerj-code/` is gitignored
+  (`.gitignore:70`); the tracked source of the same tooling is `tools/xerj-code/`
+  (`.gitignore:126` re-includes `tools/**/*.md`), so the fix lands in the tracked
+  source and propagates when the skill is redeployed.
+
+- **The slimmed llms.txt ask** for root cause 1 is a sibling documentation PR
+  (not in this branch): it lifts the one-command ask out of the 60-line block so
+  the duty is stated where an agent will act on it. This engineering PR ships the
+  command and the carve-out the docs PR points at.
+
+## Why this is safe
+
+The exemption waives a *signature*, never review: a maintainer still reads and
+merges the report, and the predicate is verified by unit test to reject every
+non-field-report path. `xerj feedback` invents no opinions and no numbers, and
+discloses its own authorship on line one — it makes the honest report easy, not
+the flattering one.

--- a/engine/crates/xerj-autoindex/src/feedback.rs
+++ b/engine/crates/xerj-autoindex/src/feedback.rs
@@ -1,0 +1,796 @@
+//! `xerj feedback` — draft the agent field report the repo asks every agent to
+//! file, and (optionally) open the pull request for it.
+//!
+//! ## Why this command exists
+//!
+//! `user-feedback/16-agent-field-reports/README.md` and
+//! https://xerj.org/llms.txt both say the baseline contribution asked of every
+//! agent that uses XERJ is one short field report. In practice that ask was
+//! *empirically dead*: the folder held only its README, zero reports, because
+//! the obligation was a paragraph of prose with no tooling behind it and a CLA
+//! hard-gate in front of it (see
+//! `demo/playbooks/AGENT_CONTRIBUTION_LOOP_2026-08-18.md`). This turns the ask
+//! into one command.
+//!
+//! ## What it does, and what it refuses to do
+//!
+//! It auto-fills only *facts it can actually observe*:
+//! - `xerj --version` (this binary's own version),
+//! - OS + arch (`std::env::consts`),
+//! - "what was indexed", read from a running node's `autoindex-catalog` via
+//!   [`crate::fetch_catalog_summary`] — degrading to the template placeholder
+//!   when nothing is reachable, never inventing a corpus.
+//!
+//! Every *opinion* comes from a flag (`--verdict`, `--used-for`,
+//! `--pointed-at`, `--numbers`); an omitted flag emits the template placeholder
+//! for a human or agent to fill, because a tool must not invent an opinion any
+//! more than it may invent a number.
+//!
+//! The rendered report's FIRST line states an AI agent wrote it — the same
+//! provenance rule the invitation and `.github/AI_CONTRIBUTIONS.md` apply to
+//! every agent-authored contribution.
+//!
+//! Note the name: this module is `crate::feedback` (the `xerj feedback`
+//! subcommand). It is unrelated to `xerj_common::feedback`, which is the
+//! one-line "report a bug" invitation printed in every `--help` screen.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The one fixed home of agent field reports. A report goes here and nowhere
+/// else — that fixed path is exactly what lets the CLA carve-out recognise a
+/// field-report-only pull request (see `scripts/check_cla_coauthors.py`).
+pub const FIELD_REPORT_DIR: &str = "user-feedback/16-agent-field-reports";
+
+/// The report's first line, so the provenance is impossible to miss and easy to
+/// assert. Matches the invitation's "say it was filed on behalf of a human".
+const PROVENANCE: &str =
+    "> Written by an AI agent, filed automatically on behalf of a human operator.";
+
+// Template placeholders — copied from the folder README so a drafted-but-unfilled
+// report reads exactly like the "copy this, fill it in" template, and so a
+// reviewer sees an unfilled slot rather than a fabricated claim.
+const PH_TITLE: &str = "<one line: what you used XERJ for>";
+const PH_AGENT: &str = "<model / tool>";
+const PH_POINTED_AT: &str = "<what you indexed — kind of corpus and rough size, one sentence>";
+const PH_USED_FOR: &str =
+    "<reference coding / autoindex + query / agent memory / vector or hybrid search — one sentence>";
+const PH_VERDICT: &str = "<2-4 sentences of opinion. What worked, what did not, what you would not use it for. This is the part worth reading.>";
+const PH_NUMBERS: &str =
+    "<command -> result, only if you measured it. Otherwise: \"not measured\".>";
+const PH_FILED: &str = "<link to the issue or PR you opened, or \"nothing broke\">";
+
+/// Parsed `xerj feedback` invocation.
+#[derive(Debug, Clone)]
+pub struct Cfg {
+    pub agent: Option<String>,
+    pub used_for: Option<String>,
+    pub pointed_at: Option<String>,
+    pub verdict: Option<String>,
+    pub numbers: Option<String>,
+    pub filed_alongside: Option<String>,
+    pub title: Option<String>,
+    pub slug: Option<String>,
+    pub url: String,
+    pub api_key: Option<String>,
+    pub output: Option<PathBuf>,
+    pub open_pr: bool,
+    pub dry_run: bool,
+    /// Skip the running-node catalog probe entirely — for a fully offline draft
+    /// (and for tests, so they never touch a real endpoint).
+    pub no_autofill: bool,
+}
+
+/// The fields of the report after flags, auto-fill and placeholders are all
+/// resolved. Pure data: rendering it never touches the network or the clock.
+#[derive(Debug, Clone)]
+pub struct Draft {
+    pub date: String,
+    pub title: String,
+    pub agent: String,
+    pub version: String,
+    pub platform: String,
+    pub pointed_at: String,
+    pub used_for: String,
+    pub verdict: String,
+    pub numbers: String,
+    pub filed_alongside: String,
+    pub slug: String,
+}
+
+/// Entry point for the `xerj feedback` subcommand (blocking; the server binary
+/// calls this via `spawn_blocking`). Returns the process exit code.
+pub fn run_cli() -> i32 {
+    let args: Vec<String> = std::env::args().skip(2).collect();
+    match parse(args) {
+        Ok(None) => {
+            print_help();
+            0
+        }
+        Ok(Some(cfg)) => run(&cfg),
+        Err(e) => {
+            eprintln!("error: {e}\n");
+            print_help();
+            2
+        }
+    }
+}
+
+/// Parse argv (after `xerj feedback`). `Ok(None)` means `--help`.
+pub fn parse(args: Vec<String>) -> Result<Option<Cfg>, String> {
+    let mut it = args.into_iter();
+    let mut cfg = Cfg {
+        agent: None,
+        used_for: None,
+        pointed_at: None,
+        verdict: None,
+        numbers: None,
+        filed_alongside: None,
+        title: None,
+        slug: None,
+        url: "http://localhost:9200".to_string(),
+        api_key: std::env::var("XERJ_API_KEY").ok().filter(|s| !s.is_empty()),
+        output: None,
+        open_pr: false,
+        dry_run: false,
+        no_autofill: false,
+    };
+    while let Some(arg) = it.next() {
+        let mut next = |flag: &str| it.next().ok_or_else(|| format!("{flag} needs a value"));
+        match arg.as_str() {
+            "--agent" => cfg.agent = Some(next("--agent")?),
+            "--used-for" => cfg.used_for = Some(next("--used-for")?),
+            "--pointed-at" => cfg.pointed_at = Some(next("--pointed-at")?),
+            "--verdict" => cfg.verdict = Some(next("--verdict")?),
+            "--numbers" => cfg.numbers = Some(next("--numbers")?),
+            "--filed-alongside" => cfg.filed_alongside = Some(next("--filed-alongside")?),
+            "--title" => cfg.title = Some(next("--title")?),
+            "--slug" => cfg.slug = Some(next("--slug")?),
+            "--url" => cfg.url = next("--url")?,
+            "--api-key" => cfg.api_key = Some(next("--api-key")?),
+            "-o" | "--output" => cfg.output = Some(PathBuf::from(next("--output")?)),
+            "--open-pr" => cfg.open_pr = true,
+            "--dry-run" => cfg.dry_run = true,
+            "--no-autofill" => cfg.no_autofill = true,
+            // Scanned out of band by `xerj_common::feedback`; accepted here so
+            // it is not "unknown".
+            xerj_common::feedback::DISABLE_FLAG => {}
+            "--help" | "-h" => return Ok(None),
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    // `--open-pr` acts; `--dry-run` explicitly does nothing. Honouring one and
+    // silently dropping the other is the accepted-and-ignored class this repo
+    // refuses (#204), so name the contradiction instead.
+    if cfg.open_pr && cfg.dry_run {
+        return Err(
+            "--open-pr and --dry-run contradict each other: --dry-run only prints the plan and \
+             opens no pull request. Drop one of the two"
+                .into(),
+        );
+    }
+    Ok(Some(cfg))
+}
+
+/// Resolve the draft, render it, and act on the mode (`--dry-run`, `--open-pr`,
+/// or the default stdout/`-o`).
+fn run(cfg: &Cfg) -> i32 {
+    let date = today();
+    // Auto-fill "what was indexed" only when asked to and only from a node that
+    // actually answers; any failure leaves `None` → placeholder, never a
+    // fabricated corpus.
+    let indexed = if cfg.no_autofill {
+        None
+    } else {
+        match crate::fetch_catalog_summary(&cfg.url, cfg.api_key.clone()) {
+            Ok(summary) => summary.one_line(),
+            Err(_) => None,
+        }
+    };
+    let draft = resolve_draft(cfg, indexed, &date);
+    let report = render_report(&draft);
+    let commands = pr_commands(&draft);
+
+    if cfg.dry_run {
+        // Print the report AND the exact commands, and do nothing else.
+        let mut out = io::stdout().lock();
+        let _ = writeln!(out, "{report}");
+        let _ = writeln!(out, "\n{commands}");
+        return 0;
+    }
+    if cfg.open_pr {
+        return open_pr(&draft, &report, &commands);
+    }
+    // Default: report to stdout, and to `-o <path>` if one was given.
+    print!("{report}");
+    if let Some(path) = &cfg.output {
+        if let Err(e) = write_report_file(path, &report) {
+            eprintln!("error: could not write {}: {e}", path.display());
+            return 1;
+        }
+        eprintln!("wrote {}", path.display());
+    }
+    0
+}
+
+/// Today's date, `YYYY-MM-DD`, in local time — "the date you filed it".
+fn today() -> String {
+    chrono::Local::now().format("%Y-%m-%d").to_string()
+}
+
+/// Collapse the flags, the auto-filled summary and the placeholders into a
+/// single [`Draft`]. Precedence for "Pointed at": an explicit `--pointed-at`
+/// wins, then the auto-filled catalog summary, then the placeholder.
+pub fn resolve_draft(cfg: &Cfg, indexed: Option<String>, date: &str) -> Draft {
+    let non_empty = |o: &Option<String>| {
+        o.as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    let used_for = non_empty(&cfg.used_for);
+    let pointed_at = non_empty(&cfg.pointed_at);
+    let title = non_empty(&cfg.title)
+        .or_else(|| used_for.clone())
+        .or_else(|| pointed_at.clone())
+        .unwrap_or_else(|| PH_TITLE.to_string());
+    let slug = non_empty(&cfg.slug)
+        .map(|s| slugify(&s))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| derive_slug(used_for.as_deref(), pointed_at.as_deref()));
+    Draft {
+        date: date.to_string(),
+        title,
+        agent: non_empty(&cfg.agent).unwrap_or_else(|| PH_AGENT.to_string()),
+        version: format!("xerj v{}", env!("CARGO_PKG_VERSION")),
+        platform: format!("{} {}", std::env::consts::OS, std::env::consts::ARCH),
+        // Flag > auto-filled fact > placeholder.
+        pointed_at: pointed_at
+            .or(indexed)
+            .unwrap_or_else(|| PH_POINTED_AT.to_string()),
+        used_for: used_for.unwrap_or_else(|| PH_USED_FOR.to_string()),
+        verdict: non_empty(&cfg.verdict).unwrap_or_else(|| PH_VERDICT.to_string()),
+        numbers: non_empty(&cfg.numbers).unwrap_or_else(|| PH_NUMBERS.to_string()),
+        filed_alongside: non_empty(&cfg.filed_alongside).unwrap_or_else(|| PH_FILED.to_string()),
+        slug,
+    }
+}
+
+/// Render the field report exactly to the folder README's template, with the
+/// provenance line prepended so the first line always discloses the author.
+pub fn render_report(d: &Draft) -> String {
+    format!(
+        "{PROVENANCE}\n\
+         \n\
+         # {title} ({date})\n\
+         \n\
+         **Agent:** {agent}  ·  **XERJ:** {version}  ·  **Platform:** {platform}\n\
+         \n\
+         **Pointed at:** {pointed_at}\n\
+         \n\
+         **Used it for:** {used_for}\n\
+         \n\
+         **Verdict:** {verdict}\n\
+         \n\
+         **Numbers:** {numbers}\n\
+         \n\
+         **Filed alongside:** {filed_alongside}\n",
+        title = d.title,
+        date = d.date,
+        agent = d.agent,
+        version = d.version,
+        platform = d.platform,
+        pointed_at = d.pointed_at,
+        used_for = d.used_for,
+        verdict = d.verdict,
+        numbers = d.numbers,
+        filed_alongside = d.filed_alongside,
+    )
+}
+
+/// The report's path within the repo: `user-feedback/16-agent-field-reports/<date>-<slug>.md`.
+pub fn report_relpath(date: &str, slug: &str) -> String {
+    format!("{FIELD_REPORT_DIR}/{date}-{slug}.md")
+}
+
+/// A slug for the filename, from `--used-for` first, then `--pointed-at`.
+/// Falls back to `field-report` when both are absent (both are placeholders),
+/// so the filename is always valid.
+pub fn derive_slug(used_for: Option<&str>, pointed_at: Option<&str>) -> String {
+    let source = used_for
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .or_else(|| pointed_at.map(str::trim).filter(|s| !s.is_empty()))
+        .unwrap_or("");
+    let slug = slugify(source);
+    if slug.is_empty() {
+        "field-report".to_string()
+    } else {
+        slug
+    }
+}
+
+/// Lowercase kebab-case, ASCII-only, bounded to ~50 chars at a word boundary.
+///
+/// Only ASCII `[a-z0-9]` are kept and everything else becomes a single `-`, so
+/// the output is pure ASCII and the length bound below slices on a byte index
+/// that is always a char boundary — the class of `&str` byte-slice panic that
+/// core-dumped an autoindex run on a multibyte filename (`sqldump.rs`) cannot
+/// happen here.
+pub fn slugify(s: &str) -> String {
+    let mut out = String::new();
+    let mut pending_dash = false;
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() {
+            if pending_dash && !out.is_empty() {
+                out.push('-');
+            }
+            pending_dash = false;
+            out.push(c.to_ascii_lowercase());
+        } else {
+            pending_dash = true;
+        }
+    }
+    let out = out.trim_matches('-').to_string();
+    if out.len() <= 50 {
+        return out;
+    }
+    let head = &out[..50];
+    match head.rfind('-') {
+        Some(pos) if pos > 0 => head[..pos].to_string(),
+        _ => head.trim_matches('-').to_string(),
+    }
+}
+
+/// The exact, copy-pasteable git + gh commands that file this report — printed
+/// by `--dry-run`, and again as the honest fallback when `--open-pr` cannot run
+/// `gh` itself.
+pub fn pr_commands(d: &Draft) -> String {
+    let relpath = report_relpath(&d.date, &d.slug);
+    let branch = format!("field-report/{}", d.slug);
+    format!(
+        "# Ready-to-run — files ONLY the field report, nothing else:\n\
+         xerj feedback \\\n\
+         \x20 --used-for {used_for:?} --pointed-at {pointed_at:?} \\\n\
+         \x20 --verdict {verdict:?} --numbers {numbers:?} \\\n\
+         \x20 -o {relpath}\n\
+         git checkout -b {branch}\n\
+         git add {relpath}\n\
+         git commit -m \"docs(field-report): {slug}\"\n\
+         git push -u origin {branch}\n\
+         gh pr create --base main --head {branch} \\\n\
+         \x20 --title \"Agent field report: {title}\" \\\n\
+         \x20 --body \"Written by an AI agent on behalf of a human. Field report only; see {relpath}.\"",
+        used_for = d.used_for,
+        pointed_at = d.pointed_at,
+        verdict = d.verdict,
+        numbers = d.numbers,
+        relpath = relpath,
+        branch = branch,
+        slug = d.slug,
+        title = d.title,
+    )
+}
+
+/// Write the report to `path`, creating the field-reports directory if the path
+/// points inside it.
+fn write_report_file(path: &Path, report: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, report)
+}
+
+/// `--open-pr`: commit ONLY the field report on a new branch and run
+/// `gh pr create`. If `gh` is missing or unauthenticated, FAIL LOUDLY and print
+/// the exact ready-to-run commands — the honest sandboxed-agent path, never a
+/// silent partial success.
+fn open_pr(draft: &Draft, report: &str, commands: &str) -> i32 {
+    let relpath = report_relpath(&draft.date, &draft.slug);
+    let branch = format!("field-report/{}", draft.slug);
+
+    // Preconditions first, before we touch the working tree: a `gh` that cannot
+    // open the PR turns a committed branch into a dead end. Say so and hand over
+    // the commands instead.
+    if let Err(reason) = gh_ready() {
+        eprintln!("error: cannot open the pull request automatically: {reason}");
+        eprintln!(
+            "Falling back to the exact commands — run these yourself (the sandboxed-agent path):\n"
+        );
+        println!("{commands}");
+        return 1;
+    }
+    if !in_git_repo() {
+        eprintln!(
+            "error: `xerj feedback --open-pr` must run inside a checkout of the xerj repository \
+             (no .git found)."
+        );
+        eprintln!("Falling back to the exact commands:\n");
+        println!("{commands}");
+        return 1;
+    }
+
+    let steps: [(&str, Vec<String>); 5] = [
+        (
+            "git checkout -b",
+            vec!["checkout".into(), "-b".into(), branch.clone()],
+        ),
+        ("write report", vec![]), // handled specially below
+        ("git add", vec!["add".into(), relpath.clone()]),
+        (
+            "git commit",
+            vec![
+                "commit".into(),
+                "-m".into(),
+                format!("docs(field-report): {}", draft.slug),
+            ],
+        ),
+        (
+            "git push",
+            vec!["push".into(), "-u".into(), "origin".into(), branch.clone()],
+        ),
+    ];
+
+    for (label, argv) in steps {
+        if label == "write report" {
+            if let Err(e) = write_report_file(Path::new(&relpath), report) {
+                eprintln!("error: could not write {relpath}: {e}");
+                eprintln!("Falling back to the exact commands:\n");
+                println!("{commands}");
+                return 1;
+            }
+            continue;
+        }
+        if !run_cmd("git", &argv) {
+            eprintln!("error: `git {}` failed.", argv.join(" "));
+            eprintln!("Falling back to the exact commands:\n");
+            println!("{commands}");
+            return 1;
+        }
+    }
+
+    let pr_body =
+        format!("Written by an AI agent on behalf of a human. Field report only; see {relpath}.");
+    let pr_args = vec![
+        "pr".to_string(),
+        "create".to_string(),
+        "--base".to_string(),
+        "main".to_string(),
+        "--head".to_string(),
+        branch.clone(),
+        "--title".to_string(),
+        format!("Agent field report: {}", draft.title),
+        "--body".to_string(),
+        pr_body,
+    ];
+    if !run_cmd("gh", &pr_args) {
+        eprintln!("error: `gh pr create` failed — the branch and commit are in place.");
+        eprintln!("Finish it yourself with:\n");
+        println!("{commands}");
+        return 1;
+    }
+    0
+}
+
+/// Whether `gh` is on PATH and authenticated. Both are required to open a PR;
+/// either missing is a loud failure, not a silent skip.
+fn gh_ready() -> Result<(), String> {
+    if Command::new("gh").arg("--version").output().is_err() {
+        return Err("`gh` (the GitHub CLI) is not installed or not on PATH".into());
+    }
+    match Command::new("gh").args(["auth", "status"]).output() {
+        Ok(o) if o.status.success() => Ok(()),
+        Ok(_) => Err("`gh` is installed but not authenticated (run `gh auth login`)".into()),
+        Err(e) => Err(format!("could not run `gh auth status`: {e}")),
+    }
+}
+
+fn in_git_repo() -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_cmd(bin: &str, args: &[String]) -> bool {
+    Command::new(bin)
+        .args(args)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+pub fn print_help() {
+    println!("{}", help_text(xerj_common::feedback::enabled()));
+}
+
+/// The help text as a value so a test can assert a flag stays documented.
+pub fn help_text(feedback: bool) -> String {
+    format!(
+        "xerj feedback — draft the agent field report XERJ asks every agent to file\n\
+         \n\
+         {feedback_block}\
+         USAGE:\n\
+             xerj feedback [OPTIONS]              draft a field report to stdout\n\
+             xerj feedback -o <PATH> [OPTIONS]    also write it to <PATH>\n\
+             xerj feedback --open-pr [OPTIONS]    commit ONLY the report + open a PR\n\
+             xerj feedback --dry-run [OPTIONS]    print the report AND the commands; do nothing\n\
+         \n\
+         The report auto-fills only facts it can observe — this binary's version,\n\
+         OS + arch, and (from a running node's autoindex-catalog) what was indexed.\n\
+         When no node answers, the \"Pointed at\" line degrades to the template\n\
+         placeholder rather than inventing a corpus. Every OPINION comes from a\n\
+         flag; an omitted flag leaves the template placeholder for you to fill.\n\
+         The report's first line states an AI agent wrote it.\n\
+         \n\
+         OPINION (all optional; omitted → template placeholder, never invented):\n\
+             --verdict <TEXT>     2-4 sentences: what worked, what did not\n\
+             --used-for <TEXT>    reference coding / autoindex+query / memory / vector search\n\
+             --pointed-at <TEXT>  what you indexed (overrides the auto-filled summary)\n\
+             --numbers <TEXT>     command -> result, only if you measured it\n\
+             --filed-alongside <TEXT>  link to the issue/PR you opened, or \"nothing broke\"\n\
+             --agent <TEXT>       the model / tool writing this (e.g. 'Claude Code')\n\
+             --title <TEXT>       one-line report title (default: --used-for / --pointed-at)\n\
+         \n\
+         OUTPUT + FILING:\n\
+             -o, --output <PATH>  also write the report to <PATH>\n\
+             --slug <TEXT>        filename slug (default: derived from --used-for/--pointed-at);\n\
+                                  the file lands at {dir}/<YYYY-MM-DD>-<slug>.md\n\
+             --open-pr            create branch field-report/<slug>, commit ONLY that one file,\n\
+                                  and run `gh pr create`. If gh is missing/unauth it FAILS\n\
+                                  LOUDLY and prints the exact commands to run by hand\n\
+             --dry-run            print the report AND the exact commands, and do nothing\n\
+                                  (opens no PR, writes no file)\n\
+         \n\
+         READING THE CATALOG (auto-fill source):\n\
+             --url <U>            ES-compat endpoint (default http://localhost:9200)\n\
+             --api-key <K>        Authorization header (or env XERJ_API_KEY)\n\
+             --no-autofill        skip the node probe; draft fully offline\n\
+         \n\
+             --disable-feedback   do not print the invitation above (env XERJ_DISABLE_FEEDBACK)\n\
+             --help, -h           this help\n\
+         \n\
+         CLA: a pull request that adds ONLY files under {dir}/ (markdown field\n\
+         reports, nothing else) is exempted from the CLA gate — see CLA.md and\n\
+         .github/AI_CONTRIBUTIONS.md. Bundling any other change re-arms the gate.\n",
+        feedback_block = xerj_common::feedback::block(feedback),
+        dir = FIELD_REPORT_DIR,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_cfg() -> Cfg {
+        Cfg {
+            agent: None,
+            used_for: None,
+            pointed_at: None,
+            verdict: None,
+            numbers: None,
+            filed_alongside: None,
+            title: None,
+            slug: None,
+            url: "http://127.0.0.1:1".to_string(),
+            api_key: None,
+            output: None,
+            open_pr: false,
+            dry_run: false,
+            no_autofill: true,
+        }
+    }
+
+    #[test]
+    fn provenance_is_always_the_first_line() {
+        let d = resolve_draft(&base_cfg(), None, "2026-08-18");
+        let report = render_report(&d);
+        assert_eq!(
+            report.lines().next().unwrap(),
+            PROVENANCE,
+            "the first line must disclose the AI author"
+        );
+        assert!(report.lines().next().unwrap().contains("AI agent"));
+    }
+
+    #[test]
+    fn a_fully_filled_report_carries_every_field_and_no_placeholder() {
+        let cfg = Cfg {
+            agent: Some("Claude Code".into()),
+            used_for: Some("reference coding a Rust monorepo".into()),
+            pointed_at: Some("~2k Rust files, 40 MB".into()),
+            verdict: Some("Retrieval beat grep on unfamiliar code.".into()),
+            numbers: Some("xc sift 9/9 hits".into()),
+            filed_alongside: Some("nothing broke".into()),
+            ..base_cfg()
+        };
+        let d = resolve_draft(&cfg, None, "2026-08-18");
+        let report = render_report(&d);
+        for expected in [
+            "Claude Code",
+            "reference coding a Rust monorepo",
+            "~2k Rust files, 40 MB",
+            "Retrieval beat grep on unfamiliar code.",
+            "xc sift 9/9 hits",
+            "nothing broke",
+            "2026-08-18",
+        ] {
+            assert!(report.contains(expected), "report is missing {expected:?}");
+        }
+        // No template placeholder survived a fully-filled draft.
+        for ph in [
+            PH_TITLE,
+            PH_AGENT,
+            PH_POINTED_AT,
+            PH_USED_FOR,
+            PH_VERDICT,
+            PH_NUMBERS,
+            PH_FILED,
+        ] {
+            assert!(!report.contains(ph), "a filled report still shows {ph:?}");
+        }
+        // The version line is this binary's real version, not a guess.
+        assert!(report.contains(&format!("xerj v{}", env!("CARGO_PKG_VERSION"))));
+    }
+
+    #[test]
+    fn omitted_opinions_become_placeholders_and_are_never_invented() {
+        let d = resolve_draft(&base_cfg(), None, "2026-08-18");
+        let report = render_report(&d);
+        // Every opinion field falls back to its exact template placeholder.
+        for ph in [
+            PH_VERDICT,
+            PH_USED_FOR,
+            PH_POINTED_AT,
+            PH_NUMBERS,
+            PH_FILED,
+            PH_AGENT,
+        ] {
+            assert!(report.contains(ph), "missing placeholder {ph:?}");
+        }
+        // Facts are still filled in — placeholders are for OPINION only.
+        assert!(report.contains(std::env::consts::OS));
+        assert!(report.contains(std::env::consts::ARCH));
+    }
+
+    #[test]
+    fn the_catalog_summary_fills_pointed_at_only_when_no_flag_is_given() {
+        // Auto-filled fact, no --pointed-at → the fact wins over the placeholder.
+        let d = resolve_draft(
+            &base_cfg(),
+            Some("1234 records across 3 dataset(s)".into()),
+            "2026-08-18",
+        );
+        assert_eq!(d.pointed_at, "1234 records across 3 dataset(s)");
+        assert!(!render_report(&d).contains(PH_POINTED_AT));
+
+        // An explicit --pointed-at always wins over the auto-fill.
+        let cfg = Cfg {
+            pointed_at: Some("my own words".into()),
+            ..base_cfg()
+        };
+        let d = resolve_draft(
+            &cfg,
+            Some("1234 records across 3 dataset(s)".into()),
+            "2026-08-18",
+        );
+        assert_eq!(d.pointed_at, "my own words");
+    }
+
+    #[test]
+    fn slug_and_path_are_derived_correctly() {
+        assert_eq!(
+            slugify("Reference Coding a Rust Monorepo!"),
+            "reference-coding-a-rust-monorepo"
+        );
+        // used-for wins over pointed-at for the slug.
+        assert_eq!(
+            derive_slug(Some("autoindex + query"), Some("logs")),
+            "autoindex-query"
+        );
+        assert_eq!(derive_slug(None, Some("A PDF folder")), "a-pdf-folder");
+        // Both absent → a valid fallback, never an empty filename.
+        assert_eq!(derive_slug(None, None), "field-report");
+        assert_eq!(derive_slug(Some("   "), Some("")), "field-report");
+        // A non-ASCII-only source still yields a usable slug and never panics.
+        assert_eq!(derive_slug(Some("设计 ا"), None), "field-report");
+
+        assert_eq!(
+            report_relpath("2026-08-18", "a-pdf-folder"),
+            "user-feedback/16-agent-field-reports/2026-08-18-a-pdf-folder.md"
+        );
+    }
+
+    #[test]
+    fn a_long_source_slugs_to_a_bounded_ascii_string_at_a_word_boundary() {
+        let long = "reference coding across a very large multi language monorepo with many crates and services";
+        let slug = slugify(long);
+        assert!(slug.len() <= 50, "{} chars: {slug}", slug.len());
+        assert!(slug.is_ascii());
+        assert!(!slug.starts_with('-') && !slug.ends_with('-'));
+        assert!(!slug.contains("--"));
+    }
+
+    #[test]
+    fn dry_run_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("report.md");
+        let d = resolve_draft(&base_cfg(), None, "2026-08-18");
+        let report = render_report(&d);
+        let commands = pr_commands(&d);
+        // Exercise the exact emit path --dry-run takes: write to an in-memory
+        // sink, and prove no file is touched.
+        let mut sink: Vec<u8> = Vec::new();
+        writeln!(sink, "{report}").unwrap();
+        writeln!(sink, "\n{commands}").unwrap();
+        assert!(!out.exists(), "dry-run must not create the -o file");
+        let text = String::from_utf8(sink).unwrap();
+        assert!(text.contains("git checkout -b"), "commands must be printed");
+        assert!(text.contains(PROVENANCE), "the report must be printed");
+    }
+
+    #[test]
+    fn the_output_path_write_actually_writes_the_report_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join(FIELD_REPORT_DIR).join("2026-08-18-x.md");
+        let d = resolve_draft(&base_cfg(), None, "2026-08-18");
+        let report = render_report(&d);
+        write_report_file(&out, &report).unwrap();
+        assert!(out.exists());
+        assert_eq!(std::fs::read_to_string(&out).unwrap(), report);
+    }
+
+    #[test]
+    fn open_pr_and_dry_run_together_are_refused() {
+        let err = parse(vec!["--open-pr".into(), "--dry-run".into()]).unwrap_err();
+        assert!(err.contains("contradict"), "{err}");
+    }
+
+    #[test]
+    fn unknown_flags_are_refused_and_help_short_circuits() {
+        assert!(parse(vec!["--nope".into()])
+            .unwrap_err()
+            .contains("unknown"));
+        assert!(parse(vec!["--help".into()]).unwrap().is_none());
+        assert!(parse(vec!["-h".into()]).unwrap().is_none());
+    }
+
+    #[test]
+    fn flags_populate_the_cfg() {
+        let cfg = parse(vec![
+            "--verdict".into(),
+            "great".into(),
+            "--used-for".into(),
+            "reference coding".into(),
+            "-o".into(),
+            "/tmp/r.md".into(),
+            "--no-autofill".into(),
+        ])
+        .unwrap()
+        .unwrap();
+        assert_eq!(cfg.verdict.as_deref(), Some("great"));
+        assert_eq!(cfg.used_for.as_deref(), Some("reference coding"));
+        assert_eq!(cfg.output.as_deref(), Some(Path::new("/tmp/r.md")));
+        assert!(cfg.no_autofill);
+    }
+
+    #[test]
+    fn help_documents_the_contract_and_the_carveout() {
+        let help = help_text(true);
+        for expected in [
+            "--open-pr",
+            "--dry-run",
+            "--verdict",
+            "--pointed-at",
+            "first line states an AI agent wrote it",
+            "exempted from the CLA gate",
+            FIELD_REPORT_DIR,
+        ] {
+            assert!(help.contains(expected), "help missing {expected:?}");
+        }
+    }
+}

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -13,6 +13,7 @@ pub mod detect;
 pub mod esclient;
 pub mod estimate;
 pub mod extract;
+pub mod feedback;
 pub mod gate;
 mod generation_catalog;
 #[cfg(test)]
@@ -5753,6 +5754,117 @@ fn run_map(cfg: MapCfg) -> Result<i32> {
         }
     }
     Ok(0)
+}
+
+// ─── catalog summary (reused by `xerj feedback`) ─────────────────────────
+
+/// A compact, factual view of what the latest autoindex run put on a node.
+///
+/// `xerj feedback` uses it to auto-fill the "what was indexed" line of a field
+/// report without re-deriving the catalog queries `run_map` already owns. It is
+/// deliberately read-only and narrow: the latest run document and the dataset
+/// documents, nothing else. Everything else the caller needs (correlations,
+/// junk, gotchas) belongs to the full `autoindex map`, not to a one-line
+/// summary.
+pub struct CatalogSummary {
+    /// The most recent `doc_kind: run` document, if any run has been recorded.
+    pub run: Option<Value>,
+    /// Every `doc_kind: dataset` document, most records first — the same order
+    /// `run_map` renders them in.
+    pub datasets: Vec<Value>,
+}
+
+impl CatalogSummary {
+    /// A single honest sentence for a field report's "Pointed at" line, or
+    /// `None` when nothing was indexed (so the caller emits a placeholder
+    /// rather than a sentence that says "0 records"). Never fabricates: every
+    /// number here comes straight from the catalog the server wrote.
+    pub fn one_line(&self) -> Option<String> {
+        if self.datasets.is_empty() {
+            return None;
+        }
+        let get = |v: &Value, k: &str| v.get(k).cloned().unwrap_or(Value::Null);
+        // Prefer the run document's own total; fall back to summing datasets so
+        // a node whose run doc predates that field still reports a real count.
+        let records = self
+            .run
+            .as_ref()
+            .and_then(|r| get(r, "records_total").as_u64())
+            .unwrap_or_else(|| {
+                self.datasets
+                    .iter()
+                    .filter_map(|d| d.get("record_count").and_then(Value::as_u64))
+                    .sum()
+            });
+        let mut sentence = format!(
+            "{records} records across {} dataset(s)",
+            self.datasets.len()
+        );
+        if let Some(root) = self
+            .run
+            .as_ref()
+            .and_then(|r| r.get("root"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+        {
+            sentence.push_str(&format!(" under {root}"));
+        }
+        if let Some(run_id) = self
+            .run
+            .as_ref()
+            .and_then(|r| r.get("run_id"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+        {
+            sentence.push_str(&format!(" (autoindex run {run_id})"));
+        }
+        Some(sentence)
+    }
+}
+
+/// Fetch the [`CatalogSummary`] from a running node's `autoindex-catalog`.
+///
+/// Reuses the same catalog index and query shapes as `run_map`, minus the
+/// correlation/junk/duplicate passes a one-line summary does not need. Any
+/// failure — endpoint unreachable, auth rejected, no catalog yet — is returned
+/// as an `Err`, so `xerj feedback` can degrade to a template placeholder
+/// instead of inventing a number (the repo's honest-claims rule).
+pub fn fetch_catalog_summary(url: &str, api_key: Option<String>) -> Result<CatalogSummary> {
+    let es = Es::new(url, api_key)?;
+    es.ping()?;
+    let fetch = |query: Value, size: usize, sort: Option<Value>| -> Result<Vec<Value>> {
+        let mut body = json!({"query": query, "size": size});
+        if let Some(s) = sort {
+            body["sort"] = s;
+        }
+        let v = es.search(catalog::CATALOG_INDEX, &body)?;
+        Ok(v.pointer("/hits/hits")
+            .and_then(|h| h.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|h| h.get("_source").cloned())
+                    .collect()
+            })
+            .unwrap_or_default())
+    };
+    let datasets = fetch(
+        json!({"term": {"doc_kind": "dataset"}}),
+        500,
+        Some(json!([{"record_count": "desc"}])),
+    )?;
+    let mut runs = fetch(json!({"term": {"doc_kind": "run"}}), 50, None)?;
+    runs.sort_by_key(|r| {
+        std::cmp::Reverse(
+            r.get("started")
+                .and_then(|s| s.as_str())
+                .unwrap_or("")
+                .to_string(),
+        )
+    });
+    Ok(CatalogSummary {
+        run: runs.into_iter().next(),
+        datasets,
+    })
 }
 
 // ─── status subcommand ───────────────────────────────────────────────────

--- a/engine/crates/xerj-server/src/main.rs
+++ b/engine/crates/xerj-server/src/main.rs
@@ -208,6 +208,8 @@ fn help_text(feedback: bool) -> String {
                                                   index --help)\n\
              xerj brain <folder>                 index + browse in one command (see xerj\n\
                                                   brain --help)\n\
+             xerj feedback [OPTIONS]             draft the agent field report (and open its\n\
+                                                  PR) — see xerj feedback --help\n\
          \n\
          OPTIONS (for `xerj [OPTIONS]`, the bare server start):\n\
              --config,   -c <PATH>  Path to TOML config file\n\
@@ -277,6 +279,9 @@ fn help_text(feedback: bool) -> String {
                                              (search, semantic, vector, hybrid, memory, second-brain)\n\
                                              to any MCP client. Proxies to a node you already started\n\
                                              — set XERJ_URL or --url (see xerj mcp --help)\n\
+             xerj feedback   [opts]          draft the agent field report XERJ asks every agent to\n\
+                                             file, auto-filling version/OS/what-was-indexed; --open-pr\n\
+                                             files it, --dry-run just prints (see xerj feedback --help)\n\
          \n\
          SEARCHING A CODEBASE:\n\
              A search hit returns the whole indexed document, which for source code is the\n\
@@ -1880,6 +1885,16 @@ async fn async_main() -> Result<()> {
         // then opens the console. Fully synchronous internally — run it off
         // the async runtime like `autoindex`.
         let code = tokio::task::spawn_blocking(brain::run_cli)
+            .await
+            .unwrap_or(1);
+        std::process::exit(code);
+    }
+    if matches!(argv1.as_deref(), Some("feedback")) {
+        // Draft the agent field report XERJ asks every agent to file, and
+        // optionally open its pull request. Pure ES-compat client + local
+        // git/gh; fully synchronous internally — run it off the async runtime
+        // like `autoindex` and `brain`.
+        let code = tokio::task::spawn_blocking(xerj_autoindex::feedback::run_cli)
             .await
             .unwrap_or(1);
         std::process::exit(code);

--- a/scripts/check_cla_coauthors.py
+++ b/scripts/check_cla_coauthors.py
@@ -22,8 +22,29 @@ An email resolves to a login by, in order:
 Anything unresolvable FAILS the gate, deliberately: an identity the gate
 cannot attribute is exactly what it exists to flag.
 
-Usage (CI): check_cla_coauthors.py --pr <number>
-  Needs `gh` and GH_TOKEN; repo comes from GITHUB_REPOSITORY or --repo.
+Field-report carve-out (issue: the agent field-report loop was dead)
+-------------------------------------------------------------------
+
+A pull request whose ENTIRE diff is agent field reports — new markdown files
+under ``user-feedback/16-agent-field-reports/`` and nothing else — is exempt
+from this trailer gate. That folder is documentation of the *experience* of
+using XERJ (see its README and https://xerj.org/llms.txt); requiring a CLA to
+add one file there is exactly the friction that kept the folder empty. The
+exemption is deliberately narrow: it needs every changed path to be a
+field-report ``*.md``, so bundling any code, CI, or other-docs change with a
+field report re-arms the full gate — a mixed PR must never slip a code change in
+under a field report. ``README.md`` in that folder is NOT a field report and
+does not qualify. See :func:`is_field_report_only`.
+
+Usage (CI):
+  check_cla_coauthors.py --pr <number> [--changed-files "<paths>"]
+    Runs the trailer gate. If --changed-files is a field-report-only set, the
+    gate is skipped (exempt) and this exits 0 without a network lookup.
+  check_cla_coauthors.py --is-field-report-only --changed-files "<paths>"
+    Prints nothing; exits 0 iff the paths are a field-report-only set, else 1.
+    Used by the separate CI job that provides `verification/cla-signed` for
+    strictly field-report-only pull requests.
+  Needs `gh` and GH_TOKEN for --pr; repo comes from GITHUB_REPOSITORY or --repo.
 
 Tests: scripts/test_cla_coauthors.py
 """
@@ -62,6 +83,39 @@ def noreply_login(email):
     """Login embedded in a GitHub noreply address, or None."""
     m = _NOREPLY_RE.match(email.strip())
     return m.group("login") if m else None
+
+
+# The one directory agent field reports live in. Kept in lock-step with
+# xerj-autoindex's `feedback::FIELD_REPORT_DIR`; the `xerj feedback` command
+# writes reports here and the carve-out below recognises them here.
+FIELD_REPORT_DIR = "user-feedback/16-agent-field-reports/"
+
+
+def is_field_report_only(paths):
+    """True iff `paths` is a non-empty set of ONLY field-report markdown files.
+
+    A field report is a ``*.md`` file directly inside FIELD_REPORT_DIR — not a
+    nested subdirectory, and not the folder's own ``README.md`` (which is the
+    template, not a report). An empty diff is NOT field-report-only: "nothing
+    changed" must never read as "exempt". Any single non-qualifying path makes
+    the whole set non-exempt, so a code change bundled with a field report gets
+    the full gate.
+    """
+    paths = [p for p in paths if p.strip()]
+    if not paths:
+        return False
+    for p in paths:
+        p = p.strip()
+        if not p.startswith(FIELD_REPORT_DIR):
+            return False
+        rest = p[len(FIELD_REPORT_DIR):]
+        if "/" in rest:  # a nested subdirectory, not a direct field report
+            return False
+        if not rest.endswith(".md"):
+            return False
+        if rest == "README.md":  # the folder template is not a field report
+            return False
+    return True
 
 
 def check_commits(commits, contributors, resolve):
@@ -134,15 +188,51 @@ def make_repo_resolver(repo):
     return resolve
 
 
+def _split_paths(raw):
+    """Changed-file paths from a --changed-files value (whitespace/newline sep)."""
+    return [] if raw is None else raw.split()
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--pr", required=True, type=int, help="pull request number")
+    ap.add_argument("--pr", type=int, help="pull request number")
     ap.add_argument(
         "--repo",
         default=os.environ.get("GITHUB_REPOSITORY", "xerj-org/xerj"),
         help="owner/name (default: $GITHUB_REPOSITORY or xerj-org/xerj)",
     )
+    ap.add_argument(
+        "--changed-files",
+        help="whitespace/newline-separated changed paths in the PR. When this is "
+        "a field-report-only set, the trailer gate is skipped (exempt).",
+    )
+    ap.add_argument(
+        "--is-field-report-only",
+        action="store_true",
+        help="predicate mode: exit 0 iff --changed-files is a field-report-only "
+        "set, else 1. Prints nothing; used by the exemption CI job.",
+    )
     args = ap.parse_args()
+
+    paths = _split_paths(args.changed_files)
+
+    # Predicate mode: no PR, no network — just answer the path question.
+    if args.is_field_report_only:
+        return 0 if is_field_report_only(paths) else 1
+
+    if args.pr is None:
+        ap.error("--pr is required unless --is-field-report-only is given")
+
+    # Carve-out: a field-report-only PR skips the trailer gate entirely. The
+    # predicate is a guard here, so check_commits() stays untouched and every
+    # mixed or non-field-report PR runs the full check below.
+    if args.changed_files is not None and is_field_report_only(paths):
+        print(
+            f"CLA co-author check EXEMPT for PR #{args.pr}: the diff is "
+            f"{len(paths)} field-report file(s) under {FIELD_REPORT_DIR} and "
+            "nothing else."
+        )
+        return 0
 
     contributors = json.loads((REPO_ROOT / ".contributors").read_text())
     raw = _gh_api(f"repos/{args.repo}/pulls/{args.pr}/commits?per_page=100")

--- a/scripts/test_cla_coauthors.py
+++ b/scripts/test_cla_coauthors.py
@@ -17,7 +17,13 @@ import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from check_cla_coauthors import check_commits, noreply_login, parse_coauthors
+from check_cla_coauthors import (
+    FIELD_REPORT_DIR,
+    check_commits,
+    is_field_report_only,
+    noreply_login,
+    parse_coauthors,
+)
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -146,11 +152,75 @@ class GateTests(unittest.TestCase):
         self.assertEqual(calls, ["leonsbox@gmail.com"])
 
 
+class FieldReportExemptionTests(unittest.TestCase):
+    """The narrow carve-out: a field-report-only diff is exempt; anything else
+    is not. Bundling a code change with a field report must NOT bypass the gate
+    — that would be a security hole, so the mixed case is asserted explicitly."""
+
+    def _report(self, name):
+        return f"{FIELD_REPORT_DIR}{name}"
+
+    def test_single_field_report_is_exempt(self):
+        self.assertTrue(
+            is_field_report_only([self._report("2026-08-18-reference-coding.md")])
+        )
+
+    def test_several_field_reports_are_exempt(self):
+        self.assertTrue(
+            is_field_report_only(
+                [
+                    self._report("2026-08-18-a.md"),
+                    self._report("2026-08-18-b.md"),
+                ]
+            )
+        )
+
+    def test_field_report_plus_code_is_NOT_exempt(self):
+        # THE security case: a code change riding along with a field report must
+        # get the full gate, never the exemption.
+        self.assertFalse(
+            is_field_report_only(
+                [
+                    self._report("2026-08-18-a.md"),
+                    "engine/crates/xerj-server/src/main.rs",
+                ]
+            )
+        )
+
+    def test_field_report_plus_other_docs_is_NOT_exempt(self):
+        self.assertFalse(
+            is_field_report_only([self._report("2026-08-18-a.md"), "README.md"])
+        )
+
+    def test_the_folder_readme_is_NOT_a_field_report(self):
+        self.assertFalse(is_field_report_only([self._report("README.md")]))
+
+    def test_a_nested_path_is_NOT_a_field_report(self):
+        self.assertFalse(is_field_report_only([self._report("sub/2026-08-18-a.md")]))
+
+    def test_a_non_markdown_file_in_the_folder_is_NOT_exempt(self):
+        self.assertFalse(is_field_report_only([self._report("2026-08-18-a.txt")]))
+
+    def test_an_empty_diff_is_NOT_exempt(self):
+        # "nothing changed" must never read as "exempt".
+        self.assertFalse(is_field_report_only([]))
+        self.assertFalse(is_field_report_only([""]))
+
+    def test_a_lookalike_prefix_outside_the_folder_is_NOT_exempt(self):
+        # A path that merely starts with the folder name but is not inside it.
+        self.assertFalse(
+            is_field_report_only(["user-feedback/16-agent-field-reports-notes.md"])
+        )
+
+
 class WiringTests(unittest.TestCase):
     """A checker CI never runs is not a gate (cf. the #207 lesson)."""
 
+    def _ci(self):
+        return (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+
     def _cla_job(self):
-        ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+        ci = self._ci()
         m = re.search(r"\n  cla-config:\n(.*?)(?=\n  \S)", ci, re.S)
         self.assertIsNotNone(m, "cla-config job missing from ci.yml")
         return m.group(1)
@@ -160,6 +230,24 @@ class WiringTests(unittest.TestCase):
 
     def test_ci_runs_these_tests(self):
         self.assertIn("test_cla_coauthors.py", self._cla_job())
+
+    def test_cla_config_computes_changed_files_for_the_carveout(self):
+        # The carve-out only works if the job actually passes the PR's changed
+        # files to the checker — otherwise every PR runs the full gate.
+        self.assertIn("--changed-files", self._cla_job())
+
+    def test_a_separate_job_provides_the_field_report_status(self):
+        # cla-bot cannot path-scope itself, so the required `verification/cla-signed`
+        # status for a strictly field-report-only PR is provided by a dedicated
+        # workflow, guarded by the same predicate.
+        wf = REPO_ROOT / ".github" / "workflows" / "cla-field-report-exempt.yml"
+        self.assertTrue(wf.exists(), "field-report exemption workflow missing")
+        text = wf.read_text()
+        self.assertIn("verification/cla-signed", text)
+        self.assertIn("--is-field-report-only", text)
+        # It must never run the PR's own code under the elevated token.
+        self.assertIn("pull_request_target", text)
+        self.assertIn("base.sha", text)
 
 
 if __name__ == "__main__":

--- a/tools/xerj-code/SKILL.md
+++ b/tools/xerj-code/SKILL.md
@@ -256,3 +256,25 @@ Two rules that decide whether a result means anything:
   256-value table from recall, and retrieval then shows as pure overhead. The
   honest test bed is code that was never in a training set — your own private
   code is the realistic case.
+
+## After the session: file the field report
+
+Retrieval is only half the loop. The other half is telling the maintainers what
+using XERJ was actually like — the baseline contribution asked of every agent
+that uses it (`user-feedback/16-agent-field-reports/README.md`,
+https://xerj.org/llms.txt). One command drafts it and fills in the facts
+(version, OS, what was indexed) for you:
+
+```sh
+# opens the PR (branch + commit of ONLY the report + gh pr create):
+xerj feedback --open-pr --used-for "reference coding" \
+  --verdict "…what worked, what did not…"
+
+# sandboxed and cannot push? draft it and print the exact git+gh commands:
+xerj feedback --dry-run --used-for "reference coding" --verdict "…"
+```
+
+It only ever auto-fills facts it can observe and leaves every opinion as a
+placeholder for you to fill — never an invented verdict. A pull request that adds
+only a field report is exempt from the CLA gate, so this costs a signature
+nothing. `xerj feedback --help` has the full contract.

--- a/tools/xerj-code/scripts/xc.py
+++ b/tools/xerj-code/scripts/xc.py
@@ -41,6 +41,38 @@ def die(msg, code=2):
     sys.exit(code)
 
 
+def field_report_nudge():
+    """One line, on STDERR, at most once a day: file the field report.
+
+    The reference-coding loop had no path back to the maintainers — an agent
+    retrieved, wrote code, and left, and the folder that asks for a short field
+    report stayed empty. This is that missing path, surfaced where the agent
+    already is. It is deliberately unobtrusive: it writes only to stderr, so it
+    can NEVER corrupt the retrieval passages a caller parses on stdout; it fires
+    at most once per day per machine via a marker under ROOT, so a session's many
+    queries do not turn it into spam; and it is silenced entirely by
+    XERJ_CODE_NO_NUDGE. A cache we cannot write is a reason to stay quiet, not to
+    nag every query.
+    """
+    if os.environ.get("XERJ_CODE_NO_NUDGE"):
+        return
+    try:
+        marker = os.path.join(ROOT, f".field-report-nudge-{datetime.now():%Y%m%d}")
+        if os.path.exists(marker):
+            return
+        os.makedirs(ROOT, exist_ok=True)
+        open(marker, "w").close()
+    except OSError:
+        return
+    print(
+        "xc: wrapping up? `xerj feedback --open-pr` files the one short field "
+        "report XERJ asks every agent for (or --dry-run if sandboxed); it "
+        "auto-fills the facts and a field-report-only PR skips the CLA gate. "
+        "Silence with XERJ_CODE_NO_NUDGE=1.",
+        file=sys.stderr,
+    )
+
+
 def load_state(corpus):
     path = os.path.join(ROOT, "state", f"{corpus}.json")
     if not os.path.exists(path):
@@ -581,6 +613,10 @@ def main():
         print(f"\n{len(hits)} passages from '{args.corpus}'"
               + (f" (index {age}d old)" if age else ""))
         print("Cite file:line for anything you rely on.")
+
+    # Stderr-only, once a day: the loop back to the maintainers. Kept out of the
+    # retrieval output on stdout on purpose (see field_report_nudge).
+    field_report_nudge()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The loop that was empirically dead

`user-feedback/16-agent-field-reports/README.md` and xerj.org/llms.txt both say
the baseline contribution asked of every agent that uses XERJ is one short field
report. In practice that ask was dead: the folder held only its README — zero
reports — because the obligation was a paragraph of prose with **no tooling
behind it** and a **CLA hard-gate in front of it**. The full diagnosis is in
`demo/playbooks/AGENT_CONTRIBUTION_LOOP_2026-08-18.md`.

This PR turns the ask into one command and removes the CLA friction for that one
narrow case — without weakening the CLA gate anywhere else.

## `xerj feedback` — the command

```
xerj feedback [--verdict/--used-for/--pointed-at/--numbers/--agent TEXT] \
              [-o PATH] [--open-pr | --dry-run] [--no-autofill] [--url U] [--api-key K]
```

Drafts an agent field report to stdout (or `-o PATH`). It **auto-fills only
facts it can observe** — this binary's version, OS + arch, and "what was
indexed" read from a running node's `autoindex-catalog` (via the reused
`fetch_catalog_summary`). When no node answers, "Pointed at" degrades to the
template placeholder rather than inventing a corpus. Every **opinion**
(`--verdict`, `--used-for`, …) comes from a flag; an omitted flag leaves the
exact template placeholder — a tool must not invent an opinion any more than a
number (repo honest-claims rule). The report's **first line always discloses the
AI author**.

- `--open-pr` commits **ONLY** `user-feedback/16-agent-field-reports/<date>-<slug>.md`
  on a `field-report/<slug>` branch and runs `gh pr create`; if `gh` is
  missing/unauth it **fails loudly** and prints the exact git+gh commands (the
  sandboxed-agent path), never a silent partial success.
- `--dry-run` prints the report **and** the commands and does nothing (opens no
  PR, writes no file). `--open-pr` + `--dry-run` is refused as a contradiction.

## The narrow field-report-only CLA exemption — and why it is safe

A PR is exempt from the CLA gate **if and only if** its changed-file set is
non-empty and *every* path is a direct `*.md` file under
`user-feedback/16-agent-field-reports/` — excluding that folder's own
`README.md`, excluding any nested subpath, excluding any non-`.md` file, and
excluding any path outside the folder. **A single non-qualifying path (code, CI,
other docs, or the folder README) re-arms the FULL gate for the entire PR; an
empty diff is NOT exempt.** Implemented once as `is_field_report_only(paths)` in
`scripts/check_cla_coauthors.py` and consumed two ways:

1. **Internal trailer gate** (`ci.yml` `cla-config`) computes the PR's changed
   files via the GitHub API and passes `--changed-files`, skipping the
   Co-authored-by trailer check only for a field-report-only set.
2. **Binding `verification/cla-signed` status** — which cla-bot cannot
   path-scope — is posted for a field-report-only PR by a separate
   same-predicate job (`.github/workflows/cla-field-report-exempt.yml`). That job
   runs under `pull_request_target` but checks out **only the trusted base sha**,
   reads the changed FILE LIST from the API, passes attacker-controllable values
   via `env:` (no `${{ }}` interpolated into `run:`), holds minimal permissions
   (`statuses: write`), and **never checks out or runs the PR head**. Because it
   only fires on a strictly field-report-only diff, a mixed PR is left entirely
   to cla-bot's full gate. The last-writer race with cla-bot on that status
   context is documented in the workflow and cannot fire on a mixed PR.

The security property — **no mixed diff can bypass the CLA gate, and no non-`.md`
path can ever enter an exempt set** — is pinned by tests: the field-report+code
case, README, nested, non-md, empty, and lookalike-prefix cases all assert
NOT-exempt.

## Dogfood loop fix

The reference-coding skill now closes the loop back to the maintainers:
`tools/xerj-code/SKILL.md` gains an "After the session: file the field report"
step, and `tools/xerj-code/scripts/xc.py` adds `field_report_nudge()` — one line,
**stderr-only** (never corrupts stdout retrieval passages), at most once per day
via a marker under `ROOT`, silenceable with `XERJ_CODE_NO_NUDGE`. These live in
the **tracked** tooling source (`tools/**` is re-included in `.gitignore`), not
the gitignored scout copy.

## Tests

- `cargo test --release -p xerj-autoindex feedback::` — **12 passed / 0 failed**
  (provenance-first-line, omitted-opinion→placeholder, catalog-fill precedence,
  dry-run-writes-nothing, `--open-pr`+`--dry-run` refused, bounded ASCII slug).
- `python3 scripts/test_cla_coauthors.py` — **27 passed / 0 failed**, including
  field-report-only ⇒ exempt and field-report+code / README / nested / non-md /
  empty / lookalike ⇒ NOT exempt, plus wiring assertions (CI passes
  `--changed-files`; the exemption workflow is `pull_request_target` + `base.sha`
  + the shared predicate).
- Scoped release builds clean: `xerj-autoindex` and `xerj-server`; `cargo fmt`
  clean on both changed crates. Binary smoke-tested: `--dry-run`, `--help`,
  `-o` write, contradiction guard, and the CLA predicate CLI (exit 0 exempt /
  exit 1 mixed).

## ES-YAML conformance

This feature touches no query/response semantics — it is a CLI subcommand, a
read-only catalog summary, the CLA scripts, CI, and docs. The ES-YAML gate runs
on CI.

## Files

10 files, +1371/-6. New: `engine/crates/xerj-autoindex/src/feedback.rs`,
`.github/workflows/cla-field-report-exempt.yml`,
`demo/playbooks/AGENT_CONTRIBUTION_LOOP_2026-08-18.md`. Modified:
`engine/crates/xerj-autoindex/src/lib.rs` (+`fetch_catalog_summary`),
`engine/crates/xerj-server/src/main.rs` (dispatch arm + help),
`scripts/check_cla_coauthors.py`, `scripts/test_cla_coauthors.py`,
`.github/workflows/ci.yml`, `tools/xerj-code/SKILL.md`,
`tools/xerj-code/scripts/xc.py`.
