### PR TITLE
chore(deps): patch h2 for RUSTSEC-2026-0258 (unbounded empty DATA frames)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -143,14 +143,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -1313,7 +1313,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1432,7 +1432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1961,9 +1961,9 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2246,7 +2246,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2494,7 +2494,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2820,9 +2820,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -2928,7 +2928,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin 0.9.9",
  "version_check",
 ]
 
@@ -3006,7 +3006,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3868,7 +3868,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3906,7 +3906,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4296,7 +4296,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4662,7 +4662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4678,9 +4678,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"
@@ -4867,7 +4867,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6240,7 +6240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## CI is failing repo-wide, and it is not any PR's fault

`cargo audit` pulls the advisory database fresh on every run, so a new advisory reddens CI without anything changing in the repo. RUSTSEC-2026-0258 was published `2026-08-18T06:11:21Z`.

**Correction to an earlier revision of this description:** it said main's audit passed at `01:45:19Z` and failed at `08:28:35Z`. That was wrong and a reviewer caught it. `01:45:19Z` was #460's head, not main, and the `08:28:37Z` failure was on `fix/474-no-future-release-promises` — an unrelated docs branch whose diff cannot touch dependencies, which is how I found this. **Main's audit last ran, and passed, at `04:08:02Z`** — before the advisory existed — so main is not red yet, and fails on its next run.

## The failure is a real vulnerability, not a warning

```
error: 1 vulnerability found!
Crate:  h2
Title:  h2 unbounded empty DATA frames
ID:     RUSTSEC-2026-0258
```

`h2` is the HTTP/2 implementation under `hyper`, so it sits beneath **every listener this server runs** — ES-compat and native REST through axum, gRPC through tonic. An unbounded stream of empty DATA frames is a remote resource-exhaustion vector against any node that is reachable at all. `0.4.13` → `0.4.16`.

## Also bumped

Both were flagged `unsound` in the same run and both are fixed upstream, so there is no reason to keep carrying them:

| crate | from → to | advisory |
|---|---|---|
| `anyhow` | 1.0.102 → 1.0.104 | RUSTSEC-2026-0190, unsoundness in `Error::downcast_mut()` |
| `memmap2` | 0.9.10 → 0.9.11 | RUSTSEC-2026-0186, unchecked pointer offset |

Lockfile only — no manifest range changes.

## Deliberately not addressed

These are reported but are warnings, not vulnerabilities, and none has a successor reachable without a semver-major manifest change:

- unmaintained: `number_prefix`, `paste`, `rustls-pemfile`, `ttf-parser`.

Being precise, since the loose version of this sentence is what was wrong about `spin`: `axum-server 0.8.0` **does** drop `rustls-pemfile`, and `indicatif 0.18.6` **does** drop `number_prefix`. Neither is reachable here — `axum-server` is a direct `xerj-server` dependency and `hf-hub 0.4.3` pins `indicatif ^0.17` — so both need a major-version manifest edit, unlike `spin`, which was an in-range three-line lockfile bump.

**Correction:** an earlier revision of this PR also listed yanked `spin 0.9.8` here, claiming no upgrade was available because `multer 3.1.0` pins the 0.9 line. That was wrong, and two independent reviewers caught it. `multer` does pin `^0.9`, but **`spin 0.9.9` is on that line, is not yanked, and was published on 2026-07-13 to un-strand exactly this case** — every 0.9.x before it is yanked. It is now bumped, in three more lines of lockfile.

None of them fails the job today. If the project decides they should, that is a policy choice and belongs in an `audit.toml`, not a silent dependency bump inside a security patch.

## The fix is not a no-op, and it introduces a limit worth knowing about

Verified by flooding a real node with raw HTTP/2 empty DATA frames on both builds:

| build | result |
|---|---|
| h2 0.4.13 (main) | 5,000 empty DATA frames **all accepted**, no GOAWAY |
| h2 0.4.16 (this PR) | `GOAWAY ENHANCE_YOUR_CALM(0xb) debug='too_many_data_frames'` after 101 frames |

So the advisory is real and the bump genuinely changes behaviour under attack.

It also adds a **per-connection budget**, which is a behavioural change for legitimate
clients too — `h2-0.4.16` (constants defined in `src/proto/mod.rs:38-39`, applied in `src/proto/streams/counts.rs:95-110`):

```rust
pub const DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD: usize = 256;
pub const DEFAULT_DATA_FRAME_BUDGET: usize = DEFAULT_DATA_FRAME_OVERHEAD_THRESHOLD * 100; // 25600
```

Every DATA frame **smaller than 256 bytes** consumes `256 - payload_len` of a 25,600-byte
budget; frames larger than 256 bytes replenish it. Exhausting it is a connection-level
GOAWAY at `streams.rs:646`. A client that streams many tiny DATA frames on one connection —
a chatty gRPC stream, or a bulk ingest that flushes per-document — can reach it without
being an attacker. Nothing in our test suite does, and no XERJ default produces frames that
small, but it is the kind of thing that surfaces in someone's production traffic rather than
in CI, so it belongs in the record rather than in a changelog nobody reads.

## One more thing this bump drags along

The h2 update alone re-resolves **socket2 0.6.3 → 0.5.10** beneath `hyper-util`, `quinn` and
`quinn-udp`, plus ten `windows-sys` edge changes — 13 edges I did not mention in the first
revision. That is the socket layer under every listener, so it deserves saying out loud.

It is unavoidable rather than sloppy: a reviewer reconstructed the lockfile from
`origin/main` with only the three `--precise` bumps and got a **byte-identical** file
(`sha256 fd2aa538…` for the three-bump file; the shipped lockfile including the spin bump is `5c05690f…`). `hyper-util` requires `socket2 >=0.5.9, <0.7` and quinn `>=0.5, <0.7`,
so cargo re-unifies onto the 0.5.10 that tonic already forces into the graph. `--locked`
builds clean.

## Verification

rustc 1.97.1 throughout: `cargo build --workspace --profile ci-test` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test -p xerj-server --profile ci-test` 10 suites / 65 tests / 0 failed.

I could not run `cargo audit` locally — it is not installed on this host — so the proof that the job goes green is CI on this PR.



