### PR TITLE
fix(autoindex): a non-resumable embedder no longer blocks a first generation (#367)

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -28,6 +28,8 @@ struct HttpState {
     /// executor now, so the shape has to be proven here too.
     partially_apply_next_data_bulk: bool,
     fail_embedding_identity: bool,
+    /// #367: the `neural` and `proxy` backends report this `false`.
+    embedding_not_resumable: bool,
     stop: bool,
     embedding_identity_sha256: String,
     saw_dataset_mapping_update: bool,
@@ -149,7 +151,7 @@ fn handle_http(mut stream: TcpStream, state: &Arc<Mutex<HttpState>>) {
                     "identity_sha256": locked.embedding_identity_sha256.clone(),
                     "dimensions": 384,
                     "semantic_contract": "semantic_text-derived-vector.v1",
-                    "resumable": true
+                    "resumable": !locked.embedding_not_resumable
                 }, "took_ms": 0, "request_id": "incremental-http-test"}),
             )
         }
@@ -1874,5 +1876,62 @@ fn a_journal_that_fails_its_own_revalidation_names_the_rebuild_route() {
     assert!(
         rendered.contains("Rebuild with a new --state-dir and a new --prefix"),
         "the refusal must name the recovery route, not just the invariant: {rendered}"
+    );
+}
+
+/// #367: a genesis run must not be refused for a non-resumable identity, and a
+/// later cutover must still be.
+///
+/// `resumable` is `false` by construction on the `neural` and `proxy` backends,
+/// because their identity hashes the configured model *name* rather than its
+/// bytes. That makes reuse unsafe — a model swapped in under the same name
+/// yields the same digest, so the drift check cannot see it — but it says
+/// nothing about whether a first generation may be created. Asserting it on
+/// every run made `--embed-mode neural` unable to index anything at all: one
+/// small file was enough, and `apache/lucene` failed after a full local
+/// extraction.
+///
+/// Both halves are pinned here because the fix is a narrowing, and a narrowing
+/// that goes too far would silently permit mixing two vector spaces in one
+/// index.
+#[test]
+fn a_non_resumable_identity_allows_genesis_and_still_refuses_a_cutover() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("report.txt"),
+        "Initial quarterly report discusses durable subscription revenue and operating income.",
+    )
+    .unwrap();
+    let endpoint = HttpEndpoint::start();
+    endpoint.state.lock().unwrap().embedding_not_resumable = true;
+
+    // Genesis: nothing to carry forward, so it proceeds.
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, true);
+    assert_eq!(
+        run_index(config).unwrap(),
+        0,
+        "a genesis generation has no prior vectors to mix, so a non-resumable \
+         identity must not refuse it"
+    );
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+
+    // Cutover: now there IS a committed generation, so it must refuse.
+    fs::write(
+        corpus.path().join("report.txt"),
+        "Revised quarterly report discusses durable subscription revenue, operating income and churn.",
+    )
+    .unwrap();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, true);
+    let err = run_index(config)
+        .expect_err("carrying a non-resumable identity across a generation must still be refused");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("across a generation requires a resumable"),
+        "the refusal must name what it is refusing, got: {msg}"
     );
 }

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -414,7 +414,7 @@ fn begin_non_graph_generation(
     root_identity: &str,
     inventory: &content::Inventory,
     plan: Plan,
-) -> Result<()> {
+) -> Result<Option<String>> {
     anyhow::ensure!(
         cfg.no_graph,
         "non-graph generation cutover requires --no-graph"
@@ -446,18 +446,54 @@ fn begin_non_graph_generation(
         .datasets
         .iter()
         .any(|dataset| dataset.semantic_field.is_some());
+    let mut non_resumable_note: Option<String> = None;
     let identity = if semantic {
         let identity = es
             .embedding_execution_identity()
             .context("generation cutover could not pin the server embedding execution identity")?;
-        anyhow::ensure!(
-            identity.resumable,
-            "generation cutover requires a resumable embedding execution identity: {}",
-            identity
-                .non_resumable_reason
-                .as_deref()
-                .unwrap_or("the server did not provide an immutable identity")
-        );
+        // Scoped to a cutover that actually carries vectors forward (issue #367).
+        //
+        // `resumable` answers "may I reuse vectors a PREVIOUS run wrote". On a
+        // genesis run there are none: `sync_bootstrap_genesis` builds generation
+        // 0 with an empty plan and `execution: None`, so there is no prior vector
+        // space to mix. Asserting it unconditionally refused every `--no-graph`
+        // semantic run on the `neural` and `proxy` backends, which report
+        // `resumable:false` by construction because their identity hashes the
+        // configured model NAME rather than its bytes. One 6 KB file was enough
+        // to trigger it; `apache/lucene`, the flagship reference-coding corpus,
+        // could not be indexed at all. The error even named `--fresh` as the
+        // remedy, which cannot help: `cfg.fresh` is client-side state, while the
+        // `false` is a property of the server's backend.
+        //
+        // The graph path already scopes it this way — `state.rs:1084` bails only
+        // `if self.resumed && !resumable` — so this brings the two into line.
+        //
+        // Carrying a non-resumable identity ACROSS a generation is still refused
+        // below, because for these backends a model swapped in under the same
+        // name yields the same digest, so the drift check cannot see it.
+        if base.generation > 0 || base.execution.is_some() {
+            anyhow::ensure!(
+                identity.resumable,
+                "carrying an embedding execution identity across a generation requires a \
+                 resumable one: {}",
+                identity
+                    .non_resumable_reason
+                    .as_deref()
+                    .unwrap_or("the server did not provide an immutable identity")
+            );
+        } else if !identity.resumable {
+            // Handed back rather than printed: stderr belongs to the progress
+            // surface, so `--progress none` stays silent and `--progress json`
+            // stays one parseable stream (#241).
+            non_resumable_note = Some(format!(
+                "autoindex: this embedding identity is not content-addressed, so a model \
+                 swapped in under the same name would not be detected on a later run: {}",
+                identity
+                    .non_resumable_reason
+                    .as_deref()
+                    .unwrap_or("the server did not provide an immutable identity")
+            ));
+        }
         journal.pin_embedding_identity(
             &identity.identity_sha256,
             identity.resumable,
@@ -577,7 +613,8 @@ fn begin_non_graph_generation(
             state_dir.display()
         )
     })?;
-    journal.sync_begin(&pending)
+    journal.sync_begin(&pending)?;
+    Ok(non_resumable_note)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -3196,7 +3233,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             &root_str,
             &inventory,
             plan,
-        )?;
+        )?
+        .inspect(|note| pr.note(note));
         let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);
         sync_executor::replay_pending_operations(&state_dir, &mut journal, &mut backend)?;
         let summary = finish_generated_run(&es, &mut journal, &cfg)?;
@@ -3803,7 +3841,8 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             &root_str,
             &inventory,
             plan,
-        )?;
+        )?
+        .inspect(|note| pr.note(note));
         let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);
         sync_executor::replay_pending_operations(&state_dir, &mut journal, &mut backend)?;
         let summary = finish_generated_run(&es, &mut journal, &cfg)?;

--- a/engine/crates/xerj-autoindex/src/sync.rs
+++ b/engine/crates/xerj-autoindex/src/sync.rs
@@ -778,10 +778,16 @@ fn validate_manifest(manifest: &GenerationManifest, legacy: bool) -> Result<()> 
             execution.embedding_dimension != Some(0),
             "embedding execution dimension must be positive when the server pins one"
         );
-        anyhow::ensure!(
-            execution.embedding_resumable,
-            "a durable generation requires a resumable embedding execution identity"
-        );
+        // Not asserted here (issue #367). Its neighbours are structural — a
+        // 64-char lowercase hex digest, a non-zero dimension — and say the record
+        // is well formed. `embedding_resumable` says something else: whether
+        // vectors could survive the model being swapped under the same name.
+        // That is a property of REUSE, decided where a cutover actually carries
+        // vectors forward (`begin_non_graph_generation`), not of whether this
+        // record is valid. The `neural` and `proxy` backends report it `false` by
+        // construction, so asserting it here refused every durable generation
+        // those backends could produce. The flag is still recorded on the
+        // execution and travels with it.
         match &execution.source_policy {
             SourceExecutionPolicy::DurableSnapshot {
                 reference,


### PR DESCRIPTION
Fixes the neural half of #367 — the issue blocking reference coding, this project's main use case, on `apache/lucene`.

## What was broken

`--embed-mode neural` could not index **anything**. Minimal reproduction is one 6 KB file in 0.6 s:

```
xerj --data-dir $D --port 57010 --embed-mode neural --insecure &
xerj autoindex /tmp/one --url http://127.0.0.1:57010 --prefix p --state-dir $S --no-graph
# xerj-done ok=false exit=1 reason=aborted
# error: generation cutover requires a resumable embedding execution identity
```

Nothing about Lucene mattered — the full 6,012-file corpus produced the byte-identical message, just 229 s later, after writing a 303 MB snapshot and **zero** documents. `--embed-mode proxy` failed the same way. The trigger was exactly: a backend reporting `resumable:false`, plus `--no-graph`, plus any semantic field.

## Why

`resumable` answers *"may I reuse vectors a previous run wrote"*. It is `false` by construction for `neural` and `proxy` because their identity hashes the model **name**, not its bytes. Three gates use it to decide something it does not answer. Two of them gate whether a generation may **begin**, and are fixed here:

- `lib.rs:453` — fired on every run, including genesis, where `sync_bootstrap_genesis` builds generation 0 with an empty plan and `execution: None`. Its suggested remedy, `--fresh`, is unsatisfiable: that flag is client-side state, the `false` is a server property.
- `sync.rs:781` — a second copy in a *record validator*, beside genuinely structural checks. I only found it because fixing the first exposed it.

The third, `lib.rs:3210`, is **not** touched here. It guards a genuine resume, so the conjunction is in the right place — but `resumable` sits in it beside four `current == expected` comparisons, so a second run over an unchanged corpus fails with "embedding execution identity changed" when nothing changed. That makes `neural`/`proxy` indexing one-shot. Filed as #487 rather than folded in: the fix there is either a better message or content-addressing the neural identity, and neither belongs in this diff.

The graph path already scopes the *genesis* case correctly (`state.rs:1084`: `if self.resumed && !resumable`), which is why dropping `--no-graph` indexed the same corpus cleanly. `xc-index.sh` passes `--no-graph` unconditionally.

## What is deliberately kept

Carrying a non-resumable identity **across** a generation is still refused. For these backends a model swapped in under the same name yields the same digest, so the drift check cannot see it. My first attempt removed the gate outright; the diagnosis caught it. To be exact about what that would have cost: `state.rs:1084` still refuses a resumed journal, so it would not have been *silent* — it would have failed later, naming the wrong cause. This gate is defence in depth, not the last wall.

Genesis under a non-resumable identity now carries a warning saying what cannot be detected. It is handed back to the caller and delivered through `pr.note()`, not printed: `stderr` belongs to the progress surface, so `--progress none` stays silent, `--progress json` stays one parseable stream, and the text goes through `sanitize` (#241). That last part is not hygiene — the reason string comes from the server, and a bare `eprintln!` let a proxy embed a newline and forge a trailing `xerj-done ok=true exit=0`. Measured after the fix: `NON_JSON_STDERR_LINES = 0` under `--progress json`, warning still delivered.

## Verification

Fail-before, reverting only the two source hunks and keeping the test:

```
called `Result::unwrap()` on an `Err`: generation cutover requires a resumable embedding execution identity
test result: FAILED. 0 passed; 1 failed
```

End-to-end on one node, neural backend:

```
RUN 1 (genesis)  exit=0  generation=1  + warning that the identity is not content-addressed
RUN 2 (cutover)  exit=1  error: carrying an embedding execution identity across a generation
                          requires a resumable one
```

The regression test pins **both** directions. Writing it caught two ways it could have passed vacuously — a second file triggers dataset evolution before the gate, and a corpus without prose yields no semantic field, so the gate is never reached. Both are now avoided explicitly.

Suites: `-p xerj-autoindex` 679 passed on **both** ci-test and dev profiles, fmt and clippy clean under rustc 1.97.1.

## Not in this PR

- The **lexical** failure on the same corpus (`catalog read-back for ds:docs disagrees…`) is a different defect — diagnosed as `_source` loss in the storage layer. #367 stays open for it.
- The wrapper/`xc.py` symptom in the issue **already landed** in `cfba338`; at HEAD a failed run salvages what was written (measured: 87,514 records across 23 indices, and `xc.py` then answers correctly). Note the issue's paths are stale — the real ones are `tools/xerj-code/scripts/`.
- Content-addressing the neural embedder (so it could report `resumable:true`) is the complementary fix and exists on unmerged branch `fix/issue-367`; it does not touch these gates, so `proxy` would stay broken without this change.
