### PR TITLE
ci: don't cancel main's CI runs so the badge stops showing cancelled-as-failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,13 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR branch).
+# Cancel superseded runs on a PR branch (rapid pushes), but NEVER on `main`:
+# every commit that lands on the default branch must run CI to completion, or a
+# later merge cancels the earlier merge's run and the branch's status badge shows
+# that cancellation as "failing" even though nothing broke.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
## The badge is red but nothing is broken

The CI status badge (`ci.yml?branch=main`) reads the latest **completed** run on `main`. Recent merges show:

```
#497 merge -> cancelled
#496 merge -> cancelled
#495 merge -> cancelled
#494 merge -> success
```

Those `cancelled` runs are why the badge reads "failing" — shields.io renders any non-success conclusion as failing. Nothing actually failed: each was cancelled by the concurrency group when the **next** merge pushed to `main`.

## Cause

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true   # applies to main too
```

The comment says the intent is rapid pushes to a *PR branch*, but `github.ref` gives each `main` push its own group, so a merge cancels the previous merge's in-flight main run.

## Fix

`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` — PR branches keep the cancellation; `main` runs every landed commit to completion. One line, no job logic touched.

The current red will also clear on its own once the in-flight #477 run finishes (it is passing, 0 job failures).