### PR TITLE
fix(governor): both memory env knobs accept auto|off|unlimited|<MiB> (#502)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,17 @@
 [![Default embedder](https://img.shields.io/badge/default%20embedder-lexical%2C%20offline-teal?style=flat-square)](https://xerj.org/docs/vectors.html)
 [![Neural](https://img.shields.io/badge/neural%20embedder-opt--in%2C%20downloads%20~90%20MB-9c6ade?style=flat-square)](https://xerj.org/docs/vectors.html)
 
-XERJ makes an AI agent read the exact code it needs instead of grepping whole files into
-its context window. Point it at a folder and your agent retrieves the precise passage, so
-it can see how a peer project already solved a problem before writing its own. A controlled
-study measured 2.7x fewer output tokens than a grep-driven agent at the same 16/16 solve
-rate ([case study](https://xerj.org/case-studies/reference-coding.html)); people using it
-day to day report roughly 5x fewer tokens end to end
+XERJ is a community-trusted local AI search that indexes any folder automatically, so your
+coding agent stops burning tokens reading files one by one and pulls the exact code it
+needs instead. Reference coding is its main use case and the clearest win: point an agent
+at a task and it downloads the open-source repos closest to it, indexes them, and reuses
+how they solved the problem before writing its own code. In a controlled study that cut a
+coding agent's output tokens by 2.7x at the same 16/16 solve rate
+([case study](https://xerj.org/case-studies/reference-coding.html)), and people report
+roughly 5x in everyday work
 ([field reports](./user-feedback/11-reference-coding-field-reports/2026-08-11-token-savings-reports.md)).
-Install it by pasting one prompt to your agent:
+It is enough for a smaller, cheaper model to out-code a pricier one working from memory,
+while you spend less time in fix loops. Try it now with a one-prompt install:
 
 ```text
 Install XERJ (docs: https://xerj.org/llms.txt), index this project's sources, and set up

--- a/engine/crates/xerj-common/src/config.rs
+++ b/engine/crates/xerj-common/src/config.rs
@@ -1477,7 +1477,7 @@ pub struct LimitsConfig {
     ///     with the machine.
     ///
     /// Override at runtime without editing config via the environment:
-    /// `XERJ_MAX_PROCESS_MEMORY_MB=auto|off|<MiB>` (env wins over this value;
+    /// `XERJ_MAX_PROCESS_MEMORY_MB=auto|off|unlimited|<MiB>` (env wins over this value;
     /// `off`/`unlimited` == `0`; a bare `0` is ambiguous and falls back here).
     pub max_process_memory_mb: u64,
 }

--- a/engine/crates/xerj-engine/src/governor.rs
+++ b/engine/crates/xerj-engine/src/governor.rs
@@ -466,7 +466,7 @@ struct ResolvedProcessMemoryCap {
 }
 
 /// Resolve the process-memory cap from config + optional env override, mirroring
-/// the `XERJ_SEGMENT_HYDRATION_CACHE_MB` grammar (`auto` | `off` | `<MiB>`).
+/// the `XERJ_SEGMENT_HYDRATION_CACHE_MB` grammar (`auto` | `off` | `unlimited` | `<MiB>`).
 ///
 /// Precedence: env wins over config. Semantics preserved from the flat-cap era —
 /// the AUTO sentinel means "tier it", `0` means UNCAPPED (whole machine), and a
@@ -526,7 +526,7 @@ fn resolve_process_memory_cap(
             Err(_) => {
                 let mut fallback = from_config();
                 fallback.warning = Some(format!(
-                    "invalid XERJ_MAX_PROCESS_MEMORY_MB={value:?}; expected auto, off, or a positive MiB value; falling back to config"
+                    "invalid XERJ_MAX_PROCESS_MEMORY_MB={value:?}; expected auto, off, unlimited, or a positive MiB value; falling back to config"
                 ));
                 fallback
             }
@@ -591,7 +591,7 @@ fn resolve_segment_hydration_budget(
             source: SegmentHydrationBudgetSource::Env,
             warning: None,
         },
-        Some("off") => ResolvedSegmentHydrationBudget {
+        Some("off") | Some("unlimited") => ResolvedSegmentHydrationBudget {
             bytes: 0,
             source: SegmentHydrationBudgetSource::Env,
             warning: None,
@@ -611,7 +611,7 @@ fn resolve_segment_hydration_budget(
                 let mut fallback =
                     resolve_segment_hydration_budget(effective_limit, configured_mb, None);
                 fallback.warning = Some(format!(
-                    "invalid XERJ_SEGMENT_HYDRATION_CACHE_MB={value:?}; expected auto, off, or a positive MiB value; falling back to config"
+                    "invalid XERJ_SEGMENT_HYDRATION_CACHE_MB={value:?}; expected auto, off, unlimited, or a positive MiB value; falling back to config"
                 ));
                 fallback
             }
@@ -1061,6 +1061,12 @@ mod tests {
         let off = resolve_segment_hydration_budget(8 * GIB, 1024, Some("off"));
         assert_eq!(off.bytes, 0);
         assert_eq!(off.source, SegmentHydrationBudgetSource::Env);
+
+        // `unlimited` is an accepted synonym for `off`, so this resolver actually
+        // mirrors the XERJ_MAX_PROCESS_MEMORY_MB grammar it claims to (#502).
+        let unlimited = resolve_segment_hydration_budget(8 * GIB, 1024, Some("unlimited"));
+        assert_eq!(unlimited.bytes, 0);
+        assert_eq!(unlimited.source, SegmentHydrationBudgetSource::Env);
 
         let env = resolve_segment_hydration_budget(8 * GIB, 1024, Some("2048"));
         assert_eq!(env.bytes, 2 * GIB);


### PR DESCRIPTION
Closes #502.

`XERJ_MAX_PROCESS_MEMORY_MB` accepted `unlimited` (code at governor.rs:505, tested at :1202, and the config clause says `off`/`unlimited` == 0), but the grammar line, the resolver's doc comment ("mirrors the XERJ_SEGMENT_HYDRATION_CACHE_MB grammar `auto | off | <MiB>`"), and the hydration resolver itself all said only `auto|off|<MiB>`. The two memory env knobs disagreed and the docs disagreed with the code.

Unified **up** (kept the working, tested, documented synonym rather than deleting it):
- hydration resolver now accepts `unlimited` too (governor.rs:594) so the "mirrors" claim is true; new assertion covers it
- both grammar docs now read `auto | off | unlimited | <MiB>`
- the two `expected ...` warnings list `unlimited`

`unlimited`==`off`==uncapped(0), so no numeric outcome changes. Verified rustc 1.97.1: governor 19/19 (dev + ci-test), xerj-common 94, clippy -D warnings clean, fmt clean.