### PR TITLE
ci(landing): wire the landing-constants-guard into CI, then re-stamp the site (#489)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,26 @@ jobs:
       - name: Vetted hub manifests validate
         run: python3 tools/xerj-code/tests/validate_manifest.py --hub tools/xerj-code/hub/*.json
 
+  # #489: this script existed, worked, and had been failing locally for three
+  # releases — the version footer, headline and narrative on landing/index.html
+  # stayed pinned to rc.15 through rc.16 and rc.17 because nothing ran it. It is
+  # fast, needs no toolchain, and only touches static HTML/text, so it belongs
+  # beside the other docs/tooling gates rather than in the release job —
+  # catching drift at PR time is the point, not after the site has been stale
+  # for weeks. fetch-depth: 0 is required (not the default fetch-depth: 1):
+  # the guard resolves "the newest released tag" via `git tag --list`, which a
+  # shallow checkout does not fetch.
+  landing-constants-guard:
+    name: Landing constants guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Landing page constants agree with the newest release
+        run: bash .github/scripts/landing-constants-guard.sh
+
   lint:
     name: Format + Clippy
     runs-on: ubuntu-latest

--- a/landing/agent-search/index.html
+++ b/landing/agent-search/index.html
@@ -220,7 +220,7 @@ curl -X POST localhost:9200/kb/_search -H 'Content-Type: application/json' -d '{
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · AGENT SEARCH · V1.0.0-RC.15</span>
+  <span>XERJ.AI · AGENT SEARCH · V1.0.0-RC.18</span>
   <span>PORTED FROM THE ENGINE · BIT-EXACT</span>
   <span><a href="/index.html">HOME</a> · <a href="/docs/recipes/semantic-search-rag.html">SEMANTIC RECIPE</a> · <a href="/docs/recipes/index.html">RECIPES</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/agents/endpoints.html
+++ b/landing/docs/agents/endpoints.html
@@ -320,7 +320,7 @@ POST /logs/_bulk
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/agents/index.html
+++ b/landing/docs/agents/index.html
@@ -183,7 +183,7 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/agents/quickstart.html
+++ b/landing/docs/agents/quickstart.html
@@ -228,7 +228,7 @@ $ curl -sXDELETE localhost:9200/notes
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/aggregations.html
+++ b/landing/docs/aggregations.html
@@ -226,7 +226,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Aggregations</span>
   </div>
@@ -234,7 +234,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/analyzers.html
+++ b/landing/docs/analyzers.html
@@ -152,7 +152,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Analyzers</span>
   </div>
@@ -160,7 +160,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/api-es-compat.html
+++ b/landing/docs/api-es-compat.html
@@ -245,7 +245,7 @@ JSON</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>ES-compatible API</span>
   </div>
@@ -253,7 +253,7 @@ JSON</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/api-native.html
+++ b/landing/docs/api-native.html
@@ -207,7 +207,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Native REST API</span>
   </div>
@@ -215,7 +215,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/backup-restore.html
+++ b/landing/docs/backup-restore.html
@@ -192,7 +192,7 @@ $ curl -sXPOST .../v1/cluster/nodes/b/activate</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Backup & restore</span>
   </div>
@@ -200,7 +200,7 @@ $ curl -sXPOST .../v1/cluster/nodes/b/activate</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/cli.html
+++ b/landing/docs/cli.html
@@ -231,7 +231,7 @@ OPTIONS:
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>CLI reference</span>
   </div>
@@ -239,7 +239,7 @@ OPTIONS:
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/clustering.html
+++ b/landing/docs/clustering.html
@@ -247,7 +247,7 @@ $ curl -sXPOST -H "Authorization: ApiKey $XERJ_API_KEY" \
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Clustering</span>
   </div>
@@ -255,7 +255,7 @@ $ curl -sXPOST -H "Authorization: ApiKey $XERJ_API_KEY" \
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/compression.html
+++ b/landing/docs/compression.html
@@ -156,7 +156,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Compression & encodings</span>
   </div>
@@ -164,7 +164,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/config.html
+++ b/landing/docs/config.html
@@ -254,7 +254,7 @@ tick_ms = 50</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Config TOML</span>
   </div>
@@ -262,7 +262,7 @@ tick_ms = 50</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/env.html
+++ b/landing/docs/env.html
@@ -151,7 +151,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Environment variables</span>
   </div>
@@ -159,7 +159,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/index.html
+++ b/landing/docs/index.html
@@ -273,7 +273,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Read the source.</span>
   </div>
@@ -281,7 +281,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/ingest.html
+++ b/landing/docs/ingest.html
@@ -158,7 +158,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Ingest pipelines</span>
   </div>
@@ -166,7 +166,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/install.html
+++ b/landing/docs/install.html
@@ -242,7 +242,7 @@ $ docker run -d --name xerj \
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Install</span>
   </div>
@@ -250,7 +250,7 @@ $ docker run -d --name xerj \
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/metrics.html
+++ b/landing/docs/metrics.html
@@ -168,7 +168,7 @@ scrape_configs:
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Metrics</span>
   </div>
@@ -176,7 +176,7 @@ scrape_configs:
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/migration-from-es.html
+++ b/landing/docs/migration-from-es.html
@@ -176,7 +176,7 @@ $ diff &lt;(curl -s http://es:9200/logs-2026-04/_search -d @q.json) \
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Migrate from Elasticsearch</span>
   </div>
@@ -184,7 +184,7 @@ $ diff &lt;(curl -s http://es:9200/logs-2026-04/_search -d @q.json) \
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/operations.html
+++ b/landing/docs/operations.html
@@ -232,7 +232,7 @@ scrape_configs:
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Running in production</span>
   </div>
@@ -240,7 +240,7 @@ scrape_configs:
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/playbooks/full-text.html
+++ b/landing/docs/playbooks/full-text.html
@@ -187,7 +187,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Playbook · Full-text search</span>
   </div>
@@ -195,7 +195,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/playbooks/log-analytics.html
+++ b/landing/docs/playbooks/log-analytics.html
@@ -195,7 +195,7 @@ time_partition = "1h"</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Playbook · Log analytics</span>
   </div>
@@ -203,7 +203,7 @@ time_partition = "1h"</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/playbooks/observability.html
+++ b/landing/docs/playbooks/observability.html
@@ -193,7 +193,7 @@ $ OTEL_EXPORTER_OTLP_ENDPOINT=http://xerj:8080/v1/indices/traces/otlp \
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Playbook · Observability</span>
   </div>
@@ -201,7 +201,7 @@ $ OTEL_EXPORTER_OTLP_ENDPOINT=http://xerj:8080/v1/indices/traces/otlp \
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/playbooks/siem.html
+++ b/landing/docs/playbooks/siem.html
@@ -245,7 +245,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Playbook · SIEM</span>
   </div>
@@ -253,7 +253,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/playbooks/vector-search.html
+++ b/landing/docs/playbooks/vector-search.html
@@ -203,7 +203,7 @@ timeout_ms       = 5000</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Playbook · Vector & RAG</span>
   </div>
@@ -211,7 +211,7 @@ timeout_ms       = 5000</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/queries.html
+++ b/landing/docs/queries.html
@@ -226,7 +226,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Query types</span>
   </div>
@@ -234,7 +234,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/quickstart.html
+++ b/landing/docs/quickstart.html
@@ -187,7 +187,7 @@ $ xerj autoindex ~/my-project        # picks up XERJ_API_KEY, or take --api-key<
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+    <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Quickstart</span>
   </div>
@@ -195,7 +195,7 @@ $ xerj autoindex ~/my-project        # picks up XERJ_API_KEY, or take --api-key<
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/agentic-memory.html
+++ b/landing/docs/recipes/agentic-memory.html
@@ -272,7 +272,7 @@ All assertions passed.</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/anomaly-detection.html
+++ b/landing/docs/recipes/anomaly-detection.html
@@ -291,7 +291,7 @@ OK: spike at 00:12 flagged (score 100.0); 11 normal buckets, none flagged (top n
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/continuous-anomaly-datafeeds.html
+++ b/landing/docs/recipes/continuous-anomaly-datafeeds.html
@@ -305,7 +305,7 @@ OK: 2 anomalies detected continuously; datafeed stopped cleanly.</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/document-folder-index.html
+++ b/landing/docs/recipes/document-folder-index.html
@@ -355,7 +355,7 @@ node compare.mjs</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipe · Index a folder of docs</span>
   </div>
@@ -363,7 +363,7 @@ node compare.mjs</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/hybrid-search.html
+++ b/landing/docs/recipes/hybrid-search.html
@@ -254,7 +254,7 @@ OK</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipe · Hybrid search</span>
   </div>
@@ -262,7 +262,7 @@ OK</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/index.html
+++ b/landing/docs/recipes/index.html
@@ -194,7 +194,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipes</span>
   </div>
@@ -202,7 +202,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/log-analytics.html
+++ b/landing/docs/recipes/log-analytics.html
@@ -260,7 +260,7 @@ Q3  top services:       catalog 190 · search 187 · checkout 150 · payments 73
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipe · Log analytics</span>
   </div>
@@ -268,7 +268,7 @@ Q3  top services:       catalog 190 · search 187 · checkout 150 · payments 73
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/migrate-from-elasticsearch.html
+++ b/landing/docs/recipes/migrate-from-elasticsearch.html
@@ -311,7 +311,7 @@ ES=http://localhost:9200 bash docs/examples/migrate-from-elasticsearch/migrate_d
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/passage-retrieval.html
+++ b/landing/docs/recipes/passage-retrieval.html
@@ -196,7 +196,7 @@ compendium reached the top-3:
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipe · Passage retrieval</span>
   </div>
@@ -204,7 +204,7 @@ compendium reached the top-3:
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/semantic-search-rag.html
+++ b/landing/docs/recipes/semantic-search-rag.html
@@ -281,7 +281,7 @@ unknown-metric -&gt; HTTP 400 (fail-loud, not a misleading number)</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipe · Semantic search &amp; RAG</span>
   </div>
@@ -289,7 +289,7 @@ unknown-metric -&gt; HTTP 400 (fail-loud, not a misleading number)</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/vector-quantization.html
+++ b/landing/docs/recipes/vector-quantization.html
@@ -215,7 +215,7 @@ python3 docs/examples/vector-quantization/quant_demo.py</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/vector-search-knn.html
+++ b/landing/docs/recipes/vector-search-knn.html
@@ -260,7 +260,7 @@ ALL ASSERTIONS PASSED</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipe · Vector search · kNN</span>
   </div>
@@ -268,7 +268,7 @@ ALL ASSERTIONS PASSED</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/recipes/zero-config-autoindex.html
+++ b/landing/docs/recipes/zero-config-autoindex.html
@@ -287,7 +287,7 @@ curl localhost:9200/ax-*/_search -H 'Content-Type: application/json' \
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Recipe · Zero-config autoindex</span>
   </div>
@@ -295,7 +295,7 @@ curl localhost:9200/ax-*/_search -H 'Content-Type: application/json' \
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/security.html
+++ b/landing/docs/security.html
@@ -158,7 +158,7 @@ $ sudo journalctl -u xerj | grep -A4 'First-run'</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Auth & TLS</span>
   </div>
@@ -166,7 +166,7 @@ $ sudo journalctl -u xerj | grep -A4 'First-run'</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/storage.html
+++ b/landing/docs/storage.html
@@ -176,7 +176,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Storage & WAL</span>
   </div>
@@ -184,7 +184,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/troubleshooting.html
+++ b/landing/docs/troubleshooting.html
@@ -185,7 +185,7 @@ contents:
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Troubleshooting</span>
   </div>
@@ -193,7 +193,7 @@ contents:
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/upgrades.html
+++ b/landing/docs/upgrades.html
@@ -182,7 +182,7 @@ $ sudo systemctl start xerj</pre>
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Upgrades</span>
   </div>
@@ -190,7 +190,7 @@ $ sudo systemctl start xerj</pre>
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/docs/vectors.html
+++ b/landing/docs/vectors.html
@@ -192,7 +192,7 @@
 
   <!-- Print-only branded footer (hidden on screen, visible in PDF) -->
   <div class="print-footer" style="display:none;">
-    <span>XERJ.AI · V1.0.0-RC.15 · 2026-08-11</span>
+    <span>XERJ.AI · V1.0.0-RC.18 · 2026-08-11</span>
     <a href="https://xerj.org/docs/">https://xerj.org/docs/</a>
     <span>Vectors & kNN</span>
   </div>
@@ -200,7 +200,7 @@
 </div>
 
 <footer class="footer">
-  <span>XERJ.AI · DOCS · V1.0.0-RC.15</span>
+  <span>XERJ.AI · DOCS · V1.0.0-RC.18</span>
   <span>READ THE SOURCE</span>
   <span><a href="/index.html">HOME</a> · <a href="/product.html">PRODUCT</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/for-agents.html
+++ b/landing/for-agents.html
@@ -350,7 +350,7 @@ $ curl -sXPOST localhost:9200/docfolder/_search \
 </a>
 
 <footer class="footer">
-  <span>XERJ.AI · FOR AI · V1.0.0-RC.15</span>
+  <span>XERJ.AI · FOR AI · V1.0.0-RC.18</span>
   <span>ONE BINARY. THREE STORES.</span>
   <span><a href="/index.html">HOME</a> · <a href="/docs/index.html">DOCS</a> · <a href="/docs/recipes/index.html">RECIPES</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/index.html
+++ b/landing/index.html
@@ -236,11 +236,11 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
 <!-- 04 — SHIPPING NOW ---------------------------------------->
 <section class="scene-section">
   <div class="kicker"><span class="accent">04</span><span class="dash">·</span><span>SHIPPING NOW · THE CURRENT BUILD</span></div>
-  <h2 class="scene">RC.15.<br><span class="accent">AND COUNTING.</span></h2>
+  <h2 class="scene">RC.18.<br><span class="accent">AND COUNTING.</span></h2>
 
   <p class="wide">
-    <strong>15 release candidates in 34 days</strong> — v1.0.0-rc.1 shipped
-    2026-07-07, <strong>v1.0.0-rc.15</strong> on 2026-08-10, and the installers
+    <strong>18 release candidates in 43 days</strong> — v1.0.0-rc.1 shipped
+    2026-07-07, <strong>v1.0.0-rc.18</strong> on 2026-08-19, and the installers
     above always resolve the latest. Every commit re-runs the
     <strong>1,366 / 1,369</strong> ES-YAML conformance suite; the changelog
     states known defects instead of implying their absence. In the current
@@ -328,7 +328,7 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
 </section>
 
 <footer class="footer">
-  <span>XERJ.AI · V1.0.0-RC.15 · 2026</span>
+  <span>XERJ.AI · V1.0.0-RC.18 · 2026</span>
   <span>SEARCH FOR THE AGENT ERA</span>
   <span><a href="/product.html">PRODUCT</a> · <a href="/docs/index.html">DOCS</a> · <a href="/brand.html">BRAND</a> · <a href="/playground.html">DASHBOARDS</a> &middot; <a href="/llms.txt">LLMS.TXT</a></span>
 </footer>

--- a/landing/llms.txt
+++ b/landing/llms.txt
@@ -297,7 +297,7 @@ Tool definitions for the operations above, ready to paste into an agent framewor
 - [openai-tools.json](https://xerj.org/docs/agents/schemas/openai-tools.json) — OpenAI function-calling shape: an array of `{"type":"function","function":{name, description, parameters}}`.
 - [anthropic-tools.json](https://xerj.org/docs/agents/schemas/anthropic-tools.json) — Anthropic tool-use shape: an array of `{name, description, input_schema}`.
 
-The OpenAI and Anthropic files define the same six operations — `xerj_search`, `xerj_semantic_search`, `xerj_vector_search`, `xerj_hybrid_search`, `xerj_memory_store`, `xerj_memory_recall`.
+The OpenAI and Anthropic files define six of the seven canonical operations — the HTTP-reachable ones: `xerj_search`, `xerj_semantic_search`, `xerj_vector_search`, `xerj_hybrid_search`, `xerj_memory_store`, `xerj_memory_recall`. (`xerj_autoindex`, the seventh, is CLI-only and has no HTTP route to describe — see above.)
 
 If you *can* run a process, `xerj mcp` is an MCP stdio server inside the same binary (since **v1.0.0-rc.16**) serving those ten tools. It does not start a node — point it at one you already started.
 


### PR DESCRIPTION
Fixes #489.

## The bug

`.github/scripts/landing-constants-guard.sh` exists, works, and currently **fails** — but is wired into no workflow:

```
$ bash .github/scripts/landing-constants-guard.sh
FAIL  version stamps disagree with the newest released tag (v1.0.0-rc.18)
FAIL  the site claims both six and seven canonical agent operations
landing-constants-guard: 2 check(s) failed

$ grep -rn "landing-constants-guard" .github/workflows/
(no output)
```

The front page headline was literally `RC.15.<br>AND COUNTING.` and the footer said `V1.0.0-RC.15` on 47 files (83 occurrences) — while rc.16, rc.17 and now rc.18 shipped around it.

## Why the wiring is the actual fix

Per the issue: re-stamping the 47 files without wiring the guard buys exactly one release before it drifts again, which is the observed history (the stamps froze at `b0bfce9`, 2026-08-12, and neither rc.16 nor rc.17 touched them). Added as its own job in `ci.yml`, beside the other fast, no-toolchain docs/tooling gates (`reference-coding`) — it belongs at PR time, not in the release job.

`fetch-depth: 0` is required (not the default `fetch-depth: 1`): the guard resolves "the newest released tag" via `git tag --list`, which a shallow checkout does not fetch — without it the guard would silently no-op its own version check under CI.

## Then made it pass

- Blanket-replaced the literal string `V1.0.0-RC.15` with `V1.0.0-RC.18` across all 47 flagged files (83 occurrences). Verified first that every occurrence sits in a footer span with no snapshot-marked historical exception sharing the exact uppercase string, so a tree-wide `sed` was safe.
- `landing/index.html`'s "SHIPPING NOW" headline/narrative wasn't caught by the guard's footer-scoped regex, but is the same defect the issue names directly: `RC.15. AND COUNTING.` → `RC.18. AND COUNTING.`, `15 release candidates in 34 days` → `18 ... in 43 days`, `v1.0.0-rc.15 on 2026-08-10` → `v1.0.0-rc.18 on 2026-08-19` — verified against the real rc.1/rc.18 GitHub release dates.
- Settled the six-vs-seven contradiction: `llms.txt` described the OpenAI/Anthropic tool-schema files as defining "the same six operations", reading as a total-operation-count claim against "seven canonical agent operations" stated everywhere else. Reworded to "six of the seven canonical operations — the HTTP-reachable ones", with the existing CLI-only `xerj_autoindex` caveat — those specific schema files genuinely define six tools, so the fix is in how the sentence reads, not the number.

## Not done here

The issue's own fix list floats generating the version stamp instead of hand-writing 47 copies of it — a gate that keeps firing on the same class of drift is a sign the representation is wrong, not just the process around it. That's a bigger, separate change; this PR is the wiring plus the re-stamp it now requires.

## Verification

- `bash .github/scripts/landing-constants-guard.sh` passes clean (all 5 checks) against the current tree.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` confirms the new job parses and sits correctly in job order.

Claude-Session: https://claude.ai/code/session_01SYkHSEV3ofzGpF72efeW9w
