### PR TITLE
docs(public-sector): drop engine at-rest-crypto claims the build does not ship (#491)

### DIFF
--- a/landing/industries/public-sector.html
+++ b/landing/industries/public-sector.html
@@ -119,7 +119,7 @@
 
       <g class="node accent"><rect x="520" y="60" width="380" height="60"/>
         <text x="536" y="82" class="label">XERJ CLUSTER · 3-NODE HA</text>
-        <text x="536" y="102" class="small">inside customer tenancy · region-pinned · BYOK</text>
+        <text x="536" y="102" class="small">inside customer tenancy · region-pinned · your keys (BYOK)</text>
       </g>
 
       <line x1="710" y1="120" x2="710" y2="156"/><polygon points="706,152 714,152 710,160"/>
@@ -160,7 +160,7 @@
 
       <g class="node accent"><rect x="60" y="170" width="840" height="72"/>
         <text x="76" y="194" class="label">XERJ CLUSTER · 3-NODE HA · ON APPROVED HARDWARE</text>
-        <text x="76" y="216" class="small">FTS · VECTOR · COLUMNAR · AGENT MEMORY · AES-256-GCM + BYOK</text>
+        <text x="76" y="216" class="small">FTS · VECTOR · COLUMNAR · AGENT MEMORY</text>
         <text x="76" y="234" class="small mute">Helm chart · Kubernetes Operator · Terraform module (roadmap Q2)</text>
       </g>
 


### PR DESCRIPTION
Closes #491.

#430 withdrew unbacked security claims but two survived on the public-sector page, framed as shipped **engine** features:

- **The engine-capability row** (`... AGENT MEMORY · AES-256-GCM + BYOK`, beside FTS/VECTOR/COLUMNAR) implied the binary does at-rest encryption + BYOK. It does not — `docs/SECURITY_MODEL.md:763`: *"No encryption at rest at the engine level."* Removed the crypto claim from that row; the crypto/compliance story is already told honestly in the matrix below (CJIS `INHERITED`, DoD IL5 / FIPS `ROAD 2027`).
- **The deployment label** (`inside customer tenancy · region-pinned · BYOK`) — BYOK there is the customer's own keys for their tenancy, an inherited property. Reworded to `your keys (BYOK)` to make that unambiguous.

No status-marked matrix row was touched (INHERITED / ROAD 2027 are accurate). `landing-constants-guard` still passes. Landing page only, no engine code.

Follow-up left in #491: widen the guard to fail on a compliance term with no status marker — a larger, false-positive-sensitive change than removing these two.