### PR TITLE
docs(landing): verify release downloads on upgrades and demo pages (#454)

### DIFF
--- a/landing/demo/index.html
+++ b/landing/demo/index.html
@@ -351,7 +351,8 @@ footer .links { display: flex; gap: 28px; flex-wrap: wrap; }
 
   <pre class="cmd"><span class="prompt">$ </span>(
     ver=1.0.0-rc.1                              # this demo was captured on rc.1
-    asset="xerj-${ver}-x86_64-unknown-linux-gnu.tar.gz"
+    stage="xerj-${ver}-x86_64-unknown-linux-gnu"
+    asset="${stage}.tar.gz"
     base="https://github.com/xerj-org/xerj/releases/download/v${ver}"
 
     curl -fsSLO "$base/$asset"
@@ -365,7 +366,7 @@ footer .links { display: flex; gap: 28px; flex-wrap: wrap; }
       | LC_ALL=C grep -qxF -e "$want  $asset" -e "$want *$asset" \
       || { echo "CHECKSUM MISMATCH for $asset — do not run it" &gt;&amp;2; exit 1; }
 
-    tar xzf "$asset"
+    tar xzf "$asset" &amp;&amp; mv "$stage/xerj" ./xerj
   )
 <span class="prompt">$ </span>./xerj --insecure --data-dir ./data
 <span class="out">2026-04-27T19:11:41.6Z  INFO xerj: xerj v1.0.0-rc.1 starting

--- a/landing/demo/index.html
+++ b/landing/demo/index.html
@@ -349,8 +349,24 @@ footer .links { display: flex; gap: 28px; flex-wrap: wrap; }
     is already running on port 9200.
   </p>
 
-  <pre class="cmd"><span class="prompt">$ </span>curl -L -o xerj.tar.gz https://github.com/xerj-org/xerj/releases/download/v1.0.0-rc.1/xerj-1.0.0-rc.1-x86_64-unknown-linux-gnu.tar.gz
-<span class="prompt">$ </span>tar xzf xerj.tar.gz
+  <pre class="cmd"><span class="prompt">$ </span>(
+    ver=1.0.0-rc.1                              # this demo was captured on rc.1
+    asset="xerj-${ver}-x86_64-unknown-linux-gnu.tar.gz"
+    base="https://github.com/xerj-org/xerj/releases/download/v${ver}"
+
+    curl -fsSLO "$base/$asset"
+    curl -fsSLO "$base/$asset.sha256"
+
+    want=$( { sha256sum "$asset" 2&gt;/dev/null || shasum -a 256 "$asset"; } | cut -d ' ' -f 1 )
+    printf %s "$want" | LC_ALL=C grep -qE '^[0-9a-f]{64}$' \
+      || { echo "no working SHA-256 tool — refusing to run an unverified $asset" &gt;&amp;2; exit 1; }
+
+    tr -d '\r' &lt; "$asset.sha256" \
+      | LC_ALL=C grep -qxF -e "$want  $asset" -e "$want *$asset" \
+      || { echo "CHECKSUM MISMATCH for $asset — do not run it" &gt;&amp;2; exit 1; }
+
+    tar xzf "$asset"
+  )
 <span class="prompt">$ </span>./xerj --insecure --data-dir ./data
 <span class="out">2026-04-27T19:11:41.6Z  INFO xerj: xerj v1.0.0-rc.1 starting
 2026-04-27T19:11:41.6Z  WARN xerj: --insecure: TLS and auth disabled

--- a/landing/docs/upgrades.html
+++ b/landing/docs/upgrades.html
@@ -127,18 +127,37 @@ $ curl -sXPOST -H "Authorization: ApiKey $XERJ_API_KEY" \
     http://127.0.0.1:8080/v1/admin/backup \
     -d '{"destination":"s3://my-backups/xerj/pre-upgrade"}'
 
-# 2. Fetch the new release
-$ curl -sLO https://xerj.org/releases/xerj-0.2.0-linux-x86_64.tar.gz
-$ tar xzf xerj-0.2.0-linux-x86_64.tar.gz
+# 2. Fetch and verify the new release — extraction is chained to the checksum,
+#    so an archive that fails to verify is never unpacked over the running node
+$ (
+    ver=1.0.0-rc.18                             # the release you are upgrading to
+    target=x86_64-unknown-linux-musl            # your platform's target triple
+    stage="xerj-${ver}-${target}"
+    asset="${stage}.tar.gz"
+    base="https://github.com/xerj-org/xerj/releases/download/v${ver}"
 
-# 3. Replace the binary in place
+    curl -fsSLO "$base/$asset"
+    curl -fsSLO "$base/$asset.sha256"
+
+    want=$( { sha256sum "$asset" 2&gt;/dev/null || shasum -a 256 "$asset"; } | cut -d ' ' -f 1 )
+    printf %s "$want" | LC_ALL=C grep -qE '^[0-9a-f]{64}$' \
+      || { echo "no working SHA-256 tool — refusing to install an unverified $asset" &gt;&amp;2; exit 1; }
+
+    tr -d '\r' &lt; "$asset.sha256" \
+      | LC_ALL=C grep -qxF -e "$want  $asset" -e "$want *$asset" \
+      || { echo "CHECKSUM MISMATCH for $asset — do not install it" &gt;&amp;2; exit 1; }
+
+    tar xzf "$asset"
+  )
+
+# 3. Replace the binary in place (reached only when step 2 verified and unpacked)
 $ sudo systemctl stop xerj
-$ sudo install -m 0755 xerj /usr/local/bin/xerj
+$ sudo install -m 0755 "xerj-1.0.0-rc.18-x86_64-unknown-linux-musl/xerj" /usr/local/bin/xerj
 $ sudo systemctl start xerj
 
-# 4. Confirm
+# 4. Confirm the node reports the version you just installed
 $ curl -s http://127.0.0.1:8080/v1/health | jq .version
-"0.2.0"</pre>
+"1.0.0-rc.18"</pre>
 
   <p>Downtime is the time it takes the WAL to replay — usually a few seconds for workloads in the low millions of live docs.</p>
 


### PR DESCRIPTION
Closes #454.

Two shipped pages fetched a release archive and unpacked it with **no integrity check at all** — the shape #452 explicitly left out of scope because it fixed a verification that *fails open*, not the absence of one.

### What was wrong
- **`landing/docs/upgrades.html`** — an upgrade **over a running node** (the binary being replaced is already trusted and serving). `grep -c sha256` → `0`. It also pulled `xerj-0.2.0-linux-x86_64.tar.gz` off `xerj.org/releases` — a name and host no current release publishes, so the commands could not work as printed.
- **`landing/demo/index.html`** — pinned to the captured `v1.0.0-rc.1` build, `curl -L` following redirects to wherever, no digest.

### The fix
Reuses the fail-closed form already shipped on `install.html` (#452) verbatim, rather than inventing a third:
1. fetch the archive **and** its published `.sha256`;
2. compute the digest and **length/hex-check it** — a host with no `sha256sum`/`shasum` leaves `want` empty, and an empty digest cannot satisfy the check;
3. require the `.sha256` to contain **that exact line** (both GNU two-space and `-b` binary forms; `tr -d '\r'` for Windows-written files) — **not** `sha256sum -c`, see #444 for why;
4. **extraction is chained to the check** inside a subshell, so an archive that fails to verify is never unpacked and a refusal exits non-zero (a Dockerfile `RUN` / CI step / agent sees the failure).

- The **demo stays on rc.1** — its transcript really ran on that build (the constants guard exempts it as a dated capture) — and verifies against rc.1's own published `.sha256`.
- **upgrades.html** moves to the real GitHub release URL + target-triple naming with an operator-set `ver` (example: the current `1.0.0-rc.18`), so the printed commands actually resolve.

### Verification
- **Functional test of the exact snippet** against the real published rc.1 pair: the good archive verifies and extracts (exit 0); a `.sha256` with **one flipped hex digit** is rejected with `CHECKSUM MISMATCH` (exit 1); an empty digest (no hashing tool) is refused (exit 1).
- rc.18 musl `.tar.gz` **and** `.tar.gz.sha256` both exist, so upgrades.html's example resolves.
- `landing-constants-guard.sh` — all checks pass (version stamps match `v1.0.0-rc.18`; demo rc.1 exempt).
- Swept all of `landing/` (html + txt, incl. case studies / playbooks): **no other page** fetches a release without verifying it — closes the issue's "Not verified" note.

Docs-only; no engine code touched.