### PR TITLE
harbor-3arm: measured fixes from the first parallel campaign night

### DIFF
--- a/tools/benchmarks/harbor-3arm/README.md
+++ b/tools/benchmarks/harbor-3arm/README.md
@@ -31,6 +31,15 @@ export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-...
 export ANTHROPIC_API_KEY=...             # ONLY for senior-swe's LLM judge
 ```
 
+Parallel cells (measured): running many cells at once exhausts Docker's
+default ~30-subnet address pool ("all predefined address pools have been fully
+subnetted") — every trial creates 2 networks. Expand it once:
+
+```json
+// /etc/docker/daemon.json
+{ "default-address-pools": [ {"base": "10.200.0.0/13", "size": 24} ] }
+```
+
 Auth note (measured): Harbor's automatic key resolution remaps whatever it
 finds into `ANTHROPIC_API_KEY`, which an OAuth token cannot serve — the runner
 therefore injects `CLAUDE_CODE_OAUTH_TOKEN` + `CLAUDE_FORCE_OAUTH=true` via

--- a/tools/benchmarks/harbor-3arm/run_matrix.sh
+++ b/tools/benchmarks/harbor-3arm/run_matrix.sh
@@ -28,10 +28,15 @@ case "$ARM" in
   *) echo "unknown arm: $ARM" >&2; exit 2 ;;
 esac
 CELL="$BENCH.$MODEL.$ARM"; JOB_DIR="$JOBS_ROOT/$CELL"; mkdir -p "$JOBS_ROOT"
+# One driver per cell, ever: a second harbor process on the same job dir
+# corrupts trials (measured 2026-08-19, duplicate-runner incident).
+exec 9>"$JOBS_ROOT/.$CELL.lock"
+flock -n 9 || { echo "cell $CELL already has a running driver — refusing"; exit 3; }
 export PYTHONPATH="$HERE${PYTHONPATH:+:$PYTHONPATH}"
-AUTH_ARGS=(--ae "CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN" --ae "CLAUDE_FORCE_OAUTH=true")
+export CLAUDE_FORCE_OAUTH="${CLAUDE_FORCE_OAUTH:-true}"
+AUTH_ARGS=(--ae "CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN" --ae "CLAUDE_FORCE_OAUTH=$CLAUDE_FORCE_OAUTH")
 [ -n "${ANTHROPIC_API_KEY:-}" ] && AUTH_ARGS+=(--ae "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY")
-if [ -d "$JOB_DIR" ]; then echo "== resuming $CELL"; exec "$HARBOR" job resume "$JOB_DIR" "$@"; fi
+if [ -d "$JOB_DIR" ]; then echo "== resuming $CELL"; exec "$HARBOR" job resume -p "$JOB_DIR" -f ApiRateLimitError; fi
 echo "== starting $CELL (agent=$AGENT)"
 exec "$HARBOR" run "${DATASET[@]}" -a "$AGENT" -m "$MODEL" \
   --jobs-dir "$JOBS_ROOT" --job-name "$CELL" -n "${CONCURRENT:-4}" -y \


### PR DESCRIPTION
Follow-up to #513 (merged): four fixes measured during the live 9-cell parallel campaign — env-reference `--ae` values (harbor redacts literals and resume crashes on '[REDACTED]'), `job resume -p -f ApiRateLimitError`, a per-cell flock guard against double-driving, and the Docker default-address-pools trap under parallel cells.