### PR TITLE
docs(wal_tap): snapshot/restore only seeds a XERJ target, not cross-engine (#400)

### DIFF
--- a/engine/crates/xerj-engine/src/wal_tap.rs
+++ b/engine/crates/xerj-engine/src/wal_tap.rs
@@ -84,7 +84,11 @@
 //! included. On an index that has been running long enough to prune, at the
 //! end: the surviving generations are an arbitrary recent slice, and shipping
 //! them would look like a backfill without being one. **There is no backfill.**
-//! Seed the target with snapshot/restore if it needs the existing documents.
+//! Seed the target with the existing documents first if it needs them.
+//! snapshot/restore only seeds another XERJ node — XERJ's snapshot format
+//! (WAL + segments) is engine-specific and cannot be restored into an
+//! Elasticsearch/OpenSearch target; seed a cross-engine target with an
+//! external scan-and-push of the current documents (`_search`/PIT -> `_bulk`).
 //!
 //! **4b. What falling behind costs.** WAL retention is *not* coupled to the
 //! tap, deliberately: `IndexStore::wal_maintain_all_verified` deletes a

--- a/engine/xerj.default.toml
+++ b/engine/xerj.default.toml
@@ -518,8 +518,11 @@ access_log = false
 # Before turning it on, three behaviours you are agreeing to:
 #
 #  * No backfill. A new index (nothing pruned from its WAL yet) is shipped
-#    whole; an established one starts from the moment it is allowlisted. Seed
-#    the target with snapshot/restore first if it needs the existing documents.
+#    whole; an established one starts from the moment it is allowlisted. If it
+#    needs the pre-existing documents, seed the target first: snapshot/restore
+#    only works when the target is another XERJ node (the snapshot format is
+#    engine-specific). For an Elasticsearch/OpenSearch target, seed with an
+#    external scan-and-push of the current documents (_search/PIT -> _bulk).
 #  * At-least-once. Each action carries `version_type=external` with the WAL
 #    seq_no, so redelivery is a no-op on a target that honours it.
 #  * Retention never waits for the target. WAL generations are pruned once they


### PR DESCRIPTION
Closes #400.

The wal_tap seed guidance (`wal_tap.rs:87`, `xerj.default.toml:520-522`) said *"seed the target with snapshot/restore if it needs the existing documents."* But `create_snapshot` copies each index's WAL + segments into an **engine-specific** archive — it can only be restored into another XERJ node, never the Elasticsearch/OpenSearch target wal_tap frames as the flagship case. So the guidance is inaccurate for the majority deployment shape.

Corrected to state that snapshot/restore only seeds a XERJ target, and a cross-engine target must be seeded with an external scan-and-push of the current documents (`_search`/PIT → `_bulk`) — which is exactly the outcome the reporter offered as fine (they built `xerj-seed` for it). Docs/comment only, no behavior change.