### PR TITLE
fix(engine): 400 a knn/semantic clause on a non-vector field, not empty 200 (#498)

### DIFF
--- a/engine/crates/xerj-api/tests/knn_on_non_vector_field_fails.rs
+++ b/engine/crates/xerj-api/tests/knn_on_non_vector_field_fails.rs
@@ -1,0 +1,146 @@
+//! Issue #498: a `knn` / `semantic` clause that names a field which is absent,
+//! or is not a vector field, must fail loudly with a 400 — not return an empty,
+//! successful 200. An agent that issues a vector query against an index built
+//! without vectors otherwise gets zero hits and concludes "no relevant results
+//! exist", when the truth is "this index cannot answer vector queries at all".
+//!
+//! The second test is the false-positive guard: a `knn` against a genuine
+//! `dense_vector` field must NOT be rejected, even when the index is empty (an
+//! empty result there is a legitimate "nothing matched").
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn config_for(dir: &std::path::Path) -> xerj_common::config::Config {
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    config
+}
+
+fn app_over(dir: &std::path::Path) -> axum::Router {
+    let config = config_for(dir);
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    xerj_api::router::build_es_compat_router(state)
+}
+
+async fn send(app: &axum::Router, req: Request<Body>) -> (StatusCode, Value) {
+    let response = app.clone().oneshot(req).await.expect("response");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, body)
+}
+
+fn json_req(method: &str, path: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request")
+}
+
+#[tokio::test]
+async fn knn_on_an_absent_field_fails_with_400_not_empty_200() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = app_over(dir.path());
+
+    // A text-only index — no `dense_vector` field anywhere.
+    let (st, body) = send(
+        &app,
+        json_req(
+            "PUT",
+            "/docs",
+            json!({ "mappings": { "properties": { "body": { "type": "text" } } } }),
+        ),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create index: {body}");
+
+    let (st, _) = send(
+        &app,
+        json_req(
+            "POST",
+            "/docs/_doc?refresh=true",
+            json!({ "body": "hello world" }),
+        ),
+    )
+    .await;
+    assert!(st.is_success(), "index a document: {st}");
+
+    // A `knn` naming a field that does not exist must 400, not answer 200/0.
+    let (st, body) = send(
+        &app,
+        json_req(
+            "POST",
+            "/docs/_search",
+            json!({ "knn": { "field": "embedding", "query_vector": [0.1, 0.2, 0.3],
+                             "k": 5, "num_candidates": 50 } }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        st,
+        StatusCode::BAD_REQUEST,
+        "knn on an absent field must fail loudly, not return an empty 200: {body}"
+    );
+    let reason = body
+        .pointer("/error/reason")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    assert!(
+        reason.contains("embedding"),
+        "the 400 must name the offending field: {body}"
+    );
+}
+
+#[tokio::test]
+async fn knn_on_a_real_dense_vector_field_is_not_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = app_over(dir.path());
+
+    let (st, body) = send(
+        &app,
+        json_req(
+            "PUT",
+            "/vecs",
+            json!({ "mappings": { "properties": {
+                "vec": { "type": "dense_vector", "dims": 3 } } } }),
+        ),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create dense_vector index: {body}");
+
+    // No documents ingested: an empty result here is a legitimate "nothing
+    // matched", NOT a reason to reject the query. The guard must fire only on
+    // fields that cannot answer a vector clause at all.
+    let (st, body) = send(
+        &app,
+        json_req(
+            "POST",
+            "/vecs/_search",
+            json!({ "knn": { "field": "vec", "query_vector": [0.1, 0.2, 0.3],
+                             "k": 5, "num_candidates": 50 } }),
+        ),
+    )
+    .await;
+    assert_ne!(
+        st,
+        StatusCode::BAD_REQUEST,
+        "a knn on a genuine dense_vector field must not be rejected: {body}"
+    );
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -13870,6 +13870,13 @@ impl Index {
                     ),
                 )));
             }
+            // #498: fail loudly when a `knn`/`semantic` clause names a field
+            // that cannot answer it, instead of returning an empty 200.
+            if let Some(reason) = vector_query_field_error(&resolved, &schema.schema) {
+                return Err(EngineError::Common(xerj_common::XerjError::invalid_query(
+                    reason,
+                )));
+            }
             // #437: a sort field this engine cannot resolve (any of 11 ES
             // meta-field names besides the ones handled below, or an
             // unmapped/misspelled field) fell through to `_source` lookup
@@ -30732,6 +30739,82 @@ fn unsearchable_query_field(q: &QueryNode, schema: &Schema) -> Option<String> {
         // field-less `more_like_this` (with `fields` the parser lowers it to
         // `bool.should` of `match`, which the leaf arms above catch), and
         // `percolate` (the field holds stored queries, not data).
+        _ => None,
+    }
+}
+
+/// #498: a `knn` / `semantic` clause naming a field that is absent, or is not
+/// vector-capable, used to return an empty *successful* result instead of
+/// failing — an agent issuing a vector query against an index built without
+/// vectors got zero hits and could not tell "nothing matched" from "this index
+/// does no vector search". Real ES answers `400 illegal_argument_exception`
+/// here, so this returns the offending clause's message and the caller 400s.
+///
+/// The recursion mirrors [`unsearchable_query_field`]; only the two vector
+/// leaves validate a field. "Vector-capable" is deliberately permissive — a
+/// `dense_vector`, a `chunk`, or any field carrying an embedding config
+/// (`semantic_text`, whose companion vector exists even under the lexical
+/// feature-hash embedder) — so a legitimate vector query is never rejected;
+/// only a plainly non-vector or absent field is.
+fn vector_query_field_error(q: &QueryNode, schema: &Schema) -> Option<String> {
+    fn vector_capable(fc: &FieldConfig) -> bool {
+        matches!(fc.field_type, FieldType::Vector | FieldType::Chunk) || fc.embedding.is_some()
+    }
+    match q {
+        QueryNode::Knn { field, filter, .. } => match declared_field(schema, field) {
+            None => Some(format!(
+                "[knn] query targets field [{field}], which does not exist in the mapping"
+            )),
+            Some(fc) if !vector_capable(fc) => Some(format!(
+                "[knn] query is only supported on [dense_vector] fields, but [{field}] is of \
+                 type [{}]",
+                fc.field_type
+            )),
+            _ => filter
+                .as_deref()
+                .and_then(|f| vector_query_field_error(f, schema)),
+        },
+        QueryNode::SemanticSearch { field, filter, .. } => match declared_field(schema, field) {
+            None => Some(format!(
+                "[semantic] query targets field [{field}], which does not exist in the mapping"
+            )),
+            Some(fc) if !vector_capable(fc) => Some(format!(
+                "[semantic] query is only supported on [semantic_text] fields, but [{field}] is \
+                 of type [{}]",
+                fc.field_type
+            )),
+            _ => filter
+                .as_deref()
+                .and_then(|f| vector_query_field_error(f, schema)),
+        },
+        QueryNode::Bool {
+            must,
+            should,
+            must_not,
+            filter,
+            ..
+        } => must
+            .iter()
+            .chain(should)
+            .chain(must_not)
+            .chain(filter)
+            .find_map(|c| vector_query_field_error(c, schema)),
+        QueryNode::Constant { query, .. }
+        | QueryNode::Boosted { query, .. }
+        | QueryNode::Named { query, .. }
+        | QueryNode::Nested { query, .. }
+        | QueryNode::FunctionScore { query, .. } => vector_query_field_error(query, schema),
+        QueryNode::Pinned { organic, .. } => vector_query_field_error(organic, schema),
+        QueryNode::Boosting {
+            positive, negative, ..
+        } => vector_query_field_error(positive, schema)
+            .or_else(|| vector_query_field_error(negative, schema)),
+        QueryNode::DisMax { queries, .. } => queries
+            .iter()
+            .find_map(|c| vector_query_field_error(c, schema)),
+        QueryNode::Hybrid { queries, .. } => queries
+            .iter()
+            .find_map(|wq| vector_query_field_error(&wq.query, schema)),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #498.

A `knn` (or `semantic`) clause naming a field that is **absent**, or is **not vector-capable**, returned `HTTP 200` with `hits.total = 0` and no error. An agent issuing a vector query against an index built without vectors got zero hits and concluded *"no relevant results exist"* — when the truth is *"this index cannot answer vector queries at all."* A silent false-negative on the exact use case the vector/semantic badges advertise. It surfaced in the reference-coding benchmark: the retrieval arm's vector queries returned nothing, silently. Real ES answers `400 illegal_argument_exception` here.

### Fix
`vector_query_field_error` — a pre-execution walk of the resolved query (mirrors `unsearchable_query_field`, sibling to the #437 sort gate) that returns a 400 reason when a `Knn`/`SemanticSearch` clause names a field that does not resolve, or resolves to something that cannot answer a vector clause:
```
[knn] query targets field [embedding], which does not exist in the mapping
```
**"Vector-capable" is deliberately permissive** — `dense_vector`, `chunk`, or any field with an embedding config (`semantic_text`, whose companion vector exists even under the lexical feature-hash embedder) — so a legitimate vector query is **never** rejected; only a plainly non-vector or absent field is. Covers `knn` and `semantic`, recursing through `bool`/`hybrid`/`dis_max`/`boosting`/nested wrappers.

### Verification
- New HTTP test `knn_on_non_vector_field_fails.rs`:
  - `knn` on an absent field now **400s** and names the field — **proven fail-before** by reverting only the source hunk: it returns `200` with `hits.total: 0` (the exact bug).
  - `knn` on a genuine (empty) `dense_vector` index is **not** rejected — the false-positive guard, so real vector queries keep working.
- Under **rustc 1.97.1**: `fmt`, `clippy --workspace --all-targets -D warnings`, `build --workspace --profile ci-test` all clean; tests pass under **both** dev and ci-test.

Scope note: `semantic` is covered symmetrically. The lexical-vs-neural distinction does not change validity here — a properly-mapped `semantic_text` field has a companion vector under either embedder, so it is accepted; the check is purely schema-shaped.