### PR TITLE
test(engine): end-to-end embedder-swap refusal test (#522)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -28137,6 +28137,52 @@ mod embedding_identity_tests {
         }
     }
 
+    /// #522: the #434 guard (`validate_embedding_execution`) was unit-tested at
+    /// the identity level but never end to end. A populated index must REFUSE
+    /// to reopen under a genuinely different embedder, and must NOT refuse a
+    /// config change that resolves to the same embedder.
+    #[test]
+    fn a_populated_index_refuses_reopen_under_a_different_embedder() {
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path();
+        let lexical = xerj_common::config::EmbeddingConfig::default();
+
+        // Genesis under lexical (new, empty) records the execution identity;
+        // reopening under the SAME embedder with documents is fine.
+        validate_embedding_execution(index_dir, &lexical, true, false).unwrap();
+        validate_embedding_execution(index_dir, &lexical, false, true).unwrap();
+
+        // Reopening a POPULATED index under a genuinely different embedder
+        // (proxy with a real endpoint → backend "proxy") must refuse: querying
+        // lexical vectors against proxy vectors is silently wrong.
+        let proxy = xerj_common::config::EmbeddingConfig {
+            mode: "proxy".into(),
+            default_endpoint: "https://vectors.example/v1".into(),
+            default_model: "text-embedding-x".into(),
+            ..Default::default()
+        };
+        let err = validate_embedding_execution(index_dir, &proxy, false, true)
+            .expect_err("a lexical->proxy swap over a populated index must be refused");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("holds vectors produced by embedding backend")
+                && msg.contains("lexical")
+                && msg.contains("proxy"),
+            "the refusal must name both the recorded and the current backend: {msg}"
+        );
+
+        // Over-refusal guard: a proxy config with NO endpoint falls back to the
+        // lexical embedder, so its resolved identity is unchanged and reopening
+        // must NOT be refused.
+        let proxy_without_endpoint = xerj_common::config::EmbeddingConfig {
+            mode: "proxy".into(),
+            default_endpoint: String::new(),
+            ..Default::default()
+        };
+        validate_embedding_execution(index_dir, &proxy_without_endpoint, false, true)
+            .expect("a proxy that falls back to lexical must not be refused");
+    }
+
     #[cfg(feature = "onnx-experimental")]
     #[test]
     fn onnx_execution_identity_changes_with_asset_content() {


### PR DESCRIPTION
Closes #522 (the test half).

The #434 guard (`validate_embedding_execution`, #446) was unit-tested at the identity level but never end to end — the #446 verification flagged that no shipped test builds an index under one embedder and reopens it under another to assert the refusal.

**Adds** `a_populated_index_refuses_reopen_under_a_different_embedder`:
- record a lexical execution identity; confirm a **same-embedder** reopen with documents is allowed;
- reopen a **populated** index under `proxy`-with-endpoint and assert it is **refused**, with the message naming both the recorded and current backend;
- **over-refusal guard**: a proxy config with *no* endpoint falls back to lexical, so its resolved identity is unchanged and reopening must **not** be refused.

**Fail-before proven** by neutering the guard's identity-mismatch `return Err` — the test then fails (the swap is no longer refused). fmt / clippy `-D warnings` / build `--profile ci-test` all green under 1.97.1; `embedding_identity_tests` passes 5/5. Test-only, no engine logic changed.

Part 2 of #522 (fold the proxy `default_endpoint` into the identity material so a changed endpoint under the same model name is detected) is spun off separately — it changes the identity hash for existing proxy indices, so it needs a `PersistedEmbeddingExecution` version bump / grandfather to avoid refusing already-populated proxy indices on upgrade.