### PR TITLE
fix(site): add zero-token & semantic-analytics to sitemap.xml

### DIFF
--- a/landing/sitemap.xml
+++ b/landing/sitemap.xml
@@ -66,6 +66,16 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://xerj.org/use-cases/zero-token-ai-search.html</loc>
+    <lastmod>2026-08-19</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://xerj.org/use-cases/semantic-analytics.html</loc>
+    <lastmod>2026-07-27</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://xerj.org/case-studies.html</loc>
     <lastmod>2026-07-28</lastmod>
     <priority>0.8</priority>


### PR DESCRIPTION
Both use-case pages are on main and linked from the use-cases index, but absent from `sitemap.xml` so crawlers never found them. Adds the two `<url>` entries. Docs-only, no release-stamp change (landing-constants-guard unaffected).

Context: surfaced while diagnosing why https://xerj.org/use-cases/zero-token-ai-search.html serves the homepage — prod is a stale RC.15 Cloudflare Pages deploy; a redeploy from current main publishes the page, and this makes the sitemap correct when it does.