### PR TITLE
fix(ci): satisfy clippy 1.98 across the workspace (unblocks Format + Clippy)

### DIFF
--- a/engine/crates/xerj-api/src/lib.rs
+++ b/engine/crates/xerj-api/src/lib.rs
@@ -56,6 +56,13 @@
 //! ports via `Router::merge`. Engine API and Xerj Console API are decoupled —
 //! xerj-api itself does not depend on xerj-console-api.
 
+// `ApiError` (~152 B) and axum's `Response` are the crate's standard error
+// types, returned pervasively; a handful of small-`Ok` helpers therefore trip
+// clippy 1.98's `result_large_err`. Boxing these core types is a separate,
+// crate-wide refactor, not a lint fix — suppress the lint here (cf. the
+// crate-level allows in xerj-engine and xerj-console-api).
+#![allow(clippy::result_large_err)]
+
 pub mod audit_mw;
 pub mod auth;
 pub mod authz;

--- a/engine/crates/xerj-autoindex/src/detect/e2e.rs
+++ b/engine/crates/xerj-autoindex/src/detect/e2e.rs
@@ -198,7 +198,7 @@ fn bulk(body: &[u8], docs: &Arc<Mutex<Docs>>) -> Value {
     let mut locked = docs.lock().unwrap();
     let mut items = Vec::new();
     let mut errors = false;
-    for pair in lines.chunks_exact(2) {
+    for pair in lines.as_chunks::<2>().0 {
         let action: Value = serde_json::from_slice(pair[0]).unwrap();
         let doc: Value = serde_json::from_slice(pair[1]).unwrap();
         let (op, meta) = if let Some(m) = action.get("index") {

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -442,7 +442,9 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
     if locked.block_writes {
         // Explicit write block: per-item 403 (never 429/5xx), nothing applied.
         let items: Vec<Value> = lines
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|_| {
                 json!({"index": {
                     "status": 403,
@@ -461,7 +463,7 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
     }
     if locked.reject_first_data_item {
         let mut items = Vec::new();
-        for (nth, pair) in lines.chunks_exact(2).enumerate() {
+        for (nth, pair) in lines.as_chunks::<2>().0.iter().enumerate() {
             if nth == 0 {
                 items.push(json!({"index": {
                     "status": 400,
@@ -481,9 +483,9 @@ fn bulk_response(body: &[u8], state: &Arc<Mutex<MockState>>) -> Value {
         return json!({"errors": true, "items": items});
     }
     let fail = !locked.failed_once && locked.data_bulk_number == locked.fail_data_bulk;
-    let pairs = lines.chunks_exact(2);
+    let (pairs, _) = lines.as_chunks::<2>();
     let visible = if fail { pairs.len() / 2 } else { pairs.len() };
-    for pair in lines.chunks_exact(2).take(visible) {
+    for pair in pairs.iter().take(visible) {
         let action: Value = serde_json::from_slice(pair[0]).unwrap();
         let doc: Value = serde_json::from_slice(pair[1]).unwrap();
         let id = action.pointer("/index/_id").unwrap().as_str().unwrap();

--- a/engine/crates/xerj-engine/src/bulk.rs
+++ b/engine/crates/xerj-engine/src/bulk.rs
@@ -2987,13 +2987,13 @@ mod semantic_lifecycle_tests {
         assert!(embedded.load(std::sync::atomic::Ordering::Relaxed));
         let observations = observations.lock().unwrap();
         assert_eq!(observations.len(), 6);
-        for pair in observations.chunks_exact(2) {
+        for pair in observations.as_chunks::<2>().0 {
             assert_eq!(pair[0].0, SemanticLifecyclePoint::BeforePublication);
             assert_eq!(pair[1].0, SemanticLifecyclePoint::AfterPublication);
             assert!(pair[0].1 > pair[1].1);
             assert!(pair[0].2 > pair[1].2);
         }
-        for pair in observations.chunks_exact(2) {
+        for pair in observations.as_chunks::<2>().0 {
             assert!(pair[0].1 > 0);
             assert!(pair[0].2 > 0);
             assert_eq!(pair[1].1, 0, "published document ownership stayed charged");

--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -2161,7 +2161,7 @@ impl FtsMemtable {
     pub fn drain_with_sources_raw(
         &mut self,
     ) -> Vec<(u64, (String, HashMap<String, String>, Value))> {
-        let mut drained: Vec<MemEntry> = self.docs.drain(..).collect();
+        let mut drained: Vec<MemEntry> = std::mem::take(&mut self.docs);
         drained.sort_by_key(|e| e.seq_no);
         let result: Vec<_> = drained
             .into_iter()
@@ -2188,7 +2188,7 @@ impl FtsMemtable {
     }
 
     pub fn drain_raw(&mut self) -> Vec<(u64, (String, HashMap<String, String>))> {
-        let mut drained: Vec<MemEntry> = self.docs.drain(..).collect();
+        let mut drained: Vec<MemEntry> = std::mem::take(&mut self.docs);
         drained.sort_by_key(|e| e.seq_no);
         let result: Vec<_> = drained
             .into_iter()
@@ -3078,7 +3078,7 @@ impl FtsMemtable {
     /// RSS grows monotonically until OOM.  See CAPPED_RAM_BATTLE for the bug.
     pub fn drain(&mut self) -> Vec<(String, HashMap<String, String>)> {
         // Sort by seq_no — see `drain_with_sources` for the rationale.
-        let mut drained: Vec<MemEntry> = self.docs.drain(..).collect();
+        let mut drained: Vec<MemEntry> = std::mem::take(&mut self.docs);
         drained.sort_by_key(|e| e.seq_no);
         let result = drained
             .into_iter()
@@ -3123,7 +3123,7 @@ impl FtsMemtable {
         // get canonicalised here.  For workloads where all entries
         // carry `seq_no = 0` (the legacy `insert` path), `sort_by_key`
         // is stable so existing insertion order is preserved.
-        let mut drained: Vec<MemEntry> = self.docs.drain(..).collect();
+        let mut drained: Vec<MemEntry> = std::mem::take(&mut self.docs);
         drained.sort_by_key(|e| e.seq_no);
         let result = drained
             .into_iter()

--- a/engine/crates/xerj-vector/src/hnsw.rs
+++ b/engine/crates/xerj-vector/src/hnsw.rs
@@ -91,10 +91,13 @@ fn corrupt(msg: &str) -> XerjError {
 #[inline]
 fn dot_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut acc = [0.0f32; 8];
-    let ca = a.chunks_exact(8);
-    let cb = b.chunks_exact(8);
-    let (ra, rb) = (ca.remainder(), cb.remainder());
-    for (x, y) in ca.zip(cb) {
+    // `as_chunks::<8>()` yields the same 8-wide windows + remainder as
+    // `chunks_exact(8)` (the `x`/`y` are now `&[f32; 8]`, so the fixed
+    // indexing below is bounds-check-free); required by clippy 1.98's
+    // `chunks_exact_to_as_chunks`.
+    let (ca, ra) = a.as_chunks::<8>();
+    let (cb, rb) = b.as_chunks::<8>();
+    for (x, y) in ca.iter().zip(cb.iter()) {
         acc[0] += x[0] * y[0];
         acc[1] += x[1] * y[1];
         acc[2] += x[2] * y[2];
@@ -1328,8 +1331,11 @@ mod tests {
     fn checked_in_pre_view_v2_fixture() -> Vec<u8> {
         let hex = include_str!("../tests/fixtures/hnsw-v2-pre-storage-view.hex").trim();
         assert_eq!(hex.len() % 2, 0);
-        hex.as_bytes()
-            .chunks_exact(2)
+        // `as_chunks::<2>()` over `chunks_exact(2)` (clippy 1.98); the
+        // `% 2 == 0` assert above guarantees an empty remainder.
+        let (pairs, _rem) = hex.as_bytes().as_chunks::<2>();
+        pairs
+            .iter()
             .map(|pair| {
                 let digit = |byte: u8| match byte {
                     b'0'..=b'9' => byte - b'0',


### PR DESCRIPTION
CI's **Format + Clippy** job floats on `dtolnay/rust-toolchain@stable`, which rolled to **rustc 1.98.0** (2026-08-18). Three lints newly enforced there turned `main` red and now block **every** open PR (including a sitemap-only change) — none of them touching the flagged code. This is the exact "unpinned `@stable` + `-D warnings`" failure mode we hit at 1.97.1 (#422).

## Fixes (no behaviour change)
- **`clippy::chunks_exact_to_as_chunks`** (7): `xerj-vector/hnsw.rs` `dot_unrolled` + the hex fixture, `xerj-engine/bulk.rs`, `xerj-autoindex/{detect/e2e.rs, failure_resume_http_tests.rs}` → `slice.as_chunks::<N>().0` (identical windows + remainder; the SIMD path's chunks are now `&[f32; 8]`, so the fixed indexing is bounds-check-free).
- **`clippy::drain_collect`** (4): `xerj-engine/memtable.rs` `self.docs.drain(..).collect()` → `std::mem::take(&mut self.docs)` (the memtable is emptied for flush, so releasing capacity is fine).
- **`clippy::result_large_err`** (4): small-`Ok` helpers in `xerj-api` returning the crate's standard `ApiError` (~152 B) / axum `Response`. Boxing those pervasive types is a separate crate-wide refactor, so a documented crate-level `#![allow(clippy::result_large_err)]` (cf. existing allows in `xerj-engine`, `xerj-console-api`).

## Verification (rustc **1.98.0**, CI's actual stable — not the 1.97.1 our notes assumed)
- `clippy --workspace --all-targets -- -D warnings` **clean** (enumerated the full set in warn-mode first, since clippy stops at the first failing crate).
- `fmt --all --check` clean; `build --workspace --profile ci-test` clean.
- `xerj-vector` (42), `xerj-engine`, `xerj-autoindex` (680) suites all green.

Follow-up worth considering: pin a `rust-toolchain.toml` so a stable bump can't red every PR overnight (the `cargo-fuzz` job legitimately needs `@nightly` and would opt out).