### PR TITLE
fix(engine): 400 an unanswerable field in a multi-knn array clause (#542, multi-knn part)

### DIFF
--- a/engine/crates/xerj-api/tests/knn_on_missing_field_400s.rs
+++ b/engine/crates/xerj-api/tests/knn_on_missing_field_400s.rs
@@ -166,3 +166,58 @@ async fn knn_on_declared_but_empty_vector_field_is_empty_200() {
         .unwrap_or(u64::MAX);
     assert_eq!(total, 0, "expected an empty result set: {body}");
 }
+
+/// #542 (follow-up to #498): the MULTI-knn array form (`knn: [...]`) must also
+/// 400 a clause naming an unanswerable field — #498 only wired the check into
+/// the single top-level knn arm, so the array form still returns a silent
+/// empty 200.
+#[tokio::test]
+async fn multi_knn_on_absent_field_is_400_not_silent_empty() {
+    let (app, _dir) = app().await;
+    let (status, body) = json_req(
+        &app,
+        "PUT",
+        "/codes",
+        json!({ "mappings": { "properties": {
+            "name": { "type": "text" },
+            "code": { "type": "keyword" }
+        } } }),
+    )
+    .await;
+    assert!(status.is_success(), "create index: {status} {body}");
+    let (_s, _b) = json_req(
+        &app,
+        "POST",
+        "/codes/_doc/1",
+        json!({ "name": "sniff", "code": "fn sniff() {}" }),
+    )
+    .await;
+    let (_s, _b) = json_req(&app, "POST", "/codes/_refresh", json!({})).await;
+
+    // The ES multi-knn array form with 2+ clauses (a single-element array
+    // collapses to the single-knn path, already fixed by #498). A clause naming
+    // a field absent from the mapping must fail loudly, not return a silent
+    // empty 200.
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/codes/_search",
+        json!({ "knn": [
+            { "field": "embedding", "query_vector": [0.1, 0.2, 0.3], "k": 5, "num_candidates": 50 },
+            { "field": "embedding2", "query_vector": [0.4, 0.5, 0.6], "k": 5, "num_candidates": 50 }
+        ] }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "multi-knn on an absent field must be 400, not a silent empty 200 (#542): got {status} {body}"
+    );
+    assert!(
+        body.pointer("/error/reason")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("embedding"),
+        "the 400 must name the field: {body}"
+    );
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -14100,9 +14100,21 @@ impl Index {
         // one clause, and `hits.total` is the size of the deduplicated union
         // — matching ES 8.13 multi-kNN semantics (live-verified 2026-07-12).
         if let Some(clauses) = peel_multi_knn_query(query) {
-            return self
+            let fields: Vec<String> = clauses.iter().map(|c| c.field.clone()).collect();
+            let result = self
                 .run_multi_knn_brute_force(request, search_deadline, clauses)
-                .await;
+                .await?;
+            // #542: each knn clause validates its own field. On an empty,
+            // non-timed-out union, reject the first clause naming an
+            // unanswerable field — the same execution-truth check the single-knn
+            // arm uses (#498), so declared-but-empty and indexed-but-undeclared
+            // fields still return their real empty result.
+            if result.hits.is_empty() && !result.timed_out {
+                for field in &fields {
+                    self.reject_unanswerable_knn_field(field).await?;
+                }
+            }
+            return Ok(result);
         }
         // Nested `knn` query: `nested { path: P, query: { knn { field: P.vec } } }`.
         // ES scores each parent by the best-matching nested element and


### PR DESCRIPTION
Refs #542 (the multi-knn part). Follow-up to #498/#541.

#498 wired the execution-truth answerability 400 only into the single top-level knn arm. The ES multi-knn array form (`knn: [...]` with 2+ clauses → `run_multi_knn_brute_force`) still returned a **silent empty 200** on a clause naming an unanswerable field.

## Fix
Apply the same check to the multi-knn dispatch: on an empty, non-timed-out union, reject the first clause naming an unanswerable field (neither declared `dense_vector`/`semantic_text` nor carrying indexed vector data). Declared-but-empty and indexed-but-undeclared fields still return their real empty result.

## Verification (rustc 1.98.0)
- `multi_knn_on_absent_field_is_400_not_silent_empty` (2-element array — a single-element array collapses to the single-knn path already fixed by #498). Fail-before proven (ignored form returned 200/`total:0`).
- Full `xerj-engine` + `xerj-api` suites green; fmt + clippy `-D warnings` clean.

## Scope
The **nested-knn** arm is deliberately NOT touched — its vectors live in nested array elements, so the top-level `index_has_any_vector_at` scan would false-negative and 400 a valid undeclared nested-vector field. It needs a nested-aware presence check and stays open under #542. (The `semantic` sibling is #530.)