### PR TITLE
fix(engine): 400 an unanswerable field in a nested knn clause (#542, nested arm)

### DIFF
--- a/engine/crates/xerj-api/tests/knn_on_missing_field_400s.rs
+++ b/engine/crates/xerj-api/tests/knn_on_missing_field_400s.rs
@@ -221,3 +221,52 @@ async fn multi_knn_on_absent_field_is_400_not_silent_empty() {
         "the 400 must name the field: {body}"
     );
 }
+
+/// #542 (nested-knn arm): a `nested` knn naming a vector field absent from the
+/// nested mapping must 400, not return a silent empty 200. The nested arm is a
+/// separate dispatch from the single/multi-knn arms fixed in #498/#543.
+#[tokio::test]
+async fn nested_knn_on_absent_field_is_400_not_silent_empty() {
+    let (app, _dir) = app().await;
+    let (status, body) = json_req(
+        &app,
+        "PUT",
+        "/docs",
+        json!({ "mappings": { "properties": {
+            "items": { "type": "nested", "properties": { "name": { "type": "text" } } }
+        } } }),
+    )
+    .await;
+    assert!(status.is_success(), "create index: {status} {body}");
+    let (_s, _b) = json_req(
+        &app,
+        "POST",
+        "/docs/_doc/1",
+        json!({ "items": [ { "name": "sniff" }, { "name": "detect" } ] }),
+    )
+    .await;
+    let (_s, _b) = json_req(&app, "POST", "/docs/_refresh", json!({})).await;
+
+    // Nested knn on `items.vector`, which the nested mapping does not have.
+    let (status, body) = json_req(
+        &app,
+        "POST",
+        "/docs/_search",
+        json!({ "query": { "nested": { "path": "items", "query": { "knn": {
+            "field": "items.vector", "query_vector": [0.1, 0.2, 0.3], "k": 5, "num_candidates": 50
+        } } } } }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "nested knn on an absent field must be 400, not a silent empty 200 (#542): got {status} {body}"
+    );
+    assert!(
+        body.pointer("/error/reason")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("items.vector"),
+        "the 400 must name the field: {body}"
+    );
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -11353,6 +11353,80 @@ impl Index {
         )))
     }
 
+    /// #542: the nested-knn analogue of [`Self::index_has_any_vector_at`].
+    /// Nested vectors live at `<nested_path>[].<subfield>` (see the scoring loop
+    /// in `run_nested_knn_brute_force_with_deadline`), so the top-level scan
+    /// would false-negative on them — this mirrors that traversal exactly.
+    /// Early-exits on the first hit; only invoked on an empty nested-knn result.
+    async fn index_has_any_nested_vector_at(&self, nested_path: &str, subfield: &str) -> bool {
+        fn elem_has_vector(elem: &Value, subfield: &str) -> bool {
+            elem.get(subfield)
+                .and_then(Value::as_array)
+                .is_some_and(|a| !a.is_empty() && a.iter().all(Value::is_number))
+        }
+        fn doc_has(source: &Value, nested_path: &str, subfield: &str) -> bool {
+            match get_field_value(source, nested_path) {
+                Some(Value::Array(arr)) => arr.iter().any(|e| elem_has_vector(e, subfield)),
+                Some(single) => elem_has_vector(&single, subfield),
+                None => false,
+            }
+        }
+        for (_id, source) in self.memtable.all_docs_with_sources() {
+            if doc_has(&source, nested_path, subfield) {
+                return true;
+            }
+        }
+        let snap = self.store.snapshot();
+        for meta in snap.segments.iter() {
+            if let Some(docs) = self.stored_values_for_async(&meta.id).await {
+                for doc in docs.iter() {
+                    let src = doc.get("_source").unwrap_or(doc);
+                    if doc_has(src, nested_path, subfield) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// #542: reject a NESTED `knn` clause naming a field the index cannot
+    /// answer with a 400, symmetric with [`Self::reject_unanswerable_knn_field`].
+    /// Declared `dense_vector` (dotted path) short-circuits; otherwise the nested
+    /// vector-presence scan decides, so declared-but-empty and
+    /// indexed-but-undeclared nested fields still return their real empty result.
+    async fn reject_unanswerable_nested_knn_field(
+        &self,
+        nested_path: &str,
+        field: &str,
+    ) -> Result<()> {
+        {
+            let schema = self.schema.read().await;
+            if collect_dense_vector_fields(&schema.schema)
+                .iter()
+                .any(|f| f == field)
+            {
+                return Ok(());
+            }
+        }
+        let subfield = field
+            .strip_prefix(&format!("{nested_path}."))
+            .unwrap_or(field);
+        if self
+            .index_has_any_nested_vector_at(nested_path, subfield)
+            .await
+        {
+            return Ok(());
+        }
+        Err(EngineError::Common(xerj_common::XerjError::invalid_query(
+            format!(
+                "[knn] nested query field [{field}] is not a vector field: it is absent from \
+                 the nested mapping and carries no indexed vector data. Map it as \
+                 [dense_vector] before running vector search."
+            ),
+        )))
+    }
+
     /// Brute-force nested KNN: score each parent by the best (max)
     /// similarity among its `<nested_path>` array elements.
     ///
@@ -14144,7 +14218,7 @@ impl Index {
             // It defaults to `k` when omitted and is clamped to `>= k` (a
             // smaller fan-out than the requested top-k makes no sense).
             let num_candidates = num_candidates_opt.unwrap_or(k).max(k);
-            return self
+            let result = self
                 .run_nested_knn_brute_force_with_deadline(
                     request,
                     search_deadline,
@@ -14157,7 +14231,16 @@ impl Index {
                     post_filter,
                     &similarity,
                 )
-                .await;
+                .await?;
+            // #542: a nested knn naming a field the index cannot answer must
+            // 400, not return a silent empty 200. Checked only on a genuinely
+            // empty, non-timed-out result, so the hot path and declared-but-
+            // empty / indexed-but-undeclared nested fields are untouched.
+            if result.hits.is_empty() && !result.timed_out {
+                self.reject_unanswerable_nested_knn_field(&nested_path, &field)
+                    .await?;
+            }
+            return Ok(result);
         }
 
         // ── Semantic search short-circuit ─────────────────────────────────────


### PR DESCRIPTION
Closes #542 (completes it — #543 shipped the multi-knn arm, this is the nested arm). Follow-up to #498.

A `nested` knn (`nested { path: P, query: { knn { field: P.vec }}}`) naming a field the index cannot answer still returned a **silent empty 200**.

## Fix
Nested vectors live at `<nested_path>[].<subfield>` (the scoring loop in `run_nested_knn_brute_force_with_deadline`), so the top-level `index_has_any_vector_at` would false-negative on them and wrongly 400 a valid undeclared nested field. `index_has_any_nested_vector_at` mirrors that traversal exactly. On an empty, non-timed-out nested-knn result, 400 iff the field is neither declared `dense_vector` (dotted path short-circuits) NOR carries indexed nested vectors — preserving declared-but-empty and indexed-but-undeclared nested fields, consistent with #498/#543.

## Verification (rustc 1.98.0)
- `nested_knn_on_absent_field_is_400_not_silent_empty` — **fail-before proven** (disable the reject → 200/`total:0`).
- **Full `xerj-engine` + `xerj-api` suites green** (the nested-knn deadline tests pass); fmt + clippy `-D warnings` clean.

With this, the whole unanswerable-field 400 family is complete: single-knn (#498), multi-knn (#543), nested-knn (this), semantic (#530).