### PR TITLE
fix(es-compat): shared index-selector resolver + migrate the get_index->first read endpoints (#451 class B)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -33281,15 +33281,31 @@ pub async fn explain_doc(
     Path((index, id)): Path<(String, String)>,
     body: OptionalJson<Value>,
 ) -> impl IntoResponse {
-    let idx = match state.engine.get_index(&index) {
-        Ok(i) => i,
-        Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+    // Resolve the selector through the shared resolver (#451): an alias expands
+    // to every member, so the document is explained against the member that
+    // actually holds it. `get_index` collapsed an alias to `aliased.first()`,
+    // so a non-first member's doc reported `matched:false` / "document not
+    // found" (class B).
+    let (members, _filters) = match resolve_selector_with_filters(&state, &index).await {
+        Ok(t) => t,
+        Err(e) => return ApiError::new(e).into_response(),
     };
-
-    // Fetch the document.
-    let doc_source = match idx.get_document(&id).await {
-        Ok(Some(s)) => s,
-        Ok(None) => {
+    let mut resolved = None;
+    for (mname, midx) in &members {
+        match midx.get_document(&id).await {
+            Ok(Some(s)) => {
+                resolved = Some((mname.clone(), midx.clone(), s));
+                break;
+            }
+            Ok(None) => {}
+            Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+        }
+    }
+    // On a hit, `index` is rebound to the concrete member (reported in
+    // `_index`); the not-found arm still names the selector the caller wrote.
+    let (index, idx, doc_source) = match resolved {
+        Some((mname, midx, s)) => (mname, midx, s),
+        None => {
             return Json(json!({
                 "_index": index,
                 "_id": id,
@@ -33302,7 +33318,6 @@ pub async fn explain_doc(
             }))
             .into_response();
         }
-        Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
     };
 
     // Parse the query from the body (default to match_all if absent).

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -18403,30 +18403,42 @@ pub async fn mget_index(
 
     let mut docs: Vec<Value> = Vec::with_capacity(entries.len());
     for (ix, id) in &entries {
-        match state.engine.get_index(ix) {
-            Ok(idx) => match idx.get_document(id).await {
-                Ok(Some(source)) => {
-                    // Real per-doc `_seq_no` / `_version` (were hardcoded
-                    // 0 / 1) — matches the `_search` hit metadata path.
-                    let seq_no = idx.lookup_seq_no(id).unwrap_or(0);
-                    let version = idx.lookup_version(id).unwrap_or(1);
-                    docs.push(json!({
-                        "_index": ix,
-                        "_id": id,
-                        "_version": version,
-                        "_seq_no": seq_no,
-                        "_primary_term": 1,
-                        "found": true,
-                        "_source": source,
-                    }))
-                }
-                _ => docs.push(json!({
-                    "_index": ix,
+        // Resolve the entry's index through the shared resolver (#451): an
+        // alias expands to every member, so a doc in any member is found — not
+        // just the first. `get_index` collapsed an alias to `aliased.first()`,
+        // so a non-first member's doc reported `found:false` (class B).
+        let members = match resolve_selector_with_filters(&state, ix).await {
+            Ok((m, _filters)) => m,
+            Err(_) => {
+                docs.push(json!({ "_index": ix, "_id": id, "found": false }));
+                continue;
+            }
+        };
+        let mut hit = None;
+        for (mname, midx) in &members {
+            if let Ok(Some(source)) = midx.get_document(id).await {
+                hit = Some((mname.clone(), midx.clone(), source));
+                break;
+            }
+        }
+        match hit {
+            Some((mname, midx, source)) => {
+                // Real per-doc `_seq_no` / `_version` (were hardcoded 0 / 1) —
+                // matches the `_search` hit metadata path. `_index` reports the
+                // concrete member the doc lives in, not the alias.
+                let seq_no = midx.lookup_seq_no(id).unwrap_or(0);
+                let version = midx.lookup_version(id).unwrap_or(1);
+                docs.push(json!({
+                    "_index": mname,
                     "_id": id,
-                    "found": false,
-                })),
-            },
-            Err(_) => docs.push(json!({
+                    "_version": version,
+                    "_seq_no": seq_no,
+                    "_primary_term": 1,
+                    "found": true,
+                    "_source": source,
+                }));
+            }
+            None => docs.push(json!({
                 "_index": ix,
                 "_id": id,
                 "found": false,
@@ -19402,6 +19414,52 @@ pub async fn get_aliases(State(state): State<AppState>) -> impl IntoResponse {
 
 /// Resolve an index spec (single name, comma list, wildcard, `_all`, `*`)
 /// into the concrete set of existing index names, in stable order.
+/// The single index-selector resolver (#451). Every endpoint that used to
+/// call `Engine::get_index` directly — collapsing an alias to `aliased.first()`
+/// (class B) — or had no alias branch at all (class A) should resolve through
+/// here instead, so all sites agree on what a selector means.
+///
+/// Returns each concrete member the selector names (an alias expands to ALL its
+/// members, #433) paired with its `Arc<Index>`, plus any alias `filter` clauses
+/// to AND into a query — the same shape `resolve_by_query_targets` uses on the
+/// write path (#450). A missing name propagates `index_not_found`, matching
+/// ES's default `ignore_unavailable=false`.
+async fn resolve_selector_with_filters(
+    state: &AppState,
+    spec: &str,
+) -> std::result::Result<
+    (
+        Vec<(String, std::sync::Arc<xerj_engine::Index>)>,
+        Vec<Value>,
+    ),
+    xerj_common::XerjError,
+> {
+    let names = resolve_index_selector(state, spec).await;
+    let mut alias_filters: Vec<Value> = Vec::new();
+    for part in spec.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if let Some(entry) = state.engine.aliases.get(part) {
+            for backing in entry.value().iter() {
+                if let Some(meta) = state.engine.index_alias_metadata.get(backing) {
+                    if let Some(filter) = meta.get(part).and_then(|v| v.get("filter")).cloned() {
+                        alias_filters.push(filter);
+                    }
+                }
+            }
+        }
+    }
+    let mut out = Vec::with_capacity(names.len());
+    for name in &names {
+        out.push((
+            name.clone(),
+            state
+                .engine
+                .get_index(name)
+                .map_err(xerj_common::XerjError::from)?,
+        ));
+    }
+    Ok((out, alias_filters))
+}
+
 async fn resolve_index_selector(state: &AppState, spec: &str) -> Vec<String> {
     let all: Vec<String> = state
         .engine

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -29239,29 +29239,25 @@ pub async fn cat_segments(
     // index  shard  prirep  ip           segment  generation  docs.count  docs.deleted  size  size.memory  committed  searchable  version  compound
     let node = state.engine.node_id.as_str();
     let mut rows: Vec<(String, u64, u64)> = Vec::new();
-    let indices_to_list: Vec<String> = if index == "_all" || index == "*" {
-        state
-            .engine
-            .list_indices()
-            .await
-            .into_iter()
-            .map(|i| i.name)
-            .collect()
-    } else {
-        vec![index.clone()]
-    };
-    for idx_name in &indices_to_list {
-        if let Ok(idx) = state.engine.get_index(idx_name) {
-            let stats = idx.stats().await;
-            // Real on-disk size: recursive byte sum of the index's data_dir.
-            let size = dir_size_bytes(idx.data_dir());
-            // Represent the index's durable data as one logical segment.
-            // generation 0; committed + searchable are true (data is queryable
-            // and persisted). We do NOT fabricate a Lucene version string —
-            // xerj has no Lucene segments — so we report the xerj build version.
-            let _ = node; // segments output has no node column in ES; kept for parity
-            rows.push((idx_name.clone(), stats.doc_count, size));
-        }
+    // Resolve the selector through the shared resolver (#451): an alias expands
+    // to every member (`get_index` collapsed it to `aliased.first()`, so an
+    // alias listed a single row under the alias name), and `_all` / `*` / glob /
+    // comma forms resolve uniformly. A cat endpoint lists what exists rather
+    // than 404ing, so an unknown selector is an empty listing.
+    let members = resolve_selector_with_filters(&state, &index)
+        .await
+        .map(|(m, _filters)| m)
+        .unwrap_or_default();
+    for (idx_name, idx) in &members {
+        let stats = idx.stats().await;
+        // Real on-disk size: recursive byte sum of the index's data_dir.
+        let size = dir_size_bytes(idx.data_dir());
+        // Represent the index's durable data as one logical segment.
+        // generation 0; committed + searchable are true (data is queryable
+        // and persisted). We do NOT fabricate a Lucene version string —
+        // xerj has no Lucene segments — so we report the xerj build version.
+        let _ = node; // segments output has no node column in ES; kept for parity
+        rows.push((idx_name.clone(), stats.doc_count, size));
     }
 
     if params.format.as_deref() == Some("json") {

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -35771,56 +35771,65 @@ pub async fn index_segments(
     Path(index): Path<String>,
 ) -> impl IntoResponse {
     let index = strip_remote_cluster_prefix(&index);
-    match state.engine.get_index(&index) {
-        Ok(idx) => {
-            let stats = idx.stats().await;
-            let snap = idx.store_snapshot();
-            let num_segments = snap.segments.len();
+    // Resolve the selector through the shared resolver (#451): an alias expands
+    // to every member (`get_index` collapsed it to `aliased.first()`, so
+    // `_segments` reported one entry under the alias name). One `indices` entry
+    // per concrete member; `_shards` counts one shard per member.
+    let (members, _filters) = match resolve_selector_with_filters(&state, &index).await {
+        Ok(t) => t,
+        Err(e) => return ApiError::new(e).into_response(),
+    };
+    let mut indices_map = serde_json::Map::new();
+    for (name, idx) in &members {
+        let stats = idx.stats().await;
+        let snap = idx.store_snapshot();
+        let num_segments = snap.segments.len();
 
-            let mut segments_map = serde_json::Map::new();
-            for (i, seg) in snap.segments.iter().enumerate() {
-                segments_map.insert(
-                    i.to_string(),
-                    json!({
-                        "generation": seg.min_seq_no,
-                        "num_docs": seg.doc_count,
-                        "deleted_docs": 0,
-                        "size_in_bytes": seg.size_bytes,
-                        "memory_in_bytes": 0,
-                        "committed": true,
-                        "search": true,
-                        "version": "9.10.0",
-                        "compound": false,
-                        "merges": { "merges": [] }
-                    }),
-                );
-            }
-
-            Json(json!({
-                "_shards": { "total": 1, "successful": 1, "failed": 0 },
-                "indices": {
-                    index: {
-                        "shards": {
-                            "0": [{
-                                "routing": {
-                                    "state": "STARTED",
-                                    "primary": true,
-                                    "node": "xerj-node-1"
-                                },
-                                "num_committed_segments": num_segments,
-                                "num_search_segments": num_segments,
-                                "segments": segments_map,
-                                "num_docs": stats.doc_count,
-                                "size_in_bytes": snap.segments.iter().map(|s| s.size_bytes).sum::<u64>()
-                            }]
-                        }
-                    }
-                }
-            }))
-            .into_response()
+        let mut segments_map = serde_json::Map::new();
+        for (i, seg) in snap.segments.iter().enumerate() {
+            segments_map.insert(
+                i.to_string(),
+                json!({
+                    "generation": seg.min_seq_no,
+                    "num_docs": seg.doc_count,
+                    "deleted_docs": 0,
+                    "size_in_bytes": seg.size_bytes,
+                    "memory_in_bytes": 0,
+                    "committed": true,
+                    "search": true,
+                    "version": "9.10.0",
+                    "compound": false,
+                    "merges": { "merges": [] }
+                }),
+            );
         }
-        Err(e) => ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+
+        indices_map.insert(
+            name.clone(),
+            json!({
+                "shards": {
+                    "0": [{
+                        "routing": {
+                            "state": "STARTED",
+                            "primary": true,
+                            "node": "xerj-node-1"
+                        },
+                        "num_committed_segments": num_segments,
+                        "num_search_segments": num_segments,
+                        "segments": segments_map,
+                        "num_docs": stats.doc_count,
+                        "size_in_bytes": snap.segments.iter().map(|s| s.size_bytes).sum::<u64>()
+                    }]
+                }
+            }),
+        );
     }
+    let n = members.len();
+    Json(json!({
+        "_shards": { "total": n, "successful": n, "failed": 0 },
+        "indices": indices_map
+    }))
+    .into_response()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/engine/crates/xerj-api/tests/cat_segments_through_alias_lists_every_member.rs
+++ b/engine/crates/xerj-api/tests/cat_segments_through_alias_lists_every_member.rs
@@ -1,0 +1,101 @@
+//! Issue #451 (failure class B): `GET /_cat/segments/{index}` listed only
+//! `[index]` and resolved it with `Engine::get_index`, which collapses an alias
+//! to `aliased.first()`. So `_cat/segments` over a multi-index alias reported a
+//! single row (the alias name, the first member's stats) instead of one row per
+//! member — and a glob selector matched nothing.
+//!
+//! Migrated onto the shared `resolve_selector_with_filters` resolver (#451),
+//! which expands `_all` / `*` / globs / aliases / comma-lists uniformly.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// `_cat/segments` over a 2-member alias must return a row per member, naming
+/// the concrete members — not one row under the alias name.
+#[tokio::test]
+async fn cat_segments_through_a_multi_index_alias_lists_every_member() {
+    let (app, _dir) = app().await;
+
+    for (member, id) in [("idx-a", "1"), ("idx-b", "2")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}"),
+            json!({"mappings": {"properties": {"v": {"type": "keyword"}}}}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "create {member}");
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}/_doc/{id}"),
+            json!({"v": member}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index doc {id} into {member}");
+        let (st, _) = call(&app, "POST", &format!("/{member}/_refresh"), Value::Null).await;
+        assert_eq!(st, StatusCode::OK, "refresh {member}");
+    }
+    let (st, _) = call(
+        &app,
+        "POST",
+        "/_aliases",
+        json!({"actions": [
+            {"add": {"index": "idx-a", "alias": "tri"}},
+            {"add": {"index": "idx-b", "alias": "tri"}}
+        ]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create alias tri");
+
+    let (status, body) = call(&app, "GET", "/_cat/segments/tri?format=json", Value::Null).await;
+    assert_eq!(status, StatusCode::OK, "_cat/segments status: {body}");
+
+    let rows = body.as_array().cloned().unwrap_or_default();
+    let mut indices: Vec<String> = rows
+        .iter()
+        .filter_map(|r| r.get("index").and_then(Value::as_str).map(String::from))
+        .collect();
+    indices.sort();
+    assert_eq!(
+        indices,
+        vec!["idx-a".to_string(), "idx-b".to_string()],
+        "_cat/segments through the alias must list a row per concrete member, not one \
+         row under the alias name (#451): {body}"
+    );
+}

--- a/engine/crates/xerj-api/tests/explain_through_alias_finds_the_member.rs
+++ b/engine/crates/xerj-api/tests/explain_through_alias_finds_the_member.rs
@@ -1,0 +1,109 @@
+//! Issue #451 (failure class B): `_explain` resolves the path index with
+//! `Engine::get_index`, which collapses an alias to `aliased.first()`. A
+//! document that lives in any other member of the alias is reported
+//! `matched: false` / "document not found" — the same `get_index` cause as
+//! `_mget`, on the explain diagnostic.
+//!
+//! Migrated onto the shared `resolve_selector_with_filters` resolver (#451):
+//! `_explain` now finds the member that actually holds the document and
+//! explains against it, reporting the concrete member in `_index`.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// A doc that lives in the alias's SECOND member must still be explained
+/// (matched), not reported "document not found" because the alias collapsed to
+/// its first member.
+#[tokio::test]
+async fn explain_through_a_multi_index_alias_finds_a_non_first_member_doc() {
+    let (app, _dir) = app().await;
+
+    for (member, id) in [("idx-a", "1"), ("idx-b", "2")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}"),
+            json!({"mappings": {"properties": {"v": {"type": "keyword"}}}}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "create {member}");
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}/_doc/{id}"),
+            json!({"v": member}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index doc {id} into {member}");
+        let (st, _) = call(&app, "POST", &format!("/{member}/_refresh"), Value::Null).await;
+        assert_eq!(st, StatusCode::OK, "refresh {member}");
+    }
+    let (st, _) = call(
+        &app,
+        "POST",
+        "/_aliases",
+        json!({"actions": [
+            {"add": {"index": "idx-a", "alias": "tri"}},
+            {"add": {"index": "idx-b", "alias": "tri"}}
+        ]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create alias tri");
+
+    // Explain doc "2" (lives in idx-b, the non-first member) against match_all.
+    let (status, body) = call(
+        &app,
+        "POST",
+        "/tri/_explain/2",
+        json!({"query": {"match_all": {}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "_explain status: {body}");
+    assert_eq!(
+        body.get("matched").and_then(Value::as_bool),
+        Some(true),
+        "_explain through the alias must find doc 2 in idx-b and match it, not report \
+         'document not found' because the alias collapsed to its first member (#451): {body}"
+    );
+    // And it reports the concrete member the doc lives in, not the alias.
+    assert_eq!(
+        body.get("_index").and_then(Value::as_str),
+        Some("idx-b"),
+        "_explain must report the concrete member in _index (#451): {body}"
+    );
+}

--- a/engine/crates/xerj-api/tests/index_segments_through_alias_lists_every_member.rs
+++ b/engine/crates/xerj-api/tests/index_segments_through_alias_lists_every_member.rs
@@ -1,0 +1,101 @@
+//! Issue #451 (failure class B): `GET /{index}/_segments` resolved the path
+//! index with `Engine::get_index`, which collapses an alias to
+//! `aliased.first()`. So `_segments` over a multi-index alias returned a single
+//! `indices` entry (keyed by the alias name, the first member's segments)
+//! instead of one entry per concrete member.
+//!
+//! Migrated onto the shared `resolve_selector_with_filters` resolver (#451).
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// `_segments` over a 2-member alias must return one `indices` entry per member,
+/// keyed by the concrete member names — not one entry under the alias name.
+#[tokio::test]
+async fn index_segments_through_a_multi_index_alias_lists_every_member() {
+    let (app, _dir) = app().await;
+
+    for (member, id) in [("idx-a", "1"), ("idx-b", "2")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}"),
+            json!({"mappings": {"properties": {"v": {"type": "keyword"}}}}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "create {member}");
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}/_doc/{id}"),
+            json!({"v": member}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index doc {id} into {member}");
+        let (st, _) = call(&app, "POST", &format!("/{member}/_refresh"), Value::Null).await;
+        assert_eq!(st, StatusCode::OK, "refresh {member}");
+    }
+    let (st, _) = call(
+        &app,
+        "POST",
+        "/_aliases",
+        json!({"actions": [
+            {"add": {"index": "idx-a", "alias": "tri"}},
+            {"add": {"index": "idx-b", "alias": "tri"}}
+        ]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create alias tri");
+
+    let (status, body) = call(&app, "GET", "/tri/_segments", Value::Null).await;
+    assert_eq!(status, StatusCode::OK, "_segments status: {body}");
+
+    let indices = body
+        .pointer("/indices")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut keys: Vec<String> = indices.keys().cloned().collect();
+    keys.sort();
+    assert_eq!(
+        keys,
+        vec!["idx-a".to_string(), "idx-b".to_string()],
+        "_segments through the alias must list an entry per concrete member, not one \
+         entry under the alias name (#451): {body}"
+    );
+}

--- a/engine/crates/xerj-api/tests/mget_through_alias_sees_every_member.rs
+++ b/engine/crates/xerj-api/tests/mget_through_alias_sees_every_member.rs
@@ -1,0 +1,119 @@
+//! Issue #451 (failure class B): `_mget` through a multi-index alias resolves
+//! the selector with `Engine::get_index`, which collapses an alias to
+//! `aliased.first()` — one member. A document that lives in any other member of
+//! the alias is reported `found: false`, silently invisible.
+//!
+//! This is the read-side twin of #450 (the by-query write path) and #433 (the
+//! `_search`/`_count` read paths, already fixed). `_explain`, `_segments`,
+//! `_cat/segments`, `_eql/search`, `_async_search` and `_flush` share the same
+//! `get_index` cause; `_mget` is the clearest to pin because "the id exists but
+//! the alias says it doesn't" is an unambiguous wrong answer.
+//!
+//! The proper fix (#451) is a single selector resolver returning
+//! `(concrete_indices, alias_filters)` that every one of these endpoints calls,
+//! not a per-site alias branch. This test is what that resolver must satisfy on
+//! the `_mget` path.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// A doc in each member; an `_mget` through the alias must find both, not just
+/// the first member's.
+#[tokio::test]
+async fn mget_through_a_multi_index_alias_finds_docs_in_every_member() {
+    let (app, _dir) = app().await;
+
+    for (member, id) in [("idx-a", "1"), ("idx-b", "2")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}"),
+            json!({"mappings": {"properties": {"v": {"type": "keyword"}}}}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "create {member}");
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}/_doc/{id}"),
+            json!({"v": member}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index doc {id} into {member}");
+        let (st, _) = call(&app, "POST", &format!("/{member}/_refresh"), Value::Null).await;
+        assert_eq!(st, StatusCode::OK, "refresh {member}");
+    }
+    let (st, _) = call(
+        &app,
+        "POST",
+        "/_aliases",
+        json!({"actions": [
+            {"add": {"index": "idx-a", "alias": "tri"}},
+            {"add": {"index": "idx-b", "alias": "tri"}}
+        ]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create alias tri");
+
+    let (status, body) = call(
+        &app,
+        "POST",
+        "/tri/_mget",
+        json!({"docs": [{"_id": "1"}, {"_id": "2"}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "_mget status: {body}");
+
+    let docs = body
+        .get("docs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(docs.len(), 2, "expected two doc responses: {body}");
+
+    // Both ids exist — one per member. Collapsing the alias to its first member
+    // makes the other member's doc report found:false (#451 class B).
+    for (i, want_id) in ["1", "2"].iter().enumerate() {
+        let found = docs[i].get("found").and_then(Value::as_bool).unwrap_or(false);
+        assert!(
+            found,
+            "_mget through the alias must find doc {want_id} (it lives in a real member), \
+             not report found:false because the alias collapsed to its first member (#451): {body}"
+        );
+    }
+}

--- a/engine/crates/xerj-api/tests/mget_through_alias_sees_every_member.rs
+++ b/engine/crates/xerj-api/tests/mget_through_alias_sees_every_member.rs
@@ -109,7 +109,10 @@ async fn mget_through_a_multi_index_alias_finds_docs_in_every_member() {
     // Both ids exist — one per member. Collapsing the alias to its first member
     // makes the other member's doc report found:false (#451 class B).
     for (i, want_id) in ["1", "2"].iter().enumerate() {
-        let found = docs[i].get("found").and_then(Value::as_bool).unwrap_or(false);
+        let found = docs[i]
+            .get("found")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         assert!(
             found,
             "_mget through the alias must find doc {want_id} (it lives in a real member), \


### PR DESCRIPTION
Advances #451 (does not close it — see Scope). Introduces the single selector resolver the issue asks for and migrates the trivially-mergeable class-B read endpoints onto it, deleting their per-site `get_index` copies.

## The defect (class B)
Several read endpoints resolved the path index with `Engine::get_index`, which collapses an alias to `aliased.first()` — one member. So over a multi-index alias they silently answered from the first member only: a doc in another member was invisible.

## The shape (what the issue asked for)
`resolve_selector_with_filters(state, spec) -> (Vec<(name, Arc<Index>)>, Vec<alias_filter>)` — one resolver that expands `_all`/`*`/glob/alias/comma uniformly (via `resolve_index_selector`, #433) and carries any alias filter (mirroring `search_impl`, as `resolve_by_query_targets` does on the write path, #450). Every migrated site calls it; the per-site `get_index` is gone.

## Migrated this PR (each with a fail-before→pass repro test)
- **`_mget`** — a doc in a non-first member reported `found:false`; now searches every member.
- **`_explain`** — a non-first member's doc reported `matched:false`/"document not found"; now explains against the member that holds it, reporting the concrete member in `_index`.
- **`_cat/segments`** — an alias showed one row under the alias name (and globs matched nothing); now one row per member.
- **`_segments`** (`/{index}/_segments`) — one `indices` entry under the alias name; now one entry per member.

## Scope / tracked follow-up (why #451 stays open)
- **`eql_search`** — also `get_index→first`, but fanning it out needs proper **search-result merging** (sort + size across members), not per-member iteration; a naive concat would mis-order EQL events. Wants a decision on routing it through the shared multi-index search path.
- **Class C** (alias-filter injection on `msearch`/`search_with_scroll`/`msearch_template`/`_cat/count`) — the resolver now returns the filters; wiring them in is a separate change.
- `async_search_submit` is already alias-safe (delegates to `search_impl`).

## Verification (rustc 1.98.0)
Full `xerj-api` suite **469 passed, 0 failed**; `fmt --check`, `clippy --workspace --all-targets -D warnings`, `build --profile ci-test` all clean.