### PR TITLE
test(es-compat): lock the filtered-alias by-query over-delete safety + _update_by_query aggregate deleted:0 (#553)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -24456,6 +24456,13 @@ fn aggregate_by_query_results(mut results: Vec<Value>, count_key: &str) -> Value
     out.insert("timed_out".into(), json!(timed_out));
     out.insert("total".into(), json!(total));
     out.insert(count_key.to_string(), json!(affected));
+    // `_update_by_query` bodies also carry a `"deleted": 0` field (an update
+    // never deletes); the single-member response includes it, so the aggregate
+    // does too — otherwise the 2+-member update body drops a field the
+    // 1-member body has (#553 nit).
+    if count_key == "updated" {
+        out.insert("deleted".into(), json!(0));
+    }
     out.insert("batches".into(), json!(batches));
     out.insert("version_conflicts".into(), json!(version_conflicts));
     out.insert("noops".into(), json!(noops));

--- a/engine/crates/xerj-api/tests/filtered_alias_by_query_deletes_only_its_slice.rs
+++ b/engine/crates/xerj-api/tests/filtered_alias_by_query_deletes_only_its_slice.rs
@@ -1,0 +1,132 @@
+//! Issue #553 (fast-follow to #450): the #450 fix ANDs an alias's `filter` into
+//! the by-query so a `_delete_by_query` through a FILTERED alias removes only
+//! the slice the filter names — never the whole backing index (the #524
+//! over-delete hazard). The 3-skeptic verification of #552 confirmed this is
+//! correct by code inspection but flagged that no test EXERCISES it. This is
+//! that test: it fails loudly if the alias filter is ever dropped and a filtered
+//! by-query starts draining out-of-slice documents.
+//!
+//! Two members, each holding one in-slice (`status:active`) and one out-of-slice
+//! (`status:archived`) document, behind a filtered alias. A `match_all`
+//! `_delete_by_query` through the alias must delete exactly the two active docs
+//! and leave the two archived docs untouched.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn count(app: &axum::Router, index: &str) -> u64 {
+    let (_, body) = call(app, "GET", &format!("/{index}/_count"), Value::Null).await;
+    body.get("count")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX)
+}
+
+/// A `_delete_by_query` through a FILTERED multi-index alias deletes only the
+/// in-slice documents, never the whole backing index (#553 / #524).
+#[tokio::test]
+async fn delete_by_query_through_a_filtered_alias_deletes_only_the_slice() {
+    let (app, _dir) = app().await;
+
+    // Two members; each has one active (in-slice) and one archived (out-of-slice) doc.
+    for member in ["idx-a", "idx-b"] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/{member}"),
+            json!({"mappings": {"properties": {"status": {"type": "keyword"}}}}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "create {member}");
+        for (id, status) in [("active", "active"), ("archived", "archived")] {
+            let (st, _) = call(
+                &app,
+                "PUT",
+                &format!("/{member}/_doc/{id}"),
+                json!({"status": status}),
+            )
+            .await;
+            assert_eq!(st, StatusCode::CREATED, "index {id} into {member}");
+        }
+        let (st, _) = call(&app, "POST", &format!("/{member}/_refresh"), Value::Null).await;
+        assert_eq!(st, StatusCode::OK, "refresh {member}");
+    }
+
+    // Filtered alias 'hot' over both members: only status=active is in-slice.
+    let the_filter = json!({ "term": { "status": "active" } });
+    for member in ["idx-a", "idx-b"] {
+        let (st, body) = call(
+            &app,
+            "PUT",
+            &format!("/{member}/_alias/hot"),
+            json!({ "filter": the_filter }),
+        )
+        .await;
+        assert_eq!(
+            st,
+            StatusCode::OK,
+            "create filtered alias on {member}: {body}"
+        );
+    }
+
+    // A match_all delete through the filtered alias must touch ONLY the slice.
+    let (status, body) = call(
+        &app,
+        "POST",
+        "/hot/_delete_by_query",
+        json!({"query": {"match_all": {}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "_delete_by_query status: {body}");
+    assert_eq!(
+        body.get("deleted").and_then(Value::as_u64),
+        Some(2),
+        "a match_all delete through a filtered alias must delete only the two in-slice \
+         (active) docs, not the whole backing index (#553/#524): {body}"
+    );
+
+    // The archived (out-of-slice) doc in each member must SURVIVE — the alias
+    // filter is what stands between "delete my slice" and "empty my index".
+    for member in ["idx-a", "idx-b"] {
+        assert_eq!(
+            count(&app, member).await,
+            1,
+            "member {member} must keep its out-of-slice (archived) doc after a filtered-alias \
+             delete — over-deleting past the filter is the #524 data-loss hazard: {member}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #553 (fast-follow to #450 / PR #552).

## The gap this closes
The 3-skeptic verification of #552 confirmed — by code inspection — that a `_delete_by_query` through a **filtered** alias removes only the slice the filter names (never the whole backing index, the #524 hazard), because the alias filter is ANDed into the query applied to every member. But two skeptics independently flagged that **no test exercises it**: the load-bearing over-delete-safety property was verified only by reading.

## The test
A `match_all` `_delete_by_query` through a **filtered 2-member alias** (`hot`, `filter: status=active`, over `idx-a`/`idx-b`, each holding one active + one archived doc) must:
- report `deleted: 2` (only the in-slice active docs), and
- leave each member's archived (out-of-slice) doc intact.

**Non-vacuous:** without the filter, `match_all` would delete all 4 and empty both members — so the test fails loudly the moment the alias filter is ever dropped. It passes on current `main` (the #450 fix is correct).

## Nit (also flagged by the skeptics)
`aggregate_by_query_results` now emits `"deleted": 0` for `_update_by_query`, matching the single-member update body — previously the 2+-member update response dropped a field the 1-member body has.

## Verification (rustc 1.98.0)
Full `xerj-api` suite **468 passed, 0 failed**; `fmt --check`, `clippy --workspace --all-targets -D warnings` clean. Test-only + a 6-line response-consistency fix.