### PR TITLE
fix(engine): dispatch a single-clause bool wrapping a semantic clause (#395 case B)

### DIFF
--- a/engine/crates/xerj-api/tests/nested_vector_clause_in_bool_not_dropped.rs
+++ b/engine/crates/xerj-api/tests/nested_vector_clause_in_bool_not_dropped.rs
@@ -1,0 +1,128 @@
+//! Issue #395: a `semantic`/`knn` clause nested inside a `bool` is silently
+//! dropped — the engine only *peels the top* of the query tree, so a vector
+//! clause that is not at the top (or is one of several `bool` clauses) never
+//! reaches the vector path. The request answers `200 OK` with the purely lexical
+//! result set, no error and no `_shards.failed`.
+//!
+//! Case B from the report: a `bool` whose only clause is `semantic` returns zero
+//! hits, while the same clause at the top level returns all three documents.
+//! Whatever the resolution (dispatch the nested clause, or reject it loudly),
+//! `bool{must:[semantic]}` must not silently answer `200`/zero.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn total(app: &axum::Router, query: Value) -> (StatusCode, u64) {
+    let (status, body) = call(
+        app,
+        "POST",
+        "/docs/_search",
+        json!({ "query": query, "size": 10, "track_total_hits": true }),
+    )
+    .await;
+    let t = body
+        .pointer("/hits/total/value")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    (status, t)
+}
+
+/// A `bool` whose only clause is `semantic` must return the same documents as
+/// the bare `semantic` clause — not silently drop the vector half to zero (#395).
+#[tokio::test]
+async fn semantic_clause_nested_in_bool_is_not_silently_dropped() {
+    let (app, _dir) = app().await;
+    let (st, body) = call(
+        &app,
+        "PUT",
+        "/docs",
+        json!({"mappings": {"properties": {
+            "ctx": { "type": "semantic_text", "dimensions": 32 }
+        }}}),
+    )
+    .await;
+    assert!(st.is_success(), "create semantic_text index: {st} {body}");
+
+    for (id, text) in [
+        ("0", "graph edges connect nodes in a network"),
+        ("1", "weather forecast sunshine and rain today"),
+        ("2", "edges and vertices form a graph structure"),
+    ] {
+        let (st, _) = call(
+            &app,
+            "POST",
+            &format!("/docs/_doc/{id}"),
+            json!({ "ctx": text }),
+        )
+        .await;
+        assert!(st.is_success(), "index doc {id}: {st}");
+    }
+    let (_s, _b) = call(&app, "POST", "/docs/_refresh", Value::Null).await;
+
+    let q = "graph edges";
+    let sem = json!({ "semantic": { "field": "ctx", "query": q, "k": 10 } });
+
+    // A: bare semantic — the baseline the nested form must match.
+    let (sa, bare_total) = total(&app, sem.clone()).await;
+    assert_eq!(sa, StatusCode::OK, "bare semantic status");
+    assert!(
+        bare_total > 0,
+        "precondition: bare semantic must find the semantic_text docs (got {bare_total})"
+    );
+
+    // B: the SAME clause nested in a single-clause bool.must.
+    let (sb, nested_total) = total(&app, json!({ "bool": { "must": [ sem ] } })).await;
+
+    // If the executor cannot dispatch the nested clause it must say so (400),
+    // not answer 200 with a silently lexical/empty result. Either way it must
+    // NOT return a smaller, misleading hit set than the bare form.
+    if sb == StatusCode::OK {
+        assert_eq!(
+            nested_total, bare_total,
+            "a bool wrapping only a `semantic` clause returned {nested_total} hits vs {bare_total} \
+             for the bare clause — the vector half was silently dropped (#395)"
+        );
+    } else {
+        assert_eq!(
+            sb,
+            StatusCode::BAD_REQUEST,
+            "a nested vector clause that cannot be dispatched must 400 (naming `hybrid`), \
+             not answer a silent lexical 200 (#395): got {sb}"
+        );
+    }
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -30541,6 +30541,46 @@ fn peel_semantic_query(q: &QueryNode) -> Option<(String, String, usize, Option<B
         QueryNode::Constant { query, .. }
         | QueryNode::Boosted { query, .. }
         | QueryNode::Named { query, .. } => peel_semantic_query(query),
+        QueryNode::Bool {
+            must,
+            should,
+            filter,
+            must_not,
+            ..
+        } => {
+            // Mirror peel_knn_query: dispatch the simple case of a bool with
+            // exactly one must/should clause holding a `semantic`, ANDing any
+            // bool `filter` clauses into the semantic filter. Without this arm a
+            // `bool{must:[semantic]}` fell through to the lexical path and
+            // silently returned zero hits with a 200 (#395) — knn already peeled
+            // this exact shape, so semantic was the odd one out. Multi-clause
+            // bools (a semantic clause beside a lexical one) still fall through;
+            // fusing those is the separate #395 dispatch/reject decision.
+            if !must_not.is_empty() {
+                return None;
+            }
+            let candidates: Vec<&QueryNode> = must.iter().chain(should.iter()).collect();
+            if candidates.len() != 1 {
+                return None;
+            }
+            let (field, text, k, inner_filter) = peel_semantic_query(candidates[0])?;
+            let mut merged_filters: Vec<QueryNode> = filter.clone();
+            if let Some(fi) = inner_filter {
+                merged_filters.push(*fi);
+            }
+            let merged = match merged_filters.len() {
+                0 => None,
+                1 => Some(Box::new(merged_filters.into_iter().next().unwrap())),
+                _ => Some(Box::new(QueryNode::Bool {
+                    must: Vec::new(),
+                    should: Vec::new(),
+                    filter: merged_filters,
+                    must_not: Vec::new(),
+                    minimum_should_match: None,
+                })),
+            };
+            Some((field, text, k, merged))
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
Advances #395 (does not close it — see Scope). Fixes the clearest, unambiguous slice: a `bool` whose only clause is `semantic` silently returned zero hits.

## The defect (case B)
`peel_semantic_query` matched `SemanticSearch` under `Constant`/`Boosted`/`Named` but had **no `Bool` arm**, so `{"bool":{"must":[{"semantic":…}]}}` fell through to the lexical path and answered `200 OK` with **zero hits** — while the same clause at the top level returns all its documents. `peel_knn_query` already peels this exact single-clause-bool shape for `knn`, so `semantic` was simply the odd one out.

## The fix
Add the mirroring `Bool` arm to `peel_semantic_query`: a `bool` with exactly one `must`/`should` clause holding a `semantic` is dispatched to the vector path, with any `bool.filter` clauses ANDed into the semantic filter (byte-for-byte the logic `peel_knn_query` uses). No maintainer decision needed — this only makes `semantic` consistent with `knn`.

Fail-before: `bool{must:[semantic]}` → `0` hits vs `3` for the bare clause; now `3`.

## Scope / why #395 stays open
Only the **single-clause** case is fixed. The **multi-clause** cases still fall through: case D (`bool.should[match, semantic]`) and case G (the canonical ES 8.x `knn` block beside a `query`, folded to `bool.should[query, knn]`). Fusing vs rejecting those is the separate #395 decision — and importantly, G is a **valid ES 8.x hybrid shape**, so a blanket reject would break wire-compat; that path wants the dispatch/fuse treatment (`hybrid` already does it), which is a larger change.

## Verification (rustc 1.98.0)
New repro test passes (case B); 88 semantic/knn/hybrid tests green, 0 failures; `clippy --workspace --all-targets -D warnings` clean; `fmt --check` clean. Note: a combined `-p xerj-engine -p xerj-api` run flaked once on `painless_script_limits` (deep-recursion stack pressure, unrelated to this change — passes in isolation, 9/0).