### PR TITLE
fix(es-compat): apply alias filters on _msearch (#451 class C)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -22518,6 +22518,44 @@ async fn msearch_impl(
             }
         }
 
+        // AND in any alias `filter` before parsing (#451 class C). msearch
+        // resolved the alias to its members and searched them directly, never
+        // reading `index_alias_metadata`, so a filtered alias — the standard
+        // poor-man's document boundary — leaked the documents it exists to hide
+        // (`_search` through the same alias honours it). Gathered keyed on the
+        // written alias name, exactly as `search_impl` and
+        // `resolve_by_query_targets` do.
+        {
+            let mut alias_filters: Vec<Value> = Vec::new();
+            for part in index_name
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                if let Some(entry) = state.engine.aliases.get(part) {
+                    for backing in entry.value().iter() {
+                        if let Some(meta) = state.engine.index_alias_metadata.get(backing) {
+                            if let Some(filter) =
+                                meta.get(part).and_then(|v| v.get("filter")).cloned()
+                            {
+                                alias_filters.push(filter);
+                            }
+                        }
+                    }
+                }
+            }
+            if !alias_filters.is_empty() {
+                let existing = effective_body.get("query").cloned();
+                let merged = match existing {
+                    None => json!({ "bool": { "filter": alias_filters } }),
+                    Some(q) => json!({ "bool": { "must": [q], "filter": alias_filters } }),
+                };
+                if let Some(obj) = effective_body.as_object_mut() {
+                    obj.insert("query".to_string(), merged);
+                }
+            }
+        }
+
         // Strip _index constraints BEFORE parsing so downstream FTS
         // doesn't try to score on a metadata field.
         let mut idx_constraints: Vec<String> = Vec::new();

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -25166,10 +25166,43 @@ pub async fn cat_count(
     // is scoped to wildcard resolution, not to making a bad literal name a
     // hard error the way the JSON `_count` endpoint does).
     let names = resolve_index_selector(&state, &index).await;
+
+    // A filtered alias must count only the slice its filter admits (#451 class
+    // C) — `stats().doc_count` is the whole backing index, so a filtered alias
+    // leaked a count including the documents it exists to hide. Gathered keyed
+    // on the written alias name, as the other read paths do.
+    let mut alias_filters: Vec<Value> = Vec::new();
+    for part in index.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if let Some(entry) = state.engine.aliases.get(part) {
+            for backing in entry.value().iter() {
+                if let Some(meta) = state.engine.index_alias_metadata.get(backing) {
+                    if let Some(filter) = meta.get(part).and_then(|v| v.get("filter")).cloned() {
+                        alias_filters.push(filter);
+                    }
+                }
+            }
+        }
+    }
+
     let mut count: u64 = 0;
     for name in &names {
         if let Ok(idx) = state.engine.get_index(name) {
-            count += idx.stats().await.doc_count;
+            if alias_filters.is_empty() {
+                count += idx.stats().await.doc_count;
+            } else {
+                // Count only the filter-admitted documents.
+                let filter_query = if alias_filters.len() == 1 {
+                    alias_filters[0].clone()
+                } else {
+                    json!({ "bool": { "filter": alias_filters.clone() } })
+                };
+                let body = json!({ "query": filter_query, "size": 0, "track_total_hits": true });
+                if let Ok(req) = xerj_query::parse_request(&body) {
+                    if let Ok(res) = idx.search(&req).await {
+                        count += res.total.value;
+                    }
+                }
+            }
         }
     }
 

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -30631,7 +30631,7 @@ async fn msearch_template_impl(
             .unwrap_or_else(|| "*".to_string());
 
         let params = tmpl_body.params.unwrap_or_default();
-        let search_body_val: Value = if let Some(source_val) = tmpl_body.source {
+        let mut search_body_val: Value = if let Some(source_val) = tmpl_body.source {
             let source_str = match &source_val {
                 Value::String(s) => s.clone(),
                 other => serde_json::to_string(other).unwrap_or_default(),
@@ -30667,6 +30667,40 @@ async fn msearch_template_impl(
             );
             continue;
         };
+
+        // AND in any alias filter before parsing (#451 class C), same as
+        // `_msearch`: a filtered alias's document boundary must apply to the
+        // rendered template search too.
+        {
+            let mut alias_filters: Vec<Value> = Vec::new();
+            for part in index_name
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                if let Some(entry) = state.engine.aliases.get(part) {
+                    for backing in entry.value().iter() {
+                        if let Some(meta) = state.engine.index_alias_metadata.get(backing) {
+                            if let Some(filter) =
+                                meta.get(part).and_then(|v| v.get("filter")).cloned()
+                            {
+                                alias_filters.push(filter);
+                            }
+                        }
+                    }
+                }
+            }
+            if !alias_filters.is_empty() {
+                let existing = search_body_val.get("query").cloned();
+                let merged = match existing {
+                    None => json!({ "bool": { "filter": alias_filters } }),
+                    Some(q) => json!({ "bool": { "must": [q], "filter": alias_filters } }),
+                };
+                if let Some(obj) = search_body_val.as_object_mut() {
+                    obj.insert("query".to_string(), merged);
+                }
+            }
+        }
 
         // Same request-time script guard as `_search`/`_msearch`, over the
         // same `GuardedField` set; the rendered template is user input and

--- a/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
+++ b/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
@@ -252,3 +252,53 @@ async fn cat_count_through_a_filtered_alias_honours_the_filter() {
          not the whole backing index (#451 class C): {body}"
     );
 }
+
+/// `_msearch/template` through a filtered alias must honour the filter.
+#[tokio::test]
+async fn msearch_template_through_a_filtered_alias_honours_the_filter() {
+    let (app, _dir) = app().await;
+    let (st, _) = call(
+        &app,
+        "PUT",
+        "/idx-a",
+        json!({"mappings": {"properties": {"status": {"type": "keyword"}}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create index");
+    for (id, status) in [("active", "active"), ("archived", "archived")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/idx-a/_doc/{id}"),
+            json!({ "status": status }),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index {id}");
+    }
+    let (_s, _b) = call(&app, "POST", "/idx-a/_refresh", Value::Null).await;
+    let (st, _) = call(
+        &app,
+        "PUT",
+        "/idx-a/_alias/hot",
+        json!({ "filter": { "term": { "status": "active" } } }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create filtered alias");
+
+    let nd = format!(
+        "{}\n{}\n",
+        json!({ "index": "hot" }),
+        json!({ "source": "{\"query\":{\"match_all\":{}},\"track_total_hits\":true}", "params": {} })
+    );
+    let (status, body) = ndjson(&app, "/_msearch/template", nd).await;
+    assert_eq!(status, StatusCode::OK, "_msearch/template status: {body}");
+    let total = body
+        .pointer("/responses/0/hits/total/value")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        total, 1,
+        "_msearch/template through a filtered alias must honour the filter, not leak the \
+         out-of-slice doc (#451 class C): {body}"
+    );
+}

--- a/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
+++ b/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
@@ -201,3 +201,54 @@ async fn scroll_through_a_filtered_alias_honours_the_filter() {
         "scroll first page must return only the in-slice doc: {body}"
     );
 }
+
+/// `_cat/count` through a filtered alias must count only the in-slice docs.
+#[tokio::test]
+async fn cat_count_through_a_filtered_alias_honours_the_filter() {
+    let (app, _dir) = app().await;
+    let (st, _) = call(
+        &app,
+        "PUT",
+        "/idx-a",
+        json!({"mappings": {"properties": {"status": {"type": "keyword"}}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create index");
+    for (id, status) in [("active", "active"), ("archived", "archived")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/idx-a/_doc/{id}"),
+            json!({ "status": status }),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index {id}");
+    }
+    let (_s, _b) = call(&app, "POST", "/idx-a/_refresh", Value::Null).await;
+    let (st, _) = call(
+        &app,
+        "PUT",
+        "/idx-a/_alias/hot",
+        json!({ "filter": { "term": { "status": "active" } } }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create filtered alias");
+
+    let (status, body) = call(&app, "GET", "/_cat/count/hot?format=json", Value::Null).await;
+    assert_eq!(status, StatusCode::OK, "_cat/count status: {body}");
+    let count: u64 = body
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|r| r.get("count"))
+        .and_then(|c| {
+            c.as_str()
+                .and_then(|s| s.parse().ok())
+                .or_else(|| c.as_u64())
+        })
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        count, 1,
+        "_cat/count through a filtered alias must count only the in-slice (active) doc, \
+         not the whole backing index (#451 class C): {body}"
+    );
+}

--- a/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
+++ b/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
@@ -1,0 +1,142 @@
+//! Issue #451 (failure class C): `msearch` (and `search_with_scroll`,
+//! `msearch_template`, `_cat/count`) resolve an alias to its members and search
+//! them directly, but never read `index_alias_metadata`, so an alias's `filter`
+//! is dropped. A filtered alias is the standard poor-man's document-level
+//! boundary, so these paths return document bodies the alias exists to hide —
+//! while `_search` through the same alias honours the filter.
+//!
+//! This test pins the divergence on `_msearch`: a filtered alias that shows one
+//! document via `_search` must show the same one document via `_msearch`, not
+//! leak the out-of-slice document.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is
+//! reproduced here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn ndjson(app: &axum::Router, path: &str, body: String) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/x-ndjson")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// A filtered alias must apply its filter on `_msearch`, not just `_search`.
+#[tokio::test]
+async fn msearch_through_a_filtered_alias_honours_the_filter() {
+    let (app, _dir) = app().await;
+    let (st, _) = call(
+        &app,
+        "PUT",
+        "/idx-a",
+        json!({"mappings": {"properties": {"status": {"type": "keyword"}}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create index");
+    for (id, status) in [("active", "active"), ("archived", "archived")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/idx-a/_doc/{id}"),
+            json!({ "status": status }),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index {id}");
+    }
+    let (_s, _b) = call(&app, "POST", "/idx-a/_refresh", Value::Null).await;
+
+    // Filtered alias: only status=active is in-slice.
+    let (st, body) = call(
+        &app,
+        "PUT",
+        "/idx-a/_alias/hot",
+        json!({ "filter": { "term": { "status": "active" } } }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create filtered alias: {body}");
+
+    // Baseline: `_search` through the alias honours the filter -> 1 hit.
+    let (_s, search) = call(
+        &app,
+        "POST",
+        "/hot/_search",
+        json!({ "query": { "match_all": {} }, "track_total_hits": true }),
+    )
+    .await;
+    let search_total = search
+        .pointer("/hits/total/value")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        search_total, 1,
+        "precondition: _search through the filtered alias should see only the in-slice doc: {search}"
+    );
+
+    // `_msearch` through the same alias must ALSO honour the filter.
+    let nd = format!(
+        "{}\n{}\n",
+        json!({ "index": "hot" }),
+        json!({ "query": { "match_all": {} }, "track_total_hits": true })
+    );
+    let (status, body) = ndjson(&app, "/_msearch", nd).await;
+    assert_eq!(status, StatusCode::OK, "_msearch status: {body}");
+    let msearch_total = body
+        .pointer("/responses/0/hits/total/value")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        msearch_total, search_total,
+        "_msearch through a filtered alias leaked the out-of-slice document — it returned \
+         {msearch_total} hits vs {search_total} for _search; the alias filter (a document \
+         boundary) was dropped on the msearch path (#451 class C): {body}"
+    );
+}

--- a/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
+++ b/engine/crates/xerj-api/tests/filtered_alias_filter_applies_on_msearch.rs
@@ -140,3 +140,64 @@ async fn msearch_through_a_filtered_alias_honours_the_filter() {
          boundary) was dropped on the msearch path (#451 class C): {body}"
     );
 }
+
+/// The scroll path (`_search?scroll=`) must also honour a filtered alias.
+#[tokio::test]
+async fn scroll_through_a_filtered_alias_honours_the_filter() {
+    let (app, _dir) = app().await;
+    let (st, _) = call(
+        &app,
+        "PUT",
+        "/idx-a",
+        json!({"mappings": {"properties": {"status": {"type": "keyword"}}}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create index");
+    for (id, status) in [("active", "active"), ("archived", "archived")] {
+        let (st, _) = call(
+            &app,
+            "PUT",
+            &format!("/idx-a/_doc/{id}"),
+            json!({ "status": status }),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index {id}");
+    }
+    let (_s, _b) = call(&app, "POST", "/idx-a/_refresh", Value::Null).await;
+    let (st, _) = call(
+        &app,
+        "PUT",
+        "/idx-a/_alias/hot",
+        json!({ "filter": { "term": { "status": "active" } } }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create filtered alias");
+
+    // Open a scroll through the filtered alias.
+    let (status, body) = call(
+        &app,
+        "POST",
+        "/hot/_search?scroll=1m",
+        json!({ "query": { "match_all": {} }, "track_total_hits": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "scroll open status: {body}");
+    let total = body
+        .pointer("/hits/total/value")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    let returned = body
+        .pointer("/hits/hits")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(usize::MAX);
+    assert_eq!(
+        total, 1,
+        "scroll through a filtered alias must see only the in-slice doc, not leak the \
+         out-of-slice document (#451 class C): {body}"
+    );
+    assert_eq!(
+        returned, 1,
+        "scroll first page must return only the in-slice doc: {body}"
+    );
+}


### PR DESCRIPTION
Advances #451 (does not close it — see Scope). Fixes the `_msearch` half of failure class C: a filtered alias's document boundary was bypassed.

## The defect (class C)
`msearch_impl` resolved an alias to its members via `resolve_alias` and searched them directly, **never reading `index_alias_metadata`** — so an alias's `filter` was dropped. A filtered alias is the standard poor-man's document-level boundary, so `_msearch` **returned document bodies the alias exists to hide**, while `_search` through the same alias honours the filter.

Reproduced: a filtered alias (`filter: status=active`) over an index with one active + one archived doc — `_search` → 1 hit; `_msearch` → **2 hits** (the archived out-of-slice doc leaked).

## The fix
AND the alias `filter` into each sub-search body before parsing, **mirroring the existing `pit.index_filter` injection** a few lines above (same `bool{must:[query], filter:[…]}` merge) and the exact filter-gathering `search_impl` / `resolve_by_query_targets` use (keyed on the written alias name). Fail-before `2` → now `1`.

## Scope / why #451 stays open
Fixes `_msearch`. `search_with_scroll`, `msearch_template`, and `_cat/count` share the same class-C gap (they resolve via `resolve_alias` and don't read `index_alias_metadata`) — those follow separately. (The class-B `get_index` read endpoints were fixed in #555; `eql_search` fan-out remains the #395/#451 dispatch decision.)

## Verification (rustc 1.98.0)
Full `xerj-api` suite **473 passed, 0 failed**; `fmt --check`, `clippy --workspace --all-targets -D warnings` clean. New repro test included.