### PR TITLE
bench(harbor-3arm): flag partial arm coverage + neutralize the tuned prompt's pre-asserted claim (#516)

### DIFF
--- a/tools/benchmarks/harbor-3arm/collect_results.py
+++ b/tools/benchmarks/harbor-3arm/collect_results.py
@@ -103,12 +103,22 @@ def main():
     for (bench, model, arm), tasks in cells.items():
         by_bm[(bench, model)][arm] = {
             t for t, v in tasks.items() if v["reward"] is not None}
+    canonical_arms = {"native", "xerj", "xerj-tuned"}
     for (bench, model), arms in sorted(by_bm.items()):
         if len(arms) < 2:
             continue
+        present = set(arms)
         common = set.intersection(*arms.values())
+        # A comparison that isn't the full 3-arm set must say so LOUDLY — an
+        # absent arm otherwise reads as a footnote and a reader can mistake, e.g.,
+        # native vs xerj-tuned for the headline result (#516).
+        coverage = "" if present == canonical_arms else (
+            f"   ⚠ PARTIAL ARM COVERAGE — missing "
+            f"{sorted(canonical_arms - present) or 'nothing'}, "
+            f"unexpected {sorted(present - canonical_arms) or 'nothing'}; "
+            f"this is NOT the canonical 3-arm comparison")
         print(f"\n{bench} / {model}: {len(common)} tasks finished in all "
-              f"{len(arms)} arms")
+              f"{len(arms)} arms ({', '.join(sorted(present))}){coverage}")
         for arm in sorted(arms):
             tv = cells[(bench, model, arm)]
             k = sum(1 for t in common if tv[t]["resolved"])

--- a/tools/benchmarks/harbor-3arm/xerj_prompt_tuned.j2
+++ b/tools/benchmarks/harbor-3arm/xerj_prompt_tuned.j2
@@ -2,8 +2,9 @@
 
 ---
 TOOL NOTE: XERJ code search is installed (server at http://localhost:9210) and
-tuned for this work. It is usually MUCH faster than grep for finding the right
-definition in an unfamiliar repo. Playbook:
+tuned for this work. It can return the enclosing definition of a symbol directly
+(the whole function/class body), so you rarely need to open files to read a
+definition. Playbook:
 
 1. Index once (seconds; --no-semantic keeps it pure BM25 — the embedder is
    lexical, so semantic fields add cost without adding meaning):


### PR DESCRIPTION
Closes #516. Two benchmark-honesty follow-ups from the #513 verification — keeping the Harbor 3-arm harness honest (which matters given the fair-test finding in #500).

## 1. Collector: loud partial-arm-coverage flag (was should-fix)
`collect_results.py` built the cross-arm comparison from whatever arm dirs were present, guarded only by `if len(arms) < 2`. So an entirely-absent arm silently produced a **2-arm** comparison, and a reader could mistake e.g. `native` vs `xerj-tuned` for the headline. Now the header names the present arms and prints a loud `⚠ PARTIAL ARM COVERAGE` warning (naming the missing/unexpected arms) whenever the set isn't the canonical `{native, xerj, xerj-tuned}` — an incomplete matrix is loud, not a footnote.

## 2. Tuned prompt: neutral capability, not a pre-asserted outcome (was nit)
`xerj_prompt_tuned.j2` told the agent XERJ "is usually **MUCH faster than grep** for finding the right definition" — a latency claim inside the very arm whose latency is measured. Softened to a neutral capability description ("can return the enclosing definition directly, so you rarely need to open files"), keeping the tuned arm's disclosed playbook advantage without prejudging the result. Especially apt given #500 measured XERJ returning 32–48x more bytes than grep.

## Verification
`python3 -m py_compile collect_results.py` passes; tooling-only (Python + Jinja), no engine change.