### PR TITLE
fix(es-compat): propagate per-member errors in cat_count instead of undercounting (#563)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -25188,22 +25188,35 @@ pub async fn cat_count(
 
     let mut count: u64 = 0;
     for name in &names {
-        if let Ok(idx) = state.engine.get_index(name) {
-            if alias_filters.is_empty() {
-                count += idx.stats().await.doc_count;
+        // #563: a per-member get_index / parse / search error must NOT silently
+        // contribute 0 — that made `_cat/count` quietly UNDER-report a filtered
+        // alias (the safe direction, but still a wrong number with no signal).
+        // Propagate it, like the scroll fan-out above does, so the caller gets a
+        // loud error instead of a plausible undercount.
+        let idx = match state.engine.get_index(name) {
+            Ok(i) => i,
+            Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
+        };
+        if alias_filters.is_empty() {
+            count += idx.stats().await.doc_count;
+        } else {
+            // Count only the filter-admitted documents.
+            let filter_query = if alias_filters.len() == 1 {
+                alias_filters[0].clone()
             } else {
-                // Count only the filter-admitted documents.
-                let filter_query = if alias_filters.len() == 1 {
-                    alias_filters[0].clone()
-                } else {
-                    json!({ "bool": { "filter": alias_filters.clone() } })
-                };
-                let body = json!({ "query": filter_query, "size": 0, "track_total_hits": true });
-                if let Ok(req) = xerj_query::parse_request(&body) {
-                    if let Ok(res) = idx.search(&req).await {
-                        count += res.total.value;
-                    }
+                json!({ "bool": { "filter": alias_filters.clone() } })
+            };
+            let body = json!({ "query": filter_query, "size": 0, "track_total_hits": true });
+            let req = match xerj_query::parse_request(&body) {
+                Ok(r) => r,
+                Err(e) => {
+                    return ApiError::new(xerj_common::XerjError::invalid_query(e.to_string()))
+                        .into_response()
                 }
+            };
+            match idx.search(&req).await {
+                Ok(res) => count += res.total.value,
+                Err(e) => return ApiError::new(xerj_common::XerjError::from(e)).into_response(),
             }
         }
     }


### PR DESCRIPTION
Closes #563.

## The defect
The filtered-alias branch of `_cat/count` (`es_compat.rs`) counted each member with nested `if let Ok`:
```rust
if let Ok(idx) = state.engine.get_index(name) {
    …
    if let Ok(req) = xerj_query::parse_request(&body) {
        if let Ok(res) = idx.search(&req).await { count += res.total.value }
    }
}
```
A per-member `get_index` / `parse_request` / `search` **error** made that member silently contribute **0** — a plausible `200` undercount with no `_shards.failed`, no warning. It's the *safe* direction (better than the `stats().doc_count` over-count #559 replaced) and only bites a filtered alias when a member errors, which is why #559's verification rated it non-blocking — but a quietly-wrong count is still worth removing.

## The fix
Propagate the error, exactly like the scroll fan-out earlier in this file already does (`Err(e) => return ApiError::new(…).into_response()`). `_cat/count` now returns the correct count or a loud error, never a silent undercount. The `Ok` path is byte-identical.

## Verification (rustc 1.98.0)
- `clippy --workspace --all-targets -- -D warnings` clean; full `xerj-api` suite green.
- The existing `filtered_alias_filter_applies_on_msearch` `_cat/count` guard (counts only in-slice docs) is unaffected — the happy path is unchanged.

**Honesty note:** the error path isn't triggerable through the public API (a stored alias filter always re-parses, and a `term`/`bool` filter over a live index doesn't error), so there is no runtime fail-before test — this is a defensive hardening confirmed by inspection of the swallowing `if let Ok` and by the suite staying green. If a reviewer prefers keeping a partial count with an explicit `_shards.failed` signal instead of failing the request, say so and I'll switch to that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)