### PR TITLE
fix(autoindex): don't abort re-index on a field absent-but-unscored in the frozen schema (#580)

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -625,6 +625,51 @@ fn add_change_delete_and_rename_converge_over_real_http() {
     assert_eq!(journal_events(state_dir.path(), "sync_commit"), 5);
 }
 
+/// #580: re-indexing a **code file** must not abort. The AST file document
+/// carries a `symbols` array (of objects); `FieldAcc` does not scalar-type it,
+/// so it is pruned from the frozen dataset schema at genesis — and the second
+/// generation observed `symbols` again and aborted with `field symbols is
+/// absent from frozen dataset`. A field with no scalar values is now allowed to
+/// be absent from the frozen schema.
+#[test]
+fn code_file_reindex_does_not_abort_on_absent_symbols_field() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("lib.rs"),
+        "pub struct AlphaConfig {\n    pub retries: u32,\n}\n",
+    )
+    .unwrap();
+    let endpoint = HttpEndpoint::start();
+    let config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    // Genesis.
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    // Edit the code file and re-index — before #580 this aborted the whole run
+    // on the frozen `symbols` field.
+    fs::write(
+        corpus.path().join("lib.rs"),
+        "pub struct AlphaConfig {\n    pub retries: u64,\n}\n",
+    )
+    .unwrap();
+    assert_eq!(
+        run_index(config).unwrap(),
+        0,
+        "re-indexing a code file must reconcile, not abort on the frozen `symbols` field (#580)"
+    );
+    // The struct is still indexed (file doc + its symbol doc).
+    assert!(
+        endpoint
+            .data_docs()
+            .iter()
+            .any(|d| d.get("name").is_some_and(|n| n == "AlphaConfig")),
+        "the struct's symbol doc must survive the re-index"
+    );
+}
+
 #[test]
 fn pending_generation_replays_sealed_source_after_live_source_mutates() {
     let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());

--- a/engine/crates/xerj-autoindex/src/reconcile_plan.rs
+++ b/engine/crates/xerj-autoindex/src/reconcile_plan.rs
@@ -348,12 +348,24 @@ fn ensure_compatible(fields: &HashMap<String, FieldAcc>, dataset: &PlanDataset) 
         .map(|spec| (spec.name.as_str(), spec))
         .collect();
     for (name, acc) in fields {
-        let spec = specs.get(name.as_str()).with_context(|| {
-            format!(
+        let Some(spec) = specs.get(name.as_str()) else {
+            // A field observed with NO scalar values (`acc.n == 0`) — e.g. the
+            // code file's `symbols` sidecar (an array of objects, which
+            // `FieldAcc` deliberately does not scalar-type) — legitimately never
+            // received a frozen `FieldSpec` at genesis: it has nothing to type.
+            // Its absence is therefore not drift; there is nothing to validate,
+            // so mirror `compatible_with_spec`'s `acc.n == 0 => true` and skip
+            // it. Without this, re-indexing ANY code file aborted the whole run
+            // (#580), because `symbols` is observed on every generation but was
+            // pruned from the frozen schema. A field that DOES carry scalar
+            // values yet is absent is still a real incompatibility.
+            anyhow::ensure!(
+                acc.n == 0,
                 "field {name} is absent from frozen dataset {}",
                 dataset.slug
-            )
-        })?;
+            );
+            continue;
+        };
         anyhow::ensure!(
             compatible_with_spec(acc, spec),
             "field {name} is incompatible with frozen {} mapping in dataset {}",


### PR DESCRIPTION
Closes #580.

## The defect
Re-indexing **any code file** aborted the entire run: `project retained file …: field symbols is absent from frozen dataset docs`. So a corpus with source files could be indexed once but never updated. (Found by PR #579's verification; reproduced on `main` — pre-existing, and it blocks #500's per-declaration docs from ever reconciling on a file edit.)

## Root cause
The AST file document carries a `symbols` array (of `{name,kind,line}` objects). `FieldAcc::add` deliberately ignores object values (`Value::Object(_) => {}`, "flattened upstream"), and its `Value::Array` arm recurses into elements — so an array **of objects** contributes no scalar observation: `symbols` accumulates `n == 0`, receives no frozen `FieldSpec` at genesis, and is pruned from the dataset schema. On the next generation `symbols` is observed again, and `ensure_compatible` (`reconcile_plan.rs`) rejected it as absent from the frozen schema → fatal.

## The fix
A field observed with **no scalar values** (`acc.n == 0`) has nothing to type-validate, so its absence from the frozen schema is not drift. `ensure_compatible` now skips such a field (mirroring `compatible_with_spec`'s own `acc.n == 0 => true`). A field that **does** carry scalar values yet is absent still fails the reconcile (real drift is still caught).

## Verification (rustc 1.98.0)
- **Fail-before proven** (revert only the `reconcile_plan.rs` hunk): the new `code_file_reindex_does_not_abort_on_absent_symbols_field` panics with the exact `field symbols is absent from frozen dataset docs` error; with the fix it reconciles and the struct's symbol doc survives.
- Full `xerj-autoindex` suite **green (696 passed, 0 failed)**; `clippy -D warnings` clean; ci-test profile checked.
