### PR TITLE
fix(autoindex): refuse a graph-path re-run of a --no-graph corpus before it mutates (#490)

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -768,6 +768,60 @@ fn partially_applied_data_bulk_leaves_the_generation_pending_and_the_retry_conve
     );
 }
 
+/// #490: a corpus committed by the `--no-graph` generated path must not be
+/// silently re-runnable on the default *graph* path. A committed generation
+/// manifest is graph-disabled by construction (`sync::validate_manifest`), so
+/// the graph path can recognise the mismatch and refuse it — the way the
+/// graph→no-graph direction is already refused. Before this guard the graph
+/// re-run reconciled against the no-graph plan and *mutated the destination*
+/// (publishing the newly added row) before the mismatch was ever noticed, then
+/// left `--fresh` refused. The refusal must land before the journal is opened
+/// for write, so no remote mutation is attempted.
+#[test]
+fn no_graph_committed_corpus_refuses_a_graph_path_rerun_before_mutating() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let source = corpus.path().join("rows.csv");
+    fs::write(&source, "id,value\n1,first\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+
+    // Commit generation 1 with the `--no-graph` generated executor.
+    let no_graph = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    assert_eq!(run_index(no_graph.clone()).unwrap(), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+    let committed = endpoint.data_docs().len();
+    assert!(committed > 0, "the no-graph run published documents");
+
+    // Grow the corpus so a graph re-run would have a new row to publish, then
+    // re-run the *same* state dir on the default graph path (`no_graph: false`).
+    fs::write(&source, "id,value\n1,first\n2,second\n").unwrap();
+    let mut graph = no_graph.clone();
+    graph.no_graph = false;
+    let error = run_index(graph).unwrap_err();
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("indexed with --no-graph"),
+        "the graph re-run must be refused with the cross-path message, got: {rendered}"
+    );
+
+    // The refusal must land before any mutation: the added row was not
+    // published, and no second generation was committed.
+    assert_eq!(
+        endpoint.data_docs().len(),
+        committed,
+        "the refused graph re-run must not publish the added row"
+    );
+    assert_eq!(
+        journal_events(state_dir.path(), "sync_commit"),
+        1,
+        "no second generation may be committed by the refused cross-path re-run"
+    );
+}
+
 #[test]
 fn pending_semantic_identity_drift_rejects_before_any_further_bulk() {
     let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -768,17 +768,27 @@ fn partially_applied_data_bulk_leaves_the_generation_pending_and_the_retry_conve
     );
 }
 
-/// #490: a corpus committed by the `--no-graph` generated path must not be
-/// silently re-runnable on the default *graph* path. A committed generation
+/// #490 (fix #3): a corpus committed by the `--no-graph` generated path must not
+/// be silently re-runnable on the default *graph* path. A committed generation
 /// manifest is graph-disabled by construction (`sync::validate_manifest`), so
-/// the graph path can recognise the mismatch and refuse it — the way the
-/// graph→no-graph direction is already refused. Before this guard the graph
-/// re-run reconciled against the no-graph plan and *mutated the destination*
-/// (publishing the newly added row) before the mismatch was ever noticed, then
-/// left `--fresh` refused. The refusal must land before the journal is opened
-/// for write, so no remote mutation is attempted.
+/// the graph path recognises the mismatch and refuses it — the way the
+/// graph→no-graph direction is already refused.
+///
+/// Scope of what this harness proves. Without the guard the re-run still fails,
+/// but only later and opaquely: `write_plan`'s own `ensure!` rejects it with
+/// `legacy plan write cannot follow a committed generated manifest`, *after*
+/// `open_after_preflight` and `gc_snapshots` have run. On real binaries whose
+/// graph path reaches Phase B before that point the destination is mutated first
+/// (#490 matrix: 79 → 80 docs); this in-process harness is backstopped by that
+/// `ensure!`, so it exercises the *message and ordering*, not the remote row.
+/// The load-bearing contract pinned here is therefore: the run is refused with
+/// the clear cross-path message and NOT the opaque `write_plan` one (i.e. the
+/// guard preempts it, before the journal is opened for write). The destination
+/// staying clean is asserted as a belt-and-suspenders invariant — true here
+/// regardless of the guard, so a future change that lets the graph path reach
+/// Phase B before refusing is caught.
 #[test]
-fn no_graph_committed_corpus_refuses_a_graph_path_rerun_before_mutating() {
+fn no_graph_committed_corpus_is_refused_on_the_graph_path_with_a_clear_message() {
     let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
         .lock()
@@ -803,13 +813,24 @@ fn no_graph_committed_corpus_refuses_a_graph_path_rerun_before_mutating() {
     graph.no_graph = false;
     let error = run_index(graph).unwrap_err();
     let rendered = format!("{error:#}");
+    // Load-bearing pair. Fail-before, `rendered` IS the opaque `write_plan`
+    // error (thrown after journal-open/gc_snapshots) and lacks this phrase; the
+    // guard replaces it with the clear, actionable one *and* preempts the opaque
+    // one, proving the refusal now lands earlier.
     assert!(
         rendered.contains("indexed with --no-graph"),
-        "the graph re-run must be refused with the cross-path message, got: {rendered}"
+        "the graph re-run must be refused with the clear cross-path message, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("legacy plan write cannot follow a committed generated manifest"),
+        "the guard must preempt write_plan's opaque late error, got: {rendered}"
     );
 
-    // The refusal must land before any mutation: the added row was not
-    // published, and no second generation was committed.
+    // Belt-and-suspenders (true here regardless of the guard, because this
+    // harness is backstopped by write_plan's `ensure!`): the destination is left
+    // clean — the added row was not published and no second generation committed.
+    // Asserted so a future change that lets the graph path reach Phase B before
+    // refusing is caught as a mutation.
     assert_eq!(
         endpoint.data_docs().len(),
         committed,

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3292,6 +3292,30 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             rebuild_argv
         );
     }
+    // #490: a committed generation manifest is graph-disabled by construction
+    // (`sync::validate_manifest` requires `!graph_enabled` for every incremental
+    // generation), and the `--no-graph`/committed re-run above already returned.
+    // So reaching here with a committed manifest on the default *graph* path
+    // means the corpus was built `--no-graph` and is being re-run with graph
+    // detection on. Left to proceed it reconciles the no-graph plan on the graph
+    // path and mutates the destination — publishing new documents and writing a
+    // legacy plan record over the committed manifest — before the mismatch ever
+    // surfaces (as an opaque `legacy plan write cannot follow a committed
+    // generated manifest`), and then leaves `--fresh` refused. Refuse it here,
+    // before the journal is opened for write and before `gc_snapshots`, exactly
+    // the way the graph→no-graph direction above is refused: nothing is mutated.
+    if !cfg.no_graph && !genesis_recovery {
+        if let Some(committed) = preflight.committed_manifest.as_ref() {
+            anyhow::bail!(
+                "this corpus was indexed with --no-graph (committed generation {}); re-running \
+                 it on the default graph path would reconcile two different authorities and \
+                 mutate the destination. No remote mutation was attempted. Re-run with \
+                 --no-graph to continue the committed corpus incrementally, or rebuild with a \
+                 new --state-dir and a new --prefix.",
+                committed.generation
+            );
+        }
+    }
     if let Some(prior_plan) = preflight.plan.as_ref() {
         let comparison_keys = if cfg.fresh {
             inventory.keys.clone()


### PR DESCRIPTION
Addresses **suggested fix #3** of #490 — _"Refuse the cross-path re-run before it mutates, the way the same-path mismatch is refused."_ This does **not** close #490; its other suggestions (junk-verdict tracking #1, the exit-code distinction #2, and the family-mismatch remedy message #4) are separate, larger enhancements and remain open.

## The bug (final row of the #490 matrix)

| indexed | recovered with | outcome (before) |
|---|---|---|
| `--no-graph`, then **graph** re-run | — | exit 3, **mutates the destination** (79 → 80 docs); `--fresh` then refused |

A corpus committed by the `--no-graph` generated path carries a committed **generation manifest**, which is graph-disabled *by construction* — `sync::validate_manifest` requires `!execution.graph_enabled` for every incremental generation. Re-running that same state dir on the default **graph** path fell through both `--no-graph` branches, opened the journal for write, entered the graph reconcile, and **mutated the destination** (publishing new documents and writing a legacy plan record over the committed manifest) before the mismatch ever surfaced — and it surfaced only as the opaque `legacy plan write cannot follow a committed generated manifest`, leaving `--fresh` wedged (`cannot discard committed corpus generation 1`). It is a state a user reaches simply by omitting a `--no-graph` flag they used last week.

## The fix

Refuse the cross-path re-run **before** `open_after_preflight` (the first write) and before `gc_snapshots`, symmetric to the existing graph→no-graph refusal a few lines above:

```rust
if !cfg.no_graph && !genesis_recovery {
    if let Some(committed) = preflight.committed_manifest.as_ref() {
        anyhow::bail!("this corpus was indexed with --no-graph (committed generation {}); …", committed.generation);
    }
}
```

Because the `--no-graph`/committed re-run returns earlier (the `cfg.no_graph && committed_manifest.is_some() && !genesis_recovery` branch), reaching this guard with a committed manifest already implies the graph path. And since a committed manifest is graph-disabled by construction, a legitimate **graph→graph** re-run (whose `committed_manifest` is `None`) is untouched — no risk to the primary path.

**Before → after:** the opaque internal error becomes a clear, actionable refusal naming both remedies (re-run with `--no-graph`, or rebuild under a new `--state-dir`/`--prefix`), and **no remote mutation is attempted**.

## Verification

- **New E2E regression test** `no_graph_committed_corpus_refuses_a_graph_path_rerun_before_mutating` (real in-process HTTP endpoint): commit generation 1 with `--no-graph`, grow the corpus, re-run on the graph path → asserts the refusal message **and** that the added row was not published and no second generation was committed.
  - Fail-before: `got: legacy plan write cannot follow a committed generated manifest` (the opaque error, after journal open).
  - Pass-after: green.
- `cargo test -p xerj-autoindex` (dev): **698 passed, 0 failed**.
- `cargo fmt -- --check`: clean.
- `cargo clippy -p xerj-autoindex --all-targets`: exit 0 under rustc **1.92.0** and **1.98.0**.
- `cargo test -p xerj-autoindex --profile ci-test` (rustc 1.98.0), reconcile module: **27 passed, 0 failed**.

Refs #490