### PR TITLE
fix(engine): deterministically await the stale HNSW rebuild in its test, killing the flake (#536)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -10166,6 +10166,23 @@ impl Index {
         }
     }
 
+    /// Await the in-flight stale HNSW rebuild to completion, if one is running.
+    ///
+    /// A deterministic alternative to polling `hnsw_stats` for tests and
+    /// diagnostics (#536): the background task clears `hnsw_rebuilding` and
+    /// publishes the healed graph *before* its `JoinHandle` resolves, so a
+    /// caller observes `stale == false` / `rebuilding == false` immediately
+    /// after this returns — with no timeout that can flake under parallel test
+    /// load. A no-op when no rebuild was spawned (the snapshot was already
+    /// fresh). The handle is `take`n, so a subsequent close/abort is a no-op
+    /// (the task has already finished).
+    pub async fn await_hnsw_rebuild(&self) {
+        let handle = self.hnsw_rebuild_task.lock().take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
+    }
+
     /// Re-derive the HNSW graph from the authoritative doc set and clear
     /// `hnsw_stale` (RC4 W2 item 17). Returns `Ok(true)` once converged.
     ///

--- a/engine/crates/xerj-engine/tests/integration.rs
+++ b/engine/crates/xerj-engine/tests/integration.rs
@@ -5153,22 +5153,26 @@ async fn test_hnsw_stale_snapshot_rebuilds_on_open() {
     // converge, clear the flag, and leave every doc graphed.
     let engine = make_engine(&dir);
     let idx = engine.get_index("vecs").unwrap();
-    let mut healed = false;
-    let mut last = json!(null);
-    for _ in 0..100 {
-        last = idx.hnsw_stats().await;
-        if last["present"] == json!(true)
-            && last["stale"] == json!(false)
-            && last["rebuilding"] == json!(false)
-        {
-            healed = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-    assert!(
-        healed,
-        "stale HNSW snapshot must be healed by the background rebuild; last stats: {last}"
+    // Deterministically wait for the background rebuild to converge instead of
+    // polling `hnsw_stats` on a fixed 10s budget that flaked under parallel test
+    // load (#536): the rebuild task clears `rebuilding` and publishes the healed
+    // graph before its handle resolves, so after this the stats are settled.
+    idx.await_hnsw_rebuild().await;
+    let last = idx.hnsw_stats().await;
+    assert_eq!(
+        last["present"],
+        json!(true),
+        "healed graph present after rebuild: {last}"
+    );
+    assert_eq!(
+        last["stale"],
+        json!(false),
+        "stale flag cleared after rebuild: {last}"
+    );
+    assert_eq!(
+        last["rebuilding"],
+        json!(false),
+        "rebuilding flag cleared after rebuild: {last}"
     );
     assert_eq!(
         last["doc_coverage"],


### PR DESCRIPTION
Closes #536.

## The flake
`test_hnsw_stale_snapshot_rebuilds_on_open` forges a stale `ids.json` stamp, reopens, and polls `hnsw_stats()` on a fixed **100×100ms = 10s** budget for the background rebuild to converge. Under parallel `cargo test` load the tokio rebuild task is CPU-starved and 10s is not always enough → the poll times out and the test intermittently fails, while passing 2/2 in isolation. It red-flags unrelated PRs (observed while verifying #415).

Each test uses its own `TempDir`, so this is **not** a shared-fixture issue — it is a timeout.

## The fix (deterministic, not a wider timeout)
`spawn_hnsw_rebuild_if_stale` stores the rebuild's `JoinHandle` (`hnsw_rebuild_task`), and the spawned task clears `hnsw_rebuilding` and publishes the healed graph **before** its handle resolves. New `Index::await_hnsw_rebuild` takes and awaits that handle; the test awaits it instead of polling, observing the settled stats deterministically — no timeout to flake, at any load. A no-op when no rebuild was spawned.

## Verification
- **Fail-before** (await removed, stats read immediately): fails with `stale:true, rebuilding:true` — the rebuild has not converged, exactly the race the poll tolerated probabilistically.
- **Pass-after**: the test completes in ~0.3s deterministically.
- Full `cargo test -p xerj-engine`: **0 failed**. `cargo fmt --check`: clean. `cargo clippy -p xerj-engine --all-targets -- -D warnings` (1.98.0): exit 0.

An independent 3-skeptic verification follows in a comment.