### PR TITLE
fix(engine): schema-evolution throttle must re-evolve on a value-SHAPE change, not just field names (#382)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -33257,48 +33257,76 @@ fn object_keys_of(val: &Value) -> Option<&serde_json::Map<String, Value>> {
         .or_else(|| val.as_array()?.iter().find(|v| !v.is_null())?.as_object())
 }
 
-/// FNV-1a hash of every field NAME in `val`, at EVERY nesting depth, into
-/// `h` -- not just the top-level keys. Used by the single-doc ingest path's
-/// schema-evolution throttle (`index_document_with_version_inner_guarded`)
-/// to fingerprint "does this document's field-name shape differ from the
-/// last one we evolved the schema for". A shallow, top-level-only hash
-/// would miss a document whose top-level keys are unchanged but whose
-/// NESTED shape changed -- e.g. `metadata.kind` on one document,
-/// `metadata.project` on the next -- silently suppressing the schema-evolve
-/// call that new nested key needs, for up to 100 documents. For a
-/// document with no nested objects this hashes exactly the same bytes in
-/// the same order as hashing only the top-level keys, so it's a strict
-/// superset, not a behavior change, for the common flat-document case.
+/// FNV-1a fingerprint of `val`'s full field-name-and-value-*shape*, folded
+/// into `h`. Used by the single-doc ingest path's schema-evolution throttle
+/// (`index_document_with_version_inner_guarded`) to answer "does this
+/// document's shape differ from the last one we evolved the schema for" and
+/// skip `evolve_schema_from_doc` while it is unchanged, re-checking only every
+/// ~100 documents. The fingerprint MUST reach everywhere the evolution path it
+/// gates reaches, or a genuinely-new field is suppressed for up to 100 docs
+/// and queries against it answer 0 hits until the throttle expires. So it:
+/// * hashes every field NAME at every nesting depth, INCLUDING keys nested
+///   inside arrays-of-objects -- `object_keys_of` /
+///   `merge_dynamic_children_into` unwrap arrays of objects and register
+///   nested keys across their elements, so this must descend into arrays too
+///   (e.g. `metadata.kind` on one document vs `metadata.project` on the next,
+///   whether `metadata` is an object or a single-element array of objects);
+/// * folds each leaf's value-TYPE tag (null/bool/number/string), so a key
+///   *refused* a `FieldConfig` for value-shape reasons -- e.g. a dense_vector
+///   companion first seen as a numeric array -- re-triggers evolution the
+///   moment a differently-typed value arrives under it (#382);
+/// * folds an array tag and recurses into every element, so an array whose
+///   element shape changes (scalar type, or nested object keys one array-wrap
+///   deep -- `["a"]` -> `[[1]]`, `[{kind}]` -> `[{project}]`) changes the
+///   fingerprint instead of staying an opaque leaf.
+///
+/// A homogeneous corpus (one shape per field) still produces a stable hash, so
+/// the throttle's fast path is unchanged for the common case it exists for.
 fn hash_all_field_names(val: &Value, h: &mut u64) {
-    let Some(obj) = val.as_object() else {
-        // #382: mix the leaf value's TYPE into the hash. The schema-evolution
-        // throttle skips `evolve_schema_from_doc` while this hash is unchanged,
-        // and hashing key NAMES alone left a key that was *refused* a FieldConfig
-        // (for value-shape reasons — e.g. a dense_vector companion) with the same
-        // hash when a later document put a differently-typed value under it. That
-        // suppressed evolution for up to 100 docs, so the new value shape stayed
-        // unregistered and queries answered 0 hits until the throttle expired.
-        // Folding the leaf type in makes a `string` after an `array`/`object`/
-        // number re-trigger evolution. A homogeneous corpus (one type per field)
-        // still produces a stable hash, so the fast path is unchanged for it.
-        let tag: u64 = match val {
-            Value::Null => 1,
-            Value::Bool(_) => 2,
-            Value::Number(_) => 3,
-            Value::String(_) => 4,
-            Value::Array(_) => 5,
-            Value::Object(_) => 6, // unreachable: `as_object` returned None
-        };
-        *h ^= tag;
-        *h = h.wrapping_mul(0x00000100000001b3);
-        return;
-    };
-    for (k, v) in obj {
-        for b in k.bytes() {
-            *h ^= b as u64;
+    match val {
+        Value::Object(obj) => {
+            for (k, v) in obj {
+                for b in k.bytes() {
+                    *h ^= b as u64;
+                    *h = h.wrapping_mul(0x00000100000001b3);
+                }
+                hash_all_field_names(v, h);
+            }
+        }
+        Value::Array(arr) => {
+            // #382 (array variant): fold the array tag AND recurse into every
+            // element. The evolution path this hash gates unwraps arrays of
+            // objects (`object_keys_of`) and merges nested keys across all
+            // elements (`merge_dynamic_children_into`), so treating an array as
+            // one opaque leaf would let `[{kind}]` -> `[{project}]` or
+            // `["a","b"]` -> `[[1,2]]` keep the same fingerprint and suppress the
+            // evolve those transitions need for up to 100 docs. Recursing over
+            // all elements matches that across-elements reach; a homogeneous
+            // array still hashes stably doc-to-doc.
+            *h ^= 5;
+            *h = h.wrapping_mul(0x00000100000001b3);
+            for elem in arr {
+                hash_all_field_names(elem, h);
+            }
+        }
+        // #382: mix each leaf's value TYPE into the hash so a key refused a
+        // `FieldConfig` for value-shape reasons re-triggers evolution the moment
+        // a differently-typed value arrives under it. Hashing NAMES alone left
+        // the old and new documents with the same fingerprint, suppressing
+        // evolution for up to 100 docs -> the new value stayed unregistered and
+        // queries answered 0 hits until the throttle expired.
+        _ => {
+            let tag: u64 = match val {
+                Value::Null => 1,
+                Value::Bool(_) => 2,
+                Value::Number(_) => 3,
+                Value::String(_) => 4,
+                // Object and Array are handled by the arms above.
+                Value::Array(_) | Value::Object(_) => unreachable!(),
+            };
+            *h ^= tag;
             *h = h.wrapping_mul(0x00000100000001b3);
         }
-        hash_all_field_names(v, h);
     }
 }
 
@@ -42184,6 +42212,45 @@ mod date_detection_tests {
             mk(&serde_json::json!({"k": "a"})),
             mk(&serde_json::json!({"k": "b"})),
             "same leaf type, different value → stable hash (throttle preserved)"
+        );
+    }
+
+    /// #382 (array variant): the throttle fingerprint must reach *inside* arrays,
+    /// because the evolution path it gates (`object_keys_of` /
+    /// `merge_dynamic_children_into`) unwraps arrays-of-objects and registers keys
+    /// across their elements. Treating an array as one opaque leaf let
+    /// `[{kind}]` -> `[{project}]` and `["a"]` -> `[[1]]` keep the same hash, so a
+    /// legitimately-new nested field stayed suppressed (0 hits) for up to 100 docs
+    /// — the same defect one array-wrap deeper than the scalar case above.
+    #[test]
+    fn hash_all_field_names_recurses_into_array_elements() {
+        let mk = |v: &serde_json::Value| {
+            let mut h: u64 = 0xcbf29ce484222325;
+            hash_all_field_names(v, &mut h);
+            h
+        };
+        // Array-of-objects: a new nested key under the same array-valued field is
+        // what `merge_dynamic_children_into` would register — the fingerprint must
+        // change so evolution is not throttled away.
+        assert_ne!(
+            mk(&serde_json::json!({"items": [{"kind": "note"}]})),
+            mk(&serde_json::json!({"items": [{"project": "xerj"}]})),
+            "a new key inside an array-of-objects must change the fingerprint (#382)"
+        );
+        // Element-type change: a flat string array vs a multi-vector companion
+        // (array-of-arrays). The string array is not a multi-vector, so evolution
+        // would register it — but only if the throttle lets the call through.
+        assert_ne!(
+            mk(&serde_json::json!({"emb": ["tenant-a", "tenant-b"]})),
+            mk(&serde_json::json!({"emb": [[1.0, 2.0]]})),
+            "an array's element type changing must change the fingerprint (#382)"
+        );
+        // Stability: same array shape, different scalar values → stable hash, so
+        // the throttle's fast path is preserved for a homogeneous corpus.
+        assert_eq!(
+            mk(&serde_json::json!({"items": [{"kind": "note"}]})),
+            mk(&serde_json::json!({"items": [{"kind": "task"}]})),
+            "same array shape, different values → stable hash (throttle preserved)"
         );
     }
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -33266,11 +33266,13 @@ fn object_keys_of(val: &Value) -> Option<&serde_json::Map<String, Value>> {
 /// gates reaches, or a genuinely-new field is suppressed for up to 100 docs
 /// and queries against it answer 0 hits until the throttle expires. So it:
 /// * hashes every field NAME at every nesting depth, INCLUDING keys nested
-///   inside arrays-of-objects -- `object_keys_of` /
-///   `merge_dynamic_children_into` unwrap arrays of objects and register
-///   nested keys across their elements, so this must descend into arrays too
-///   (e.g. `metadata.kind` on one document vs `metadata.project` on the next,
-///   whether `metadata` is an object or a single-element array of objects);
+///   inside arrays-of-objects -- the evolution path unwraps an array of
+///   objects to its FIRST non-null object element (`object_keys_of`) and
+///   registers that element's keys, so this must descend into arrays too;
+///   recursing over every element (below) is a deliberate conservative
+///   superset of that first-element reach (e.g. `metadata.kind` on one
+///   document vs `metadata.project` on the next, whether `metadata` is an
+///   object or an array of objects);
 /// * folds each leaf's value-TYPE tag (null/bool/number/string), so a key
 ///   *refused* a `FieldConfig` for value-shape reasons -- e.g. a dense_vector
 ///   companion first seen as a numeric array -- re-triggers evolution the
@@ -33295,14 +33297,14 @@ fn hash_all_field_names(val: &Value, h: &mut u64) {
         }
         Value::Array(arr) => {
             // #382 (array variant): fold the array tag AND recurse into every
-            // element. The evolution path this hash gates unwraps arrays of
-            // objects (`object_keys_of`) and merges nested keys across all
-            // elements (`merge_dynamic_children_into`), so treating an array as
+            // element. The evolution path this hash gates unwraps an array of
+            // objects to its first non-null object element (`object_keys_of`)
+            // and registers that element's nested keys, so treating an array as
             // one opaque leaf would let `[{kind}]` -> `[{project}]` or
             // `["a","b"]` -> `[[1,2]]` keep the same fingerprint and suppress the
             // evolve those transitions need for up to 100 docs. Recursing over
-            // all elements matches that across-elements reach; a homogeneous
-            // array still hashes stably doc-to-doc.
+            // EVERY element is a conservative superset of that first-element
+            // reach; a homogeneous array still hashes stably doc-to-doc.
             *h ^= 5;
             *h = h.wrapping_mul(0x00000100000001b3);
             for elem in arr {
@@ -42216,9 +42218,10 @@ mod date_detection_tests {
     }
 
     /// #382 (array variant): the throttle fingerprint must reach *inside* arrays,
-    /// because the evolution path it gates (`object_keys_of` /
-    /// `merge_dynamic_children_into`) unwraps arrays-of-objects and registers keys
-    /// across their elements. Treating an array as one opaque leaf let
+    /// because the evolution path it gates unwraps an array of objects to its
+    /// first non-null object element (`object_keys_of`) and registers its keys;
+    /// the fingerprint recurses over every element, a conservative superset of
+    /// that reach. Treating an array as one opaque leaf let
     /// `[{kind}]` -> `[{project}]` and `["a"]` -> `[[1]]` keep the same hash, so a
     /// legitimately-new nested field stayed suppressed (0 hits) for up to 100 docs
     /// — the same defect one array-wrap deeper than the scalar case above.

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -33271,6 +33271,26 @@ fn object_keys_of(val: &Value) -> Option<&serde_json::Map<String, Value>> {
 /// superset, not a behavior change, for the common flat-document case.
 fn hash_all_field_names(val: &Value, h: &mut u64) {
     let Some(obj) = val.as_object() else {
+        // #382: mix the leaf value's TYPE into the hash. The schema-evolution
+        // throttle skips `evolve_schema_from_doc` while this hash is unchanged,
+        // and hashing key NAMES alone left a key that was *refused* a FieldConfig
+        // (for value-shape reasons — e.g. a dense_vector companion) with the same
+        // hash when a later document put a differently-typed value under it. That
+        // suppressed evolution for up to 100 docs, so the new value shape stayed
+        // unregistered and queries answered 0 hits until the throttle expired.
+        // Folding the leaf type in makes a `string` after an `array`/`object`/
+        // number re-trigger evolution. A homogeneous corpus (one type per field)
+        // still produces a stable hash, so the fast path is unchanged for it.
+        let tag: u64 = match val {
+            Value::Null => 1,
+            Value::Bool(_) => 2,
+            Value::Number(_) => 3,
+            Value::String(_) => 4,
+            Value::Array(_) => 5,
+            Value::Object(_) => 6, // unreachable: `as_object` returned None
+        };
+        *h ^= tag;
+        *h = h.wrapping_mul(0x00000100000001b3);
         return;
     };
     for (k, v) in obj {
@@ -42121,9 +42141,9 @@ mod date_detection_tests {
             "same top-level keys, different nested shape, must hash differently"
         );
 
-        // Sanity: a flat document with no nested objects hashes the exact
-        // same bytes as hashing only its top-level keys would (no behavior
-        // change for the common case this throttle was written for).
+        // Sanity: a flat document hashes each top-level key AND that key's leaf
+        // value TYPE (#382 folds the type tag in — number == 3 — so a later,
+        // differently-typed value under the same key re-triggers evolution).
         let mut h_flat: u64 = 0xcbf29ce484222325;
         hash_all_field_names(&serde_json::json!({"a": 1, "b": 2}), &mut h_flat);
         let mut h_manual: u64 = 0xcbf29ce484222325;
@@ -42132,8 +42152,39 @@ mod date_detection_tests {
                 h_manual ^= b as u64;
                 h_manual = h_manual.wrapping_mul(0x00000100000001b3);
             }
+            h_manual ^= 3; // Value::Number leaf-type tag
+            h_manual = h_manual.wrapping_mul(0x00000100000001b3);
         }
         assert_eq!(h_flat, h_manual);
+    }
+
+    /// #382: the throttle hash must change when a value's TYPE changes under an
+    /// unchanged key name, so a key refused a `FieldConfig` (value-shape reasons)
+    /// re-triggers `evolve_schema_from_doc` when a differently-typed value later
+    /// arrives — instead of staying unregistered (0 hits) for up to 100 docs.
+    #[test]
+    fn hash_all_field_names_distinguishes_leaf_value_types_under_the_same_key() {
+        let mk = |v: &serde_json::Value| {
+            let mut h: u64 = 0xcbf29ce484222325;
+            hash_all_field_names(v, &mut h);
+            h
+        };
+        let as_array = mk(&serde_json::json!({"emb_chunks": [[1.0, 2.0]]}));
+        let as_string = mk(&serde_json::json!({"emb_chunks": "tenant-a"}));
+        let as_number = mk(&serde_json::json!({"emb_chunks": 5}));
+        assert_ne!(
+            as_array, as_string,
+            "an array vs a string under the same key must hash differently (#382)"
+        );
+        assert_ne!(as_string, as_number, "string vs number under the same key");
+        assert_ne!(as_array, as_number, "array vs number under the same key");
+        // A homogeneous corpus (one type per field) still hashes stably, so the
+        // throttle's fast path is unchanged for the common case.
+        assert_eq!(
+            mk(&serde_json::json!({"k": "a"})),
+            mk(&serde_json::json!({"k": "b"})),
+            "same leaf type, different value → stable hash (throttle preserved)"
+        );
     }
 
     /// Ingest-time acceptance for default-format date fields: lenient on

--- a/engine/crates/xerj-engine/tests/schema_throttle_value_shape_e2e.rs
+++ b/engine/crates/xerj-engine/tests/schema_throttle_value_shape_e2e.rs
@@ -1,0 +1,104 @@
+//! Issue #382 (end-to-end): the schema-evolution throttle must not suppress the
+//! evolve call a value-shape transition needs.
+//!
+//! The single-doc ingest path caches a hash of each document's shape
+//! (`hash_all_field_names`) and skips `evolve_schema_from_doc` while it is
+//! unchanged, re-checking only every ~100 docs. A `<base>_chunks` companion
+//! (`base` declared `dense_vector`) first seen as a rectangular numeric
+//! multi-vector `[[..]]` is *refused* a keyword mapping; when the SAME key later
+//! arrives as a flat string array it is a legitimately-new keyword field. While
+//! the throttle hashed an array as one opaque leaf, both documents hashed
+//! identically, the evolve was skipped, and a `term` query answered 0 hits for
+//! up to ~100 docs (self-healing on throttle expiry — corpus-size-dependent,
+//! exactly the class of bug the unit hash tests pin one layer down).
+//!
+//! Fixed by recursing the throttle fingerprint into array elements, so the
+//! array-of-numbers -> array-of-strings transition changes the hash and forces
+//! the evolve on the very next document. This test drives the real ingest +
+//! search path (not the hash primitive) to guard the observable symptom.
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::{Engine, Index};
+use xerj_query::parse_request;
+
+fn make_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    Engine::new(config).expect("engine::new")
+}
+
+fn req(q: Value) -> xerj_query::ast::SearchRequest {
+    parse_request(&json!({ "query": q, "size": 50 })).expect("parse_request")
+}
+
+async fn hit_ids(idx: &Index, q: Value) -> Vec<String> {
+    idx.search(&req(q))
+        .await
+        .unwrap()
+        .hits
+        .iter()
+        .map(|h| h.id.clone())
+        .collect()
+}
+
+/// A `<base>_chunks` companion (base declared `dense_vector`) first seen as a
+/// multi-vector `[[..numbers..]]` is refused a keyword mapping; when it later
+/// arrives as a flat string array under the SAME key, the schema-evolution
+/// throttle must let the evolve through so the string registers and is
+/// queryable immediately — not suppress it for ~100 docs (#382).
+#[tokio::test]
+async fn refused_multivector_companion_then_string_array_is_searchable_immediately() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+
+    // Declare `passages` dense_vector so `passages_chunks` is recognised as its
+    // (refused) multi-vector companion — the value-shape refusal #382 is about.
+    let mut schema = Schema::empty();
+    let mut vec_field = FieldConfig::new("passages", FieldType::Vector);
+    vec_field.options.dimensions = Some(3);
+    schema.fields.push(vec_field);
+    engine.create_index("mv", schema).unwrap();
+    let idx = engine.get_index("mv").unwrap();
+
+    // Doc "a": passages_chunks as a rectangular numeric multi-vector -> refused a
+    // keyword FieldConfig, and it seeds the throttle's cached shape fingerprint.
+    idx.index_document(
+        Some("a".into()),
+        json!({ "passages_chunks": [[0.1, 0.2, 0.3]] }),
+    )
+    .await
+    .unwrap();
+
+    // Doc "b": passages_chunks now a FLAT STRING array (not a multi-vector) ->
+    // evolution wants to register it as a keyword. Same key, different element
+    // shape: array-of-numbers -> array-of-strings, the transition the opaque-leaf
+    // hash could not see.
+    idx.index_document(
+        Some("b".into()),
+        json!({ "passages_chunks": ["searchable-tenant"] }),
+    )
+    .await
+    .unwrap();
+
+    // The string under the once-refused key must be found — pre-flush (memtable)
+    // and post-flush (segment). On the pre-fix throttle both docs hashed the same
+    // (array = opaque leaf), the evolve was skipped, and this returned {} for up
+    // to 100 docs.
+    let q = json!({ "term": { "passages_chunks": "searchable-tenant" } });
+    assert_eq!(
+        hit_ids(&idx, q.clone()).await,
+        vec!["b".to_string()],
+        "PRE-flush: a string array under a once-refused multi-vector companion must \
+         register immediately, not stay throttle-suppressed (#382)"
+    );
+
+    idx.flush().await.unwrap();
+    assert_eq!(
+        hit_ids(&idx, q).await,
+        vec!["b".to_string()],
+        "POST-flush: the once-refused companion's string value stays searchable"
+    );
+}


### PR DESCRIPTION
## #382 — wrong results: a refused key stays unqueryable for up to ~100 docs

The single-doc ingest path caches a hash of each document's shape (`hash_all_field_names`) and skips `evolve_schema_from_doc` while that hash is unchanged, re-checking only every ~100 docs. The hash folded field **names** only. So when a key was legitimately **refused** a `FieldConfig` for value-shape reasons (e.g. a `<base>_chunks` multi-vector companion) and a later document put a **differently-shaped** value under the same key, the fingerprint was identical, evolution was throttle-suppressed, and `term` queries against the new value answered **0 hits** — self-healing only when the throttle expired. It is doc-order- and corpus-size-dependent, so homogeneous fixtures never caught it.

## The fix (two hunks in `hash_all_field_names`)

1. **Leaf value-type tag** — fold each scalar leaf's type (null/bool/number/string) into the hash, so `array → string` under an unchanged key name re-triggers evolution immediately.
2. **Array element recursion** — fold the array tag **and recurse into every element**. The evolution path this hash gates (`object_keys_of` / `merge_dynamic_children_into`) descends into arrays-of-objects, so treating an array as one opaque leaf left the same defect one array-wrap deeper: `{items:[{kind}]} → {items:[{project}]}` and `emb:["a"] → emb:[[1]]` still collided. Recursing over all elements makes the fingerprint a **strict superset** of the evolution path's reach.

A homogeneous corpus (one shape per field) still hashes stably, so the throttle fast path is unchanged for the common case. The docstring was rewritten (it had overclaimed "every NAME at EVERY depth / strict superset" while never hashing names under arrays).

## Tests
- `hash_all_field_names_distinguishes_leaf_value_types_under_the_same_key` (scalar transition)
- `hash_all_field_names_recurses_into_array_elements` (array-of-objects new key; element-type change; homogeneous stability)
- **End-to-end** `schema_throttle_value_shape_e2e.rs`: a refused `passages_chunks` multi-vector companion whose value later arrives as a string array is term-queryable immediately. **Fail-before proven** (strip the element recursion → 0 hits, the exact #382 symptom) on every hunk.

## Verification
Full `xerj-engine` suite: **49 test-binaries ok / 0 failed** under CI toolchain (rustc 1.98.0). fmt clean; clippy `-D warnings` 0. A 3-independent-skeptic adversarial verification (correctness / regression / evidence) ran against the array-recursion commit; verdicts are posted as a comment. Closes #382.