### PR TITLE
fix(engine): preserve an already-empty object under a dotted _source filter (#310 part 2)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26484,13 +26484,29 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
                 // `{}` behind. An object that was ALREADY empty in the source is a
                 // real value the document carried -- but keep it ONLY in an
                 // ACCEPTING state: includes is match-all, or this object's own
-                // path is allow-listed (matches an include), NOT merely a prefix
-                // of a deeper one. In pure include mode `{"meta": {}}` under
-                // include `meta.foo` has nothing allow-listed below it, so ES
-                // drops it and so must we; under a match-all/exclude-only filter
-                // the empty object must survive (#310).
+                // path is allow-listed, NOT merely a prefix on the way to a
+                // deeper include. In pure include mode `{"meta": {}}` under
+                // include `meta.foo` (or `meta.*`) has nothing allow-listed below
+                // it, so ES drops it and so must we; under a match-all /
+                // exclude-only filter the empty object must survive (#310).
+                //
+                // `matches_path` cannot be reused as the accept test: it also
+                // returns true for a prefix (to DRIVE recursion), and its glob
+                // clause `p.ends_with(".*") && path.starts_with(p[..len-2])` marks
+                // bare `meta` as matching `meta.*`. ES's automaton needs the
+                // trailing dot -- `meta` is a live but non-accepting state of
+                // `meta.*` -- so the accept test must require it.
+                let path_is_accepting = |path: &str| {
+                    includes.iter().any(|inc| match inc.strip_suffix(".*") {
+                        // `base.*`: accept only paths strictly BELOW `base`.
+                        Some(base) => path.starts_with(&format!("{base}.")),
+                        // Plain paths and other globs: a full `matches_path`
+                        // (path is the include, under it, or a full glob match).
+                        None => matches_path(path, std::slice::from_ref(inc)),
+                    })
+                };
                 let already_empty_and_accepted =
-                    obj.is_empty() && (includes.is_empty() || matches_path(prefix, includes));
+                    obj.is_empty() && (includes.is_empty() || path_is_accepting(prefix));
                 if result.is_empty() && !prefix.is_empty() && !already_empty_and_accepted {
                     Value::Null
                 } else {
@@ -26638,6 +26654,33 @@ mod source_filter_tests {
             ),
             json!({}),
             "a non-empty object with no allow-listed leaf is dropped, same as the empty one (#310)"
+        );
+        // Glob form: `meta.*` — bare `meta` is a non-accepting prefix (ES's
+        // automaton needs the trailing dot), so an empty `{"meta":{}}` drops just
+        // as under `meta.foo`. Reusing `matches_path` as the accept test leaked
+        // this because its `.*` clause matches the dot-less prefix.
+        assert_eq!(
+            filter_object(&json!({ "meta": {} }), &["meta.*".to_string()], &[]),
+            json!({}),
+            "an empty object under a `.*` glob prefix is not allow-listed (#310)"
+        );
+        // But an empty object strictly BELOW the glob base IS accepted.
+        assert_eq!(
+            filter_object(
+                &json!({ "meta": { "foo": {} } }),
+                &["meta.*".to_string()],
+                &[]
+            ),
+            json!({ "meta": { "foo": {} } }),
+            "an empty object strictly under a `.*` glob is preserved (#310)"
+        );
+        // Boundary: a sibling key that merely shares a textual prefix
+        // (`metadata` vs glob `meta.*`) is NOT accepted -- the accept test
+        // requires the dot boundary, unlike a bare `starts_with("meta")`.
+        assert_eq!(
+            filter_object(&json!({ "metadata": {} }), &["meta.*".to_string()], &[]),
+            json!({}),
+            "a prefix-sharing sibling (metadata vs meta.*) is not accepted (#310)"
         );
     }
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26479,7 +26479,13 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
                         }
                     }
                 }
-                if result.is_empty() && !prefix.is_empty() {
+                // Prune an intermediate object that *filtering* emptied (it had
+                // keys, all removed) so a stripped subtree does not leave a bare
+                // `{}` behind. But an object that was ALREADY empty in the source
+                // (`obj.is_empty()`) is a real value the document carried -- keep
+                // it, or a dotted include/exclude anywhere in the request would
+                // silently drop every `{"meta": {}}` from every hit (#310).
+                if result.is_empty() && !prefix.is_empty() && !obj.is_empty() {
                     Value::Null
                 } else {
                     Value::Object(result)
@@ -26562,6 +26568,31 @@ mod source_filter_tests {
                 })
             );
         }
+    }
+
+    /// #310 (part 2): a dotted include/exclude anywhere in the request forces
+    /// `filter_object` into its nested branch, which pruned EVERY empty object.
+    /// An object that was already `{}` in the source is a real value the document
+    /// carried and must survive; only an object that *filtering* emptied (had
+    /// keys, all removed) is pruned. A dotted embedding `target_field` puts the
+    /// Default arm on this path, silently dropping every `{"meta": {}}` from
+    /// every hit.
+    #[test]
+    fn dotted_filter_keeps_an_already_empty_source_object_but_prunes_a_filtering_emptied_one() {
+        let source = json!({
+            "meta": {},                // already empty in the source
+            "title": "x",
+            "nested": { "drop_me": 1 } // becomes empty only via the exclude below
+        });
+        // The dotted exclude forces the nested branch (has_dotted) and empties
+        // `nested`; `meta` was already empty in the document.
+        let filtered = filter_object(&source, &[], &["nested.drop_me".to_string()]);
+        assert_eq!(
+            filtered,
+            json!({ "meta": {}, "title": "x" }),
+            "an already-empty object must survive a dotted filter; only a \
+             filtering-emptied object is pruned (#310)"
+        );
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26481,11 +26481,17 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
                 }
                 // Prune an intermediate object that *filtering* emptied (it had
                 // keys, all removed) so a stripped subtree does not leave a bare
-                // `{}` behind. But an object that was ALREADY empty in the source
-                // (`obj.is_empty()`) is a real value the document carried -- keep
-                // it, or a dotted include/exclude anywhere in the request would
-                // silently drop every `{"meta": {}}` from every hit (#310).
-                if result.is_empty() && !prefix.is_empty() && !obj.is_empty() {
+                // `{}` behind. An object that was ALREADY empty in the source is a
+                // real value the document carried -- but keep it ONLY in an
+                // ACCEPTING state: includes is match-all, or this object's own
+                // path is allow-listed (matches an include), NOT merely a prefix
+                // of a deeper one. In pure include mode `{"meta": {}}` under
+                // include `meta.foo` has nothing allow-listed below it, so ES
+                // drops it and so must we; under a match-all/exclude-only filter
+                // the empty object must survive (#310).
+                let already_empty_and_accepted =
+                    obj.is_empty() && (includes.is_empty() || matches_path(prefix, includes));
+                if result.is_empty() && !prefix.is_empty() && !already_empty_and_accepted {
                     Value::Null
                 } else {
                     Value::Object(result)
@@ -26592,6 +26598,46 @@ mod source_filter_tests {
             json!({ "meta": {}, "title": "x" }),
             "an already-empty object must survive a dotted filter; only a \
              filtering-emptied object is pruned (#310)"
+        );
+    }
+
+    /// #310 (part 2, include mode): the already-empty relaxation is gated to an
+    /// ACCEPTING state. An empty object kept only because it PREFIXES a deeper
+    /// include (`meta` for include `meta.foo`) has nothing allow-listed under it,
+    /// so ES drops it -- the fix must not resurrect it. But an empty object whose
+    /// OWN path matches an include is accepting and is preserved. (Without this
+    /// gate, `!obj.is_empty()` alone over-preserves in the prefix case.)
+    #[test]
+    fn dotted_include_keeps_an_empty_object_only_when_its_own_path_is_accepted() {
+        // Prefix-only: `meta` is a non-accepting prefix of `meta.foo`, so nothing
+        // under it is allow-listed -> dropped, exactly as ES does.
+        assert_eq!(
+            filter_object(&json!({ "meta": {} }), &["meta.foo".to_string()], &[]),
+            json!({}),
+            "an empty object that only prefixes a deeper include is not allow-listed (#310)"
+        );
+        // Own-path accepted: `meta` itself is an include (the dotted sibling
+        // `other.x` forces the nested branch) -> preserved.
+        assert_eq!(
+            filter_object(
+                &json!({ "meta": {} }),
+                &["meta".to_string(), "other.x".to_string()],
+                &[]
+            ),
+            json!({ "meta": {} }),
+            "an empty object whose own path matches an include is preserved (#310)"
+        );
+        // Consistency with a non-empty sibling under the same prefix-only include:
+        // `{"meta":{"bar":1}}` under `meta.foo` also drops `meta`, so the empty
+        // and non-empty cases now agree (no appear/disappear by source emptiness).
+        assert_eq!(
+            filter_object(
+                &json!({ "meta": { "bar": 1 } }),
+                &["meta.foo".to_string()],
+                &[]
+            ),
+            json!({}),
+            "a non-empty object with no allow-listed leaf is dropped, same as the empty one (#310)"
         );
     }
 


### PR DESCRIPTION
## #310 part 2 — silent, corpus-wide omission of already-empty objects

`filter_object` (engine/crates/xerj-engine/src/index.rs) takes its nested `collect_and_filter` branch whenever any include/exclude path is dotted, and pruned every object that filtered to empty (`result.is_empty() && !prefix.is_empty() -> Null`). It could not tell an object that *filtering* emptied from one that was **already** `{}` in the source, so a document field like `{"meta": {}}` was silently dropped from every hit as soon as any dotted path entered the request (the Default `_source` arm reaches this whenever an embedding `target_field` is dotted).

## Fix (final form, after three verification rounds)

Keep an already-empty object only in an ES **accepting** state — matching `XContentMapValues.filter`'s `isAccept`, not merely "this path is a live prefix on the way to a deeper include":

```rust
let path_is_accepting = |path: &str| {
    includes.iter().any(|inc| match inc.strip_suffix(".*") {
        Some(base) => path.starts_with(&format!("{base}.")), // base.* accepts strictly BELOW base (trailing dot required)
        None => matches_path(path, std::slice::from_ref(inc)), // plain path / full glob match
    })
};
let already_empty_and_accepted = obj.is_empty() && (includes.is_empty() || path_is_accepting(prefix));
if result.is_empty() && !prefix.is_empty() && !already_empty_and_accepted { Value::Null } else { Value::Object(result) }
```

- match-all / exclude-only → the empty object survives (the reported bug);
- plain `meta.foo` → bare `meta` is a non-accepting prefix → dropped, as ES does;
- glob `meta.*` → ES's automaton needs the trailing dot, so bare `meta` (and prefix-sharing `metadata`) drop while a path strictly below `meta` is accepted. `matches_path` could NOT be reused as the accept test — its `.*` clause matched the dot-less prefix.

Only objects that *filtering* emptied are still pruned. For non-empty objects the diff is a no-op.

## Verification
- Tests: `dotted_filter_keeps_an_already_empty_source_object_but_prunes_a_filtering_emptied_one`; `dotted_include_keeps_an_empty_object_only_when_its_own_path_is_accepted` (plain-prefix drops; own-path preserves; `.*`-glob prefix drops; strictly-under-glob preserves; prefix-sharing `metadata` drops; non-empty sibling drops the same way).
- **Fail-before proven** at each step (revert `!obj.is_empty()` → exclude case fails; revert the accept gate to `matches_path` → `.*`-glob leaks `{"meta":{}}`).
- fmt clean; clippy `-D warnings` 0; **full `xerj-engine` suite 49 binaries / 0 failed** (lib 614 passed).
- **Three** adversarial 3-skeptic rounds shaped this: round 1 caught plain-prefix over-preservation, round 2 caught `.*`-glob divergence, round 3 = 0 BLOCKING. Verdicts in the comments.

## Scope
Addresses **#310 part 2** only. Part 1 (a `fields`-named companion resolved against the Default-stripped source) is a separate cross-layer change tracked on #310. Pre-existing `matches_path` glob divergences surfaced during verification (unchanged by this PR, identical on main) are filed separately.