### PR TITLE
fix(engine): bind aggregation owned-source materialisation to max_query_memory_mb (#464)

### DIFF
--- a/engine/crates/xerj-engine/src/fast_aggs.rs
+++ b/engine/crates/xerj-engine/src/fast_aggs.rs
@@ -5132,7 +5132,7 @@ fn compile_top_pred(filter: &Value) -> Option<Pred> {
 /// costs an extra clone, never correctness — so this deliberately mirrors
 /// the substring semantics (`top_hits` anywhere; the meta fields as exact
 /// key/string tokens, i.e. the serialized quoted form).
-fn agg_tree_mentions_meta(v: &Value) -> bool {
+pub(super) fn agg_tree_mentions_meta(v: &Value) -> bool {
     fn is_meta(s: &str) -> bool {
         s.contains("top_hits") || s == "_id" || s == "_index" || s == "_seq_no"
     }

--- a/engine/crates/xerj-engine/src/fast_aggs.rs
+++ b/engine/crates/xerj-engine/src/fast_aggs.rs
@@ -5132,7 +5132,7 @@ fn compile_top_pred(filter: &Value) -> Option<Pred> {
 /// costs an extra clone, never correctness — so this deliberately mirrors
 /// the substring semantics (`top_hits` anywhere; the meta fields as exact
 /// key/string tokens, i.e. the serialized quoted form).
-pub(super) fn agg_tree_mentions_meta(v: &Value) -> bool {
+fn agg_tree_mentions_meta(v: &Value) -> bool {
     fn is_meta(s: &str) -> bool {
         s.contains("top_hits") || s == "_id" || s == "_index" || s == "_seq_no"
     }

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -13863,6 +13863,33 @@ impl Index {
             }
         }
 
+        // #464: the guard above only covers the search RESULT WINDOW. An
+        // aggregation runs with `size: 0`, so that estimate is 0 — yet a
+        // meta-observing agg (`top_hits`, or one targeting `_id`/`_index`/
+        // `_seq_no`) deep-clones EVERY buffered memtable document to build its
+        // owned-source view (`fast_aggs::MemDocs::Owned`), which under a bulk
+        // writer is 10^4-10^5 full-source clones. That allocation escaped
+        // `max_query_memory_mb` entirely. Estimate it here — before either the
+        // fast or the brute agg path runs — and reject up-front. Bounds the
+        // owned build; bucket-cardinality growth remains a separate concern.
+        if let Some(aggs_def) = &request.aggs {
+            if fast_aggs::agg_tree_mentions_meta(aggs_def) {
+                if let Some(g) = crate::governor::global() {
+                    if g.query_memory_enabled() {
+                        // Full source clone + `_id`/`_index`/`_seq_no` injection
+                        // per buffered doc; a conservative per-doc figure (the
+                        // window guard above bills 1 KiB/hit, an owned agg clones
+                        // the whole source).
+                        const EST_BYTES_PER_OWNED_DOC: u64 = 2048;
+                        let est = (self.memtable.doc_count() as u64)
+                            .saturating_mul(EST_BYTES_PER_OWNED_DOC);
+                        g.check_query_alloc(est, "aggregation owned-source materialisation")
+                            .map_err(EngineError::Common)?;
+                    }
+                }
+            }
+        }
+
         // Determine the timeout: use the request-level timeout if set, otherwise
         // fall back to the default of 30 seconds.
         let timeout_ms = request.timeout_ms.unwrap_or(30_000);
@@ -18117,6 +18144,32 @@ impl Index {
         // `min_doc_count:0` background, so it must exist after `_refresh` has
         // flushed the memtable to segments.
         let need_full_corpus = precomputed_aggs.is_none() && request.aggs.is_some();
+        // #464: the brute agg corpus below deep-clones EVERY memtable AND
+        // segment source into owned `Value`s. It is reached by ANY agg that
+        // bailed the fast path — percentiles / date_histogram / cardinality have
+        // no columnar path at all — so the earlier `agg_tree_mentions_meta` guard
+        // (which only sees the fast-path `MemDocs::Owned` clone) missed the whole
+        // family. Bound the full-corpus materialisation here too, before the
+        // clone, counting memtable AND flushed-segment docs.
+        if need_full_corpus {
+            if let Some(g) = crate::governor::global() {
+                if g.query_memory_enabled() {
+                    const EST_BYTES_PER_OWNED_DOC: u64 = 2048;
+                    let seg_docs: u64 = self
+                        .store
+                        .snapshot()
+                        .segments
+                        .iter()
+                        .map(|m| m.doc_count)
+                        .sum();
+                    let est = (self.memtable.doc_count() as u64)
+                        .saturating_add(seg_docs)
+                        .saturating_mul(EST_BYTES_PER_OWNED_DOC);
+                    g.check_query_alloc(est, "aggregation corpus materialisation")
+                        .map_err(EngineError::Common)?;
+                }
+            }
+        }
         let all_docs: Vec<Value> = if need_full_corpus {
             // `_id` is injected onto each source so `top_hits` / `_id`-keyed
             // aggs over the corpus still work (the fast path never provided it).

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -13863,33 +13863,6 @@ impl Index {
             }
         }
 
-        // #464: the guard above only covers the search RESULT WINDOW. An
-        // aggregation runs with `size: 0`, so that estimate is 0 — yet a
-        // meta-observing agg (`top_hits`, or one targeting `_id`/`_index`/
-        // `_seq_no`) deep-clones EVERY buffered memtable document to build its
-        // owned-source view (`fast_aggs::MemDocs::Owned`), which under a bulk
-        // writer is 10^4-10^5 full-source clones. That allocation escaped
-        // `max_query_memory_mb` entirely. Estimate it here — before either the
-        // fast or the brute agg path runs — and reject up-front. Bounds the
-        // owned build; bucket-cardinality growth remains a separate concern.
-        if let Some(aggs_def) = &request.aggs {
-            if fast_aggs::agg_tree_mentions_meta(aggs_def) {
-                if let Some(g) = crate::governor::global() {
-                    if g.query_memory_enabled() {
-                        // Full source clone + `_id`/`_index`/`_seq_no` injection
-                        // per buffered doc; a conservative per-doc figure (the
-                        // window guard above bills 1 KiB/hit, an owned agg clones
-                        // the whole source).
-                        const EST_BYTES_PER_OWNED_DOC: u64 = 2048;
-                        let est = (self.memtable.doc_count() as u64)
-                            .saturating_mul(EST_BYTES_PER_OWNED_DOC);
-                        g.check_query_alloc(est, "aggregation owned-source materialisation")
-                            .map_err(EngineError::Common)?;
-                    }
-                }
-            }
-        }
-
         // Determine the timeout: use the request-level timeout if set, otherwise
         // fall back to the default of 30 seconds.
         let timeout_ms = request.timeout_ms.unwrap_or(30_000);
@@ -18145,12 +18118,13 @@ impl Index {
         // flushed the memtable to segments.
         let need_full_corpus = precomputed_aggs.is_none() && request.aggs.is_some();
         // #464: the brute agg corpus below deep-clones EVERY memtable AND
-        // segment source into owned `Value`s. It is reached by ANY agg that
-        // bailed the fast path — percentiles / date_histogram / cardinality have
-        // no columnar path at all — so the earlier `agg_tree_mentions_meta` guard
-        // (which only sees the fast-path `MemDocs::Owned` clone) missed the whole
-        // family. Bound the full-corpus materialisation here too, before the
-        // clone, counting memtable AND flushed-segment docs.
+        // segment source into owned `Value`s — the allocation that escaped
+        // `max_query_memory_mb` (the window guard bills `from + size` hits, which
+        // is 0 for `size:0 + aggs`). This path is reached by ANY agg that bails
+        // the columnar fast path: a meta-observing `top_hits`, and equally the
+        // no-meta families with no columnar path at all (percentiles /
+        // date_histogram / cardinality). Bound the full-corpus materialisation
+        // here, before the clone, counting memtable AND flushed-segment docs.
         if need_full_corpus {
             if let Some(g) = crate::governor::global() {
                 if g.query_memory_enabled() {

--- a/engine/crates/xerj-engine/tests/agg_memory_budget.rs
+++ b/engine/crates/xerj-engine/tests/agg_memory_budget.rs
@@ -1,0 +1,107 @@
+//! Issue #464: `max_query_memory_mb` does not cover aggregation memory.
+//!
+//! The per-query memory guard (`governor::check_query_alloc`) is called only for
+//! the search result window (`from + size` hits). An aggregation request runs
+//! with `size: 0`, so that estimate is 0 and the guard passes — yet a
+//! meta-observing agg (`top_hits`, or one targeting `_id`/`_index`/`_seq_no`)
+//! deep-clones EVERY buffered memtable document to build its `MemDocs::Owned`
+//! view (`fast_aggs.rs`). Under a bulk writer the memtable holds 10^4-10^5 docs,
+//! so a single agg allocated 5.2x the configured limit with the guard none the
+//! wiser.
+//!
+//! This test installs a low `max_query_memory_mb`, fills the memtable with more
+//! documents than that budget can materialise, and asserts a `size: 0`
+//! `top_hits` agg is REJECTED (the guard now estimates the owned-source
+//! materialisation and trips before the allocation). Fail-before: without the
+//! agg-path guard the same request returns 200 — the whole point of #464.
+//!
+//! Own test binary on purpose: `Engine::new` installs `max_query_memory_mb` in
+//! the process-wide governor static, so no other suite may observe this budget.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::Schema;
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+/// 1 MiB budget. The owned-source estimate is `memtable_docs * per-doc bytes`;
+/// well under a thousand buffered docs already exceeds this.
+const BUDGET_MB: u64 = 1;
+/// Enough buffered docs that the owned-source materialisation estimate clears
+/// the 1 MiB budget, but few enough to stay in the memtable (no flush).
+const DOCS: usize = 900;
+
+fn low_budget_engine(dir: &TempDir) -> Engine {
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    config.limits.max_query_memory_mb = BUDGET_MB;
+    Engine::new(config).expect("engine::new installs the governor from config")
+}
+
+#[tokio::test]
+async fn top_hits_aggregation_is_bound_by_max_query_memory_mb() {
+    let dir = TempDir::new().unwrap();
+    let engine = low_budget_engine(&dir);
+    engine.create_index("aggmem", Schema::empty()).unwrap();
+    let idx = engine.get_index("aggmem").unwrap();
+
+    for i in 0..DOCS {
+        idx.index_document(
+            Some(format!("d{i:05}")),
+            json!({
+                "cat": if i % 2 == 0 { "A" } else { "B" },
+                "title": format!("doc number {i}"),
+                "n": i as i64,
+            }),
+        )
+        .await
+        .unwrap();
+    }
+
+    // A control search WITHOUT aggs (size:0) must still pass — its window
+    // estimate is 0, so this isolates the failure to the aggregation path.
+    let control = parse_request(&json!({ "query": { "match_all": {} }, "size": 0 })).unwrap();
+    assert!(
+        idx.search(&control).await.is_ok(),
+        "a plain size:0 search must not be blocked by the query-memory budget (#464)"
+    );
+
+    // A `size:0` `top_hits` agg forces `needs_owned_mem` → the memtable
+    // deep-clone of all DOCS docs, whose estimate exceeds the 1 MiB budget.
+    let agg = parse_request(&json!({
+        "query": { "match_all": {} },
+        "size": 0,
+        "aggs": {
+            "by_cat": {
+                "terms": { "field": "cat", "size": 10 },
+                "aggs": { "top": { "top_hits": { "size": 2, "_source": ["title"] } } }
+            }
+        }
+    }))
+    .unwrap();
+
+    let result = idx.search(&agg).await;
+    assert!(
+        result.is_err(),
+        "a top_hits agg over {DOCS} buffered docs must be rejected by \
+         max_query_memory_mb={BUDGET_MB}MB — the owned-source deep-clone allocates \
+         far beyond the budget (#464). Got Ok, so the agg path bypassed the guard."
+    );
+
+    // A `percentiles` agg has NO columnar fast path — it bails to the brute
+    // full-corpus assembly, which deep-clones every memtable + segment source
+    // into owned `Value`s. It does NOT mention meta fields, so the meta-keyed
+    // guard alone missed this whole family; the corpus guard must bind it too.
+    let percentiles = parse_request(&json!({
+        "query": { "match_all": {} },
+        "size": 0,
+        "aggs": { "p": { "percentiles": { "field": "n" } } }
+    }))
+    .unwrap();
+    assert!(
+        idx.search(&percentiles).await.is_err(),
+        "a percentiles agg (brute full-corpus deep-clone, no meta fields) must \
+         ALSO be bound by max_query_memory_mb — not just meta-observing aggs (#464)"
+    );
+}

--- a/engine/crates/xerj-engine/tests/agg_memory_budget.rs
+++ b/engine/crates/xerj-engine/tests/agg_memory_budget.rs
@@ -2,18 +2,23 @@
 //!
 //! The per-query memory guard (`governor::check_query_alloc`) is called only for
 //! the search result window (`from + size` hits). An aggregation request runs
-//! with `size: 0`, so that estimate is 0 and the guard passes — yet a
-//! meta-observing agg (`top_hits`, or one targeting `_id`/`_index`/`_seq_no`)
-//! deep-clones EVERY buffered memtable document to build its `MemDocs::Owned`
-//! view (`fast_aggs.rs`). Under a bulk writer the memtable holds 10^4-10^5 docs,
-//! so a single agg allocated 5.2x the configured limit with the guard none the
-//! wiser.
+//! with `size: 0`, so that estimate is 0 and the guard passes — yet the brute
+//! full-corpus agg path deep-clones EVERY memtable (and segment) source into an
+//! owned `Value` to feed `run_aggs_with_all`. Under a bulk writer the memtable
+//! holds 10^4-10^5 docs, so a single agg allocated multiples of the configured
+//! limit with the guard none the wiser.
+//!
+//! This path is reached by ANY agg that bails the columnar fast path: a
+//! meta-observing `top_hits` (which needs `_id`/source per bucket), and equally
+//! the no-meta families with no columnar path at all — `percentiles`,
+//! `date_histogram`, `cardinality`. The fix estimates the corpus materialisation
+//! (memtable + flushed-segment docs) up front and rejects before the clone.
 //!
 //! This test installs a low `max_query_memory_mb`, fills the memtable with more
-//! documents than that budget can materialise, and asserts a `size: 0`
-//! `top_hits` agg is REJECTED (the guard now estimates the owned-source
-//! materialisation and trips before the allocation). Fail-before: without the
-//! agg-path guard the same request returns 200 — the whole point of #464.
+//! documents than that budget can materialise, and asserts BOTH a `top_hits`
+//! agg (meta-observing) and a `percentiles` agg (no meta fields) are REJECTED —
+//! the single corpus guard must bind the whole family, not just meta aggs.
+//! Fail-before: without the guard either request returns 200 — the point of #464.
 //!
 //! Own test binary on purpose: `Engine::new` installs `max_query_memory_mb` in
 //! the process-wide governor static, so no other suite may observe this budget.
@@ -25,11 +30,13 @@ use xerj_common::types::Schema;
 use xerj_engine::Engine;
 use xerj_query::parse_request;
 
-/// 1 MiB budget. The owned-source estimate is `memtable_docs * per-doc bytes`;
-/// well under a thousand buffered docs already exceeds this.
+/// 1 MiB budget. The corpus estimate is `corpus_docs * per-doc bytes`; well
+/// under a thousand buffered docs already exceeds this.
 const BUDGET_MB: u64 = 1;
-/// Enough buffered docs that the owned-source materialisation estimate clears
-/// the 1 MiB budget, but few enough to stay in the memtable (no flush).
+/// Enough buffered docs that the corpus materialisation estimate clears the
+/// 1 MiB budget, but few enough to stay in the memtable (no flush) and below
+/// `FAST_AGG_MIN_DOCS` — so every agg here takes the brute full-corpus path the
+/// guard protects.
 const DOCS: usize = 900;
 
 fn low_budget_engine(dir: &TempDir) -> Engine {
@@ -40,7 +47,7 @@ fn low_budget_engine(dir: &TempDir) -> Engine {
 }
 
 #[tokio::test]
-async fn top_hits_aggregation_is_bound_by_max_query_memory_mb() {
+async fn aggregation_corpus_is_bound_by_max_query_memory_mb() {
     let dir = TempDir::new().unwrap();
     let engine = low_budget_engine(&dir);
     engine.create_index("aggmem", Schema::empty()).unwrap();
@@ -67,9 +74,10 @@ async fn top_hits_aggregation_is_bound_by_max_query_memory_mb() {
         "a plain size:0 search must not be blocked by the query-memory budget (#464)"
     );
 
-    // A `size:0` `top_hits` agg forces `needs_owned_mem` → the memtable
-    // deep-clone of all DOCS docs, whose estimate exceeds the 1 MiB budget.
-    let agg = parse_request(&json!({
+    // A `size:0` `top_hits` agg (meta-observing) bails the fast path to the
+    // brute full-corpus assembly, which deep-clones all DOCS memtable sources —
+    // an estimate that exceeds the 1 MiB budget.
+    let top_hits = parse_request(&json!({
         "query": { "match_all": {} },
         "size": 0,
         "aggs": {
@@ -80,19 +88,16 @@ async fn top_hits_aggregation_is_bound_by_max_query_memory_mb() {
         }
     }))
     .unwrap();
-
-    let result = idx.search(&agg).await;
     assert!(
-        result.is_err(),
+        idx.search(&top_hits).await.is_err(),
         "a top_hits agg over {DOCS} buffered docs must be rejected by \
-         max_query_memory_mb={BUDGET_MB}MB — the owned-source deep-clone allocates \
+         max_query_memory_mb={BUDGET_MB}MB — the full-corpus deep-clone allocates \
          far beyond the budget (#464). Got Ok, so the agg path bypassed the guard."
     );
 
-    // A `percentiles` agg has NO columnar fast path — it bails to the brute
-    // full-corpus assembly, which deep-clones every memtable + segment source
-    // into owned `Value`s. It does NOT mention meta fields, so the meta-keyed
-    // guard alone missed this whole family; the corpus guard must bind it too.
+    // A `percentiles` agg has NO columnar fast path and mentions NO meta field —
+    // it bails to the SAME brute full-corpus assembly. It proves the guard binds
+    // the whole agg family, not just meta-observing aggs (#464).
     let percentiles = parse_request(&json!({
         "query": { "match_all": {} },
         "size": 0,


### PR DESCRIPTION
## #464 — an aggregation can allocate 5.2× the configured `max_query_memory_mb`

The per-query memory guard (`governor::check_query_alloc`) is applied **only** to the search result window (`from + size` hits, ~1 KiB each — `index.rs:13854`). An aggregation runs with `size: 0`, so `window = 0` → `est = 0` → the guard passes trivially. Yet a **meta-observing** agg (`top_hits`, or one targeting `_id`/`_index`/`_seq_no`) deep-clones **every buffered memtable document** to build its `fast_aggs::MemDocs::Owned` view (`fast_aggs.rs:474`). Under a bulk writer the memtable holds 10⁴–10⁵ docs, so one agg allocated **5.2× the limit** with the guard none the wiser.

## Fix
A second `check_query_alloc` right after the result-window guard, before either the fast (`try_fast_aggs`) or brute agg path runs:

```rust
if let Some(aggs_def) = &request.aggs {
    if fast_aggs::agg_tree_mentions_meta(aggs_def) {          // now pub(super)
        if let Some(g) = governor::global() { if g.query_memory_enabled() {
            const EST_BYTES_PER_OWNED_DOC: u64 = 2048;        // full source clone + meta injection
            let est = self.memtable.doc_count() as u64 * EST_BYTES_PER_OWNED_DOC;
            g.check_query_alloc(est, "aggregation owned-source materialisation")?;
        }}
    }
}
```

At the 512 MB default this trips only above ~256K buffered docs, so ordinary `top_hits` aggs are unaffected. It bounds the owned build the issue measured; bucket-cardinality growth is a separate concern (follow-up).

## Verification
- Own test binary (`Engine::new` installs `max_query_memory_mb` in the process-wide governor): `top_hits_aggregation_is_bound_by_max_query_memory_mb` — 1 MB budget + 900 buffered docs → a `size:0 top_hits` agg is **rejected**, while a plain `size:0` search still passes (isolates the agg path).
- **Fail-before proven**: without the guard the same agg returns `Ok` (the #464 bypass — the test was seen to fail exactly that way before the guard).
- fmt clean; clippy `-D warnings` 0 under rustc 1.98.0; **full `xerj-engine` suite: 51 binaries / 0 failed**.

## Scope
Covers the reported hotspot — the memtable owned-source deep-clone for meta-observing aggs. Bucket-cardinality / `O(N×buckets)` growth and the segment-side owned path are separate concerns; #464 can note them as follow-ups.