### PR TITLE
fix(api): render collapse inner_hits on scroll continuation pages (#621)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8443,6 +8443,235 @@ mod inner_hit_versioning_tests {
     }
 }
 
+/// Render a collapse leader's `inner_hits` from the `__xy_collapse_group__`
+/// / `__xy_collapse_spec__` sentinels `apply_collapse` planted in its
+/// `_source`, honoring each spec's `size`/`from`/`sort`/`collapse`/`fields`
+/// and the snapshot `_version`/`_seq_no` carried per member (never a
+/// render-time live lookup — #506/#566). Shared by `search_impl` and the
+/// scroll continuation (`scroll_page_response`) so a collapsed scroll renders
+/// inner_hits identically instead of leaking the sentinels into `_source`
+/// (#621).
+fn render_collapse_inner_hits(
+    group: Vec<Value>,
+    spec: Value,
+    idx_name: &str,
+    rest_total_hits_as_int: bool,
+) -> Value {
+    let spec_list: Vec<Value> = match spec {
+        Value::Array(a) => a,
+        other => vec![other],
+    };
+    let mut combined = serde_json::Map::new();
+    for spec in &spec_list {
+        let name = spec
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("inner_hits")
+            .to_string();
+        let size = spec.get("size").and_then(Value::as_u64).unwrap_or(3) as usize;
+        let sort_spec = spec.get("sort").cloned().unwrap_or(Value::Null);
+        let from_spec = spec.get("from").and_then(Value::as_u64).unwrap_or(0) as usize;
+        let mut members = group.clone();
+        if let Value::Array(sort_arr) = &sort_spec {
+            for s in sort_arr.iter().rev() {
+                if let Some(obj) = s.as_object() {
+                    for (field, opts) in obj {
+                        let desc = match opts {
+                            Value::String(s) => s == "desc",
+                            Value::Object(o) => o
+                                .get("order")
+                                .and_then(Value::as_str)
+                                .map(|v| v == "desc")
+                                .unwrap_or(false),
+                            _ => false,
+                        };
+                        let f = field.clone();
+                        // Compare numerically when both sides
+                        // parse as numbers, else fall back to a
+                        // lexicographic string compare so keyword
+                        // and date fields sort correctly. Ties
+                        // break on `_id` so the result is
+                        // deterministic across runs and matches
+                        // ES's `_doc` secondary sort for
+                        // monotonically-assigned ids.
+                        members.sort_by(|a, b| {
+                            let av = a.get("_source").and_then(|s| s.get(&f));
+                            let bv = b.get("_source").and_then(|s| s.get(&f));
+                            let av_n = av.and_then(Value::as_f64);
+                            let bv_n = bv.and_then(Value::as_f64);
+                            let primary = match (av_n, bv_n) {
+                                (Some(x), Some(y)) => {
+                                    x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal)
+                                }
+                                _ => {
+                                    let to_str = |v: Option<&Value>| match v {
+                                        Some(Value::String(s)) => Some(s.clone()),
+                                        Some(other) if !other.is_null() => Some(other.to_string()),
+                                        _ => None,
+                                    };
+                                    let av_s = to_str(av);
+                                    let bv_s = to_str(bv);
+                                    match (av_s, bv_s) {
+                                        (Some(x), Some(y)) => x.cmp(&y),
+                                        (Some(_), None) => std::cmp::Ordering::Less,
+                                        (None, Some(_)) => std::cmp::Ordering::Greater,
+                                        (None, None) => std::cmp::Ordering::Equal,
+                                    }
+                                }
+                            };
+                            let primary = if desc { primary.reverse() } else { primary };
+                            if primary != std::cmp::Ordering::Equal {
+                                return primary;
+                            }
+                            let aid = a.get("_id").and_then(Value::as_str).unwrap_or("");
+                            let bid = b.get("_id").and_then(Value::as_str).unwrap_or("");
+                            aid.cmp(bid)
+                        });
+                    }
+                }
+            }
+        }
+        let emit_seq_no_ih = spec
+            .get("seq_no_primary_term")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let emit_version_ih = spec
+            .get("version")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        // `inner_hits.collapse.field` — second-level collapse
+        // applied to the group members. ES counts `total` against
+        // the pre-collapse member set but the returned `hits` are
+        // deduped by the inner collapse field, preserving sort
+        // order. (See ES 8.13 multi-level collapse.)
+        let total = members.len();
+        if let Some(inner_field) = spec
+            .get("collapse")
+            .and_then(|c| c.get("field"))
+            .and_then(Value::as_str)
+        {
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+            members.retain(|m| {
+                let key = m
+                    .get("_source")
+                    .and_then(|s| s.get(inner_field))
+                    .map(|v| match v {
+                        Value::String(s) => s.clone(),
+                        Value::Number(n) => n.to_string(),
+                        Value::Bool(b) => b.to_string(),
+                        Value::Null => "\0null".to_string(),
+                        other => other.to_string(),
+                    })
+                    .unwrap_or_else(|| "\0missing".to_string());
+                seen.insert(key)
+            });
+        }
+        let rendered_hits: Vec<Value> = members
+            .into_iter()
+            .skip(from_spec)
+            .take(size)
+            .map(|mut m| {
+                if let Some(src) = m.get_mut("_source").and_then(Value::as_object_mut) {
+                    src.remove("__xy_collapse_group__");
+                    src.remove("__xy_collapse_spec__");
+                }
+                let mut hit_obj = serde_json::Map::new();
+                hit_obj.insert("_index".to_string(), Value::String(idx_name.to_string()));
+                if let Some(id) = m.get("_id").cloned() {
+                    hit_obj.insert("_id".to_string(), id);
+                }
+                if let Some(score) = m.get("_score").cloned() {
+                    hit_obj.insert("_score".to_string(), score);
+                }
+                // Snapshotted `_version` / `_seq_no` carried in the
+                // collapse group (#506) — NOT a render-time live
+                // lookup, which could pair a live version with the
+                // snapshot `_source` on a collapsed scroll. An absent
+                // snapshot value is OMITTED, not fabricated (#566).
+                emit_inner_hit_versioning(&m, emit_seq_no_ih, emit_version_ih, &mut hit_obj);
+                if let Some(src) = m.get("_source").cloned() {
+                    hit_obj.insert("_source".to_string(), src);
+                }
+                // inner_hits `fields` — emit the requested
+                // source fields as a `fields: {name: [values]}`
+                // map matching top-level hit semantics.
+                let mut fmap = serde_json::Map::new();
+                if let Some(ih_fields) = spec.get("fields").and_then(Value::as_array) {
+                    for f in ih_fields {
+                        let fname = match f {
+                            Value::String(s) => s.as_str(),
+                            Value::Object(o) => {
+                                o.get("field").and_then(Value::as_str).unwrap_or("")
+                            }
+                            _ => continue,
+                        };
+                        if fname.is_empty() {
+                            continue;
+                        }
+                        if let Some(src) = m.get("_source") {
+                            if let Some(v) = src.get(fname).cloned() {
+                                let wrapped = match v {
+                                    Value::Array(a) => Value::Array(a),
+                                    Value::Null => continue,
+                                    other => Value::Array(vec![other]),
+                                };
+                                fmap.insert(fname.to_string(), wrapped);
+                            }
+                        }
+                    }
+                }
+                // ES auto-emits the inner-collapse field into
+                // `fields` even without an explicit `fields`
+                // clause, mirroring the top-level collapse
+                // behavior (see line ~7070).
+                if let Some(inner_field) = spec
+                    .get("collapse")
+                    .and_then(|c| c.get("field"))
+                    .and_then(Value::as_str)
+                {
+                    if !fmap.contains_key(inner_field) {
+                        if let Some(v) = m.get("_source").and_then(|s| s.get(inner_field)).cloned()
+                        {
+                            let wrapped = match v {
+                                Value::Array(a) => Value::Array(a),
+                                Value::Null => Value::Array(vec![]),
+                                other => Value::Array(vec![other]),
+                            };
+                            if !matches!(&wrapped, Value::Array(a) if a.is_empty()) {
+                                fmap.insert(inner_field.to_string(), wrapped);
+                            }
+                        }
+                    }
+                }
+                if !fmap.is_empty() {
+                    hit_obj.insert("fields".to_string(), Value::Object(fmap));
+                }
+                Value::Object(hit_obj)
+            })
+            .collect();
+        // When the caller set `rest_total_hits_as_int: true`
+        // on the outer request, inner_hits totals become
+        // bare numbers — mirror the top-level hits.total
+        // shape.
+        let inner_total = if rest_total_hits_as_int {
+            json!(total as u64)
+        } else {
+            json!({ "value": total as u64, "relation": "eq" })
+        };
+        combined.insert(
+            name,
+            serde_json::json!({
+                "hits": {
+                    "total": inner_total,
+                    "max_score": Value::Null,
+                    "hits": rendered_hits,
+                }
+            }),
+        );
+    }
+    Value::Object(combined)
+}
+
 async fn search_impl(
     state: AppState,
     index: String,
@@ -13240,225 +13469,12 @@ async fn search_impl(
             // The spec may be a single object or an array of objects so
             // tests can declare multiple named inner_hits per collapse.
             if let (Some(group), Some(spec)) = (collapse_group, collapse_spec) {
-                let spec_list: Vec<Value> = match spec {
-                    Value::Array(a) => a,
-                    other => vec![other],
-                };
-                let mut combined = serde_json::Map::new();
-                for spec in &spec_list {
-                    let name = spec
-                        .get("name")
-                        .and_then(Value::as_str)
-                        .unwrap_or("inner_hits")
-                        .to_string();
-                    let size = spec
-                        .get("size")
-                        .and_then(Value::as_u64)
-                        .unwrap_or(3) as usize;
-                    let sort_spec = spec.get("sort").cloned().unwrap_or(Value::Null);
-                    let from_spec = spec.get("from").and_then(Value::as_u64).unwrap_or(0) as usize;
-                    let mut members = group.clone();
-                    if let Value::Array(sort_arr) = &sort_spec {
-                        for s in sort_arr.iter().rev() {
-                            if let Some(obj) = s.as_object() {
-                                for (field, opts) in obj {
-                                    let desc = match opts {
-                                        Value::String(s) => s == "desc",
-                                        Value::Object(o) => o
-                                            .get("order")
-                                            .and_then(Value::as_str)
-                                            .map(|v| v == "desc")
-                                            .unwrap_or(false),
-                                        _ => false,
-                                    };
-                                    let f = field.clone();
-                                    // Compare numerically when both sides
-                                    // parse as numbers, else fall back to a
-                                    // lexicographic string compare so keyword
-                                    // and date fields sort correctly. Ties
-                                    // break on `_id` so the result is
-                                    // deterministic across runs and matches
-                                    // ES's `_doc` secondary sort for
-                                    // monotonically-assigned ids.
-                                    members.sort_by(|a, b| {
-                                        let av = a.get("_source").and_then(|s| s.get(&f));
-                                        let bv = b.get("_source").and_then(|s| s.get(&f));
-                                        let av_n = av.and_then(Value::as_f64);
-                                        let bv_n = bv.and_then(Value::as_f64);
-                                        let primary = match (av_n, bv_n) {
-                                            (Some(x), Some(y)) => x
-                                                .partial_cmp(&y)
-                                                .unwrap_or(std::cmp::Ordering::Equal),
-                                            _ => {
-                                                let to_str = |v: Option<&Value>| match v {
-                                                    Some(Value::String(s)) => Some(s.clone()),
-                                                    Some(other) if !other.is_null() => Some(other.to_string()),
-                                                    _ => None,
-                                                };
-                                                let av_s = to_str(av);
-                                                let bv_s = to_str(bv);
-                                                match (av_s, bv_s) {
-                                                    (Some(x), Some(y)) => x.cmp(&y),
-                                                    (Some(_), None) => std::cmp::Ordering::Less,
-                                                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                                                    (None, None) => std::cmp::Ordering::Equal,
-                                                }
-                                            }
-                                        };
-                                        let primary = if desc { primary.reverse() } else { primary };
-                                        if primary != std::cmp::Ordering::Equal { return primary; }
-                                        let aid = a.get("_id").and_then(Value::as_str).unwrap_or("");
-                                        let bid = b.get("_id").and_then(Value::as_str).unwrap_or("");
-                                        aid.cmp(bid)
-                                    });
-                                }
-                            }
-                        }
-                    }
-                    let emit_seq_no_ih = spec
-                        .get("seq_no_primary_term")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false);
-                    let emit_version_ih = spec
-                        .get("version")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false);
-                    // `inner_hits.collapse.field` — second-level collapse
-                    // applied to the group members. ES counts `total` against
-                    // the pre-collapse member set but the returned `hits` are
-                    // deduped by the inner collapse field, preserving sort
-                    // order. (See ES 8.13 multi-level collapse.)
-                    let total = members.len();
-                    if let Some(inner_field) = spec
-                        .get("collapse")
-                        .and_then(|c| c.get("field"))
-                        .and_then(Value::as_str)
-                    {
-                        let mut seen: std::collections::HashSet<String> =
-                            std::collections::HashSet::new();
-                        members.retain(|m| {
-                            let key = m
-                                .get("_source")
-                                .and_then(|s| s.get(inner_field))
-                                .map(|v| match v {
-                                    Value::String(s) => s.clone(),
-                                    Value::Number(n) => n.to_string(),
-                                    Value::Bool(b) => b.to_string(),
-                                    Value::Null => "\0null".to_string(),
-                                    other => other.to_string(),
-                                })
-                                .unwrap_or_else(|| "\0missing".to_string());
-                            seen.insert(key)
-                        });
-                    }
-                    let rendered_hits: Vec<Value> = members
-                        .into_iter()
-                        .skip(from_spec)
-                        .take(size)
-                        .map(|mut m| {
-                            if let Some(src) = m.get_mut("_source").and_then(Value::as_object_mut) {
-                                src.remove("__xy_collapse_group__");
-                                src.remove("__xy_collapse_spec__");
-                            }
-                            let mut hit_obj = serde_json::Map::new();
-                            hit_obj.insert("_index".to_string(), Value::String(idx_name.clone()));
-                            if let Some(id) = m.get("_id").cloned() {
-                                hit_obj.insert("_id".to_string(), id);
-                            }
-                            if let Some(score) = m.get("_score").cloned() {
-                                hit_obj.insert("_score".to_string(), score);
-                            }
-                            // Snapshotted `_version` / `_seq_no` carried in the
-                            // collapse group (#506) — NOT a render-time live
-                            // lookup, which could pair a live version with the
-                            // snapshot `_source` on a collapsed scroll. An absent
-                            // snapshot value is OMITTED, not fabricated (#566).
-                            emit_inner_hit_versioning(
-                                &m,
-                                emit_seq_no_ih,
-                                emit_version_ih,
-                                &mut hit_obj,
-                            );
-                            if let Some(src) = m.get("_source").cloned() {
-                                hit_obj.insert("_source".to_string(), src);
-                            }
-                            // inner_hits `fields` — emit the requested
-                            // source fields as a `fields: {name: [values]}`
-                            // map matching top-level hit semantics.
-                            let mut fmap = serde_json::Map::new();
-                            if let Some(ih_fields) = spec.get("fields").and_then(Value::as_array) {
-                                for f in ih_fields {
-                                    let fname = match f {
-                                        Value::String(s) => s.as_str(),
-                                        Value::Object(o) => o.get("field").and_then(Value::as_str).unwrap_or(""),
-                                        _ => continue,
-                                    };
-                                    if fname.is_empty() { continue; }
-                                    if let Some(src) = m.get("_source") {
-                                        if let Some(v) = src.get(fname).cloned() {
-                                            let wrapped = match v {
-                                                Value::Array(a) => Value::Array(a),
-                                                Value::Null => continue,
-                                                other => Value::Array(vec![other]),
-                                            };
-                                            fmap.insert(fname.to_string(), wrapped);
-                                        }
-                                    }
-                                }
-                            }
-                            // ES auto-emits the inner-collapse field into
-                            // `fields` even without an explicit `fields`
-                            // clause, mirroring the top-level collapse
-                            // behavior (see line ~7070).
-                            if let Some(inner_field) = spec
-                                .get("collapse")
-                                .and_then(|c| c.get("field"))
-                                .and_then(Value::as_str)
-                            {
-                                if !fmap.contains_key(inner_field) {
-                                    if let Some(v) = m
-                                        .get("_source")
-                                        .and_then(|s| s.get(inner_field))
-                                        .cloned()
-                                    {
-                                        let wrapped = match v {
-                                            Value::Array(a) => Value::Array(a),
-                                            Value::Null => Value::Array(vec![]),
-                                            other => Value::Array(vec![other]),
-                                        };
-                                        if !matches!(&wrapped, Value::Array(a) if a.is_empty()) {
-                                            fmap.insert(inner_field.to_string(), wrapped);
-                                        }
-                                    }
-                                }
-                            }
-                            if !fmap.is_empty() {
-                                hit_obj.insert("fields".to_string(), Value::Object(fmap));
-                            }
-                            Value::Object(hit_obj)
-                        })
-                        .collect();
-                    // When the caller set `rest_total_hits_as_int: true`
-                    // on the outer request, inner_hits totals become
-                    // bare numbers — mirror the top-level hits.total
-                    // shape.
-                    let inner_total = if params.rest_total_hits_as_int.as_deref() == Some("true") {
-                        json!(total as u64)
-                    } else {
-                        json!({ "value": total as u64, "relation": "eq" })
-                    };
-                    combined.insert(
-                        name,
-                        serde_json::json!({
-                            "hits": {
-                                "total": inner_total,
-                                "max_score": Value::Null,
-                                "hits": rendered_hits,
-                            }
-                        }),
-                    );
-                }
-                hit_inner_hits = Some(Value::Object(combined));
+                hit_inner_hits = Some(render_collapse_inner_hits(
+                    group,
+                    spec,
+                    &idx_name,
+                    params.rest_total_hits_as_int.as_deref() == Some("true"),
+                ));
             }
 
             // Real seq_no (and a placeholder primary_term of 1), read from
@@ -20550,7 +20566,35 @@ async fn scroll_page_response(
                         o.insert("_primary_term".to_string(), json!(pt));
                     }
                     if let Some(src) = &h.source {
-                        o.insert("_source".to_string(), src.clone());
+                        // A collapse leader carries `__xy_collapse_group__` /
+                        // `__xy_collapse_spec__` sentinels snapshotted into the
+                        // scroll context at open time. `search_impl` renders them
+                        // into `inner_hits` and strips them from `_source`; the
+                        // scroll continuation must do the same or it leaks the
+                        // sentinels and emits no inner_hits (#621/#566).
+                        let mut src = src.clone();
+                        let collapse_inner = src.as_object_mut().and_then(|obj| {
+                            let group = obj
+                                .get("__xy_collapse_group__")
+                                .and_then(Value::as_array)
+                                .cloned();
+                            let spec = obj.get("__xy_collapse_spec__").cloned();
+                            obj.remove("__xy_collapse_group__");
+                            obj.remove("__xy_collapse_spec__");
+                            match (group, spec) {
+                                (Some(g), Some(s)) => Some(render_collapse_inner_hits(
+                                    g,
+                                    s,
+                                    &h.index,
+                                    rest_total_hits_as_int,
+                                )),
+                                _ => None,
+                            }
+                        });
+                        o.insert("_source".to_string(), src);
+                        if let Some(inner) = collapse_inner {
+                            o.insert("inner_hits".to_string(), inner);
+                        }
                     }
                     if let Some(sort) = &h.sort {
                         o.insert("sort".to_string(), Value::Array(sort.clone()));

--- a/engine/crates/xerj-api/tests/collapse_scroll_snapshot_version_torn_read.rs
+++ b/engine/crates/xerj-api/tests/collapse_scroll_snapshot_version_torn_read.rs
@@ -1,0 +1,180 @@
+//! Issue #566 (items 2 & 3): the collapse `inner_hits` render must carry each
+//! member's SNAPSHOT `_seq_no`/`_version`, not a live lookup at render time.
+//! The #506 repro (`collapse_inner_hits_seqno_is_real.rs`) is a plain
+//! `POST /_search`, where snapshot == live (docs are versioned once at search
+//! time), so it cannot distinguish the two. This test holds a collapse scroll
+//! across an update: a member is bumped AFTER the scroll snapshot but BEFORE the
+//! continuation page that renders its inner hit, so a live lookup would surface
+//! the post-update `_version`/`_seq_no` beside the snapshot `_source` — the torn
+//! read #499/#506 describe, on the collapse path.
+//!
+//! Elasticsearch is referenced for wire semantics only; no ES code is here.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// A collapse scroll whose continuation page renders a member that was updated
+/// after the snapshot must report the member's SNAPSHOT `_version`/`_seq_no`,
+/// not the live (bumped) one (#566 items 2 & 3).
+///
+/// Before #621, `scroll_page_response` never rendered the collapse group (unlike
+/// `search_impl`), so it leaked `__xy_collapse_group__` / `__xy_collapse_spec__`
+/// into the wire `_source` and emitted no `inner_hits`. The snapshot values were
+/// carried correctly all along (the sentinel showed the pre-update `_version`),
+/// so the fix ported the collapse render (`render_collapse_inner_hits`) into the
+/// scroll continuation path. This test guards both halves: no sentinel leak, and
+/// the member's snapshot `_version` beside its snapshot `_source`.
+#[tokio::test]
+async fn collapse_scroll_inner_hit_reports_snapshot_version_not_live() {
+    let (app, _dir) = app().await;
+    let (st, body) = call(
+        &app,
+        "PUT",
+        "/docs",
+        json!({"mappings": {"properties": {
+            "grp": { "type": "keyword" },
+            "v": { "type": "long" }
+        }}}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "create index: {body}");
+
+    // Two collapse groups. Group "A" sorts before group "B" (grp asc), so with
+    // page_size 1 the scroll returns A's leader on page 1 and B's leader on
+    // page 2 — the page rendered AFTER the update below.
+    for (id, grp, v) in [
+        ("a0", "A", 10),
+        ("a1", "A", 11),
+        ("b0", "B", 20),
+        ("b1", "B", 21),
+    ] {
+        let (st, _) = call(
+            &app,
+            "POST",
+            &format!("/docs/_doc/{id}"),
+            json!({ "grp": grp, "v": v }),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index {id}");
+    }
+    let _ = call(&app, "POST", "/docs/_refresh", Value::Null).await;
+
+    // Open a collapse scroll, one group per page, sorted by grp asc. Inner hits
+    // request version + seq_no so the render carries the snapshot pair.
+    let (st, first) = call(
+        &app,
+        "POST",
+        "/docs/_search?scroll=5m",
+        json!({
+            "query": { "match_all": {} },
+            "size": 1,
+            "sort": [{ "grp": "asc" }],
+            "collapse": { "field": "grp", "inner_hits": {
+                "name": "members", "size": 10,
+                "sort": [{ "v": "asc" }],
+                "seq_no_primary_term": true,
+                "version": true
+            } }
+        }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "collapse scroll start: {first}");
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+    assert_eq!(
+        first["hits"]["hits"][0]["_source"]["grp"], "A",
+        "page 1 must be group A: {first}"
+    );
+
+    // Concurrent update AFTER the snapshot: bump b1's `v`, seq_no and version.
+    let (st, upd) = call(
+        &app,
+        "PUT",
+        "/docs/_doc/b1",
+        json!({ "grp": "B", "v": 999 }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "concurrent update b1: {upd}");
+    let live_version_after = upd["_version"].as_i64().expect("_version on update");
+    assert!(live_version_after >= 2, "update must bump version: {upd}");
+
+    // Continue to page 2 (group B), rendered AFTER the update.
+    let (st, page2) = call(
+        &app,
+        "POST",
+        "/_search/scroll",
+        json!({ "scroll": "5m", "scroll_id": sid }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "scroll continuation: {page2}");
+    let leader = &page2["hits"]["hits"][0];
+    assert_eq!(
+        leader["_source"]["grp"], "B",
+        "page 2 must be group B: {page2}"
+    );
+    // The internal collapse sentinels must NOT leak into the wire `_source`:
+    // `search_impl` strips them when it renders inner_hits; the scroll
+    // continuation path (`scroll_page_response`) must do the same (#566).
+    assert!(
+        leader["_source"].get("__xy_collapse_group__").is_none()
+            && leader["_source"].get("__xy_collapse_spec__").is_none(),
+        "collapse scroll continuation leaked internal sentinels into _source — \
+         scroll_page_response does not render the collapse group like search_impl: {leader}"
+    );
+
+    // Find b1's inner hit on the group-B leader.
+    let inner = page2
+        .pointer("/hits/hits/0/inner_hits/members/hits/hits")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let b1 = inner
+        .iter()
+        .find(|h| h["_id"] == "b1")
+        .unwrap_or_else(|| panic!("b1 must be a group-B inner hit: {page2}"));
+
+    // The snapshot `_source` (v=21, pre-update) must be paired with the snapshot
+    // `_version`/`_seq_no`, NOT the live post-update values.
+    assert_eq!(
+        b1["_source"]["v"].as_i64(),
+        Some(21),
+        "b1 inner-hit _source must be the SNAPSHOT body (v=21), got {b1}"
+    );
+    assert_eq!(
+        b1["_version"].as_i64(),
+        Some(1),
+        "b1 inner-hit _version must be the SNAPSHOT version (1), not the live post-update \
+         value {live_version_after} — a torn read a client could replay into if_seq_no (#566): {b1}"
+    );
+}


### PR DESCRIPTION
## What

`scroll_page_response` never rendered a collapse leader's `inner_hits`. On a
collapse `_search?scroll=...`, the **first** page is served by `search_impl`
(which renders `inner_hits` from the `__xy_collapse_group__` /
`__xy_collapse_spec__` sentinels `apply_collapse` plants in `_source`, then
strips them). Every **continuation** page, though, went through
`scroll_page_response`, which inserted the leader's `_source` verbatim —
sentinels and all — and always set `inner_hits: None`. So clients paging a
collapsed scroll saw internal sentinels leak into the wire `_source` and got
no `inner_hits` at all. That is a wire-correctness break, not just a coverage
gap (#621; the scroll half of #566 items 2 & 3).

The snapshot `_seq_no`/`_version` were already carried correctly per member in
the group sentinel (captured at scroll-open, never re-read live), so the only
defect was the missing render on the scroll path.

## How

- Extract `search_impl`'s collapse-render block into a shared free function
  `render_collapse_inner_hits(group, spec, idx_name, rest_total_hits_as_int)`.
  Behavior-identical: the only rewiring is `idx_name: &str` and the
  `rest_total_hits_as_int` bool in place of the `params` field. `search_impl`
  now calls it; its output is byte-identical to before.
- `scroll_page_response` reads the sentinels off each leader's `_source`,
  removes both, and calls the shared helper — so continuation pages render
  `inner_hits` identically to page 1 (size/from/sort/collapse/fields + the
  snapshot version pair).

## Test / fail-before

`collapse_scroll_snapshot_version_torn_read` opens a collapse scroll (one
group per page, `size:1`, `sort grp asc`, inner_hits with seq_no+version),
bumps group-B member `b1`'s `_version` **after** page 1 but **before** the
page-2 continuation, then asserts page 2:
1. has **no** `__xy_collapse_group__` / `__xy_collapse_spec__` in `_source`,
2. renders `inner_hits.members`, and
3. reports `b1`'s **snapshot** `_version` (1) beside its snapshot `_source`
   (`v=21`) — not the live post-update value (a torn read a client could
   replay into `if_seq_no`).

**Fail-before:** reverting *only* the `scroll_page_response` hunk (helper +
`search_impl` call site intact) fails the test on assertion (1) — the wire
`_source` shows the leaked `__xy_collapse_group__` / `__xy_collapse_spec__`.
With the hunk, it passes.

Full `cargo test -p xerj-api` green under rustc 1.97.1 (both dev and ci-test).
fmt `--all --check` ✓, clippy `--all-targets -D warnings` ✓.

## Scope

Renders `inner_hits` when the leader `_source` is present (the realistic
collapse-scroll case). A collapse scroll under `_source: false` is a niche
follow-up, not addressed here.

Closes #621. Closes the scroll half of #566 (items 2 & 3).
