### PR TITLE
refactor(api): route scroll hit-render paths through resolve_hit_versioning (#614)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -20140,56 +20140,44 @@ pub async fn search_with_scroll(
         let first_page: Vec<EsHit> = all_hits
             .iter()
             .take(page_size)
-            .map(|(idx_name, h)| EsHit {
-                index: idx_name.clone(),
-                id: h.id.clone(),
-                score: Some(h.score as f64),
-                version: if emit_version {
-                    // #603: absent `_version` omitted, never defaulted to 1.
-                    h.version
-                } else {
-                    None
-                },
-                seq_no: if emit_seq_no {
-                    // #603: absent `_seq_no` omitted, never a positional
-                    // `hit_idx` a client could replay into OCC.
-                    h.seq_no
-                } else {
-                    None
-                },
-                // #603: `_primary_term` only alongside a real `_seq_no`.
-                primary_term: if emit_seq_no {
-                    h.seq_no.map(|_| 1)
-                } else {
-                    None
-                },
-                source: if h.source.is_null() {
-                    None
-                } else {
-                    Some(h.source.clone())
-                },
-                fields: passage_fields(h),
-                sort: if h.sort.is_empty() {
-                    None
-                } else {
-                    Some(h.sort.clone())
-                },
-                highlight: h.highlight.clone(),
-                explanation: None,
-                inner_hits: None,
-                matched_queries: if h.matched_queries.is_empty() {
-                    Value::Null
-                } else {
-                    Value::Array(
-                        h.matched_queries
-                            .iter()
-                            .cloned()
-                            .map(Value::String)
-                            .collect(),
-                    )
-                },
-                ignored: None,
-                ignored_field_values: None,
+            .map(|(idx_name, h)| {
+                let (version, seq_no, primary_term) =
+                    resolve_hit_versioning(h.seq_no, h.version, emit_seq_no, emit_version);
+                EsHit {
+                    index: idx_name.clone(),
+                    id: h.id.clone(),
+                    score: Some(h.score as f64),
+                    version,
+                    seq_no,
+                    primary_term,
+                    source: if h.source.is_null() {
+                        None
+                    } else {
+                        Some(h.source.clone())
+                    },
+                    fields: passage_fields(h),
+                    sort: if h.sort.is_empty() {
+                        None
+                    } else {
+                        Some(h.sort.clone())
+                    },
+                    highlight: h.highlight.clone(),
+                    explanation: None,
+                    inner_hits: None,
+                    matched_queries: if h.matched_queries.is_empty() {
+                        Value::Null
+                    } else {
+                        Value::Array(
+                            h.matched_queries
+                                .iter()
+                                .cloned()
+                                .map(Value::String)
+                                .collect(),
+                        )
+                    },
+                    ignored: None,
+                    ignored_field_values: None,
+                }
             })
             .collect();
 
@@ -20479,57 +20467,45 @@ async fn scroll_page_response(
                 .iter()
                 .skip(position)
                 .take(page_size)
-                .map(|(hit_index, h)| EsHit {
-                    // Per-hit index, not the context-level one (#414).
-                    index: hit_index.clone(),
-                    id: h.id.clone(),
-                    score: Some(h.score as f64),
-                    version: if emit_version {
-                        // #603: absent `_version` omitted, never defaulted to 1.
-                        h.version
-                    } else {
-                        None
-                    },
-                    seq_no: if emit_seq_no {
-                        // #603: absent `_seq_no` omitted, never a positional
-                        // `hit_idx` a client could replay into OCC.
-                        h.seq_no
-                    } else {
-                        None
-                    },
-                    // #603: `_primary_term` only alongside a real `_seq_no`.
-                    primary_term: if emit_seq_no {
-                        h.seq_no.map(|_| 1)
-                    } else {
-                        None
-                    },
-                    source: if h.source.is_null() {
-                        None
-                    } else {
-                        Some(h.source.clone())
-                    },
-                    fields: passage_fields(h),
-                    sort: if h.sort.is_empty() {
-                        None
-                    } else {
-                        Some(h.sort.clone())
-                    },
-                    highlight: h.highlight.clone(),
-                    explanation: None,
-                    inner_hits: None,
-                    matched_queries: if h.matched_queries.is_empty() {
-                        Value::Null
-                    } else {
-                        Value::Array(
-                            h.matched_queries
-                                .iter()
-                                .cloned()
-                                .map(Value::String)
-                                .collect(),
-                        )
-                    },
-                    ignored: None,
-                    ignored_field_values: None,
+                .map(|(hit_index, h)| {
+                    let (version, seq_no, primary_term) =
+                        resolve_hit_versioning(h.seq_no, h.version, emit_seq_no, emit_version);
+                    EsHit {
+                        // Per-hit index, not the context-level one (#414).
+                        index: hit_index.clone(),
+                        id: h.id.clone(),
+                        score: Some(h.score as f64),
+                        version,
+                        seq_no,
+                        primary_term,
+                        source: if h.source.is_null() {
+                            None
+                        } else {
+                            Some(h.source.clone())
+                        },
+                        fields: passage_fields(h),
+                        sort: if h.sort.is_empty() {
+                            None
+                        } else {
+                            Some(h.sort.clone())
+                        },
+                        highlight: h.highlight.clone(),
+                        explanation: None,
+                        inner_hits: None,
+                        matched_queries: if h.matched_queries.is_empty() {
+                            Value::Null
+                        } else {
+                            Value::Array(
+                                h.matched_queries
+                                    .iter()
+                                    .cloned()
+                                    .map(Value::String)
+                                    .collect(),
+                            )
+                        },
+                        ignored: None,
+                        ignored_field_values: None,
+                    }
                 })
                 .collect();
 


### PR DESCRIPTION
## What

#603 extracted `resolve_hit_versioning` and pinned the **top-level** render's
omit-on-absent contract (absent `_seq_no`/`_version` omitted, never fabricated
into a positional index or a default `1`; `_primary_term` only alongside a real
`_seq_no`). The scroll render closures carried byte-equivalent logic INLINE and
matched the helper only by inspection (a #612-verification NIT, tracked as #614).

## How

Route the two scroll hit-render closures — `search_with_scroll`'s first page and
`scroll_page_response`'s continuation — through
`resolve_hit_versioning(h.seq_no, h.version, emit_seq_no, emit_version)`, so the
omit-on-absent contract lives in one place. Net **−24 lines**. (The
`/:index/_search?scroll=` first-page render in `search_impl` was already routed
through the helper by #603.)

Byte-identical — the helper reproduces the inline arms exactly:
- `out_version = if emit_version { version } else { None }`
- `(out_seq_no, out_primary_term) = (true, Some(sn)) => (Some(sn), Some(1)); _ => (None, None)`

## Coverage (corrected after verification)

The continuation path (`scroll_page_response`) gets **genuine transitive
coverage**: the verification's corrupt-helper experiment (force
`resolve_hit_versioning` to return wrong values) makes 2/3 `scroll_seq_no_torn_read`
tests fail, proving the render actually executes the helper on the live scroll
path (`search_impl` first page + `scroll_page_response` continuation).

Honest caveat: `search_with_scroll`'s first-page `EsHit` versioning is currently
**discarded** — its response JSON (es_compat.rs ~20207-20228) is hand-built and
only serializes `_index`/`_id`/`_score`/`_source`. So the refactor there is a
byte-identical dedup, but the unit test cannot be transitive to a value that
never reaches the wire. That discard is itself a latent, pre-existing bug (the
`_search_scroll` first page drops `_seq_no`/`_version` even when requested),
filed separately as **#630**; when it is fixed, the 20145 helper call becomes
live and covered.

## Proof

Pure refactor → behavior must be unchanged. Full `cargo test -p xerj-api` green
under rustc 1.97.1 in **both** dev and ci-test, including the scroll versioning
guards. fmt `--all --check` ✓, clippy `--all-targets -D warnings` ✓.

Closes #614. Latent first-page-versioning bug tracked as #630.