### PR TITLE
perf(engine): residual gate skips Hit materialisation under count_only (part 1 of #577)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -16569,23 +16569,34 @@ impl Index {
                                         }
                                         total_count += 1;
                                         seen_ids.insert(id.clone());
-                                        let hit = Hit {
-                                            id,
-                                            score: sh.score,
-                                            source,
-                                            seq_no: hit_seq_no,
-                                            version: hit_version,
-                                            sort: Vec::new(),
-                                            explain: None,
-                                            highlight: None,
-                                            matched_queries: Vec::new(),
-                                            passage: None,
-                                        };
-                                        if let Some(topk) = sort_topk.as_mut() {
-                                            let seq = hit_seq_no.unwrap_or(u64::MAX);
-                                            topk.offer(hit, seq, self);
-                                        } else {
-                                            all_hits.push(hit);
+                                        // #577: under `count_only` (size:0) the page is
+                                        // empty, so — exactly like the normal walk, which
+                                        // does NOT materialise a hit at all under
+                                        // count_only (the `if !count_only` guards near
+                                        // this pass at ~14939/14975) — skip the `Hit`
+                                        // build and `_source` retention; only the count
+                                        // matters. Without this a size:0 bool with a
+                                        // non-projectable filter held O(matches) hydrated
+                                        // `Hit`s before the (empty) slice discarded them.
+                                        if !count_only {
+                                            let hit = Hit {
+                                                id,
+                                                score: sh.score,
+                                                source,
+                                                seq_no: hit_seq_no,
+                                                version: hit_version,
+                                                sort: Vec::new(),
+                                                explain: None,
+                                                highlight: None,
+                                                matched_queries: Vec::new(),
+                                                passage: None,
+                                            };
+                                            if let Some(topk) = sort_topk.as_mut() {
+                                                let seq = hit_seq_no.unwrap_or(u64::MAX);
+                                                topk.offer(hit, seq, self);
+                                            } else {
+                                                all_hits.push(hit);
+                                            }
                                         }
                                     }
                                     // Preserve the segment-tail deadline propagation

--- a/engine/crates/xerj-engine/tests/bool_filter_is_non_scoring.rs
+++ b/engine/crates/xerj-engine/tests/bool_filter_is_non_scoring.rs
@@ -355,6 +355,60 @@ async fn residual_filter_still_excludes_nonmatching_docs() {
     }
 }
 
+/// #577: a `count_only` (size:0) residual query must return the exact total via
+/// the membership gate with ZERO materialised hits. The residual pass now skips
+/// the `Hit` build under count_only (mirroring the normal walk), rather than
+/// hydrating O(matches) `Hit`s for a page that is empty. Result-invariant guard:
+/// the count stays exact and the page stays empty.
+#[tokio::test]
+async fn residual_count_only_returns_exact_total_with_no_hits() {
+    let dir = TempDir::new().unwrap();
+    let engine = make_engine(&dir);
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("body", FieldType::Text));
+    schema
+        .fields
+        .push(FieldConfig::new("tag", FieldType::Keyword));
+    engine.create_index("residual-count-only", schema).unwrap();
+    let idx = engine.get_index("residual-count-only").unwrap();
+    for i in 0..120usize {
+        let alphas = "alpha ".repeat(1 + i % 5);
+        let mut doc = json!({ "body": alphas });
+        if i % 2 == 0 {
+            doc.as_object_mut()
+                .unwrap()
+                .insert("tag".into(), json!("kept"));
+        }
+        idx.index_document(Some(format!("d{i:03}")), doc)
+            .await
+            .unwrap();
+    }
+    idx.flush().await.unwrap();
+
+    let counted = idx
+        .search(&req(
+            json!({"bool": {
+                "must": [{"match": {"body": "alpha"}}],
+                "filter": [{"exists": {"field": "tag"}}]
+            }}),
+            0,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        counted.total.value, 60,
+        "count_only must still apply the residual membership gate — only the 60 \
+         even docs carry `tag`"
+    );
+    assert_eq!(
+        counted.hits.len(),
+        0,
+        "size:0 returns no hits — the residual pass must not materialise any (#577)"
+    );
+}
+
 /// The residual gate must be page-size-invariant: forcing full materialisation
 /// and re-counting survivors must give the same top hit, the same score, and
 /// the same total at size:1 and size:200 (a gate that miscounts or mis-ranks


### PR DESCRIPTION
## What

The #361/#576 `residual_gate` pass (index.rs, after `fts_scored_applied = true`)
re-applies membership via `doc_matches_query` for bools with a non-projectable
non-scoring `filter`/`must_not`. For every survivor it built a full `Hit` (with a
hydrated `_source`) and pushed it into `all_hits`/`sort_topk` — **even under
`count_only` (size:0)**, where the page is empty and each `Hit` is discarded by
the post-loop slice. A size:0 bool with a selective non-projectable filter over a
large match set therefore held **O(matches)** hydrated `Hit`s in memory for
nothing (the memory cliff #576's verification flagged as a NIT).

## How

The normal walk already does NOT materialise a hit under `count_only` ("we do NOT
materialise the hit at all", index.rs ~14906; the `if !count_only` guards near
this pass at ~14939/14975). Mirror that: under `count_only`, run the membership
gate and `total_count += 1` but skip the `Hit` build and `_source` retention. The
liveness/staleness check and the exact count are unchanged.

## Verification

This is **result-invariant** — a size:0 query returns the same total and the same
(empty) page as before, so there is no wire change and thus no traditional
fail-before. Correctness is pinned by:
- a new guard `residual_count_only_returns_exact_total_with_no_hits` — a size:0
  `bool{must:[match], filter:[exists:tag]}` over 120 docs (60 carry `tag`) returns
  `total 60, 0 hits`;
- the 8 existing `bool_filter_is_non_scoring` tests (residual gate correctness /
  page-size invariance) — all still pass.

The memory win: the per-survivor `Hit` + `_source` alloc is now skipped under
`count_only`. Full `cargo test -p xerj-engine` green under rustc 1.97.1 in **both**
dev and ci-test. fmt `--all --check` ✓, clippy `--all-targets -D warnings` ✓.

## Scope

#577 **part 1** (the count_only alloc). Part 2 — periodically trimming `all_hits`
to `materialisation_limit` in the residual loop for the `size>0` case — needs a
score-bounded collector (the residual `seg_hits` is forced to the full match set,
not top-cap-by-score, so a plain FIFO cut could drop a page hit) and is left as a
follow-up. **Refs #577** (does not close it).
