### PR TITLE
fix: make rescore ranking integration coverage non-vacuous

### DIFF
--- a/engine/crates/xerj-engine/tests/integration.rs
+++ b/engine/crates/xerj-engine/tests/integration.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 use xerj_common::config::Config;
 use xerj_common::types::{FieldConfig, FieldType, Schema};
 use xerj_engine::{detect_log_format, Engine, LogFormat};
-use xerj_query::ast::{QueryNode, SearchRequest};
+use xerj_query::ast::{QueryNode, RescoreQuery, RescoreQueryInner, SearchRequest};
 use xerj_query::parse_request;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -5355,82 +5355,69 @@ async fn test_rescore_changes_ranking() {
     let dir = TempDir::new().unwrap();
     let engine = make_engine(&dir);
 
-    engine.create_index("rescore_idx", Schema::empty()).unwrap();
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("kw", FieldType::Keyword));
+    engine.create_index("rescore_idx", schema).unwrap();
     let idx = engine.get_index("rescore_idx").unwrap();
 
-    // Doc "a": lots of "search", few "engine" mentions → high score for "search"
-    idx.index_document(
-        Some("a".into()),
-        json!({ "title": "search", "body": "search search search" }),
-    )
-    .await
-    .unwrap();
+    idx.index_document(Some("partial".into()), json!({ "kw": "claude" }))
+        .await
+        .unwrap();
+    idx.index_document(Some("whole".into()), json!({ "kw": "claude code" }))
+        .await
+        .unwrap();
 
-    // Doc "b": lots of "engine" mentions → would rank lower for "search", higher for "engine"
-    idx.index_document(
-        Some("b".into()),
-        json!({ "title": "engine", "body": "engine engine engine engine engine" }),
-    )
-    .await
-    .unwrap();
-
-    // Doc "c": mentions "search engine" once
-    idx.index_document(
-        Some("c".into()),
-        json!({ "title": "search engine", "body": "search engine" }),
-    )
-    .await
-    .unwrap();
-
-    // Primary query: search for "search" — doc "a" should rank highest initially.
-    let primary_req = parse_request(&json!({
-        "query": { "match": { "body": "search" } },
+    let mut request = parse_request(&json!({
+        "query": { "match_all": {} },
         "size": 10,
     }))
     .unwrap();
-    let primary_result = idx.search(&primary_req).await.unwrap();
-    assert!(!primary_result.hits.is_empty());
-    let primary_top = primary_result.hits[0].id.clone();
-
-    // Now add rescore that weights "engine" matches heavily.
-    // This should boost doc "b" (many "engine" occurrences) up.
-    let rescore_req = parse_request(&json!({
-        "query": { "match": { "body": "search" } },
-        "size": 10,
-        "rescore": {
-            "window_size": 10,
-            "query": {
-                "rescore_query": { "match": { "title": "engine" } },
-                "query_weight": 0.1,
-                "rescore_query_weight": 10.0
-            }
-        }
-    }))
-    .unwrap();
-    let rescore_result = idx.search(&rescore_req).await.unwrap();
-    assert!(
-        !rescore_result.hits.is_empty(),
-        "rescore search should return hits"
+    let primary = idx.search(&request).await.unwrap();
+    assert_eq!(primary.total.value, 2);
+    assert_eq!(primary.hits.len(), 2);
+    assert_eq!(
+        primary
+            .hits
+            .iter()
+            .map(|hit| hit.id.as_str())
+            .collect::<Vec<_>>(),
+        ["partial", "whole"],
+        "tied primary hits should preserve insertion order"
+    );
+    assert_eq!(
+        primary.hits[0].score.to_bits(),
+        primary.hits[1].score.to_bits(),
+        "match_all must establish a tied primary score"
     );
 
-    // After rescoring, doc "b" (title contains "engine") should appear — check scores changed.
-    let rescore_scores: Vec<(&str, f32)> = rescore_result
-        .hits
-        .iter()
-        .map(|h| (h.id.as_str(), h.score))
-        .collect();
-    // Verify the rescore was applied (scores differ from primary).
-    let primary_scores: Vec<(&str, f32)> = primary_result
-        .hits
-        .iter()
-        .map(|h| (h.id.as_str(), h.score))
-        .collect();
-    // At least the top score should differ since rescore applies different weights.
-    let _ = (rescore_scores, primary_scores, primary_top);
-    // Just verify that the request parsed and executed successfully with rescore.
+    request.rescore = vec![RescoreQuery {
+        window_size: 10,
+        query: Some(RescoreQueryInner {
+            rescore_query: xerj_query::parse_query(&json!({
+                "match": { "kw": "claude code" }
+            }))
+            .unwrap(),
+            query_weight: 0.0,
+            rescore_query_weight: 1.0,
+        }),
+        script: None,
+    }];
+
+    let rescored = idx.search(&request).await.unwrap();
+    assert_eq!(rescored.total.value, 2);
+    assert_eq!(rescored.hits.len(), 2);
+    assert_eq!(rescored.hits[0].id, "whole", "rescore must flip the order");
+    assert_eq!(rescored.hits[1].id, "partial");
     assert!(
-        rescore_result.total.value > 0,
-        "should have hits after rescoring"
+        rescored.hits[0].score > 0.0,
+        "the whole keyword value must receive a rescore contribution"
+    );
+    assert_eq!(
+        rescored.hits[1].score.to_bits(),
+        0.0f32.to_bits(),
+        "a partial keyword token must receive no rescore contribution"
     );
 }
 


### PR DESCRIPTION
## What this changes, and why

Replace the vacuous body of `test_rescore_changes_ranking` with one deterministic engine-level regression scenario that covers both requested gaps. Create an explicit keyword mapping, index a partial-token value before the exact whole value, run a tied primary query to establish the partial document's initial lead, then attach a `RescoreQuery` directly to the parsed `SearchRequest`, following the established patterns in `tied_score_resorts.rs` and `painless_script_limits.rs` rather than pretending the native parser accepts ES `rescore` JSON. Give the primary score zero weight so the assertions can prove that only the whole-value keyword document receives a rescore contribution, while also asserting that the result order flips after rescoring.

The engine's committed coverage proves the keyword-rescore rewrite only at the helper's unit-test boundary, not through `Index::search` where `resolved_rescore` must reach the application loop. The existing `test_rescore_changes_ranking` appears to cover that path but builds the request with `xerj_query::parse_request`, which intentionally leaves `SearchRequest.rescore` empty, and then asserts only that some hits exist. Consequently it neither executes rescoring nor verifies a rank change, and a future swap from `resolved_rescore` back to the raw request stages could pass unnoticed. This is a test-quality follow-up to the already-merged #626 behavior fix; production semantics are not in scope.

Fixes #627

## Evidence

No command output was captured in the environment that produced this change;
the checks below are left for CI.

## Checks

- [ ] `cargo fmt --all` (CI runs `rustfmt --check` and `clippy -D warnings`)
  Not run in this workspace, so this is left for CI to confirm.
- [ ] Scoped release build of the crates touched: `cargo build --release -j 32 -p <crate>`
  Not run in this workspace, so this is left for CI to confirm.
- [ ] `cargo test -p <crate>` passes (`cargo check` is not sufficient — test code is interleaved with production code)
  Not run in this workspace, so this is left for CI to confirm.
- [ ] ES-YAML conformance suite at **0 failed** (`cargo run --release -p es-yaml-runner -- --dir tests/es-compat-yaml/yaml`), or: not applicable because this change is docs/landing-only
  Not run in this workspace, so this is left for CI to confirm.
- [ ] New ES-compatible behaviour has a matching YAML case under `engine/tests/es-compat-yaml/yaml/`
  Not run in this workspace, so this is left for CI to confirm.
- [ ] Docs updated if user-visible behaviour changed
- [ ] For non-trivial changes: the applicable audit in [`docs/CONTRIBUTION_REVIEW.md`](../docs/CONTRIBUTION_REVIEW.md)
  Not run in this workspace, so this is left for CI to confirm.
- [ ] For non-trivial changes: if this PR changes an operational document or runnable recipe, complete the operational audit in [`docs/CONTRIBUTION_REVIEW.md`](../docs/CONTRIBUTION_REVIEW.md). Record a negative control that exits non-zero with no artifact extracted, installed, published, or served. Keep verification and its action in one block; rerun the control with the failing exit discarded and with the next documented block appended, and require that neither reaches an artifact or unsafe/privileged path. List tested variants and unsupported variants separately, and verify every publication copy. Otherwise mark this item `N/A` with a reason.
  Not run in this workspace, so this is left for CI to confirm.


## Provenance

- **Written by:** an automated contribution run (Codex implementation, human
  operator: @mvanhorn). No human reviewed the diff before submission.
- **Verified** (commands run, output observed): none. No build or test command
  was executed in the authoring environment.
- **Assumed** (not tested, and what would falsify it): that attaching a
  `RescoreQuery` directly to the parsed `SearchRequest` reaches the application
  loop via `resolved_rescore`, and that the zero-weight primary makes the rank
  flip attributable solely to the rescore contribution. A failing or passing-
  for-the-wrong-reason run of `cargo test -p xerj-engine` on this test would
  falsify it.
