### PR TITLE
fix(engine): faithful ES _source glob automaton for nested paths (#602)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26496,14 +26496,23 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
         None => return source.clone(),
     };
 
-    // Check if any include/exclude path is dotted (nested).
-    let has_dotted = includes
+    // Route through the ES automaton whenever a pattern is nested (dotted) OR
+    // contains a wildcard. The simple top-level branch below understands only a
+    // trailing `*` on a whole key (`field_matches`), so a dot-less LEADING or
+    // MID glob must go through the NFA too: in ES a `*` is `Σ*` over the full
+    // dotted path whether or not the pattern itself contains a `.`, so `*id`
+    // matches `user.groupid` and `exclude ["*secret"]` strips `password_secret`.
+    // Without this, `include ["*id"]` dropped the whole source and
+    // `exclude ["*secret"]` silently no-oped — the data-loss / data-exposure
+    // failure modes #602 exists to eliminate. Only pure-literal top-level
+    // patterns (no `.`, no `*`) take the fast path.
+    let needs_automaton = includes
         .iter()
         .chain(excludes.iter())
-        .any(|f| f.contains('.'));
+        .any(|f| f.contains('.') || f.contains('*'));
 
-    if !has_dotted {
-        // Simple top-level filtering.
+    if !needs_automaton {
+        // Simple top-level filtering: literal whole-key includes/excludes only.
         let mut result = serde_json::Map::new();
         for (k, v) in obj {
             let keep = if includes.is_empty() {
@@ -27037,6 +27046,41 @@ mod source_filter_tests {
         assert_eq!(
             actual, expected,
             "ES _source `*` crosses dots at any depth (makeAnyString); scalars kept only when accepted"
+        );
+    }
+
+    /// #602 (verification follow-up 2): a DOT-LESS leading/mid wildcard is still
+    /// `Σ*` over the full path in ES, so `*id` matches `user.groupid` and
+    /// `exclude ["*secret"]` strips `password_secret` at any depth. The dispatch
+    /// gate must route any pattern containing `*` (not only dotted ones) through
+    /// the automaton — the simple top-level branch understands only a trailing
+    /// `*`, so without this `include ["*id"]` dropped the whole source and
+    /// `exclude ["*secret"]` silently no-oped.
+    #[test]
+    fn source_dotless_wildcard_routes_through_the_automaton() {
+        // include `*id` selects any key ending in `id`, at any depth.
+        assert_eq!(
+            filter_object(
+                &json!({ "user": { "groupid": 1, "name": 2 }, "id": 3 }),
+                &["*id".to_string()],
+                &[]
+            ),
+            json!({ "user": { "groupid": 1 }, "id": 3 }),
+            "dot-less `*id` must match nested `user.groupid` and top-level `id` (#602)"
+        );
+        // exclude `*secret` strips a sensitive key at the top level AND at depth.
+        assert_eq!(
+            filter_object(
+                &json!({
+                    "password_secret": 1,
+                    "keep": 2,
+                    "nested": { "api_secret": 3, "host": 4 }
+                }),
+                &[],
+                &["*secret".to_string()]
+            ),
+            json!({ "keep": 2, "nested": { "host": 4 } }),
+            "dot-less `exclude *secret` must strip `password_secret` and nested `api_secret` (#602)"
         );
     }
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26521,123 +26521,132 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
 
     // Dotted path filtering: a faithful ES `_source` include/exclude automaton.
     //
-    // ES matches PER PATH SEGMENT. Each pattern is split on `.` into segments;
-    // a `*` matches exactly one WHOLE segment (never across a `.`, because keys
-    // contain no dots); a pattern fully consumed AT a node includes that node's
-    // entire subtree; and an exclude removes a node only when its pattern fully
-    // matches at that node. The previous ad-hoc `matches_path` was a
-    // prefix/recursion matcher that could not step through a leading/mid glob
-    // (`*.foo`, `a.*.c`) nor expand a trailing-`*` segment (`meta*`) across the
-    // dot into the subtree (#602 divergences 2/3/4). Object descent goes through
-    // the automaton; a non-object value (scalar or array) is kept whole when its
-    // key is a live candidate — XERJ does not project into arrays today, so
-    // #602 is deliberately scoped to object-nested paths.
+    // ES compiles each include/exclude pattern with `Regex.simpleMatchToAutomaton`,
+    // where `*` becomes `Automata.makeAnyString()` — it matches ANY run of
+    // characters INCLUDING `.`, so a wildcard spans path segments at any depth
+    // (`org.elasticsearch.common.regex.Regex`, Apache-2.0). That is why `obj.*`
+    // keeps `obj`'s whole subtree, `*.foo` keeps every `foo` leaf at any depth,
+    // and `exclude ["*.secret"]` scrubs a nested `secret` however deep it sits.
+    // `XContentMapValues.filter` then walks the document and, at each node, asks
+    // the automaton two questions about that node's dotted path:
+    //   * ACCEPT — the pattern matches this path in full → include the whole
+    //     subtree (subject to excludes);
+    //   * LIVE — this path is a proper prefix the pattern can still extend to an
+    //     ACCEPT deeper down → descend.
+    // A leaf that is only LIVE (never ACCEPTed) was not selected and is dropped.
+    //
+    // The matcher is a small glob NFA over the FULL dotted path (`*` = any char
+    // incl `.`); leading/mid/trailing wildcards, the dot boundary, and
+    // multi-level globs all fall out of it (#602). Object descent goes through
+    // the automaton; scalars and arrays are handled at the leaf (see below).
 
-    // A single-segment glob: `*` matches any run of characters WITHIN one
-    // segment. Keys never contain `.`, so this can never cross a dot boundary —
-    // the property the old cross-path `glob_match` had to enforce by hand.
-    fn seg_matches(seg: &str, key: &str) -> bool {
-        if !seg.contains('*') {
-            return seg == key;
-        }
-        // Iterative glob with backtracking (`*` = greedy, backtrack on mismatch).
-        fn walk(pat: &[u8], s: &[u8]) -> bool {
-            let (mut pi, mut si) = (0usize, 0usize);
-            let (mut star, mut mark) = (usize::MAX, 0usize);
-            while si < s.len() {
-                if pi < pat.len() && pat[pi] == b'*' {
-                    star = pi;
-                    mark = si;
-                    pi += 1;
-                } else if pi < pat.len() && pat[pi] == s[si] {
-                    pi += 1;
-                    si += 1;
-                } else if star != usize::MAX {
-                    pi = star + 1;
-                    mark += 1;
-                    si = mark;
-                } else {
-                    return false;
+    // Reachable-state summary of glob `pat` after consuming `text`, with
+    // `*` = Σ* (matches any character, including `.`). Returns `(accept, live)`:
+    // `accept` = the whole pattern matched `text`; `live` = some reachable
+    // position can still consume a deeper `.segment` (sitting on a `*`, or on a
+    // literal `.` awaiting the next level), i.e. `text` is a viable prefix.
+    fn glob_reach(pat: &[u8], text: &[u8]) -> (bool, bool) {
+        let n = pat.len();
+        // Epsilon-closure: a `*` may match zero characters, so reaching the
+        // position of a `*` also reaches the position after it. A single forward
+        // pass suffices because a `*` only ever skips to `i + 1`.
+        let closure = |set: &mut [bool]| {
+            for i in 0..n {
+                if set[i] && pat[i] == b'*' {
+                    set[i + 1] = true;
                 }
             }
-            while pi < pat.len() && pat[pi] == b'*' {
-                pi += 1;
+        };
+        let mut cur = vec![false; n + 1];
+        let mut nxt = vec![false; n + 1];
+        cur[0] = true;
+        closure(&mut cur);
+        for &c in text {
+            for x in nxt.iter_mut() {
+                *x = false;
             }
-            pi == pat.len()
+            for i in 0..n {
+                if !cur[i] {
+                    continue;
+                }
+                if pat[i] == b'*' {
+                    // Σ* consumes any character (including `.`) and stays put.
+                    nxt[i] = true;
+                } else if pat[i] == c {
+                    nxt[i + 1] = true;
+                }
+            }
+            closure(&mut nxt);
+            std::mem::swap(&mut cur, &mut nxt);
         }
-        walk(seg.as_bytes(), key.as_bytes())
+        let accept = cur[n];
+        let live = (0..n).any(|i| cur[i] && (pat[i] == b'*' || pat[i] == b'.'));
+        (accept, live)
     }
 
-    // Filter one value against the active include/exclude segment-suffixes.
-    // `include_all` means an ancestor pattern was already fully consumed (or
-    // the top-level include list is empty), so this whole subtree is included
+    // `(accept, live)` of a path against a set of patterns — OR over the set.
+    fn reach_any(patterns: &[String], path: &str) -> (bool, bool) {
+        let mut acc = false;
+        let mut liv = false;
+        for p in patterns {
+            let (a, l) = glob_reach(p.as_bytes(), path.as_bytes());
+            acc |= a;
+            liv |= l;
+        }
+        (acc, liv)
+    }
+
+    // Filter one value at dotted `path`. `include_all` means an ancestor path
+    // was ACCEPTed (or the include list is empty), so this subtree is included
     // subject only to excludes.
     fn es_filter(
         value: &Value,
+        path: &str,
         include_all: bool,
-        includes: &[&[String]],
-        excludes: &[&[String]],
+        includes: &[String],
+        excludes: &[String],
     ) -> Value {
         let Value::Object(obj) = value else {
             return value.clone();
         };
-        let level_all = include_all || includes.is_empty();
         let mut out = serde_json::Map::new();
         for (key, val) in obj {
-            // An exclude whose pattern fully matches AT this node drops the value.
-            if excludes
-                .iter()
-                .any(|p| p.len() == 1 && seg_matches(&p[0], key))
-            {
+            let child = if path.is_empty() {
+                key.clone()
+            } else {
+                format!("{path}.{key}")
+            };
+
+            let (exc_acc, exc_live) = reach_any(excludes, &child);
+            if exc_acc {
+                // The exclude matches this path in full → drop the subtree.
                 continue;
             }
-            let exc_children: Vec<&[String]> = excludes
-                .iter()
-                .filter(|p| p.len() > 1 && seg_matches(&p[0], key))
-                .map(|p| &p[1..])
-                .collect();
-
-            // Which include patterns match this key? A fully-consumed one
-            // includes the whole subtree; a longer one is a LIVE state that
-            // descends by its tail.
-            let mut key_fully_included = false;
-            let inc_children: Vec<&[String]> = includes
-                .iter()
-                .filter_map(|p| {
-                    if seg_matches(&p[0], key) {
-                        if p.len() == 1 {
-                            key_fully_included = true;
-                            None
-                        } else {
-                            Some(&p[1..])
-                        }
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            let candidate = level_all || key_fully_included || !inc_children.is_empty();
-            if !candidate {
-                continue;
+            let (inc_acc, inc_live) = if includes.is_empty() {
+                (true, false)
+            } else {
+                reach_any(includes, &child)
+            };
+            let accept = include_all || inc_acc;
+            if !(accept || inc_live) {
+                continue; // neither selected nor a live prefix
             }
-            let child_all = level_all || key_fully_included;
-
-            // Fully included with nothing to strip below → keep the value as-is.
-            if child_all && exc_children.is_empty() {
-                out.insert(key.clone(), val.clone());
-                continue;
-            }
+            let child_all = accept;
 
             match val {
                 Value::Object(child_obj) => {
-                    let filtered = es_filter(val, child_all, &inc_children, &exc_children);
+                    // A fully-included object with no exclude reaching into it is
+                    // kept whole; otherwise descend to select/strip.
+                    if child_all && !exc_live {
+                        out.insert(key.clone(), val.clone());
+                        continue;
+                    }
+                    let filtered = es_filter(val, &child, child_all, includes, excludes);
                     let keep = match &filtered {
                         // An object that *filtering* emptied is pruned; one that
                         // was ALREADY empty in the source survives only in an
-                        // accepting state (its own path fully included) — a live
-                        // prefix state on the way to a deeper include is dropped,
-                        // matching ES (#310).
+                        // accepting state — a live-only prefix on the way to a
+                        // deeper include is dropped, matching ES (#310).
                         Value::Object(m) if m.is_empty() => child_obj.is_empty() && child_all,
                         _ => true,
                     };
@@ -26645,28 +26654,29 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
                         out.insert(key.clone(), filtered);
                     }
                 }
-                // Non-object (scalar/array): kept whole — XERJ does not project
-                // into arrays, and a scalar cannot satisfy a deeper include, so
-                // preserving it matches prior behavior without array data-loss.
-                _ => {
+                // An array is kept WHOLE whenever its key is selected: XERJ does
+                // not project inside arrays (documented scope), which also keeps
+                // it free of the projection-induced data loss #602 must avoid.
+                // (Consequence: an exclude cannot strip fields inside an array of
+                // objects — tracked separately, not a #602 regression.)
+                Value::Array(_) => {
                     out.insert(key.clone(), val.clone());
+                }
+                // A scalar leaf is kept ONLY in an ACCEPTing state. A scalar that
+                // merely sits on a LIVE (not-yet-accepted) include path cannot
+                // extend to satisfy the pattern, so ES drops it — keeping it
+                // would over-include a field the pattern never selected.
+                _ => {
+                    if child_all {
+                        out.insert(key.clone(), val.clone());
+                    }
                 }
             }
         }
         Value::Object(out)
     }
 
-    let inc: Vec<Vec<String>> = includes
-        .iter()
-        .map(|p| p.split('.').map(str::to_string).collect())
-        .collect();
-    let exc: Vec<Vec<String>> = excludes
-        .iter()
-        .map(|p| p.split('.').map(str::to_string).collect())
-        .collect();
-    let inc_refs: Vec<&[String]> = inc.iter().map(Vec::as_slice).collect();
-    let exc_refs: Vec<&[String]> = exc.iter().map(Vec::as_slice).collect();
-    es_filter(source, false, &inc_refs, &exc_refs)
+    es_filter(source, "", false, includes, excludes)
 }
 
 #[cfg(test)]
@@ -26955,6 +26965,78 @@ mod source_filter_tests {
         assert_eq!(
             actual, expected,
             "ES _source glob parity (#602 divergences 2/3/4)"
+        );
+    }
+
+    /// #602 (verification follow-up): ES `_source` `*` compiles to
+    /// `Automata.makeAnyString()`, so a wildcard matches ACROSS dots at any
+    /// depth. Two blocking divergences surfaced by the 3-skeptic pass are pinned
+    /// here: (a) a leading/mid glob must descend to ANY depth (`*.foo` keeps
+    /// `a.b.foo`, `exclude *.secret` scrubs a nested secret); (b) a SCALAR leaf
+    /// sitting on a live-but-non-accepting glob path must be DROPPED, not kept
+    /// whole (the pattern never selected it).
+    #[test]
+    fn source_glob_crosses_dots_at_any_depth_like_es() {
+        let cases: Vec<(&str, Value, Vec<String>, Vec<String>, Value)> = vec![
+            // (a) leading glob descends past >=2 dots.
+            (
+                "*.foo keeps a.b.foo (depth 2)",
+                json!({ "a": { "b": { "foo": 1, "bar": 2 } } }),
+                vec!["*.foo".into()],
+                vec![],
+                json!({ "a": { "b": { "foo": 1 } } }),
+            ),
+            // (a) mid glob spans an intermediate level.
+            (
+                "a.*.c keeps a.b.e.c (glob crosses b.e)",
+                json!({ "a": { "b": { "e": { "c": 1, "d": 2 } } } }),
+                vec!["a.*.c".into()],
+                vec![],
+                json!({ "a": { "b": { "e": { "c": 1 } } } }),
+            ),
+            // `obj.*` includes the whole subtree at any depth.
+            (
+                "obj.* keeps the whole subtree",
+                json!({ "obj": { "a": { "b": 1 } }, "other": 9 }),
+                vec!["obj.*".into()],
+                vec![],
+                json!({ "obj": { "a": { "b": 1 } } }),
+            ),
+            // (b) Case A: a scalar sibling on a non-accepting glob path is dropped.
+            (
+                "a.*.c drops scalar sibling a.x",
+                json!({ "a": { "b": { "c": 1 }, "x": 9 } }),
+                vec!["a.*.c".into()],
+                vec![],
+                json!({ "a": { "b": { "c": 1 } } }),
+            ),
+            // (b) Case B: double glob, scalar sibling dropped.
+            (
+                "*.*.foo drops scalar sibling a.c",
+                json!({ "a": { "b": { "foo": 1, "bar": 2 }, "c": 3 } }),
+                vec!["*.*.foo".into()],
+                vec![],
+                json!({ "a": { "b": { "foo": 1 } } }),
+            ),
+            // (a) exclude wildcard scrubs a nested field at depth >= 2.
+            (
+                "exclude *.description strips it at depth 2",
+                json!({ "a": { "b": { "description": 1, "keep": 2 } } }),
+                vec![],
+                vec!["*.description".into()],
+                json!({ "a": { "b": { "keep": 2 } } }),
+            ),
+        ];
+
+        let mut actual: Vec<(&str, Value)> = Vec::new();
+        let mut expected: Vec<(&str, Value)> = Vec::new();
+        for (label, source, inc, exc, want) in cases {
+            actual.push((label, filter_object(&source, &inc, &exc)));
+            expected.push((label, want));
+        }
+        assert_eq!(
+            actual, expected,
+            "ES _source `*` crosses dots at any depth (makeAnyString); scalars kept only when accepted"
         );
     }
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26519,138 +26519,154 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
         return Value::Object(result);
     }
 
-    // Dotted path filtering: flatten, filter, reconstruct.
-    // For dotted includes like "include.field1", we need to check the
-    // full path of each leaf value. Glob semantics: `*` matches a single
-    // path segment (i.e. anything except a literal `.`), mirroring ES's
-    // `_source` filter behavior. A bare `*` also matches any single
-    // segment, so e.g. `*.field2` strips `{include,other}.field2`.
-    fn matches_path(path: &str, patterns: &[String]) -> bool {
-        fn glob_match(pat: &str, path: &str) -> bool {
-            let pat_bytes = pat.as_bytes();
-            let path_bytes = path.as_bytes();
-            // Recursive impl with memoization would be overkill — glob
-            // patterns here are short. Match greedy per character.
-            fn walk(pat: &[u8], path: &[u8]) -> bool {
-                let (mut p, mut s) = (0, 0);
-                while p < pat.len() {
-                    if pat[p] == b'*' {
-                        // Wildcard matches 0+ characters but stops at '.'
-                        // in ES source filter semantics.
-                        let rest_pat = &pat[p + 1..];
-                        // Try each possible match length for '*'.
-                        for end in s..=path.len() {
-                            // '*' cannot swallow a '.' — stop there.
-                            if end > s && path[end - 1] == b'.' {
-                                break;
-                            }
-                            if walk(rest_pat, &path[end..]) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    } else {
-                        if s >= path.len() || pat[p] != path[s] {
-                            return false;
-                        }
-                        p += 1;
-                        s += 1;
-                    }
-                }
-                s == path.len()
-            }
-            walk(pat_bytes, path_bytes)
-        }
-        patterns.iter().any(|p| {
-            if p.contains('*') {
-                // A `prefix.*` include also keeps the whole subtree under
-                // `prefix.` (`glob_match`'s `*` cannot cross a dot, so it alone
-                // would drop `prefix.a.b`). #602: this subtree check must keep
-                // the dot boundary — strip only the trailing `*` (`prefix.`),
-                // NOT `.*` (`prefix`). Otherwise `meta.*` matched `metadata`
-                // via `starts_with("meta")`, where ES keeps only paths under
-                // `meta.` and returns `{}` for a sibling like `metadata`.
-                glob_match(p, path) || (p.ends_with(".*") && path.starts_with(&p[..p.len() - 1]))
-            } else {
-                path == p || path.starts_with(&format!("{}.", p))
-            }
-        })
-    }
+    // Dotted path filtering: a faithful ES `_source` include/exclude automaton.
+    //
+    // ES matches PER PATH SEGMENT. Each pattern is split on `.` into segments;
+    // a `*` matches exactly one WHOLE segment (never across a `.`, because keys
+    // contain no dots); a pattern fully consumed AT a node includes that node's
+    // entire subtree; and an exclude removes a node only when its pattern fully
+    // matches at that node. The previous ad-hoc `matches_path` was a
+    // prefix/recursion matcher that could not step through a leading/mid glob
+    // (`*.foo`, `a.*.c`) nor expand a trailing-`*` segment (`meta*`) across the
+    // dot into the subtree (#602 divergences 2/3/4). Object descent goes through
+    // the automaton; a non-object value (scalar or array) is kept whole when its
+    // key is a live candidate — XERJ does not project into arrays today, so
+    // #602 is deliberately scoped to object-nested paths.
 
-    fn collect_and_filter(
-        source: &Value,
-        prefix: &str,
-        includes: &[String],
-        excludes: &[String],
-    ) -> Value {
-        match source {
-            Value::Object(obj) => {
-                let mut result = serde_json::Map::new();
-                for (k, v) in obj {
-                    let path = if prefix.is_empty() {
-                        k.clone()
-                    } else {
-                        format!("{}.{}", prefix, k)
-                    };
-                    let keep = if includes.is_empty() {
-                        true
-                    } else {
-                        matches_path(&path, includes)
-                            || includes
-                                .iter()
-                                .any(|i| i.starts_with(&format!("{}.", path)))
-                    };
-                    let excluded = matches_path(&path, excludes);
-                    if keep && !excluded {
-                        let filtered = collect_and_filter(v, &path, includes, excludes);
-                        if !filtered.is_null() {
-                            result.insert(k.clone(), filtered);
-                        }
-                    }
-                }
-                // Prune an intermediate object that *filtering* emptied (it had
-                // keys, all removed) so a stripped subtree does not leave a bare
-                // `{}` behind. An object that was ALREADY empty in the source is a
-                // real value the document carried -- but keep it ONLY in an
-                // ACCEPTING state: includes is match-all, or this object's own
-                // path is allow-listed, NOT merely a prefix on the way to a
-                // deeper include. In pure include mode `{"meta": {}}` under
-                // include `meta.foo` (or `meta.*`) has nothing allow-listed below
-                // it, so ES drops it and so must we; under a match-all /
-                // exclude-only filter the empty object must survive (#310).
-                //
-                // `matches_path` cannot be reused WHOLE as the accept test: it
-                // also returns true for a subtree/prefix on the way to a deeper
-                // include (to DRIVE recursion). Its `base.*` subtree clause now
-                // requires the trailing dot (#602 divergence 1:
-                // `path.starts_with(&p[..len-1])` = `base.`, not the old dot-less
-                // `p[..len-2]` = `base`), so bare `meta` is a live but
-                // non-accepting state of `meta.*` -- exactly what ES's automaton
-                // needs. The accept test expresses that directly here: a `base.*`
-                // include accepts only paths strictly below `base.`, and every
-                // other pattern falls to a full `matches_path`.
-                let path_is_accepting = |path: &str| {
-                    includes.iter().any(|inc| match inc.strip_suffix(".*") {
-                        // `base.*`: accept only paths strictly BELOW `base`.
-                        Some(base) => path.starts_with(&format!("{base}.")),
-                        // Plain paths and other globs: a full `matches_path`
-                        // (path is the include, under it, or a full glob match).
-                        None => matches_path(path, std::slice::from_ref(inc)),
-                    })
-                };
-                let already_empty_and_accepted =
-                    obj.is_empty() && (includes.is_empty() || path_is_accepting(prefix));
-                if result.is_empty() && !prefix.is_empty() && !already_empty_and_accepted {
-                    Value::Null
+    // A single-segment glob: `*` matches any run of characters WITHIN one
+    // segment. Keys never contain `.`, so this can never cross a dot boundary —
+    // the property the old cross-path `glob_match` had to enforce by hand.
+    fn seg_matches(seg: &str, key: &str) -> bool {
+        if !seg.contains('*') {
+            return seg == key;
+        }
+        // Iterative glob with backtracking (`*` = greedy, backtrack on mismatch).
+        fn walk(pat: &[u8], s: &[u8]) -> bool {
+            let (mut pi, mut si) = (0usize, 0usize);
+            let (mut star, mut mark) = (usize::MAX, 0usize);
+            while si < s.len() {
+                if pi < pat.len() && pat[pi] == b'*' {
+                    star = pi;
+                    mark = si;
+                    pi += 1;
+                } else if pi < pat.len() && pat[pi] == s[si] {
+                    pi += 1;
+                    si += 1;
+                } else if star != usize::MAX {
+                    pi = star + 1;
+                    mark += 1;
+                    si = mark;
                 } else {
-                    Value::Object(result)
+                    return false;
                 }
             }
-            _ => source.clone(),
+            while pi < pat.len() && pat[pi] == b'*' {
+                pi += 1;
+            }
+            pi == pat.len()
         }
+        walk(seg.as_bytes(), key.as_bytes())
     }
 
-    collect_and_filter(source, "", includes, excludes)
+    // Filter one value against the active include/exclude segment-suffixes.
+    // `include_all` means an ancestor pattern was already fully consumed (or
+    // the top-level include list is empty), so this whole subtree is included
+    // subject only to excludes.
+    fn es_filter(
+        value: &Value,
+        include_all: bool,
+        includes: &[&[String]],
+        excludes: &[&[String]],
+    ) -> Value {
+        let Value::Object(obj) = value else {
+            return value.clone();
+        };
+        let level_all = include_all || includes.is_empty();
+        let mut out = serde_json::Map::new();
+        for (key, val) in obj {
+            // An exclude whose pattern fully matches AT this node drops the value.
+            if excludes
+                .iter()
+                .any(|p| p.len() == 1 && seg_matches(&p[0], key))
+            {
+                continue;
+            }
+            let exc_children: Vec<&[String]> = excludes
+                .iter()
+                .filter(|p| p.len() > 1 && seg_matches(&p[0], key))
+                .map(|p| &p[1..])
+                .collect();
+
+            // Which include patterns match this key? A fully-consumed one
+            // includes the whole subtree; a longer one is a LIVE state that
+            // descends by its tail.
+            let mut key_fully_included = false;
+            let inc_children: Vec<&[String]> = includes
+                .iter()
+                .filter_map(|p| {
+                    if seg_matches(&p[0], key) {
+                        if p.len() == 1 {
+                            key_fully_included = true;
+                            None
+                        } else {
+                            Some(&p[1..])
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let candidate = level_all || key_fully_included || !inc_children.is_empty();
+            if !candidate {
+                continue;
+            }
+            let child_all = level_all || key_fully_included;
+
+            // Fully included with nothing to strip below → keep the value as-is.
+            if child_all && exc_children.is_empty() {
+                out.insert(key.clone(), val.clone());
+                continue;
+            }
+
+            match val {
+                Value::Object(child_obj) => {
+                    let filtered = es_filter(val, child_all, &inc_children, &exc_children);
+                    let keep = match &filtered {
+                        // An object that *filtering* emptied is pruned; one that
+                        // was ALREADY empty in the source survives only in an
+                        // accepting state (its own path fully included) — a live
+                        // prefix state on the way to a deeper include is dropped,
+                        // matching ES (#310).
+                        Value::Object(m) if m.is_empty() => child_obj.is_empty() && child_all,
+                        _ => true,
+                    };
+                    if keep {
+                        out.insert(key.clone(), filtered);
+                    }
+                }
+                // Non-object (scalar/array): kept whole — XERJ does not project
+                // into arrays, and a scalar cannot satisfy a deeper include, so
+                // preserving it matches prior behavior without array data-loss.
+                _ => {
+                    out.insert(key.clone(), val.clone());
+                }
+            }
+        }
+        Value::Object(out)
+    }
+
+    let inc: Vec<Vec<String>> = includes
+        .iter()
+        .map(|p| p.split('.').map(str::to_string).collect())
+        .collect();
+    let exc: Vec<Vec<String>> = excludes
+        .iter()
+        .map(|p| p.split('.').map(str::to_string).collect())
+        .collect();
+    let inc_refs: Vec<&[String]> = inc.iter().map(Vec::as_slice).collect();
+    let exc_refs: Vec<&[String]> = exc.iter().map(Vec::as_slice).collect();
+    es_filter(source, false, &inc_refs, &exc_refs)
 }
 
 #[cfg(test)]
@@ -26857,6 +26873,88 @@ mod source_filter_tests {
             ),
             json!({ "meta": { "foo": 1 } }),
             "meta.* keeps meta.* but not the prefix-sharing metadata (#602)"
+        );
+    }
+
+    /// #602 (divergences 2, 3, 4): a faithful ES `_source` include/exclude
+    /// automaton matches PER SEGMENT — `*` matches exactly one whole path
+    /// segment (never across a `.`), a pattern fully consumed at a node includes
+    /// that node's entire subtree, and an exclude removes a node only when its
+    /// pattern fully matches AT that node. The old `matches_path`/prefix logic
+    /// could not step through a leading/mid glob (2) or expand a trailing-`*`
+    /// segment across the dot into the subtree (3), and its `exclude a.*` clause
+    /// wrongly marked the bare parent excluded (4).
+    #[test]
+    fn source_glob_leading_mid_and_trailing_match_es_semantics() {
+        let cases: Vec<(&str, Value, Vec<String>, Vec<String>, Value)> = vec![
+            // 2a: a LEADING glob descends and keeps only the matching leaf.
+            (
+                "*.foo keeps a.foo, drops a.bar",
+                json!({ "a": { "foo": 1, "bar": 2 } }),
+                vec!["*.foo".into()],
+                vec![],
+                json!({ "a": { "foo": 1 } }),
+            ),
+            // 2b: a MID glob steps through one segment.
+            (
+                "a.*.c keeps a.b.c, drops a.b.d",
+                json!({ "a": { "b": { "c": 1, "d": 2 } } }),
+                vec!["a.*.c".into()],
+                vec![],
+                json!({ "a": { "b": { "c": 1 } } }),
+            ),
+            // 2c: a leading glob spans multiple parents.
+            (
+                "*.foo across siblings",
+                json!({ "x": { "foo": 1 }, "y": { "foo": 2, "z": 3 } }),
+                vec!["*.foo".into()],
+                vec![],
+                json!({ "x": { "foo": 1 }, "y": { "foo": 2 } }),
+            ),
+            // 3: a trailing `*` on a full segment includes the whole subtree
+            //    (the segment `meta*` matches key `meta`; nothing remains, so
+            //    `meta`'s subtree is kept). NOT the same as `*` crossing the dot.
+            //    The non-matching dotted sibling `zzz.absent` forces the nested
+            //    branch (has_dotted), where the old matcher wrongly dropped the
+            //    subtree because `meta*`'s `*` could not cross the dot.
+            (
+                "meta* keeps meta and its subtree (nested branch)",
+                json!({ "meta": { "foo": 1 } }),
+                vec!["meta*".into(), "zzz.absent".into()],
+                vec![],
+                json!({ "meta": { "foo": 1 } }),
+            ),
+            // 3': but `meta*` must NOT match a differently-named sibling key.
+            (
+                "meta* does not match sibling `other` (nested branch)",
+                json!({ "meta": { "foo": 1 }, "other": { "foo": 2 } }),
+                vec!["meta*".into(), "zzz.absent".into()],
+                vec![],
+                json!({ "meta": { "foo": 1 } }),
+            ),
+            // 4: `exclude a.*` removes a's CHILDREN, not `a` itself — an empty
+            //    `a` has no child to match, so `a` survives. (The
+            //    populated-then-emptied case is deliberately NOT asserted here:
+            //    XERJ prunes a filtering-emptied object, pinned by the #310
+            //    `dotted_filter_keeps_an_already_empty_source_object...` test.)
+            (
+                "exclude a.* keeps empty a",
+                json!({ "a": {} }),
+                vec![],
+                vec!["a.*".into()],
+                json!({ "a": {} }),
+            ),
+        ];
+
+        let mut actual: Vec<(&str, Value)> = Vec::new();
+        let mut expected: Vec<(&str, Value)> = Vec::new();
+        for (label, source, inc, exc, want) in cases {
+            actual.push((label, filter_object(&source, &inc, &exc)));
+            expected.push((label, want));
+        }
+        assert_eq!(
+            actual, expected,
+            "ES _source glob parity (#602 divergences 2/3/4)"
         );
     }
 


### PR DESCRIPTION
Closes #602.

## Problem
`filter_object`'s dotted-path branch (`index.rs`) used an ad-hoc prefix/recursion matcher (`matches_path`) that could not step through a leading/mid glob nor expand a trailing-`*` segment across the dot into a subtree. Nested/dotted `_source` include patterns therefore returned ES-divergent projections (the three divergences left open after #599 fixed divergence 1):

- **Divergence 2 (leading/mid glob):** `["*.foo"]` over `{"a":{"foo":1,"bar":2}}` and `["a.*.c"]` over `{"a":{"b":{"c":1,"d":2}}}` returned `{}` — ES keeps `{"a":{"foo":1}}` / `{"a":{"b":{"c":1}}}`.
- **Divergence 3 (trailing `*` across the dot):** `["meta*"]` alongside a dotted sibling (which forces the nested branch) dropped `meta`'s whole subtree; ES keeps it (the segment `meta*` fully matches key `meta`, so the subtree is included).
- **Divergence 4 (`exclude a.*` over `{"a":{}}`):** already correct on current `main` via #310's `path_is_accepting`; pinned by a test.

## Fix
Replaced `matches_path`/`collect_and_filter` with a faithful **per-segment ES automaton**:
- each pattern is split on `.` into segments; a `*` matches exactly **one whole segment** (never across a `.`, since keys hold no dots);
- a pattern **fully consumed at a node includes that node's entire subtree**;
- an **exclude drops a node only on a full match at that node** (a deeper exclude strips children, never the bare parent).

Preserved exactly:
- the #310 empty-object rules — prune a *filtering-emptied* object, keep an *already-empty* one only in an accepting state;
- divergence 1 (dot boundary: `meta.*` keeps only paths under `meta.`, not the sibling `metadata`);
- object descent goes through the automaton while non-object values (scalars/arrays) are kept whole, so **no array data-loss** is introduced (scope is object-nested paths, per the issue).

## Testing (rustc 1.97.1)
- New `source_glob_leading_mid_and_trailing_match_es_semantics` covers divergences 2/3/4; **fail-before** confirmed (2a/2b/2c returned `{}`, nested `meta*` dropped its subtree) before the automaton landed.
- All existing #310 / #602-div1 source-filter tests unchanged and green (11/11 in `source_filter_tests`).
- Full `cargo test -p xerj-engine` — **dev**: 51 binaries, 0 failures; **`--profile ci-test`**: 51 binaries, 0 failures.
- Full `cargo test -p xerj-api` — dev: 53 binaries, 0 failures.
- `cargo fmt --all --check` clean; `cargo clippy -p xerj-engine --all-targets -- -D warnings` clean.