### PR TITLE
fix(api): fields/docvalue_fields resolve a named companion under the default _source (#310)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -10866,9 +10866,11 @@ async fn search_impl(
         Vec::new()
     };
     // One schema read-lock per participating index, and only for a request that
-    // could actually consume the answer.
+    // could actually consume the answer. (The collapse `inner_hits` companion
+    // leak under a default projection is a separate, pre-existing gap tracked as
+    // a follow-up; it is not driven by the pierce, so it is not populated here.)
     let mut companions_by_index: HashMap<String, HashSet<String>> = HashMap::new();
-    if default_source_projection && (!value_bearing_names.is_empty() || body.collapse.is_some()) {
+    if default_source_projection && !value_bearing_names.is_empty() {
         for idx_name in &index_names {
             let Ok(idx) = state.engine.get_index(idx_name) else {
                 continue;
@@ -11755,7 +11757,23 @@ async fn search_impl(
     let scroll_snapshot: Option<Vec<(String, xerj_query::executor::Hit)>> = if is_scroll_request {
         // Keep the index name with each hit (#414): dropping it here is what
         // made continuation pages fall back to a single context-level name.
-        Some(merged_hits.clone())
+        let mut snap = merged_hits.clone();
+        // #310 emission site 3: the snapshot outlives this response, and every
+        // later page is rendered by `scroll_page_response`, which carries no
+        // `fields` clause of its own and so has no reason to hold companions.
+        // Undo the pierce before the context is stored — otherwise page 1
+        // honours #309 and pages 2..n ship the companion in `_source`.
+        if pierce_default_source {
+            for (idx_name, h) in snap.iter_mut() {
+                if let (Some(companions), Some(obj)) = (
+                    companions_by_index.get(idx_name.as_str()),
+                    h.source.as_object_mut(),
+                ) {
+                    obj.retain(|name, _| !companions.contains(name));
+                }
+            }
+        }
+        Some(snap)
     } else {
         None
     };

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -11971,6 +11971,22 @@ async fn search_impl(
                         !name.starts_with(xerj_query::executor::PASSAGE_METADATA_PREFIX)
                     });
                 }
+                // #310 emission site 1: this request pierced the default
+                // `_source` projection so the `fields` builder below could
+                // resolve an embedding companion the caller explicitly named.
+                // The pierce ends HERE — `fields` reads `h.source`, which is
+                // untouched, while the wire `_source` carries exactly what the
+                // #309 default would have carried. Miss this and #309's headline
+                // guarantee turns into a full-vector response for anyone who
+                // named a companion in `fields`.
+                if pierce_default_source {
+                    if let (Some(companions), Some(obj)) = (
+                        companions_by_index.get(idx_name.as_str()),
+                        s.as_object_mut(),
+                    ) {
+                        obj.retain(|name, _| !companions.contains(name));
+                    }
+                }
                 // Non-synthetic mode: strip the internal copy-to
                 // tracking marker; keep the copied values in the source
                 // since stored-source clients expect them.

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -34424,7 +34424,17 @@ pub(crate) fn build_docvalue_fields(
         } else {
             arr
         };
+        // A field that resolves to NO values is omitted, never emitted as a bare
+        // `[]` (#310): `{"body_vector": []}` is a positive claim that the doc has
+        // no values for that field. ES omits an unresolvable `docvalue_fields`
+        // entry entirely (mirrors the `fields` builder's `None => continue`).
+        if formatted.is_empty() {
+            continue;
+        }
         map.insert(field_name.to_string(), Value::Array(formatted));
+    }
+    if map.is_empty() {
+        return None;
     }
     Some(map)
 }

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -5992,6 +5992,47 @@ fn parse_time_to_millis(s: &str) -> Option<u64> {
     Some(n.saturating_mul(mul_ms).max(1))
 }
 
+/// Every field name this request pulls a VALUE out of the stored document for
+/// by a route other than `_source` — the `fields` clause and `docvalue_fields`.
+///
+/// Used once per request, before the engine runs, to decide whether the default
+/// `_source` projection has to be pierced (#310). It deliberately re-parses the
+/// two clauses instead of the response-time lists built later in `search_impl`:
+/// the decision has to be taken BEFORE the search, and the URL-param forms
+/// (`?fields=`, `?docvalue_fields=`) have already been promoted into `body` by
+/// then, so this sees exactly what the response layer will.
+fn value_bearing_field_names(body: &EsSearchBody, fields: &[String]) -> Vec<String> {
+    fn push_names(v: Option<&Value>, out: &mut Vec<String>) {
+        match v {
+            Some(Value::Array(arr)) => {
+                for entry in arr {
+                    match entry {
+                        Value::String(s) => out.push(s.clone()),
+                        Value::Object(o) => {
+                            if let Some(name) = o.get("field").and_then(Value::as_str) {
+                                out.push(name.to_string());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Some(Value::String(s)) => out.push(s.clone()),
+            _ => {}
+        }
+    }
+    let mut names = Vec::new();
+    match &body.fields {
+        Some(v @ (Value::Array(_) | Value::String(_))) => push_names(Some(v), &mut names),
+        // Same fallback the response-time `field_specs` builder takes: anything
+        // else (absent, or a shape the body parser does not recognise) leaves
+        // the typed request's list.
+        _ => names.extend(fields.iter().cloned()),
+    }
+    push_names(body.docvalue_fields.as_ref(), &mut names);
+    names
+}
+
 /// Build a `SearchRequest` from the ES body, forwarding all relevant options.
 fn build_search_request(
     body: &EsSearchBody,
@@ -10784,7 +10825,7 @@ async fn search_impl(
         .filter(|n| !value_type_failed_indices.contains(*n))
         .collect();
 
-    let search_req = match build_search_request(&body, aggs_value) {
+    let mut search_req = match build_search_request(&body, aggs_value) {
         Ok(mut r) => {
             // ES 7.16 leaf ordering for the implicit auto-@timestamp hint
             // (see the injection block above) — internal field, never on
@@ -10797,6 +10838,57 @@ async fn search_impl(
         }
         Err(e) => return ApiError::new(e).into_response(),
     };
+
+    // ── The default `_source` projection, and who has to see past it (#310) ──
+    //
+    // Since #309 a request with no `_source` clause gets `SourceFilter::Default`
+    // and the engine drops the generated embedding companions before the
+    // response layer ever sees a hit. But `_source` is not the only consumer of
+    // the stored document: `fields` and `docvalue_fields` resolve their values
+    // out of that same `hit.source`, AFTER the projection has narrowed it. So
+    // `{"fields": ["body_vector"]}` came back with nothing — silently, because an
+    // unresolvable `fields` entry is legally omitted — while the very same clause
+    // under `"_source": false` returned the whole vector, since `Enabled(false)`
+    // deliberately keeps the raw source for exactly this resolution. Two spellings
+    // of "I do not want `_source`", opposite answers.
+    //
+    // The fix: if a caller named a companion in `fields`/`docvalue_fields` and
+    // wrote no `_source` clause, ask the engine for the intact source and narrow
+    // it back to the default at each emission site below. Wire bytes are
+    // unchanged; the caller gets the value they explicitly asked for. Decided in
+    // the API (the only layer that sees the `fields` clause), not the engine —
+    // teaching the engine to treat `Default` as `Enabled(true)` would put
+    // companions back into every internal `SearchRequest::default()`.
+    let default_source_projection = body.source.is_none();
+    let value_bearing_names = if default_source_projection {
+        value_bearing_field_names(&body, &search_req.fields)
+    } else {
+        Vec::new()
+    };
+    // One schema read-lock per participating index, and only for a request that
+    // could actually consume the answer.
+    let mut companions_by_index: HashMap<String, HashSet<String>> = HashMap::new();
+    if default_source_projection && (!value_bearing_names.is_empty() || body.collapse.is_some()) {
+        for idx_name in &index_names {
+            let Ok(idx) = state.engine.get_index(idx_name) else {
+                continue;
+            };
+            let companions = idx.embedding_companion_fields().await;
+            if !companions.is_empty() {
+                companions_by_index.insert((*idx_name).to_string(), companions);
+            }
+        }
+    }
+    // The pierce, and the obligation it creates: every site that emits a
+    // `_source` for this response must undo it (top-level hit, collapse
+    // `inner_hits`, scroll snapshot).
+    let pierce_default_source = value_bearing_names
+        .iter()
+        .any(|f| companions_by_index.values().any(|c| c.contains(f)));
+    if pierce_default_source {
+        search_req.source = xerj_query::ast::SourceFilter::Enabled(true);
+    }
+    let search_req = search_req;
 
     // Execute search on each index and merge results.
     let mut merged_hits: Vec<(String, xerj_query::executor::Hit)> = Vec::new(); // (index_name, hit)

--- a/engine/crates/xerj-api/tests/fields_pierce_default_source.rs
+++ b/engine/crates/xerj-api/tests/fields_pierce_default_source.rs
@@ -1,0 +1,296 @@
+//! Issue #310 — a `fields` clause must see past the default `_source`
+//! projection, and must not drag the projection open on the wire.
+//!
+//! Since #309 a request with no `_source` clause gets `SourceFilter::Default`
+//! and the engine strips the generated embedding companions before the response
+//! layer runs. `fields` and `docvalue_fields` resolve their values out of that
+//! same `hit.source`, so a caller who explicitly named `body_vector` in `fields`
+//! got nothing back — silently, since an unresolvable `fields` entry is legally
+//! omitted — while the identical clause under `"_source": false` returned every
+//! float, because `Enabled(false)` deliberately keeps the raw source.
+//!
+//! Every assertion below is paired. The POSITIVE half (the value comes back) is
+//! the fix; the NEGATIVE half (`_source` still has no companion key) is what
+//! makes the test worth having, because the fix works by asking the engine for
+//! the intact source and re-narrowing it at emission — miss one emission site
+//! and #309's guarantee regresses to a full-vector response with the positive
+//! assertions still passing.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use xerj_common::types::{EmbeddingConfig, FieldConfig, FieldType, Schema};
+
+const DIMS: usize = 32;
+
+async fn seeded_app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+
+    let mut schema = Schema::empty();
+    let mut body = FieldConfig::new("body", FieldType::Text);
+    body.options.dimensions = Some(DIMS);
+    body.options.similarity = Some("cosine".into());
+    body.embedding = Some(EmbeddingConfig {
+        endpoint: None,
+        model: None,
+        target_field: Some("body_vector".into()),
+    });
+    schema.add_field(body).expect("body field");
+    let mut companion = FieldConfig::new("body_vector", FieldType::Vector);
+    companion.options.dimensions = Some(DIMS);
+    companion.options.similarity = Some("cosine".into());
+    schema.add_field(companion).expect("body_vector field");
+    schema
+        .add_field(FieldConfig::new("title", FieldType::Keyword))
+        .expect("title field");
+
+    state.engine.create_index("docs", schema).expect("create");
+    let idx = state.engine.get_index("docs").expect("get index");
+    idx.index_document(
+        Some("1".into()),
+        json!({
+            "body": "XERJ resolves an explicitly named embedding companion \
+                     through the fields API without widening _source. "
+                .repeat(8),
+            "title": "first",
+        }),
+    )
+    .await
+    .expect("index document");
+    idx.refresh().await.expect("refresh");
+
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn post(app: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(path)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let value: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+fn first_hit(response: &Value) -> &Value {
+    &response["hits"]["hits"][0]
+}
+
+/// The three spellings of the same `fields` request must agree.
+///
+/// `_source` omitted was the broken one: it returned nothing while `_source:
+/// false` — a strictly *stronger* statement of "do not send me the document" —
+/// returned all 32 floats.
+#[tokio::test]
+async fn fields_resolves_a_named_companion_under_every_source_spelling() {
+    let (app, _dir) = seeded_app().await;
+
+    for source_clause in [None, Some(json!(false)), Some(json!(true))] {
+        let mut body = json!({
+            "query": { "match_all": {} },
+            "size": 1,
+            "fields": ["body_vector"],
+        });
+        if let Some(clause) = source_clause.clone() {
+            body["_source"] = clause;
+        }
+        let label = source_clause
+            .as_ref()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "omitted".to_string());
+
+        let (status, response) = post(&app, "/docs/_search", body).await;
+        assert_eq!(status, StatusCode::OK, "_source {label}: {response}");
+
+        let values = first_hit(&response)["fields"]["body_vector"]
+            .as_array()
+            .unwrap_or_else(|| panic!("_source {label}: no fields.body_vector in {response}"));
+        assert_eq!(
+            values.len(),
+            DIMS,
+            "_source {label}: fields.body_vector must carry the whole vector: {response}"
+        );
+    }
+}
+
+/// The #309 guarantee, restated as the negative control for the fix above: the
+/// pierce hands the engine's intact source to the `fields` builder, so the ONLY
+/// thing keeping the vector off the wire is the emission-time re-narrowing.
+#[tokio::test]
+async fn piercing_for_fields_does_not_widen_source_on_the_wire() {
+    let (app, _dir) = seeded_app().await;
+
+    let (status, response) = post(
+        &app,
+        "/docs/_search",
+        json!({
+            "query": { "match_all": {} },
+            "size": 1,
+            "fields": ["body_vector"],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response}");
+
+    let hit = first_hit(&response);
+    let source = hit["_source"]
+        .as_object()
+        .unwrap_or_else(|| panic!("_source must still be emitted: {response}"));
+    assert!(
+        !source.contains_key("body_vector"),
+        "#309: the default projection must not return the generated companion in _source: {response}"
+    );
+    assert!(
+        !source.contains_key("body_vector_chunks"),
+        "#309: the default projection must not return the generated chunks in _source: {response}"
+    );
+    assert_eq!(
+        source.get("title"),
+        Some(&json!("first")),
+        "ordinary user fields must survive the re-narrowing: {response}"
+    );
+    // …and the value the caller actually asked for is still there.
+    assert_eq!(
+        hit["fields"]["body_vector"]
+            .as_array()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        DIMS,
+        "{response}"
+    );
+}
+
+/// A request that names nothing special must be byte-identical to the #309
+/// default: no pierce, no `fields` block, no companion anywhere.
+#[tokio::test]
+async fn a_plain_default_search_is_untouched() {
+    let (app, _dir) = seeded_app().await;
+
+    let (status, response) = post(
+        &app,
+        "/docs/_search",
+        json!({ "query": { "match_all": {} }, "size": 1 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response}");
+
+    let source = first_hit(&response)["_source"]
+        .as_object()
+        .expect("_source object");
+    assert!(!source.contains_key("body_vector"), "{response}");
+    assert!(!source.contains_key("body_vector_chunks"), "{response}");
+    assert!(source.contains_key("body"), "{response}");
+}
+
+/// `docvalue_fields` is the same resolution path, and used to emit the wrong
+/// thing rather than nothing: `{"body_vector": []}` — a positive claim that the
+/// document has no values for that field. A field that resolves to nothing is
+/// omitted; a field that resolves is complete. Never an empty array.
+#[tokio::test]
+async fn docvalue_fields_never_emits_a_bare_empty_array() {
+    let (app, _dir) = seeded_app().await;
+
+    let (status, response) = post(
+        &app,
+        "/docs/_search",
+        json!({
+            "query": { "match_all": {} },
+            "size": 1,
+            "docvalue_fields": ["body_vector", "no_such_field"],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response}");
+
+    let hit = first_hit(&response);
+    assert_eq!(
+        hit["fields"]["body_vector"]
+            .as_array()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        DIMS,
+        "docvalue_fields must resolve the named companion: {response}"
+    );
+    assert!(
+        hit["fields"].get("no_such_field").is_none(),
+        "an unresolvable docvalue_field is omitted, not emitted as []: {response}"
+    );
+    let source = hit["_source"].as_object().expect("_source object");
+    assert!(
+        !source.contains_key("body_vector"),
+        "#309 must hold on the docvalue_fields route too: {response}"
+    );
+}
+
+/// Issue #310 claim 2: a dotted `embedding.target_field` used to route the
+/// default projection through the nested `_source` filter, whose empty-object
+/// pruning deleted unrelated `{}` fields from every hit of every search.
+#[tokio::test]
+async fn a_dotted_target_field_keeps_unrelated_empty_objects() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+
+    let mut schema = Schema::empty();
+    let mut body = FieldConfig::new("body", FieldType::Text);
+    body.options.dimensions = Some(DIMS);
+    body.options.similarity = Some("cosine".into());
+    body.embedding = Some(EmbeddingConfig {
+        endpoint: None,
+        model: None,
+        target_field: Some("semantic.embedding".into()),
+    });
+    schema.add_field(body).expect("body field");
+
+    state.engine.create_index("dotted", schema).expect("create");
+    let idx = state.engine.get_index("dotted").expect("get index");
+    idx.index_document(
+        Some("1".into()),
+        json!({ "body": "a dotted target field is a literal top-level key", "meta": {} }),
+    )
+    .await
+    .expect("index document");
+    idx.refresh().await.expect("refresh");
+    let app = xerj_api::router::build_es_compat_router(state);
+
+    let (status, response) = post(
+        &app,
+        "/dotted/_search",
+        json!({ "query": { "match_all": {} }, "size": 1 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response}");
+
+    let source = first_hit(&response)["_source"]
+        .as_object()
+        .expect("_source object");
+    assert_eq!(
+        source.get("meta"),
+        Some(&json!({})),
+        "an unrelated empty object must survive a dotted embedding target: {response}"
+    );
+    assert!(
+        !source.contains_key("semantic.embedding"),
+        "the dotted companion itself must still be omitted: {response}"
+    );
+}

--- a/engine/crates/xerj-api/tests/fields_pierce_default_source.rs
+++ b/engine/crates/xerj-api/tests/fields_pierce_default_source.rs
@@ -294,3 +294,74 @@ async fn a_dotted_target_field_keeps_unrelated_empty_objects() {
         "the dotted companion itself must still be omitted: {response}"
     );
 }
+
+/// #310 emission site 3: a `_search?scroll=` that pierced the default `_source`
+/// for a `fields` companion must NOT leak that companion on the CONTINUATION
+/// pages. The scroll snapshot is taken in `search_impl`; the pierce widened it
+/// to the intact source, so page 1 (rendered inline) is re-narrowed by site 1
+/// but pages 2..n (rendered by `scroll_page_response`, which has no `fields`
+/// clause) would ship the vector unless the snapshot itself is re-narrowed.
+#[tokio::test]
+async fn scroll_continuation_does_not_leak_a_companion_after_a_pierce() {
+    let (app, _dir) = seeded_app().await;
+    // A second doc so a size:1 scroll has a continuation page.
+    let (status, _) = post(
+        &app,
+        "/docs/_doc/2",
+        json!({ "body": "a second document so the scroll has a page two. ".repeat(8), "title": "second" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "index second doc");
+    let _ = post(&app, "/docs/_refresh", Value::Null).await;
+
+    // Page 1: pierce for the named companion, size 1, default `_source`.
+    let (status, page1) = post(
+        &app,
+        "/docs/_search?scroll=5m",
+        json!({ "query": { "match_all": {} }, "size": 1, "fields": ["body_vector"] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{page1}");
+    let h1 = first_hit(&page1);
+    assert_eq!(
+        h1["fields"]["body_vector"]
+            .as_array()
+            .map(|v| v.len())
+            .unwrap_or(0),
+        DIMS,
+        "page 1 must resolve the named companion via the pierce: {page1}"
+    );
+    assert!(
+        !h1["_source"]
+            .as_object()
+            .expect("_source")
+            .contains_key("body_vector"),
+        "page 1 _source must not leak the companion (#309 via site 1): {page1}"
+    );
+    let sid = page1["_scroll_id"].as_str().expect("scroll id").to_string();
+
+    // Page 2 (continuation): rendered by scroll_page_response, no `fields`
+    // clause. The companion must be absent from `_source` (site 3).
+    let (status, page2) = post(
+        &app,
+        "/_search/scroll",
+        json!({ "scroll": "5m", "scroll_id": sid }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{page2}");
+    let h2 = first_hit(&page2);
+    assert!(
+        !h2["_source"]
+            .as_object()
+            .expect("_source")
+            .contains_key("body_vector"),
+        "#310 site 3: the scroll continuation must not leak the companion: {page2}"
+    );
+    assert!(
+        !h2["_source"]
+            .as_object()
+            .expect("_source")
+            .contains_key("body_vector_chunks"),
+        "#310 site 3: the chunks companion must not leak either: {page2}"
+    );
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -8405,6 +8405,20 @@ impl Index {
     /// RAM.  This keeps memory usage bounded regardless of dataset size.
     ///
     /// Search reads: active memtable (RAM) + disk segments (file I/O).
+    /// The engine-generated embedding companion field names for this index —
+    /// exactly the keys the default `_source` projection omits (#309).
+    ///
+    /// Published for the API layer, which has to know the same set for a reason
+    /// the engine cannot serve: only the API sees the `fields`/`docvalue_fields`
+    /// clauses, and only it can decide that a caller who named a companion there
+    /// must get the intact source from the engine and the narrowed one on the
+    /// wire (#310). The mapping rule stays in `generated_embedding_companion_fields`;
+    /// this is a lock-scoped accessor for it, not a second implementation.
+    pub async fn embedding_companion_fields(&self) -> HashSet<String> {
+        let schema = self.schema.read().await;
+        generated_embedding_companion_fields(&schema.schema)
+    }
+
     pub async fn refresh(&self) -> Result<()> {
         {
             let mem = &*self.memtable;


### PR DESCRIPTION
Closes #310 (claim 1). (Claim 2 — dotted embedding `target_field` deleting empty objects — already landed via #599.)

## Problem
Since #309, a request with no `_source` clause gets `SourceFilter::Default` and the engine strips the generated embedding companions (`*_vector`, `*_vector_chunks`) before the response layer runs. But `fields` and `docvalue_fields` resolve their values out of that **same, already-narrowed** `hit.source` — so `{"fields": ["body_vector"]}` came back empty, **silently** (an unresolvable `fields` entry is legally omitted), while the identical clause under `"_source": false` returned the whole vector (because `Enabled(false)` deliberately keeps the raw source). Two spellings of "I don't want `_source`", opposite answers.

## Fix
Decided in the API (the only layer that sees the `fields` clause), not the engine — teaching the engine to treat `Default` as `Enabled(true)` would put companions back into every internal `SearchRequest::default()`.

- **`value_bearing_field_names(body, fields)`** — names pulled by a non-`_source` route (`fields` + `docvalue_fields`), computed before the search (URL `?fields=`/`?docvalue_fields=` are promoted into `body` by then).
- **Pierce**: when `_source` is `Default` and a named field is an embedding companion, set `search_req.source = Enabled(true)` so the builder resolves it from the intact source. `Index::embedding_companion_fields()` (a lock-scoped accessor over the existing `generated_embedding_companion_fields`) supplies the set.
- **Emission obligation** — re-narrow `_source` back to the #309 default at each site so the wire bytes are unchanged:
  - **site 1** — the top-level hit `_source`;
  - **site 3** — the scroll snapshot (before the `ScrollContext` is stored), so continuation pages rendered by `scroll_page_response` don't leak.
- **`build_docvalue_fields`** — an unresolvable `docvalue_field` is now **omitted** rather than emitted as a bare `[]` (`{"body_vector": []}` is a false "no values" claim); mirrors the `fields` builder's `None => continue`.

## Scope / follow-up
The collapse `inner_hits` companion leak under a default projection is **pre-existing and independent of the pierce** (the inner_hits source is stashed before the projection) — deliberately **out of scope** here and filed as **#646**. This PR therefore does not populate `companions_by_index` for a bare collapse request.

## Testing (rustc 1.97.1)
- New `fields_pierce_default_source.rs` (6 tests): `fields`/`docvalue_fields` resolve the companion under every `_source` spelling, `_source` never widens on the wire (positive+negative paired), unresolvable field omitted (not `[]`), a plain default search is untouched, and **scroll continuation does not leak the companion** (site 3).
- **Fail-before proven**: on current `main` 3/5 of the ported cases fail (companion resolves to `[]`).
- Full `cargo test -p xerj-engine` — dev + `--profile ci-test`: 52 binaries each, 0 failures.
- Full `cargo test -p xerj-api` — dev + `--profile ci-test`: 55 binaries each, 0 failures.
- `cargo fmt --all --check` clean; `cargo clippy -p xerj-api -p xerj-engine --all-targets -- -D warnings` clean.