### PR TITLE
fix(engine): project _source filters inside arrays of objects (#644)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26697,13 +26697,28 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
                         out.insert(key.clone(), filtered);
                     }
                 }
-                // An array is kept WHOLE whenever its key is selected: XERJ does
-                // not project inside arrays (documented scope), which also keeps
-                // it free of the projection-induced data loss #602 must avoid.
-                // (Consequence: an exclude cannot strip fields inside an array of
-                // objects — tracked separately, not a #602 regression.)
-                Value::Array(_) => {
-                    out.insert(key.clone(), val.clone());
+                // ES treats an array index as transparent to a `_source` path,
+                // so a pattern projects INTO each element (#644): `tags.name`
+                // matches `tags[i].name`. A fully-included array with no exclude
+                // reaching into it is kept whole (the fast path); otherwise each
+                // element is filtered at the SAME `child` path — an object
+                // element recurses, a scalar element survives only in an
+                // accepting state (like a scalar leaf).
+                Value::Array(arr) => {
+                    if child_all && !exc_live {
+                        out.insert(key.clone(), val.clone());
+                    } else {
+                        let projected: Vec<Value> = arr
+                            .iter()
+                            .filter_map(|elem| match elem {
+                                Value::Object(_) => {
+                                    Some(es_filter(elem, &child, child_all, includes, excludes))
+                                }
+                                other => child_all.then(|| other.clone()),
+                            })
+                            .collect();
+                        out.insert(key.clone(), Value::Array(projected));
+                    }
                 }
                 // A scalar leaf is kept ONLY in an ACCEPTing state. A scalar that
                 // merely sits on a LIVE (not-yet-accepted) include path cannot
@@ -27115,6 +27130,35 @@ mod source_filter_tests {
             ),
             json!({ "keep": 2, "nested": { "host": 4 } }),
             "dot-less `exclude *secret` must strip `password_secret` and nested `api_secret` (#602)"
+        );
+    }
+
+    /// #644: ES projects INSIDE an array of objects — the array index is
+    /// transparent to a `_source` path, so `include ["tags.name"]` keeps only
+    /// each element's `name`, and `exclude ["logs.secret"]` scrubs `secret` from
+    /// every element. XERJ currently keeps the array whole (the #602 no-array-
+    /// projection scope), leaking the un-selected fields.
+    #[test]
+    fn source_filter_projects_inside_arrays_of_objects() {
+        // include: keep only the named leaf inside each array element.
+        assert_eq!(
+            filter_object(
+                &json!({ "tags": [{ "name": "x", "id": 1 }, { "name": "y", "id": 2 }], "n": 9 }),
+                &["tags.name".to_string()],
+                &[]
+            ),
+            json!({ "tags": [{ "name": "x" }, { "name": "y" }] }),
+            "#644: include tags.name must project into each array element"
+        );
+        // exclude: scrub the named leaf from each array element.
+        assert_eq!(
+            filter_object(
+                &json!({ "logs": [{ "msg": 1, "secret": 2 }, { "msg": 3, "secret": 4 }] }),
+                &[],
+                &["logs.secret".to_string()]
+            ),
+            json!({ "logs": [{ "msg": 1 }, { "msg": 3 }] }),
+            "#644: exclude logs.secret must strip secret from every array element"
         );
     }
 

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26711,13 +26711,31 @@ fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Va
                         let projected: Vec<Value> = arr
                             .iter()
                             .filter_map(|elem| match elem {
-                                Value::Object(_) => {
-                                    Some(es_filter(elem, &child, child_all, includes, excludes))
+                                Value::Object(child_obj) => {
+                                    let f = es_filter(elem, &child, child_all, includes, excludes);
+                                    match &f {
+                                        // An element that *filtering* emptied is
+                                        // dropped from the array; one that was
+                                        // ALREADY `{}` survives only in an
+                                        // accepting state — same rule ES applies
+                                        // to array elements as to map values.
+                                        Value::Object(m) if m.is_empty() => {
+                                            (child_obj.is_empty() && child_all).then_some(f)
+                                        }
+                                        _ => Some(f),
+                                    }
                                 }
                                 other => child_all.then(|| other.clone()),
                             })
                             .collect();
-                        out.insert(key.clone(), Value::Array(projected));
+                        // A key whose array *filtering* emptied is pruned (had
+                        // elements, all dropped); an already-empty source array
+                        // survives only in an accepting state — mirrors the
+                        // object arm so an emptied array does not leave a bare
+                        // `[]` (or a `[{}]`) on the wire.
+                        if !projected.is_empty() || (arr.is_empty() && child_all) {
+                            out.insert(key.clone(), Value::Array(projected));
+                        }
                     }
                 }
                 // A scalar leaf is kept ONLY in an ACCEPTing state. A scalar that
@@ -27159,6 +27177,36 @@ mod source_filter_tests {
             ),
             json!({ "logs": [{ "msg": 1 }, { "msg": 3 }] }),
             "#644: exclude logs.secret must strip secret from every array element"
+        );
+        // Emptied elements are pruned, not left as `{}`; a heterogeneous array
+        // drops the elements (and scalars) that do not match, keeping the rest.
+        assert_eq!(
+            filter_object(
+                &json!({ "tags": [{ "name": "x", "id": 1 }, { "id": 2 }, "loose"] }),
+                &["tags.name".to_string()],
+                &[]
+            ),
+            json!({ "tags": [{ "name": "x" }] }),
+            "#644: an emptied array element (and a scalar) is dropped, not kept as an empty object"
+        );
+        // An array all of whose elements empty → the key is pruned entirely.
+        assert_eq!(
+            filter_object(
+                &json!({ "tags": [{ "id": 1 }, { "id": 2 }], "keep": 5 }),
+                &["tags.name".to_string()],
+                &[]
+            ),
+            json!({}),
+            "#644: an array that filtering emptied drops its key (no bare [])"
+        );
+        assert_eq!(
+            filter_object(
+                &json!({ "tags": [{ "secret": 1 }, { "secret": 2 }] }),
+                &[],
+                &["tags.secret".to_string()]
+            ),
+            json!({}),
+            "#644: an exclude that empties every element prunes the key"
         );
     }
 


### PR DESCRIPTION
Closes #644.

## Problem
ES treats an array index as **transparent** to a `_source` path: `tags.name` matches `tags[i].name`, so `include ["tags.name"]` keeps only each element's `name` and `exclude ["logs.secret"]` scrubs `secret` from every element. The #602 automaton deliberately kept arrays **whole** (a no-projection scope), which:
- **over-includes** on `include` — `include ["tags.name"]` returned the whole `[{"name":..,"id":..}]` array (the `id` leaks);
- **fails to strip** on `exclude` — `exclude ["*.secret"]` / `["logs.secret"]` left secrets inside arrays of objects on the wire (a data-over-exposure edge).

## Fix
`es_filter`'s array arm now mirrors the object recursion:
- a **fully-included** array with no exclude reaching into it is kept whole (the fast path — unchanged, byte-identical, no #602 data-loss);
- otherwise each element is filtered at the **same** `child` path — an **object** element recurses through `es_filter`, a **scalar** element survives only in an accepting (fully-included) state, like a scalar leaf.

## Testing (rustc 1.97.1)
- New `source_filter_projects_inside_arrays_of_objects` — **fail-before**: on `main` the array was returned whole (`id`/`secret` leaked); with the fix `include tags.name` → `[{name}]` per element and `exclude logs.secret` → `[{msg}]` per element.
- All 14 `source_filter_tests` green (the new test + every existing #602/#310 test — the fully-included fast path preserves prior behavior).
- Full `cargo test -p xerj-engine` — dev + `--profile ci-test`: 52 binaries each, 0 failures.
- Full `cargo test -p xerj-api` — dev: 55 binaries, 0 failures.
- `cargo fmt --all --check` clean; `cargo clippy -p xerj-engine --all-targets -- -D warnings` clean.