### PR TITLE
fix(engine): preserve collapse sentinels across an explicit _source projection (#651)

### DIFF
--- a/engine/crates/xerj-api/tests/collapse_inner_hits_under_source_includes.rs
+++ b/engine/crates/xerj-api/tests/collapse_inner_hits_under_source_includes.rs
@@ -61,7 +61,10 @@ async fn post(app: &axum::Router, path: &str, body: Value) -> (StatusCode, Value
     let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("body");
-    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
 }
 
 /// A collapse `inner_hits` must render even under an explicit

--- a/engine/crates/xerj-api/tests/collapse_inner_hits_under_source_includes.rs
+++ b/engine/crates/xerj-api/tests/collapse_inner_hits_under_source_includes.rs
@@ -1,0 +1,111 @@
+//! Issue #651: a collapse `inner_hits` block must still render when the request
+//! sets an explicit `_source: {"includes": [...]}` that does not list the
+//! internal `__xy_collapse_group__` sentinel.
+//!
+//! The collapse group members are stashed into `__xy_collapse_group__` on the
+//! leader's source; the API extracts them at render time. But the engine applies
+//! the `_source` include projection to `hit.source` FIRST, dropping that
+//! sentinel when it is not in the include list — so the leader came back with no
+//! `inner_hits` at all. ES renders `inner_hits` regardless of the top-level
+//! `_source` include list.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+
+    let mut schema = Schema::empty();
+    schema
+        .add_field(FieldConfig::new("grp", FieldType::Keyword))
+        .expect("grp field");
+    schema
+        .add_field(FieldConfig::new("title", FieldType::Text))
+        .expect("title field");
+    state.engine.create_index("docs", schema).expect("create");
+    let idx = state.engine.get_index("docs").expect("get index");
+    for (id, grp) in [("1", "A"), ("2", "A"), ("3", "B")] {
+        idx.index_document(
+            Some(id.into()),
+            json!({ "grp": grp, "title": format!("doc {id}") }),
+        )
+        .await
+        .expect("index document");
+    }
+    idx.refresh().await.expect("refresh");
+
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn post(app: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(path)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+}
+
+/// A collapse `inner_hits` must render even under an explicit
+/// `_source.includes` that omits the collapse sentinel (#651).
+#[tokio::test]
+async fn collapse_inner_hits_render_under_explicit_source_includes() {
+    let (app, _dir) = app().await;
+
+    // Collapse on grp with inner_hits AND an explicit `_source.includes` that
+    // lists only `grp` (NOT the internal collapse sentinel).
+    let (st, resp) = post(
+        &app,
+        "/docs/_search",
+        json!({
+            "query": { "match_all": {} },
+            "size": 10,
+            "_source": { "includes": ["grp"] },
+            "collapse": { "field": "grp", "inner_hits": { "name": "members", "size": 10 } }
+        }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "{resp}");
+
+    let leaders = resp["hits"]["hits"].as_array().expect("hits");
+    assert!(!leaders.is_empty(), "expected collapse leaders: {resp}");
+    // Every leader must carry its inner_hits (the explicit include must not
+    // starve them) — #651 fail-before: on main inner_hits is absent.
+    for leader in leaders {
+        assert!(
+            leader
+                .pointer("/inner_hits/members/hits/hits")
+                .and_then(Value::as_array)
+                .is_some(),
+            "#651: a collapse leader must render inner_hits under _source.includes: {leader}"
+        );
+        // And the projection still applies to the leader's own _source.
+        let src = leader["_source"].as_object().expect("leader _source");
+        assert!(
+            src.contains_key("grp") && !src.contains_key("title"),
+            "#651: the explicit include still narrows the leader _source to grp: {leader}"
+        );
+        assert!(
+            !src.contains_key("__xy_collapse_group__"),
+            "#651: the internal sentinel must not leak on the wire: {leader}"
+        );
+    }
+}

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -26263,6 +26263,39 @@ fn plural(n: usize) -> &'static str {
     }
 }
 
+/// The engine-internal collapse sentinels — a user's `_source` include/exclude
+/// list must not strip these, or the API renders no `inner_hits` (#651). They
+/// are captured before an explicit projection and re-attached after, so the API
+/// (which extracts the group and strips the sentinels from the wire `_source`)
+/// still sees them.
+const COLLAPSE_SENTINELS: [&str; 2] = ["__xy_collapse_group__", "__xy_collapse_spec__"];
+
+fn take_collapse_sentinels(source: &Value) -> Vec<(String, Value)> {
+    source
+        .as_object()
+        .map(|o| {
+            COLLAPSE_SENTINELS
+                .iter()
+                .filter_map(|k| o.get(*k).map(|v| (k.to_string(), v.clone())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn reattach_collapse_sentinels(source: &mut Value, sentinels: Vec<(String, Value)>) {
+    if sentinels.is_empty() {
+        return;
+    }
+    if !source.is_object() {
+        *source = Value::Object(serde_json::Map::new());
+    }
+    if let Some(obj) = source.as_object_mut() {
+        for (k, v) in sentinels {
+            obj.insert(k, v);
+        }
+    }
+}
+
 /// Unmeasured filtering — the shape every pre-existing test asserts on, and
 /// proof that the measurement is strictly additive rather than a rewrite of
 /// the `_source` projection semantics.
@@ -26387,13 +26420,15 @@ fn apply_source_filter_measured(
             .map(|mut h| {
                 let baseline = measuring
                     .then(|| default_projection_len(&h.source, generated_companion_fields, mode));
+                let sentinels = take_collapse_sentinels(&h.source);
                 h.source = filter_object(&h.source, fields, &[]);
                 if let Some(baseline) = baseline {
                     // Saturating: a caller who explicitly projects a generated
                     // companion gets MORE than the default, and more is not a
-                    // saving.
+                    // saving. Measured on the sentinel-free projection.
                     acc.record(&h.id, baseline.saturating_sub(json_len(&h.source, mode)));
                 }
+                reattach_collapse_sentinels(&mut h.source, sentinels);
                 h
             })
             .collect(),
@@ -26402,10 +26437,12 @@ fn apply_source_filter_measured(
             .map(|mut h| {
                 let baseline = measuring
                     .then(|| default_projection_len(&h.source, generated_companion_fields, mode));
+                let sentinels = take_collapse_sentinels(&h.source);
                 h.source = filter_object(&h.source, includes, excludes);
                 if let Some(baseline) = baseline {
                     acc.record(&h.id, baseline.saturating_sub(json_len(&h.source, mode)));
                 }
+                reattach_collapse_sentinels(&mut h.source, sentinels);
                 h
             })
             .collect(),


### PR DESCRIPTION
Closes #651.

## Problem
A collapse request with an explicit `_source: {"includes": [...]}` (or `"excludes"`, or the array form) that does **not** list the internal `__xy_collapse_group__` sentinel lost the leader's `inner_hits` entirely. The engine's `apply_source_filter` projects `hit.source` (`SourceFilter::Includes` / `SourceFilter::Fields`) **before** the API extracts the collapse group (`es_compat.rs` ~11943), so the projection stripped the sentinel and the API found no group to render. ES renders `inner_hits` independent of the top-level `_source` include list.

## Fix
The two projecting arms of `apply_source_filter_measured` now **capture** the engine-internal collapse sentinels (`__xy_collapse_group__`, `__xy_collapse_spec__`) before `filter_object` runs and **re-attach** them after — so the API still extracts the group and strips the sentinels from the wire `_source` (as it already does). The savings stat is measured on the sentinel-free projection, so it is unaffected. Non-collapse requests carry no sentinels → the capture is a no-op.

## Testing (rustc 1.97.1)
- New `collapse_inner_hits_under_source_includes.rs` — **fail-before**: on `main` the leader came back `{_source:{grp:A}}` with no `inner_hits`; with the fix the leader renders `inner_hits.members`, the leader `_source` still narrows to `grp` (not `title`), and the sentinel does not leak on the wire.
- Full `cargo test -p xerj-engine` — dev + `--profile ci-test`: 52 binaries each, 0 failures.
- Full `cargo test -p xerj-api` — dev + `--profile ci-test`: 57 binaries each, 0 failures.
- `cargo fmt --all --check` clean; `cargo clippy -p xerj-engine --all-targets -- -D warnings` clean.

_(Landing-constants guard will be red until this rebases onto post-rc.50-stamp main (#654); the rebase is landing-only, no code change.)_