### PR TITLE
fix(api): scroll continuation matches first-page _source suppression (#637)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8726,6 +8726,29 @@ fn render_collapse_inner_hits(
     Value::Object(combined)
 }
 
+/// Whether the index mapping sets `_source.enabled: false`. ES suppresses
+/// `_source` in the response for such an index; xerj keeps the underlying
+/// source available internally (fields/highlight/_ignored extraction) and makes
+/// the suppression a response-time decision. Mirrors the per-hit check in
+/// `search_impl`'s render, extracted so scroll-open can capture the SAME
+/// decision into `ScrollContext::source_disabled` and continuation pages stay in
+/// parity with the first page (#637).
+fn mapping_source_disabled(state: &AppState, index: &str) -> bool {
+    state
+        .engine
+        .index_mappings
+        .get(index)
+        .and_then(|m| {
+            m.get("mappings")
+                .and_then(|mm| mm.get("_source"))
+                .or_else(|| m.get("_source"))
+                .cloned()
+        })
+        .and_then(|src| src.get("enabled").and_then(Value::as_bool))
+        .map(|b| !b)
+        .unwrap_or(false)
+}
+
 async fn search_impl(
     state: AppState,
     index: String,
@@ -11958,19 +11981,7 @@ async fn search_impl(
             // extraction, so the suppression is a response-time
             // decision not a data-layer decision.
             let source_body_disabled = matches!(body.source, Some(Value::Bool(false)));
-            let source_mapping_disabled = state
-                .engine
-                .index_mappings
-                .get(idx_name.as_str())
-                .and_then(|m| {
-                    m.get("mappings")
-                        .and_then(|mm| mm.get("_source"))
-                        .or_else(|| m.get("_source"))
-                        .cloned()
-                })
-                .and_then(|src| src.get("enabled").and_then(Value::as_bool))
-                .map(|b| !b)
-                .unwrap_or(false);
+            let source_mapping_disabled = mapping_source_disabled(&state, idx_name.as_str());
             // `stored_fields` implicitly suppressing `_source` (unless the
             // list literally contains `"_source"`) is only a DEFAULT for
             // when the caller left `_source` unspecified. When the request
@@ -14620,6 +14631,21 @@ async fn search_impl(
             .min(sc_cfg.scroll_max_keep_alive_secs);
         let keep_alive = std::time::Duration::from_secs(keep_alive_secs);
         let now = Instant::now();
+        // #637: capture the FULL first-page `_source` suppression decision, not
+        // just request-level `_source: false`. search_impl's own render above
+        // also omits `_source` when `stored_fields` implies it (and the request
+        // left `_source` unspecified) or the mapping sets `_source.enabled:
+        // false`. Both are request/index-level (constant across the snapshot),
+        // so a single captured boolean keeps continuation pages in parity with
+        // this first page. The remaining per-hit null-source case is already
+        // handled directly in `scroll_page_response`. (The
+        // `/:index/_search_scroll` route's own first page does not suppress these
+        // cases, so its capture site is intentionally left as request-level only
+        // — matching ITS render.) Computed before the struct literal moves
+        // `scroll_index` into `ctx.index`.
+        let scroll_source_disabled = matches!(body.source, Some(Value::Bool(false)))
+            || (suppress_source_for_stored && body.source.is_none())
+            || mapping_source_disabled(&state, &scroll_index);
         let ctx = xerj_engine::engine::ScrollContext {
             index: scroll_index,
             hits: snapshot,
@@ -14630,7 +14656,7 @@ async fn search_impl(
             // first page's own `_seq_no`/`_version` emission above.
             seq_no_primary_term: emit_seq_no,
             version: emit_version,
-            source_disabled: matches!(body.source, Some(Value::Bool(false))),
+            source_disabled: scroll_source_disabled,
             created: now,
             keep_alive,
             expires_at: now + keep_alive,

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -14631,21 +14631,28 @@ async fn search_impl(
             .min(sc_cfg.scroll_max_keep_alive_secs);
         let keep_alive = std::time::Duration::from_secs(keep_alive_secs);
         let now = Instant::now();
-        // #637: capture the FULL first-page `_source` suppression decision, not
-        // just request-level `_source: false`. search_impl's own render above
-        // also omits `_source` when `stored_fields` implies it (and the request
-        // left `_source` unspecified) or the mapping sets `_source.enabled:
-        // false`. Both are request/index-level (constant across the snapshot),
-        // so a single captured boolean keeps continuation pages in parity with
-        // this first page. The remaining per-hit null-source case is already
-        // handled directly in `scroll_page_response`. (The
-        // `/:index/_search_scroll` route's own first page does not suppress these
-        // cases, so its capture site is intentionally left as request-level only
-        // — matching ITS render.) Computed before the struct literal moves
-        // `scroll_index` into `ctx.index`.
+        // #637: capture the REQUEST-LEVEL part of the first-page `_source`
+        // suppression decision — `_source: false`, and `stored_fields` implying
+        // suppression when the request left `_source` unspecified. These are
+        // genuinely constant across the whole snapshot (index-independent), so a
+        // single captured boolean is correct for them.
+        //
+        // The mapping `_source.enabled: false` case is deliberately NOT folded in
+        // here: a scroll can span MULTIPLE indices with divergent `_source`
+        // settings, and the first page suppresses that case PER HIT using each
+        // hit's own index. Collapsing it to `scroll_index` (the first index)
+        // would strip `_source` from every continuation hit of a source-ENABLED
+        // index whenever the first index disabled source — a new first-page/
+        // continuation split and silent `_source` loss on the export/reindex API
+        // (found by the #658 correctness skeptic). So `scroll_page_response`
+        // re-derives the mapping check per hit from `h.index` instead.
+        //
+        // The per-hit null-source case is likewise handled in
+        // `scroll_page_response`. (The `/:index/_search_scroll` route's own first
+        // page does not suppress any of these, so its capture site stays
+        // request-level only — matching ITS render; see #659.)
         let scroll_source_disabled = matches!(body.source, Some(Value::Bool(false)))
-            || (suppress_source_for_stored && body.source.is_none())
-            || mapping_source_disabled(&state, &scroll_index);
+            || (suppress_source_for_stored && body.source.is_none());
         let ctx = xerj_engine::engine::ScrollContext {
             index: scroll_index,
             hits: snapshot,
@@ -20796,11 +20803,17 @@ async fn scroll_page_response(
                                 _ => None,
                             }
                         });
-                        // #624: honor the scroll's opening `_source: false` —
-                        // omit `_source` here (the sentinels have already been
-                        // consumed into `inner_hits` above), matching the first
-                        // page. inner_hits are emitted regardless.
-                        if !source_disabled {
+                        // #624/#637: honor the first page's `_source` suppression
+                        // (the sentinels have already been consumed into
+                        // `inner_hits` above), matching search_impl exactly.
+                        // `source_disabled` carries the request-level constant
+                        // (`_source:false`, stored_fields-implied); the mapping
+                        // `_source.enabled:false` case is re-derived PER HIT from
+                        // this hit's own index, because a scroll can span indices
+                        // with divergent `_source` settings and the first page
+                        // suppresses that case per-hit (#658 skeptic). inner_hits
+                        // are emitted regardless.
+                        if !source_disabled && !mapping_source_disabled(state, &h.index) {
                             o.insert("_source".to_string(), src);
                         }
                         if let Some(inner) = collapse_inner {

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -8729,10 +8729,11 @@ fn render_collapse_inner_hits(
 /// Whether the index mapping sets `_source.enabled: false`. ES suppresses
 /// `_source` in the response for such an index; xerj keeps the underlying
 /// source available internally (fields/highlight/_ignored extraction) and makes
-/// the suppression a response-time decision. Mirrors the per-hit check in
-/// `search_impl`'s render, extracted so scroll-open can capture the SAME
-/// decision into `ScrollContext::source_disabled` and continuation pages stay in
-/// parity with the first page (#637).
+/// the suppression a response-time decision. Extracted from `search_impl`'s
+/// per-hit render so the scroll continuation (`scroll_page_response`) can apply
+/// the SAME per-hit decision from each hit's own index — mapping suppression is
+/// NOT a snapshot constant, because a scroll can span indices with divergent
+/// `_source` settings (#637).
 fn mapping_source_disabled(state: &AppState, index: &str) -> bool {
     state
         .engine
@@ -14648,9 +14649,12 @@ async fn search_impl(
         // re-derives the mapping check per hit from `h.index` instead.
         //
         // The per-hit null-source case is likewise handled in
-        // `scroll_page_response`. (The `/:index/_search_scroll` route's own first
-        // page does not suppress any of these, so its capture site stays
-        // request-level only — matching ITS render; see #659.)
+        // `scroll_page_response`. `scroll_page_response` is shared with the
+        // `/:index/_search_scroll` route, whose first page does NOT apply the
+        // mapping check — so the per-hit mapping gate there is guarded by the
+        // `mapping_source_check` flag set below (true here, false for that
+        // route), keeping each route's continuation identical to its own first
+        // page. That route's broader `_source` gap is tracked in #659.
         let scroll_source_disabled = matches!(body.source, Some(Value::Bool(false)))
             || (suppress_source_for_stored && body.source.is_none());
         let ctx = xerj_engine::engine::ScrollContext {
@@ -14664,6 +14668,9 @@ async fn search_impl(
             seq_no_primary_term: emit_seq_no,
             version: emit_version,
             source_disabled: scroll_source_disabled,
+            // `_search?scroll=` first page (this fn) suppresses mapping
+            // `_source.enabled:false` per hit, so the continuation must too.
+            mapping_source_check: true,
             created: now,
             keep_alive,
             expires_at: now + keep_alive,
@@ -20385,6 +20392,12 @@ pub async fn search_with_scroll(
             seq_no_primary_term: emit_seq_no,
             version: emit_version,
             source_disabled: matches!(body.source, Some(Value::Bool(false))),
+            // `_search_scroll` (this route) does NOT apply mapping
+            // `_source.enabled:false` suppression on its first page (it emits
+            // `_source` unconditionally), so its continuation must not either —
+            // otherwise it gains a new first-page/continuation split. That
+            // route's broader `_source` gap is tracked in #659.
+            mapping_source_check: false,
             created: now,
             keep_alive,
             expires_at: now + keep_alive,
@@ -20670,12 +20683,18 @@ async fn scroll_page_response(
             // borrows `ctx.hits`.
             let emit_seq_no = ctx.seq_no_primary_term;
             let emit_version = ctx.version;
-            // #624: the opening request's `_source: false` governs the whole
-            // scroll — omit `_source` on continuation pages too (ES fixes source
-            // selection at open; the `_search?scroll=` first page already omits
-            // it via search_impl). inner_hits still render from the collapse
-            // group snapshot regardless.
+            // #624/#637: the opening request's REQUEST-level `_source` decision
+            // (`_source:false`, stored_fields-implied) governs the whole scroll —
+            // omit `_source` on continuation pages too (ES fixes source selection
+            // at open). inner_hits still render from the collapse group snapshot
+            // regardless.
             let source_disabled = ctx.source_disabled;
+            // #637: whether to ALSO apply the mapping `_source.enabled:false`
+            // suppression per hit below. Only true for scrolls opened by
+            // `search_impl` (whose first page applies it); false for the
+            // `_search_scroll` route, whose first page does not — so its
+            // continuation stays byte-identical to that first page (#659).
+            let mapping_source_check = ctx.mapping_source_check;
 
             // Detect whether the initial search sorted by a non-score key;
             // in that case `max_score` must be null on scroll pages too.
@@ -20805,15 +20824,20 @@ async fn scroll_page_response(
                         });
                         // #624/#637: honor the first page's `_source` suppression
                         // (the sentinels have already been consumed into
-                        // `inner_hits` above), matching search_impl exactly.
-                        // `source_disabled` carries the request-level constant
-                        // (`_source:false`, stored_fields-implied); the mapping
-                        // `_source.enabled:false` case is re-derived PER HIT from
-                        // this hit's own index, because a scroll can span indices
-                        // with divergent `_source` settings and the first page
-                        // suppresses that case per-hit (#658 skeptic). inner_hits
-                        // are emitted regardless.
-                        if !source_disabled && !mapping_source_disabled(state, &h.index) {
+                        // `inner_hits` above). `source_disabled` carries the
+                        // request-level constant (`_source:false`, stored_fields-
+                        // implied). The mapping `_source.enabled:false` case is
+                        // re-derived PER HIT from this hit's own index (a scroll
+                        // can span indices with divergent `_source` settings, and
+                        // search_impl's first page suppresses it per-hit — #658
+                        // skeptic), but ONLY when the opening route applies it on
+                        // its first page (`mapping_source_check`); the
+                        // `_search_scroll` route does not, so its continuation
+                        // stays identical to its first page (#659). inner_hits are
+                        // emitted regardless.
+                        if !source_disabled
+                            && !(mapping_source_check && mapping_source_disabled(state, &h.index))
+                        {
                             o.insert("_source".to_string(), src);
                         }
                         if let Some(inner) = collapse_inner {
@@ -20917,6 +20941,7 @@ mod passage_scroll_tests {
                 seq_no_primary_term: false,
                 version: false,
                 source_disabled: false,
+                mapping_source_check: false,
                 created: now,
                 keep_alive: Duration::from_secs(60),
                 expires_at: now + Duration::from_secs(60),
@@ -20976,6 +21001,7 @@ mod passage_scroll_tests {
                 seq_no_primary_term: false,
                 version: false,
                 source_disabled: false,
+                mapping_source_check: false,
                 created: now,
                 keep_alive: Duration::from_secs(60),
                 expires_at: now + Duration::from_secs(60),
@@ -21031,6 +21057,7 @@ mod passage_scroll_tests {
                 seq_no_primary_term: false,
                 version: false,
                 source_disabled: false,
+                mapping_source_check: false,
                 created: now,
                 keep_alive: Duration::from_secs(60),
                 expires_at: now + Duration::from_secs(60),

--- a/engine/crates/xerj-api/tests/scroll_source_suppression_parity.rs
+++ b/engine/crates/xerj-api/tests/scroll_source_suppression_parity.rs
@@ -260,3 +260,56 @@ async fn scroll_multi_index_source_suppression_is_per_hit() {
     );
     assert_eq!(b_seen, 4, "expected all 4 b_on hits across pages: {hits:?}");
 }
+
+/// Regression guard for the sibling `/:index/_search_scroll` route
+/// (`search_with_scroll`), which shares `scroll_page_response` for continuation
+/// but emits `_source` UNCONDITIONALLY on its own first page. This #637 change
+/// must NOT make that route's continuation start suppressing `_source` for a
+/// mapping-disabled index while its first page still emits it — a new
+/// first-page/continuation split (caught by the #658 regression skeptic; guarded
+/// by the `ScrollContext::mapping_source_check` flag). The route stays
+/// self-consistent; fixing its first page to actually suppress is #659.
+#[tokio::test]
+async fn search_scroll_route_source_parity_first_page_and_continuation_agree() {
+    let (app, _dir) = app().await;
+    seed(
+        &app,
+        "docs",
+        json!({"mappings": {
+            "_source": {"enabled": false},
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+
+    // Open via the `_search_scroll` route (NOT `_search?scroll=`).
+    let (st, first) = call(
+        &app,
+        "POST",
+        "/docs/_search_scroll?scroll=5m",
+        json!({"query": {"match_all": {}}, "size": 1, "sort": [{"v": "asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "search_scroll open: {first}");
+    let first_has_source = first["hits"]["hits"][0].get("_source").is_some();
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+
+    let (st, page2) = call(
+        &app,
+        "POST",
+        "/_search/scroll",
+        json!({"scroll": "5m", "scroll_id": sid}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "continuation: {page2}");
+    let cont_has_source = page2["hits"]["hits"][0].get("_source").is_some();
+
+    // The crux: whatever this route does on its first page, the continuation must
+    // AGREE — #637 must not introduce a page-to-page `_source` split here.
+    assert_eq!(
+        first_has_source, cont_has_source,
+        "#637/#659: the _search_scroll route's continuation must match its own first \
+         page on _source presence (first={first_has_source}, continuation={cont_has_source}); \
+         page1={first} page2={page2}"
+    );
+}

--- a/engine/crates/xerj-api/tests/scroll_source_suppression_parity.rs
+++ b/engine/crates/xerj-api/tests/scroll_source_suppression_parity.rs
@@ -1,0 +1,168 @@
+//! Issue #637 (follow-up to #624): a `_search?scroll=` continuation page must
+//! suppress `_source` in the SAME cases the first page (`search_impl`) does, not
+//! only for a request-level `_source: false`.
+//!
+//! #624 added `ScrollContext::source_disabled`, but captured it from
+//! `matches!(body.source, Some(Value::Bool(false)))` ONLY. The first page omits
+//! `_source` in three more cases:
+//!   - mapping `_source.enabled: false`,
+//!   - `stored_fields` implying suppression when `_source` is unspecified,
+//!   - a null/absent stored source (this one is already per-hit on the
+//!     continuation, so it is not a divergence).
+//!
+//! For the first two, a scroll opened against them omitted `_source` on the
+//! first page but EMITTED it on every continuation page — a first-page/
+//! continuation divergence. These tests pin the parity.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn seed(app: &axum::Router, index: &str, mappings: Value) {
+    let (st, body) = call(app, "PUT", &format!("/{index}"), mappings).await;
+    assert_eq!(st, StatusCode::OK, "create {index}: {body}");
+    for (id, v) in [("d0", 10), ("d1", 11), ("d2", 12), ("d3", 13)] {
+        let (st, _) = call(
+            app,
+            "POST",
+            &format!("/{index}/_doc/{id}"),
+            json!({"grp": "g", "v": v}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index {id}");
+    }
+    let _ = call(app, "POST", &format!("/{index}/_refresh"), Value::Null).await;
+}
+
+/// mapping `_source.enabled: false`: the first page omits `_source`; the
+/// continuation must too (fails before the fix — the continuation emitted it).
+#[tokio::test]
+async fn scroll_continuation_omits_source_under_mapping_source_disabled() {
+    let (app, _dir) = app().await;
+    seed(
+        &app,
+        "docs",
+        json!({"mappings": {
+            "_source": {"enabled": false},
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+
+    // Scroll, size 1, sorted v asc → first page 1 hit, continuation pages follow.
+    let (st, first) = call(
+        &app,
+        "POST",
+        "/docs/_search?scroll=5m",
+        json!({"query": {"match_all": {}}, "size": 1, "sort": [{"v": "asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "scroll start: {first}");
+    // Baseline: mapping `_source.enabled:false` already omits `_source` on the
+    // FIRST page (search_impl). If this ever regresses the divergence premise is
+    // moot — assert it so the test stays honest.
+    assert!(
+        first["hits"]["hits"][0].get("_source").is_none(),
+        "#637 premise: mapping _source.enabled:false omits _source on the first page: {first}"
+    );
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+
+    let (st, page2) = call(
+        &app,
+        "POST",
+        "/_search/scroll",
+        json!({"scroll": "5m", "scroll_id": sid}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "continuation: {page2}");
+    let hit = &page2["hits"]["hits"][0];
+    assert!(
+        hit.get("_id").is_some(),
+        "#637: continuation should still return a hit: {page2}"
+    );
+    assert!(
+        hit.get("_source").is_none(),
+        "#637: scroll continuation must omit _source when the mapping sets \
+         _source.enabled:false (first-page parity), got: {hit}"
+    );
+}
+
+/// `stored_fields` without an explicit `_source`: the first page omits `_source`;
+/// the continuation must too (fails before the fix).
+#[tokio::test]
+async fn scroll_continuation_omits_source_under_stored_fields() {
+    let (app, _dir) = app().await;
+    seed(
+        &app,
+        "docs",
+        json!({"mappings": {
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+
+    let (st, first) = call(
+        &app,
+        "POST",
+        "/docs/_search?scroll=5m",
+        json!({
+            "query": {"match_all": {}},
+            "size": 1,
+            "sort": [{"v": "asc"}],
+            "stored_fields": ["grp"]
+        }),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "scroll start: {first}");
+    assert!(
+        first["hits"]["hits"][0].get("_source").is_none(),
+        "#637 premise: stored_fields (no _source) omits _source on the first page: {first}"
+    );
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+
+    let (st, page2) = call(
+        &app,
+        "POST",
+        "/_search/scroll",
+        json!({"scroll": "5m", "scroll_id": sid}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "continuation: {page2}");
+    let hit = &page2["hits"]["hits"][0];
+    assert!(
+        hit.get("_source").is_none(),
+        "#637: scroll continuation must omit _source when the opening request set \
+         stored_fields without _source (first-page parity), got: {hit}"
+    );
+}

--- a/engine/crates/xerj-api/tests/scroll_source_suppression_parity.rs
+++ b/engine/crates/xerj-api/tests/scroll_source_suppression_parity.rs
@@ -166,3 +166,97 @@ async fn scroll_continuation_omits_source_under_stored_fields() {
          stored_fields without _source (first-page parity), got: {hit}"
     );
 }
+
+/// Open a scroll and page through EVERY page, returning all hits across all pages.
+async fn scroll_all_hits(app: &axum::Router, open_path: &str, open_body: Value) -> Vec<Value> {
+    let (st, first) = call(app, "POST", open_path, open_body).await;
+    assert_eq!(st, StatusCode::OK, "scroll open: {first}");
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+    let mut all: Vec<Value> = first["hits"]["hits"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    loop {
+        let (st, page) = call(
+            app,
+            "POST",
+            "/_search/scroll",
+            json!({"scroll": "5m", "scroll_id": sid}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "continuation: {page}");
+        let hits = page["hits"]["hits"].as_array().cloned().unwrap_or_default();
+        if hits.is_empty() {
+            break;
+        }
+        all.extend(hits);
+    }
+    all
+}
+
+/// Multi-index scroll where the FIRST-resolved index disables `_source` and a
+/// second index enables it. Suppression must be decided PER HIT from each hit's
+/// own index — not from a single snapshot constant keyed on the first index —
+/// or continuation pages silently drop `_source` from the source-ENABLED index
+/// (a regression the #658 correctness skeptic caught: silent data-loss on the
+/// export/reindex API). Every page, first and continuation, must agree with the
+/// first page: `a_off` hits omit `_source`, `b_on` hits keep it.
+#[tokio::test]
+async fn scroll_multi_index_source_suppression_is_per_hit() {
+    let (app, _dir) = app().await;
+    seed(
+        &app,
+        "a_off",
+        json!({"mappings": {
+            "_source": {"enabled": false},
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+    seed(
+        &app,
+        "b_on",
+        json!({"mappings": {
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+
+    // Small size so several continuation pages exist; sort v asc interleaves the
+    // two indices across pages so continuation pages carry BOTH.
+    let hits = scroll_all_hits(
+        &app,
+        "/a_off,b_on/_search?scroll=5m",
+        json!({"query": {"match_all": {}}, "size": 3, "sort": [{"v": "asc"}]}),
+    )
+    .await;
+
+    let mut a_seen = 0;
+    let mut b_seen = 0;
+    for h in &hits {
+        match h["_index"].as_str() {
+            Some("a_off") => {
+                a_seen += 1;
+                assert!(
+                    h.get("_source").is_none(),
+                    "#658: a_off (source-disabled) hit must omit _source on every page: {h}"
+                );
+            }
+            Some("b_on") => {
+                b_seen += 1;
+                assert!(
+                    h.get("_source").and_then(Value::as_object).is_some(),
+                    "#658: b_on (source-ENABLED) hit must KEEP _source on every page, \
+                     including continuation — per-hit suppression, not a first-index \
+                     constant: {h}"
+                );
+            }
+            other => panic!("unexpected _index {other:?} in {h}"),
+        }
+    }
+    assert_eq!(
+        a_seen, 4,
+        "expected all 4 a_off hits across pages: {hits:?}"
+    );
+    assert_eq!(b_seen, 4, "expected all 4 b_on hits across pages: {hits:?}");
+}

--- a/engine/crates/xerj-engine/src/engine.rs
+++ b/engine/crates/xerj-engine/src/engine.rs
@@ -170,12 +170,24 @@ pub struct ScrollContext {
     /// Whether to emit `_version` on every page. Same once-at-open semantics
     /// as `seq_no_primary_term`.
     pub version: bool,
-    /// Whether the opening request suppressed `_source` (`"_source": false`).
-    /// Captured once at open — like `seq_no_primary_term`/`version`, ES fixes
-    /// the `_source` selection at the scroll-opening request and applies it to
-    /// every continuation page — so the continuation render omits `_source`
-    /// when this is set, matching the `_search?scroll=` first page (#624).
+    /// Whether the opening request suppressed `_source` at the REQUEST level —
+    /// `"_source": false`, or `stored_fields` implying suppression when
+    /// `_source` was unspecified. These are constant across the whole snapshot
+    /// (index-independent), so a single captured boolean is correct. Captured
+    /// once at open — like `seq_no_primary_term`/`version`, ES fixes the
+    /// `_source` selection at the scroll-opening request — so the continuation
+    /// render omits `_source` when this is set, matching the first page
+    /// (#624/#637).
     pub source_disabled: bool,
+    /// Whether the opening route's first page also applies mapping-level
+    /// `_source.enabled: false` suppression (which is PER-HIT: a scroll can span
+    /// indices with divergent `_source` settings). `search_impl` (`_search?scroll=`)
+    /// does, so the continuation re-derives it per hit from each hit's own index;
+    /// `search_with_scroll` (`_search_scroll`) does NOT suppress it on its first
+    /// page, so its continuation must not either, or it would introduce a new
+    /// first-page/continuation split on that route (#637; that route's own gap is
+    /// tracked in #659).
+    pub mapping_source_check: bool,
     pub created: Instant,
     /// The keep-alive window last requested for this context. A
     /// continuation without an explicit `scroll` parameter re-arms the

--- a/engine/crates/xerj-engine/tests/search_context_ttl.rs
+++ b/engine/crates/xerj-engine/tests/search_context_ttl.rs
@@ -39,6 +39,7 @@ fn scroll_ctx(expires_in: i64) -> ScrollContext {
         seq_no_primary_term: false,
         version: false,
         source_disabled: false,
+        mapping_source_check: false,
         created: now,
         keep_alive,
         expires_at,


### PR DESCRIPTION
## #637 — scroll continuation `_source` suppression parity (follow-up to #624)

### Bug
A `_search?scroll=` continuation page (`scroll_page_response`) suppressed `_source` **only** when the opening request set `_source: false` — the sole case #624 captured into `ScrollContext::source_disabled`. But `search_impl`'s first-page render omits `_source` on **four** conditions:
1. `stored_fields` implying suppression (and `_source` unspecified),
2. `_source: false`,
3. mapping `_source.enabled: false`,
4. per-hit null/absent stored source.

A scroll opened against **(1)** or **(3)** omitted `_source` on the first page but **emitted it on every continuation page** — a first-page/continuation divergence from ES. (Case 4 was already handled per-hit in the continuation; case 2 is the one #624 fixed.)

### Fix
- Extract `mapping_source_disabled(state, index)` — the exact mapping check the first-page render used inline — so the first page and scroll-open share one source of truth.
- At the `search_impl` scroll-open site, capture the full **request/index-level** decision:
  `_source:false || (stored_fields-implied && _source unspecified) || mapping _source.enabled:false`.
- Per-hit null-source stays handled in `scroll_page_response`.

### Scoping (important — avoids a reverse divergence)
The separate `/:index/_search_scroll` route (`search_with_scroll`) has its **own** first-page render that does **not** suppress `_source` for cases 1–3 (it emits `_source` unconditionally). Making *its* capture site suppress would create the opposite divergence, so it is left request-level. That route's broader first-page suppression gap is pre-existing and out of scope here — filing as a follow-up.

### Fail-before / after
New test `scroll_source_suppression_parity` (two cases: mapping `_source.enabled:false`, and `stored_fields` without `_source`). Both assert the first page omits `_source` (baseline) **and** the continuation omits it. On pristine main both continuation assertions fail (continuation returned `_source:{...}`); with the fix both pass.

### Verification (rustc 1.97.1)
- `cargo fmt --all --check` ✓ · `clippy --workspace --all-targets -D warnings` ✓
- Full `xerj-api` suite, **dev** ✓ and **ci-test** ✓ (both profiles)
- `build --workspace --profile ci-test` finishing

Refs #624, #636.