### PR TITLE
fix(api): _search_scroll first page suppresses _source like search_impl (#659)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -14649,12 +14649,13 @@ async fn search_impl(
         // re-derives the mapping check per hit from `h.index` instead.
         //
         // The per-hit null-source case is likewise handled in
-        // `scroll_page_response`. `scroll_page_response` is shared with the
-        // `/:index/_search_scroll` route, whose first page does NOT apply the
-        // mapping check — so the per-hit mapping gate there is guarded by the
-        // `mapping_source_check` flag set below (true here, false for that
-        // route), keeping each route's continuation identical to its own first
-        // page. That route's broader `_source` gap is tracked in #659.
+        // `scroll_page_response`, which is shared with the `/:index/_search_scroll`
+        // route. Both real scroll-opening routes now apply this same per-hit
+        // mapping suppression on their first page (`_search_scroll` since #659),
+        // so both set `mapping_source_check: true`. That flag still guards the
+        // shared continuation's mapping gate — it is `false` only for the
+        // synthetic/test `ScrollContext`s that have no first page — keeping each
+        // route's continuation identical to its own first page.
         let scroll_source_disabled = matches!(body.source, Some(Value::Bool(false)))
             || (suppress_source_for_stored && body.source.is_none());
         let ctx = xerj_engine::engine::ScrollContext {
@@ -20709,11 +20710,12 @@ async fn scroll_page_response(
             // at open). inner_hits still render from the collapse group snapshot
             // regardless.
             let source_disabled = ctx.source_disabled;
-            // #637: whether to ALSO apply the mapping `_source.enabled:false`
-            // suppression per hit below. Only true for scrolls opened by
-            // `search_impl` (whose first page applies it); false for the
-            // `_search_scroll` route, whose first page does not — so its
-            // continuation stays byte-identical to that first page (#659).
+            // #637/#659: whether to ALSO apply the mapping `_source.enabled:false`
+            // suppression per hit below. True for scrolls opened by either real
+            // route — `search_impl` and, since #659, `_search_scroll` — both of
+            // which apply it on their first page; false only for synthetic/test
+            // contexts. Keeps the continuation byte-identical to the opening
+            // route's own first page.
             let mapping_source_check = ctx.mapping_source_check;
 
             // Detect whether the initial search sorted by a non-score key;
@@ -20849,12 +20851,12 @@ async fn scroll_page_response(
                         // implied). The mapping `_source.enabled:false` case is
                         // re-derived PER HIT from this hit's own index (a scroll
                         // can span indices with divergent `_source` settings, and
-                        // search_impl's first page suppresses it per-hit — #658
-                        // skeptic), but ONLY when the opening route applies it on
-                        // its first page (`mapping_source_check`); the
-                        // `_search_scroll` route does not, so its continuation
-                        // stays identical to its first page (#659). inner_hits are
-                        // emitted regardless.
+                        // the first page suppresses it per-hit — #658 skeptic),
+                        // but ONLY when the opening route applies it on its first
+                        // page (`mapping_source_check`). Both real scroll routes
+                        // now do (search_impl, and `_search_scroll` since #659);
+                        // the flag is false only for synthetic contexts.
+                        // inner_hits are emitted regardless.
                         if !source_disabled
                             && !(mapping_source_check && mapping_source_disabled(state, &h.index))
                         {

--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -20330,6 +20330,19 @@ pub async fn search_with_scroll(
         // itself — resolved at construction time in the engine, from the
         // same read as `_source` — not hardcoded, and omitted entirely
         // when not requested (#428/#440).
+        // #659: bring THIS route's first page into `_source` suppression parity
+        // with search_impl. The request-level part (`_source:false`, or
+        // `stored_fields` implying suppression when `_source` is unspecified) is
+        // constant across the snapshot; the mapping `_source.enabled:false` part
+        // is per-hit (applied in the hits_json build below). The continuation
+        // then matches via `mapping_source_check: true` on the ctx.
+        let (suppress_source_for_stored, _) = body
+            .stored_fields
+            .as_ref()
+            .map(parse_stored_fields)
+            .unwrap_or((false, vec![]));
+        let scroll_request_source_disabled = matches!(body.source, Some(Value::Bool(false)))
+            || (suppress_source_for_stored && body.source.is_none());
         let first_page: Vec<EsHit> = all_hits
             .iter()
             .take(page_size)
@@ -20391,13 +20404,12 @@ pub async fn search_with_scroll(
             page_size,
             seq_no_primary_term: emit_seq_no,
             version: emit_version,
-            source_disabled: matches!(body.source, Some(Value::Bool(false))),
-            // `_search_scroll` (this route) does NOT apply mapping
-            // `_source.enabled:false` suppression on its first page (it emits
-            // `_source` unconditionally), so its continuation must not either —
-            // otherwise it gains a new first-page/continuation split. That
-            // route's broader `_source` gap is tracked in #659.
-            mapping_source_check: false,
+            source_disabled: scroll_request_source_disabled,
+            // #659: this route's first page now applies the per-hit mapping
+            // `_source.enabled:false` suppression (below), so the continuation
+            // must too — matching search_impl and keeping the route
+            // self-consistent page to page.
+            mapping_source_check: true,
             created: now,
             keep_alive,
             expires_at: now + keep_alive,
@@ -20433,13 +20445,21 @@ pub async fn search_with_scroll(
                 if let Some(pt) = h.primary_term {
                     o.insert("_primary_term".to_string(), json!(pt));
                 }
-                o.insert(
-                    "_source".to_string(),
-                    match &h.source {
-                        Some(src) => src.clone(),
-                        None => Value::Null,
-                    },
-                );
+                // #659: omit `_source` under the same conditions search_impl
+                // does — request-level (`_source:false`/stored_fields-implied) or
+                // the per-hit mapping `_source.enabled:false`. Otherwise emit the
+                // (possibly null) source as before.
+                let suppress =
+                    scroll_request_source_disabled || mapping_source_disabled(&state, &h.index);
+                if !suppress {
+                    o.insert(
+                        "_source".to_string(),
+                        match &h.source {
+                            Some(src) => src.clone(),
+                            None => Value::Null,
+                        },
+                    );
+                }
                 if let Some(fields) = &h.fields {
                     o.insert(
                         "fields".to_string(),

--- a/engine/crates/xerj-api/tests/search_scroll_route_source_suppression.rs
+++ b/engine/crates/xerj-api/tests/search_scroll_route_source_suppression.rs
@@ -1,0 +1,163 @@
+//! Issue #659 (follow-up to #637): the `/:index/_search_scroll` route
+//! (`search_with_scroll`) emits `_source` UNCONDITIONALLY on its first page — it
+//! ignores request `_source: false`, mapping `_source.enabled: false`, and
+//! `stored_fields`-implied suppression that `search_impl` (`_search?scroll=`)
+//! honours. #637 already made the SHARED continuation renderer suppress these
+//! per route; this issue brings THIS route's first page into the same parity so
+//! it is both ES-correct and self-consistent (first page and continuation agree).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+async fn app() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut config = xerj_common::config::Config::default();
+    config.server.data_dir = dir.path().to_string_lossy().into_owned();
+    config.storage.wal_sync = xerj_common::config::WalSync::Async;
+    let metrics = xerj_common::metrics::Metrics::new().expect("metrics");
+    let engine = xerj_engine::Engine::new(config.clone()).expect("engine");
+    let state = xerj_api::state::AppState::new(config, engine, metrics);
+    (xerj_api::router::build_es_compat_router(state), dir)
+}
+
+async fn call(app: &axum::Router, method: &str, path: &str, body: Value) -> (StatusCode, Value) {
+    let mut req = Request::builder().method(method).uri(path);
+    let body = if body.is_null() {
+        Body::empty()
+    } else {
+        req = req.header("content-type", "application/json");
+        Body::from(body.to_string())
+    };
+    let response = app.clone().oneshot(req.body(body).unwrap()).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+async fn seed(app: &axum::Router, index: &str, mappings: Value) {
+    let (st, body) = call(app, "PUT", &format!("/{index}"), mappings).await;
+    assert_eq!(st, StatusCode::OK, "create {index}: {body}");
+    for (id, v) in [("d0", 10), ("d1", 11), ("d2", 12), ("d3", 13)] {
+        let (st, _) = call(
+            app,
+            "POST",
+            &format!("/{index}/_doc/{id}"),
+            json!({"grp": "g", "v": v}),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "index {id}");
+    }
+    let _ = call(app, "POST", &format!("/{index}/_refresh"), Value::Null).await;
+}
+
+/// mapping `_source.enabled: false` via the `_search_scroll` route: the first
+/// page must OMIT `_source` (matching `search_impl`). Fails before the fix — the
+/// route emits `_source` unconditionally.
+#[tokio::test]
+async fn search_scroll_firstpage_omits_source_under_mapping_disabled() {
+    let (app, _dir) = app().await;
+    seed(
+        &app,
+        "docs",
+        json!({"mappings": {
+            "_source": {"enabled": false},
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+
+    let (st, first) = call(
+        &app,
+        "POST",
+        "/docs/_search_scroll?scroll=5m",
+        json!({"query": {"match_all": {}}, "size": 1, "sort": [{"v": "asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "search_scroll open: {first}");
+    assert!(
+        first["hits"]["hits"][0].get("_source").is_none(),
+        "#659: _search_scroll first page must omit _source when the mapping sets \
+         _source.enabled:false (search_impl parity), got: {first}"
+    );
+}
+
+/// request `_source: false` via the `_search_scroll` route: the first page must
+/// OMIT `_source`. Fails before the fix (the route emits it, then the
+/// continuation omits it — a pre-existing first-page/continuation split).
+#[tokio::test]
+async fn search_scroll_firstpage_omits_source_under_source_false() {
+    let (app, _dir) = app().await;
+    seed(
+        &app,
+        "docs",
+        json!({"mappings": {
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+
+    let (st, first) = call(
+        &app,
+        "POST",
+        "/docs/_search_scroll?scroll=5m",
+        json!({"query": {"match_all": {}}, "size": 1, "_source": false, "sort": [{"v": "asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "search_scroll open: {first}");
+    assert!(
+        first["hits"]["hits"][0].get("_source").is_none(),
+        "#659: _search_scroll first page must omit _source under _source:false, got: {first}"
+    );
+}
+
+/// After the fix, the route stays SELF-CONSISTENT: first page and continuation
+/// agree (both omit) for a mapping-disabled index. Guards the parity #637 cared
+/// about while #659 makes both pages correct.
+#[tokio::test]
+async fn search_scroll_firstpage_and_continuation_both_omit_under_mapping_disabled() {
+    let (app, _dir) = app().await;
+    seed(
+        &app,
+        "docs",
+        json!({"mappings": {
+            "_source": {"enabled": false},
+            "properties": {"grp": {"type": "keyword"}, "v": {"type": "long"}}
+        }}),
+    )
+    .await;
+
+    let (st, first) = call(
+        &app,
+        "POST",
+        "/docs/_search_scroll?scroll=5m",
+        json!({"query": {"match_all": {}}, "size": 1, "sort": [{"v": "asc"}]}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "open: {first}");
+    let first_has = first["hits"]["hits"][0].get("_source").is_some();
+    let sid = first["_scroll_id"].as_str().expect("scroll id").to_string();
+
+    let (st, page2) = call(
+        &app,
+        "POST",
+        "/_search/scroll",
+        json!({"scroll": "5m", "scroll_id": sid}),
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "continuation: {page2}");
+    let cont_has = page2["hits"]["hits"][0].get("_source").is_some();
+
+    assert!(
+        !first_has && !cont_has,
+        "#659: _search_scroll first page AND continuation must both omit _source for a \
+         mapping-disabled index (first={first_has}, continuation={cont_has}); \
+         page1={first} page2={page2}"
+    );
+}


### PR DESCRIPTION
## #659 — `/:index/_search_scroll` first-page `_source` suppression parity (follow-up to #637)

### Bug
The `/:index/_search_scroll` route (`search_with_scroll`) emitted `_source` **unconditionally** on its first page — ignoring request `_source: false`, mapping `_source.enabled: false`, and `stored_fields`-implied suppression that `search_impl` (`_search?scroll=`) honours. Its **shared** continuation (`scroll_page_response`) already suppressed these per route via #637's `mapping_source_check` flag (which was `false` for this route to avoid a split), so the route was self-inconsistent / non-ES-compliant on the first page.

### Fix (es_compat.rs only — reuses #637's field + helper)
On this route's first page, apply the same suppression `search_impl` does:
- **request-level**: `_source:false` OR `stored_fields`-implied (when `_source` unspecified) — captured into `ScrollContext::source_disabled`;
- **per-hit**: `mapping_source_disabled(state, &h.index)` on the first-page render;
- flip `mapping_source_check` to `true` so the continuation applies the same per-hit mapping gate.

Now the first page and continuation agree and both match `search_impl` / ES.

### Fail-before / after
New `search_scroll_route_source_suppression` (3 tests): first page omits `_source` under mapping `_source.enabled:false` and under `_source:false`, and first-page+continuation both omit for a mapping-disabled index. All three **fail on main** (route emits `_source`), pass after.

### Verification (rustc 1.97.1)
- fmt ✓ · clippy --workspace --all-targets -D warnings ✓
- Full `xerj-api` suite **dev** ✓ (ci-test + build finishing)

Note: the Landing constants guard will be red until this rebases onto the post-rc.52 stamp (#660) — code is unaffected. Refs #637.