### PR TITLE
fix(engine): #668 keyword wildcard is case-sensitive (ES default)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -22547,28 +22547,34 @@ impl Index {
                             ords: (lo as u32..hi as u32).collect(),
                         });
                     }
-                    ScoredFilterLeaf::KeywordWildcard { field, pattern } => {
+                    ScoredFilterLeaf::KeywordWildcard {
+                        field,
+                        pattern,
+                        case_insensitive,
+                    } => {
                         let Some(Column::Keyword(k)) = cols.get(field.as_str()) else {
                             return None;
                         };
-                        // SAME predicate as the brute path (`doc_matches_query`)
-                        // and the FST route (`term_matches_wildcard`): fold BOTH
-                        // sides, whole-value OR sub-token.  The old range+match
-                        // here was case-SENSITIVE, so a cased pattern (`K*1`,
-                        // case_insensitive) found nothing in a lowercase
-                        // dictionary — DV-only keyword wildcards returned 0 hits
-                        // from segments while the memtable matched.  A folded
-                        // pattern cannot bound a byte-ordered prefix range, so
-                        // walk the whole (distinct-term) dictionary — the same
-                        // cost class as the FST expansion.
+                        // #668: honor the node's case flag — the SAME predicate
+                        // the brute path (`doc_matches_query`) and the FST route
+                        // now apply. `term{case_insensitive:true}` / query_string
+                        // rewrites fold BOTH sides (whole-value OR sub-token); a
+                        // standalone `{wildcard}` matches the RAW term
+                        // case-sensitively (ES default). A folded pattern cannot
+                        // bound a byte-ordered prefix range, so walk the whole
+                        // (distinct-term) dictionary — same cost class as the FST.
                         let pat_lc = pattern.to_lowercase();
                         let ords: Vec<u32> = (0..k.terms.len())
                             .filter(|&o| {
-                                let lc = k.terms[o].to_lowercase();
-                                wildcard_match(&lc, &pat_lc)
-                                    || lc
-                                        .split(|c: char| !c.is_alphanumeric())
-                                        .any(|tok| !tok.is_empty() && wildcard_match(tok, &pat_lc))
+                                if *case_insensitive {
+                                    let lc = k.terms[o].to_lowercase();
+                                    wildcard_match(&lc, &pat_lc)
+                                        || lc.split(|c: char| !c.is_alphanumeric()).any(|tok| {
+                                            !tok.is_empty() && wildcard_match(tok, &pat_lc)
+                                        })
+                                } else {
+                                    wildcard_match(&k.terms[o], pattern.as_str())
+                                }
                             })
                             .map(|o| o as u32)
                             .collect();
@@ -35737,30 +35743,40 @@ fn doc_matches_query_typed(q: &QueryNode, source: &Value, schema: &Schema) -> bo
         QueryNode::Wildcard {
             field,
             value: pattern,
+            case_insensitive,
             ..
         } => {
-            // #396: `wildcard` must mirror its segment path per field type
+            // #396/#668: `wildcard` must mirror its segment path per field type
             // (ES never analyses the pattern):
             //  - analysed TEXT: the segment matches the RAW pattern against the
             //    lower-cased token stream (case_insensitive:false), so an
-            //    uppercase pattern matches nothing — do the same here (this is
-            //    the flush-divergence the KEYWORD-only earlier attempt missed).
-            //  - KEYWORD: the segment doc-values keyword-wildcard path folds
-            //    both sides (case-insensitive), so fold here to stay in
-            //    agreement. ES-correct case-sensitive keyword wildcard needs the
-            //    segment path changed too — tracked in #668.
-            //  - unknown field (schemaless shim caller): the pre-#423 fold-both
-            //    heuristic, byte-for-byte unchanged.
-            let is_text = matches!(
-                declared_field(schema, field).map(|f| &f.field_type),
-                Some(FieldType::Text)
-            );
+            //    uppercase pattern matches nothing — do the same here.
+            //  - KEYWORD, case-sensitive (standalone `{wildcard}`, the ES
+            //    default): match the RAW value with `wildcard_match` (#668).
+            //  - KEYWORD, case-insensitive (`term{case_insensitive:true}` /
+            //    query_string lowerings set the flag): fold both sides.
+            //  - field absent from the schema (the `EMPTY_SCHEMA` shim callers,
+            //    or a genuinely-undeclared field): the pre-#423 fold-both
+            //    heuristic. NB memtable search passes the real, dynamically-grown
+            //    schema, where an undeclared string is already mapped to `text`
+            //    and takes the branch above — so this arm is effectively the
+            //    schemaless-shim path, byte-for-byte unchanged.
+            let ft = declared_field(schema, field).map(|f| &f.field_type);
+            let is_text = matches!(ft, Some(FieldType::Text));
+            // Case-sensitive only for a declared keyword whose node did NOT ask
+            // to fold. Unknown fields (ft == None) keep folding (shim parity).
+            let keyword_case_sensitive =
+                matches!(ft, Some(FieldType::Keyword)) && !*case_insensitive;
             let pat_lc = pattern.to_lowercase();
             let matches_str = |s: &str| -> bool {
                 if is_text {
                     s.split(|c: char| !c.is_alphanumeric()).any(|tok| {
                         !tok.is_empty() && wildcard_match(&tok.to_lowercase(), pattern.as_str())
                     })
+                } else if keyword_case_sensitive {
+                    // A keyword is a single un-analysed term: match the whole
+                    // raw value, case-sensitively (mirrors the segment FST).
+                    wildcard_match(s, pattern.as_str())
                 } else {
                     let lc = s.to_lowercase();
                     wildcard_match(&lc, &pat_lc)
@@ -41052,7 +41068,7 @@ fn query_node_to_fts_with_keyword_fields(
             value,
             boost,
             constant_score,
-            case_insensitive: _,
+            case_insensitive,
         } => {
             // `wildcard` on a KEYWORD field: expand the keyword FST term
             // dictionary to every term matching the pattern (`*`=0+ chars,
@@ -41063,16 +41079,17 @@ fn query_node_to_fts_with_keyword_fields(
             // (≪ docs) instead of a per-doc O(N) scan (~150 ms/100k → ~1 ms).
             //
             // Case-insensitivity is REQUIRED, not a shortcut: XERJ's parser
-            // drops `case_insensitive` and rewrites `term{case_insensitive:true}`
-            // to a Wildcard, both relying on the matcher folding case — so a
-            // case-sensitive FST route would break those (passing) paths.
+            // rewrites `term{case_insensitive:true}` to a Wildcard, which sets
+            // the node's `case_insensitive` flag so this route keeps folding for
+            // that (passing) path. A standalone `{wildcard}` sets the flag
+            // `false` → the FST route is case-SENSITIVE (ES-correct, #668).
             // TEXT fields keep the doc-scan (None): analyzed-token semantics.
             if exact_fields.contains(field.as_str()) {
                 return Some(FtsQuery::Wildcard(xerj_fts::search::WildcardQuery {
                     field: field.clone(),
                     pattern: value.clone(),
                     boost: boost.unwrap_or(1.0),
-                    case_insensitive: true,
+                    case_insensitive: *case_insensitive,
                     // ES rewrites a standalone `wildcard` query to a
                     // constant_score.  The `term{case_insensitive}` /
                     // query_string lowerings that SHARE this node pass `false`
@@ -41765,7 +41782,13 @@ enum ScoredFilterLeaf {
     /// per segment by matching the (distinct) dictionary terms with the
     /// SAME `wildcard_match` the brute path uses, narrowed to the leading
     /// literal's prefix range first.
-    KeywordWildcard { field: String, pattern: String },
+    KeywordWildcard {
+        field: String,
+        pattern: String,
+        /// #668: fold both sides when true (term-ci / query_string rewrites);
+        /// match the raw term case-sensitively when false (standalone wildcard).
+        case_insensitive: bool,
+    },
     /// `term` on a numeric/boolean field, or `range` on a numeric field —
     /// both evaluate as an inclusive/exclusive f64 window over the numeric
     /// doc-values column (a term is the degenerate `[v, v]` window;
@@ -42419,11 +42442,12 @@ fn scored_fast_plan(
             value,
             boost,
             constant_score: true,
-            case_insensitive: _,
+            case_insensitive,
         } if fs.kw.contains(field) => Some(ScoredPlan::Filtered {
             filter: vec![ScoredFilterLeaf::KeywordWildcard {
                 field: field.clone(),
                 pattern: value.clone(),
+                case_insensitive: *case_insensitive,
             }],
             must_not: Vec::new(),
             score: scoring_boost(boost)?,

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -32634,6 +32634,7 @@ mod lexically_typeless_lowering_tests {
                 value: "0*".into(),
                 boost: None,
                 constant_score: true,
+                case_insensitive: false,
             },
             QueryNode::Match {
                 field: "emb".into(),
@@ -33765,11 +33766,13 @@ fn strip_nested_path_in_query(q: &QueryNode, path: &str) -> QueryNode {
             value,
             boost,
             constant_score,
+            case_insensitive,
         } => QueryNode::Wildcard {
             field: strip(field),
             value: value.clone(),
             boost: *boost,
             constant_score: *constant_score,
+            case_insensitive: *case_insensitive,
         },
         QueryNode::Exists { field } => QueryNode::Exists {
             field: strip(field),
@@ -41049,6 +41052,7 @@ fn query_node_to_fts_with_keyword_fields(
             value,
             boost,
             constant_score,
+            case_insensitive: _,
         } => {
             // `wildcard` on a KEYWORD field: expand the keyword FST term
             // dictionary to every term matching the pattern (`*`=0+ chars,
@@ -42415,6 +42419,7 @@ fn scored_fast_plan(
             value,
             boost,
             constant_score: true,
+            case_insensitive: _,
         } if fs.kw.contains(field) => Some(ScoredPlan::Filtered {
             filter: vec![ScoredFilterLeaf::KeywordWildcard {
                 field: field.clone(),
@@ -44336,6 +44341,7 @@ mod fts_projection_tests {
             value: "run*".into(),
             boost: None,
             constant_score: true,
+            case_insensitive: false,
         };
         match query_node_to_fts(&q, &tf, &kw(&[])).expect("text wildcard projects") {
             FtsQuery::Wildcard(w) => {

--- a/engine/crates/xerj-engine/src/sql.rs
+++ b/engine/crates/xerj-engine/src/sql.rs
@@ -638,6 +638,7 @@ fn parse_condition(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<Qu
                 value: pattern,
                 boost: None,
                 constant_score: false,
+                case_insensitive: false,
             }
         }
         "not_like" => {
@@ -655,6 +656,7 @@ fn parse_condition(tokens: &[Token], pos: &mut usize, depth: usize) -> Result<Qu
                     value: pattern,
                     boost: None,
                     constant_score: false,
+                    case_insensitive: false,
                 }],
                 minimum_should_match: None,
             }

--- a/engine/crates/xerj-engine/tests/wildcard_keyword_case_sensitive.rs
+++ b/engine/crates/xerj-engine/tests/wildcard_keyword_case_sensitive.rs
@@ -1,0 +1,72 @@
+//! Issue #668: `wildcard` on a `keyword` field must be case-SENSITIVE (ES
+//! default — the pattern is not analysed). `wildcard:{name:"hell*"}` on
+//! keyword `"Hello"` must NOT match. XERJ currently folds case on both the
+//! memtable and segment paths, so it matches (wrong result — flush-invariant
+//! but ES-incorrect).
+//!
+//! CONSTRAINT (why a blanket flip is wrong): XERJ's parser rewrites
+//! `term{case_insensitive:true}` INTO a `Wildcard` node and relies on the
+//! matcher folding case (index.rs:41061-41065). So the fix must thread a
+//! `case_insensitive` flag through `QueryNode::Wildcard`: genuine wildcard =>
+//! case-sensitive; rewritten term-ci => still folds. This test pins BOTH.
+//!
+//! IGNORED until the flag is threaded (AST + parser + memtable arm + segment
+//! FTS route index.rs:41071 + DV path index.rs:22550).
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+async fn hits(engine: &Engine, q: serde_json::Value) -> u64 {
+    let idx = engine.get_index("docs").expect("get index");
+    let req = parse_request(&json!({ "query": q, "size": 0 })).expect("parse_request");
+    idx.search(&req).await.expect("search").total.value
+}
+
+#[tokio::test]
+#[ignore = "#668: keyword wildcard folds case; un-ignored when the case_insensitive flag is threaded"]
+async fn keyword_wildcard_is_case_sensitive_but_term_ci_still_folds() {
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("name", FieldType::Keyword));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(Some("d0".to_string()), json!({ "name": "Hello" }))
+        .await
+        .expect("index");
+    idx.refresh().await.expect("refresh");
+
+    // ES-correct: keyword wildcard is case-sensitive, so a lower-case pattern
+    // does not match a capitalized value. (Currently returns 1 — the bug.)
+    assert_eq!(
+        hits(&engine, json!({ "wildcard": { "name": "hell*" } })).await,
+        0,
+        "#668: keyword `wildcard` must be case-sensitive"
+    );
+    // Sanity: a correctly-cased pattern still matches.
+    assert_eq!(
+        hits(&engine, json!({ "wildcard": { "name": "Hell*" } })).await,
+        1,
+        "case-correct wildcard still matches"
+    );
+    // CONSTRAINT: `term{case_insensitive:true}` (rewritten to a Wildcard) must
+    // KEEP folding — the fix must not break this passing path.
+    assert_eq!(
+        hits(
+            &engine,
+            json!({ "term": { "name": { "value": "hello", "case_insensitive": true } } })
+        )
+        .await,
+        1,
+        "#668: term with case_insensitive true must still fold after the fix"
+    );
+}

--- a/engine/crates/xerj-engine/tests/wildcard_keyword_case_sensitive.rs
+++ b/engine/crates/xerj-engine/tests/wildcard_keyword_case_sensitive.rs
@@ -27,7 +27,6 @@ async fn hits(engine: &Engine, q: serde_json::Value) -> u64 {
 }
 
 #[tokio::test]
-#[ignore = "#668: keyword wildcard folds case; un-ignored when the case_insensitive flag is threaded"]
 async fn keyword_wildcard_is_case_sensitive_but_term_ci_still_folds() {
     let dir = TempDir::new().unwrap();
     let mut config = Config::default();
@@ -43,30 +42,44 @@ async fn keyword_wildcard_is_case_sensitive_but_term_ci_still_folds() {
     idx.index_document(Some("d0".to_string()), json!({ "name": "Hello" }))
         .await
         .expect("index");
+
+    let wc = |p: &str| json!({ "wildcard": { "name": p } });
+    let term_ci = json!({ "term": { "name": { "value": "hello", "case_insensitive": true } } });
+
+    // Capture the buffered (memtable) answers, then flush and re-query the
+    // segment: every pair must agree (flush-invariance — the #667 lesson).
+    let pre_lower = hits(&engine, wc("hell*")).await;
+    let pre_cased = hits(&engine, wc("Hell*")).await;
+    let pre_ci = hits(&engine, term_ci.clone()).await;
     idx.refresh().await.expect("refresh");
+    let post_lower = hits(&engine, wc("hell*")).await;
+    let post_cased = hits(&engine, wc("Hell*")).await;
+    let post_ci = hits(&engine, term_ci.clone()).await;
+
+    assert_eq!(
+        pre_lower, post_lower,
+        "#668: keyword wildcard must be flush-invariant"
+    );
+    assert_eq!(
+        pre_cased, post_cased,
+        "#668: keyword wildcard must be flush-invariant"
+    );
+    assert_eq!(
+        pre_ci, post_ci,
+        "#668: term-ci wildcard must be flush-invariant"
+    );
 
     // ES-correct: keyword wildcard is case-sensitive, so a lower-case pattern
-    // does not match a capitalized value. (Currently returns 1 — the bug.)
+    // does not match a capitalized value; a correctly-cased one does.
     assert_eq!(
-        hits(&engine, json!({ "wildcard": { "name": "hell*" } })).await,
-        0,
+        post_lower, 0,
         "#668: keyword `wildcard` must be case-sensitive"
     );
-    // Sanity: a correctly-cased pattern still matches.
-    assert_eq!(
-        hits(&engine, json!({ "wildcard": { "name": "Hell*" } })).await,
-        1,
-        "case-correct wildcard still matches"
-    );
+    assert_eq!(post_cased, 1, "case-correct wildcard still matches");
     // CONSTRAINT: `term{case_insensitive:true}` (rewritten to a Wildcard) must
     // KEEP folding — the fix must not break this passing path.
     assert_eq!(
-        hits(
-            &engine,
-            json!({ "term": { "name": { "value": "hello", "case_insensitive": true } } })
-        )
-        .await,
-        1,
-        "#668: term with case_insensitive true must still fold after the fix"
+        post_ci, 1,
+        "#668: term with case_insensitive true must still fold"
     );
 }

--- a/engine/crates/xerj-query/src/ast.rs
+++ b/engine/crates/xerj-query/src/ast.rs
@@ -369,6 +369,13 @@ pub enum QueryNode {
         /// `term{case_insensitive}` / query_string lowerings that keep BM25.
         #[serde(default, skip_serializing_if = "is_false")]
         constant_score: bool,
+        /// #668: fold case on both sides when matching a KEYWORD field. `false`
+        /// (default) = ES-correct case-sensitive keyword wildcard. `true` is set
+        /// only for the `term{case_insensitive:true}` → Wildcard rewrite (and
+        /// query_string lowerings), which rely on the matcher folding case.
+        /// Ignored for `text` fields (analysed-token semantics apply regardless).
+        #[serde(default, skip_serializing_if = "is_false")]
+        case_insensitive: bool,
     },
 
     /// Matches documents where the field has any non-null value.

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -1040,6 +1040,7 @@ fn parse_term(params: &Value) -> Result<QueryNode> {
                     // threading `case_insensitive` through
                     // QueryNode::Wildcard into the columnar/FST arms.
                     constant_score: false,
+                    case_insensitive: true,
                 };
                 return Ok(maybe_named(node, name));
             }
@@ -1288,6 +1289,7 @@ fn parse_wildcard(params: &Value) -> Result<QueryNode> {
             value: value.to_string(),
             boost: None,
             constant_score: true,
+            case_insensitive: false,
         });
     }
 
@@ -1306,6 +1308,10 @@ fn parse_wildcard(params: &Value) -> Result<QueryNode> {
         value,
         boost,
         constant_score: true,
+        case_insensitive: inner
+            .get("case_insensitive")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
     })
 }
 
@@ -2107,6 +2113,7 @@ fn parse_qs_unary(toks: &[QsTok], pos: &mut usize, ctx: QsFields<'_>) -> Option<
                             value: lowered.clone(),
                             boost,
                             constant_score: true,
+                            case_insensitive: true,
                         })
                         .collect(),
                 );


### PR DESCRIPTION
## #668: `wildcard` on a `keyword` field is case-sensitive (ES default)

### Symptom
`wildcard:{name:"hell*"}` on keyword `"Hello"` matched (1). ES matches a `wildcard` on a `keyword` field **case-sensitively** (the pattern is not analysed), so it must NOT match. XERJ folded case on all three matcher paths.

### Why a blanket flip was wrong (the constraint)
XERJ's parser rewrites `term{case_insensitive:true}` (and some `query_string` forms) **into a `Wildcard` node** relying on the matcher folding case (`index.rs:41061`). A naive case-sensitive flip breaks those passing paths.

### Fix — thread a `case_insensitive` flag
- **AST** (`xerj-query/ast.rs`): add `case_insensitive: bool` (default `false`) to `QueryNode::Wildcard`.
- **Parser**: `false` for a standalone `{wildcard}` (ES default; object form parses the param), `true` for the `term{case_insensitive:true}` rewrite and `query_string` lowerings.
- **All three keyword-wildcard matcher paths honor it consistently** (so nothing split-brains at flush):
  - memtable `doc_matches_query_typed` Wildcard arm — keyword: raw `wildcard_match` when case-sensitive, else fold.
  - segment FST route (`index.rs:41081`) — `WildcardQuery.case_insensitive = node flag`.
  - segment doc-values `KeywordWildcard` (`index.rs:22550`, leaf gains the flag) — raw term match when case-sensitive, else fold.
- `text` fields and unknown (schemaless shim) fields are unchanged.

### Verification (1.97.1)
- `wildcard_keyword_case_sensitive`: keyword wildcard is case-sensitive, `term{case_insensitive:true}` still folds, and both are **flush-invariant** (memtable == segment).
- Fail-before: reverting the arm/route hunks restores the match.
- Full `xerj-engine` suite (ci-test + dev), fmt, clippy `-D warnings` — green.

Closes #668.
