### PR TITLE
fix(engine): #423/#406 keyword fuzzy is case-sensitive (ES default)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -22091,12 +22091,15 @@ impl Index {
         // ── KeywordFuzzy global expansion stats (LOSS_BATTLE_PLAN B4) ────
         // term → (folded Damerau dist, Σ df) over ALL segments'
         // dictionaries, plus the blended df (max Σdf across expansions —
-        // ES TopTermsBlendedFreqScoringRewrite).  The match predicate is
-        // the same folded whole-value-or-sub-token test as
-        // `xerj_fts::search::expand_fuzzy` / the doc-scan fuzzy arm.
-        // Sub-token-only matches (an intentional xerj leniency ES lacks)
-        // can carry a whole-value dist > max_edits; their sim clamps to
-        // ≥ 0 so the extra hits score deterministically.
+        // ES TopTermsBlendedFreqScoringRewrite).  The match predicate
+        // mirrors `xerj_fts::search::expand_fuzzy` / the doc-scan fuzzy
+        // arm EXACTLY: whole-value edit distance always, plus the
+        // sub-token fallback ONLY when folding (case_insensitive) — the
+        // case-sensitive keyword default is whole-term-only on every path
+        // (#423/#406). Sub-token-only matches (an intentional xerj
+        // leniency ES lacks, fold path only) can carry a whole-value
+        // dist > max_edits; their sim clamps to ≥ 0 so the extra hits
+        // score deterministically.
         let fuzzy_stats: Option<(HashMap<String, (usize, u64)>, u64)> = match plan {
             ScoredPlan::KeywordFuzzy {
                 field,
@@ -22116,6 +22119,19 @@ impl Index {
                 let term_matches = |cmp: &str| -> bool {
                     if levenshtein_distance(cmp, &q_ref) <= *max_edits {
                         return true;
+                    }
+                    // #423/#406: the sub-token fallback is a FOLD-path leniency
+                    // ONLY. When case-sensitive (the ES keyword default), the
+                    // memtable Fuzzy arm (`token_match`) and the FST
+                    // `expand_fuzzy` both match the whole un-analysed term and
+                    // nothing else — so this DV path must too, or a
+                    // separator-containing keyword ("alpha-beta") answers a
+                    // sub-token query ("beta") after flush but not before
+                    // (flush-invariance; caught by the PR #675 correctness
+                    // skeptic). The post-flush sub-token hit was also non-ES:
+                    // keyword fuzzy compares the whole term.
+                    if !ci {
+                        return false;
                     }
                     cmp.split(|c: char| !c.is_alphanumeric())
                         .filter(|t| !t.is_empty())

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -33826,10 +33826,12 @@ fn strip_nested_path_in_query(q: &QueryNode, path: &str) -> QueryNode {
             field,
             value,
             fuzziness,
+            case_insensitive,
         } => QueryNode::Fuzzy {
             field: strip(field),
             value: value.clone(),
             fuzziness: *fuzziness,
+            case_insensitive: *case_insensitive,
         },
         QueryNode::Regexp { field, pattern } => QueryNode::Regexp {
             field: strip(field),
@@ -36402,6 +36404,7 @@ fn doc_matches_query_typed(q: &QueryNode, source: &Value, schema: &Schema) -> bo
             field,
             value: query_value,
             fuzziness,
+            case_insensitive: _,
         } => {
             let max_edits = match fuzziness {
                 Fuzziness::Auto => auto_fuzziness(query_value),
@@ -41121,6 +41124,7 @@ fn query_node_to_fts_with_keyword_fields(
             field,
             value,
             fuzziness,
+            case_insensitive: _,
         } => {
             // `fuzzy` on a KEYWORD field: expand the keyword FST term dictionary
             // to every term within `max_edits` Damerau-Levenshtein distance and
@@ -42460,6 +42464,7 @@ fn scored_fast_plan(
             field,
             value,
             fuzziness,
+            case_insensitive: _,
         } if fs.kw.contains(field) => {
             let max_edits = match fuzziness {
                 Fuzziness::Auto => auto_fuzziness(value),
@@ -44379,6 +44384,7 @@ mod fts_projection_tests {
             field: "body".into(),
             value: "runbok".into(),
             fuzziness: Fuzziness::Fixed(1),
+            case_insensitive: false,
         };
         match query_node_to_fts(&q, &tf, &kw(&[])).expect("text fuzzy projects") {
             FtsQuery::Fuzzy(f) => {

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -22102,17 +22102,24 @@ impl Index {
                 field,
                 value,
                 max_edits,
+                case_insensitive,
                 ..
             } => {
-                let q_folded = value.to_lowercase();
-                let term_matches = |folded: &str| -> bool {
-                    if levenshtein_distance(folded, &q_folded) <= *max_edits {
+                // #423/#406: case-sensitive keyword fuzzy (the ES default)
+                // compares the RAW term; case_insensitive folds both sides.
+                let ci = *case_insensitive;
+                let q_ref = if ci {
+                    value.to_lowercase()
+                } else {
+                    value.clone()
+                };
+                let term_matches = |cmp: &str| -> bool {
+                    if levenshtein_distance(cmp, &q_ref) <= *max_edits {
                         return true;
                     }
-                    folded
-                        .split(|c: char| !c.is_alphanumeric())
+                    cmp.split(|c: char| !c.is_alphanumeric())
                         .filter(|t| !t.is_empty())
-                        .any(|tok| levenshtein_distance(tok, &q_folded) <= *max_edits)
+                        .any(|tok| levenshtein_distance(tok, &q_ref) <= *max_edits)
                 };
                 let mut map: HashMap<String, (usize, u64)> = HashMap::new();
                 for (meta, cols) in segments.iter().zip(seg_cols.iter()) {
@@ -22126,10 +22133,14 @@ impl Index {
                         return None;
                     }
                     for (ord, term) in k.terms.iter().enumerate() {
-                        let folded = term.to_lowercase();
-                        if term_matches(&folded) {
+                        let cmp = if ci {
+                            term.to_lowercase()
+                        } else {
+                            term.clone()
+                        };
+                        if term_matches(&cmp) {
                             let seg_df = k.per_ord_count.get(ord).copied().unwrap_or(0) as u64;
-                            let dist = levenshtein_distance(&folded, &q_folded);
+                            let dist = levenshtein_distance(&cmp, &q_ref);
                             let e = map.entry(term.clone()).or_insert((dist, 0));
                             e.1 += seg_df;
                         }
@@ -36404,21 +36415,34 @@ fn doc_matches_query_typed(q: &QueryNode, source: &Value, schema: &Schema) -> bo
             field,
             value: query_value,
             fuzziness,
-            case_insensitive: _,
+            case_insensitive,
         } => {
             let max_edits = match fuzziness {
                 Fuzziness::Auto => auto_fuzziness(query_value),
                 Fuzziness::Fixed(n) => *n as usize,
             };
-            let q_lower = query_value.to_lowercase();
             // ES's Fuzzy query matches at the TERM level with an UNANALYZED
             // query term. For keyword fields the indexed term is the whole
-            // field value, so first compare the full (case-folded) string
-            // against the query — e.g. doc "claude-haiku-4-5" vs query
-            // "claude-haiku-4-6" is 1 edit and must match. Then fall back to
-            // per-token comparison for text-field semantics, where each
-            // analyzed token is an indexed term.
+            // field value, so first compare the full string against the query —
+            // e.g. doc "claude-haiku-4-5" vs query "claude-haiku-4-6" is 1 edit
+            // and must match. Then fall back to per-token comparison for
+            // text-field semantics, where each analyzed token is an indexed
+            // term.
+            //
+            // #423/#406: a declared `keyword` whose node did NOT ask to fold is
+            // case-SENSITIVE (ES default) — compare the RAW whole value (a
+            // keyword is one un-analysed term). Everything else (text, an
+            // explicit case_insensitive, or an unknown/shim field) folds, as
+            // before.
+            let keyword_case_sensitive = matches!(
+                declared_field(schema, field).map(|f| &f.field_type),
+                Some(FieldType::Keyword)
+            ) && !*case_insensitive;
+            let q_lower = query_value.to_lowercase();
             let token_match = |s: &str| -> bool {
+                if keyword_case_sensitive {
+                    return levenshtein_distance(s, query_value.as_str()) <= max_edits;
+                }
                 let s_lower = s.to_lowercase();
                 if levenshtein_distance(&s_lower, &q_lower) <= max_edits {
                     return true;
@@ -41124,7 +41148,7 @@ fn query_node_to_fts_with_keyword_fields(
             field,
             value,
             fuzziness,
-            case_insensitive: _,
+            case_insensitive,
         } => {
             // `fuzzy` on a KEYWORD field: expand the keyword FST term dictionary
             // to every term within `max_edits` Damerau-Levenshtein distance and
@@ -41145,7 +41169,10 @@ fn query_node_to_fts_with_keyword_fields(
                     value: value.clone(),
                     max_edits,
                     boost: 1.0,
-                    case_insensitive: true,
+                    // #423/#406: a standalone `{fuzzy}` sets the flag false → the
+                    // keyword FST route is case-SENSITIVE (ES default); a
+                    // query_string/term-ci fuzzy sets it true and keeps folding.
+                    case_insensitive: *case_insensitive,
                 }));
             }
             // TEXT field: expand the term dictionary within `max_edits`
@@ -41856,6 +41883,9 @@ enum ScoredPlan {
         value: String,
         max_edits: usize,
         boost: f32,
+        /// #423/#406: fold both sides when true; case-sensitive raw-term match
+        /// when false (standalone keyword fuzzy, ES default).
+        case_insensitive: bool,
     },
 }
 
@@ -42464,7 +42494,7 @@ fn scored_fast_plan(
             field,
             value,
             fuzziness,
-            case_insensitive: _,
+            case_insensitive,
         } if fs.kw.contains(field) => {
             let max_edits = match fuzziness {
                 Fuzziness::Auto => auto_fuzziness(value),
@@ -42475,6 +42505,7 @@ fn scored_fast_plan(
                 value: value.clone(),
                 max_edits,
                 boost: 1.0,
+                case_insensitive: *case_insensitive,
             })
         }
         // Filter-only bool: ES scores filter context 0.0 (the brute path's

--- a/engine/crates/xerj-engine/tests/fuzzy_keyword_case_sensitive.rs
+++ b/engine/crates/xerj-engine/tests/fuzzy_keyword_case_sensitive.rs
@@ -26,7 +26,6 @@ async fn hits(engine: &Engine, q: serde_json::Value) -> u64 {
 }
 
 #[tokio::test]
-#[ignore = "#423/#406: fuzzy ignores case_insensitive (always folds); un-ignored by the fix"]
 async fn fuzzy_keyword_is_case_sensitive_but_ci_flag_still_folds() {
     let dir = TempDir::new().unwrap();
     let mut config = Config::default();
@@ -42,29 +41,43 @@ async fn fuzzy_keyword_is_case_sensitive_but_ci_flag_still_folds() {
     idx.index_document(Some("d0".to_string()), json!({ "name": "Hello" }))
         .await
         .expect("index");
+
+    let fz = |v: &str| json!({ "fuzzy": { "name": { "value": v, "fuzziness": 0 } } });
+    let fz_ci = json!({ "fuzzy": { "name": { "value": "hello", "fuzziness": 0, "case_insensitive": true } } });
+
+    // Buffered (memtable) answers, then flush and re-query the segment — every
+    // pair must agree (flush-invariance — the #668 lesson).
+    let pre_lower = hits(&engine, fz("hello")).await;
+    let pre_cased = hits(&engine, fz("Hello")).await;
+    let pre_ci = hits(&engine, fz_ci.clone()).await;
     idx.refresh().await.expect("refresh");
+    let post_lower = hits(&engine, fz("hello")).await;
+    let post_cased = hits(&engine, fz("Hello")).await;
+    let post_ci = hits(&engine, fz_ci.clone()).await;
+
+    assert_eq!(
+        pre_lower, post_lower,
+        "#423/#406: keyword fuzzy must be flush-invariant"
+    );
+    assert_eq!(
+        pre_cased, post_cased,
+        "#423/#406: keyword fuzzy must be flush-invariant"
+    );
+    assert_eq!(
+        pre_ci, post_ci,
+        "#423/#406: fuzzy case_insensitive must be flush-invariant"
+    );
 
     // ES default: case-sensitive → a lower-case value does not fuzzy-match a
-    // capitalized keyword at fuzziness 0. (Currently returns 1 — the bug.)
+    // capitalized keyword at fuzziness 0; the correctly-cased one does; and the
+    // explicit `case_insensitive: true` still folds.
     assert_eq!(
-        hits(&engine, json!({ "fuzzy": { "name": { "value": "hello", "fuzziness": 0 } } })).await,
-        0,
+        post_lower, 0,
         "#423/#406: keyword fuzzy must be case-sensitive by default"
     );
-    // Correct case still matches.
+    assert_eq!(post_cased, 1, "case-correct fuzzy matches");
     assert_eq!(
-        hits(&engine, json!({ "fuzzy": { "name": { "value": "Hello", "fuzziness": 0 } } })).await,
-        1,
-        "case-correct fuzzy matches"
-    );
-    // The explicit flag still folds.
-    assert_eq!(
-        hits(
-            &engine,
-            json!({ "fuzzy": { "name": { "value": "hello", "fuzziness": 0, "case_insensitive": true } } })
-        )
-        .await,
-        1,
+        post_ci, 1,
         "#423/#406: fuzzy with case_insensitive true still folds"
     );
 }

--- a/engine/crates/xerj-engine/tests/fuzzy_keyword_case_sensitive.rs
+++ b/engine/crates/xerj-engine/tests/fuzzy_keyword_case_sensitive.rs
@@ -1,0 +1,70 @@
+//! Issue #423 (symptom #406): `fuzzy` on a `keyword` field must be
+//! case-SENSITIVE by default (ES: `case_insensitive` defaults to false) — the
+//! value is matched against the raw term dictionary, so `fuzzy{value:"hello",
+//! fuzziness:0}` on `"Hello"` must NOT match. XERJ folds case on both the
+//! memtable and segment paths (the FST fuzzy route hardcodes
+//! `case_insensitive: true`, index.rs:~41133), so it matches (wrong result).
+//!
+//! CONSTRAINT (like keyword wildcard, #668): a `fuzzy{case_insensitive:true}`
+//! must still fold. `QueryNode::Fuzzy` carries no `case_insensitive` flag today,
+//! so the fix threads one through AST + parser + the memtable Fuzzy arm + the
+//! FTS route, exactly as #668 did for `Wildcard`.
+//!
+//! IGNORED until that fix; un-ignored by it.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+async fn hits(engine: &Engine, q: serde_json::Value) -> u64 {
+    let idx = engine.get_index("docs").expect("get index");
+    let req = parse_request(&json!({ "query": q, "size": 0 })).expect("parse_request");
+    idx.search(&req).await.expect("search").total.value
+}
+
+#[tokio::test]
+#[ignore = "#423/#406: fuzzy ignores case_insensitive (always folds); un-ignored by the fix"]
+async fn fuzzy_keyword_is_case_sensitive_but_ci_flag_still_folds() {
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("name", FieldType::Keyword));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(Some("d0".to_string()), json!({ "name": "Hello" }))
+        .await
+        .expect("index");
+    idx.refresh().await.expect("refresh");
+
+    // ES default: case-sensitive → a lower-case value does not fuzzy-match a
+    // capitalized keyword at fuzziness 0. (Currently returns 1 — the bug.)
+    assert_eq!(
+        hits(&engine, json!({ "fuzzy": { "name": { "value": "hello", "fuzziness": 0 } } })).await,
+        0,
+        "#423/#406: keyword fuzzy must be case-sensitive by default"
+    );
+    // Correct case still matches.
+    assert_eq!(
+        hits(&engine, json!({ "fuzzy": { "name": { "value": "Hello", "fuzziness": 0 } } })).await,
+        1,
+        "case-correct fuzzy matches"
+    );
+    // The explicit flag still folds.
+    assert_eq!(
+        hits(
+            &engine,
+            json!({ "fuzzy": { "name": { "value": "hello", "fuzziness": 0, "case_insensitive": true } } })
+        )
+        .await,
+        1,
+        "#423/#406: fuzzy with case_insensitive true still folds"
+    );
+}

--- a/engine/crates/xerj-engine/tests/fuzzy_keyword_case_sensitive.rs
+++ b/engine/crates/xerj-engine/tests/fuzzy_keyword_case_sensitive.rs
@@ -81,3 +81,67 @@ async fn fuzzy_keyword_is_case_sensitive_but_ci_flag_still_folds() {
         "#423/#406: fuzzy with case_insensitive true still folds"
     );
 }
+
+#[tokio::test]
+async fn fuzzy_keyword_separator_matches_whole_term_only_when_case_sensitive() {
+    // #423/#406 (PR #675 correctness skeptic): a case-SENSITIVE keyword fuzzy
+    // matches the whole un-analysed term ONLY — the sub-token fallback is a
+    // FOLD-path leniency. A separator-containing keyword "alpha-beta" must NOT
+    // fuzzy-match the sub-token query "beta" (fuzziness 0) case-sensitively,
+    // and — the load-bearing part — must answer the SAME before and after a
+    // flush. The DV `ScoredPlan::KeywordFuzzy` expansion used to run the
+    // sub-token fallback UNCONDITIONALLY, so it matched only after flush
+    // (memtable=0, segment=1). The explicit case_insensitive:true still folds,
+    // where the sub-token leniency applies and is itself flush-invariant.
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("name", FieldType::Keyword));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(Some("d0".to_string()), json!({ "name": "alpha-beta" }))
+        .await
+        .expect("index");
+
+    let fz = |v: &str| json!({ "fuzzy": { "name": { "value": v, "fuzziness": 0 } } });
+    let fz_ci = json!({ "fuzzy": { "name": { "value": "beta", "fuzziness": 0, "case_insensitive": true } } });
+
+    let pre_sub = hits(&engine, fz("beta")).await;
+    let pre_whole = hits(&engine, fz("alpha-beta")).await;
+    let pre_ci = hits(&engine, fz_ci.clone()).await;
+    idx.refresh().await.expect("refresh");
+    let post_sub = hits(&engine, fz("beta")).await;
+    let post_whole = hits(&engine, fz("alpha-beta")).await;
+    let post_ci = hits(&engine, fz_ci.clone()).await;
+
+    assert_eq!(
+        pre_sub, post_sub,
+        "#423/#406: case-sensitive keyword sub-token fuzzy must be flush-invariant"
+    );
+    assert_eq!(
+        pre_whole, post_whole,
+        "#423/#406: case-sensitive keyword whole-term fuzzy must be flush-invariant"
+    );
+    assert_eq!(
+        pre_ci, post_ci,
+        "#423/#406: fuzzy case_insensitive must be flush-invariant"
+    );
+
+    assert_eq!(
+        post_sub, 0,
+        "#423/#406: case-sensitive keyword fuzzy matches the whole term only (no sub-token)"
+    );
+    assert_eq!(
+        post_whole, 1,
+        "the whole-term case-sensitive fuzzy matches exactly"
+    );
+    assert_eq!(
+        post_ci, 1,
+        "#423/#406: case_insensitive folds and keeps the sub-token leniency"
+    );
+}

--- a/engine/crates/xerj-query/src/ast.rs
+++ b/engine/crates/xerj-query/src/ast.rs
@@ -544,6 +544,11 @@ pub enum QueryNode {
         value: String,
         #[serde(default)]
         fuzziness: Fuzziness,
+        /// #423/#406: fold case on both sides when true. `false` (default) =
+        /// ES-correct case-sensitive keyword fuzzy (the value is matched raw
+        /// against the term dictionary). Ignored for `text` fields.
+        #[serde(default, skip_serializing_if = "is_false")]
+        case_insensitive: bool,
     },
 
     /// Regular expression match against a field value.

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -902,6 +902,7 @@ fn parse_multi_match(params: &Value) -> Result<QueryNode> {
                         field: field.to_string(),
                         value: tok.to_string(),
                         fuzziness: fz,
+                        case_insensitive: false,
                     }
                 } else {
                     QueryNode::Match {
@@ -2198,6 +2199,7 @@ fn parse_fuzzy(params: &Value) -> Result<QueryNode> {
             field,
             value: value.to_string(),
             fuzziness: Fuzziness::Auto,
+            case_insensitive: false,
         });
     }
 
@@ -2227,10 +2229,15 @@ fn parse_fuzzy(params: &Value) -> Result<QueryNode> {
         _ => return invalid("`fuzzy.fuzziness` must be 'AUTO' or an integer"),
     };
 
+    let case_insensitive = inner
+        .get("case_insensitive")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     Ok(QueryNode::Fuzzy {
         field,
         value,
         fuzziness,
+        case_insensitive,
     })
 }
 
@@ -4259,6 +4266,7 @@ fn parse_match_bool_prefix(params: &Value) -> Result<QueryNode> {
                 field: field.clone(),
                 value: folded,
                 fuzziness: fz,
+                case_insensitive: true,
             }
         } else {
             QueryNode::Match {


### PR DESCRIPTION
## #423 (symptom #406): `fuzzy` on a `keyword` field is case-sensitive (ES default)

### Symptom
`fuzzy:{name:{value:"hello",fuzziness:0}}` on keyword `"Hello"` matched (1). ES matches `fuzzy` at the term level against the RAW (un-analysed) value, so keyword fuzzy is **case-sensitive** by default (`case_insensitive` defaults to false) — it must NOT match. XERJ folded case on all three matcher paths.

### Fix — thread a `case_insensitive` flag (the #668 playbook)
- **AST** (`xerj-query/ast.rs`): add `case_insensitive: bool` (default false) to `QueryNode::Fuzzy`.
- **Parser**: standalone `{fuzzy}` / object form (parses the param) → false; `query_string` fuzzy lowering → true (value pre-lowercased); match/multi_match fuzzy leaf → false.
- **All three keyword-fuzzy matcher paths honor it consistently** (so nothing splits at flush):
  - memtable `doc_matches_query_typed` Fuzzy arm — keyword+`!case_insensitive`: RAW edit distance; else fold.
  - segment FST route (`index.rs:~41161`) — `FuzzyQuery.case_insensitive = node flag`.
  - segment doc-values `ScoredPlan::KeywordFuzzy` expansion — RAW-term edit distance when case-sensitive, else fold.
- `text` fields and unknown (schemaless shim) fields are unchanged.

### Verification (1.97.1)
- `fuzzy_keyword_case_sensitive`: keyword fuzzy is case-sensitive, `case_insensitive:true` still folds, and both are **flush-invariant** (memtable == segment).
- Fail-before: reverting the memtable arm restores the fold divergence.
- Full `xerj-engine` suite (ci-test + dev), fmt, clippy `-D warnings` — green.

Advances #423 (fuzzy limb; formerly #406).
