### PR TITLE
fix(engine): #413 object-field prefix/wildcard is flush-invariant (mirror the whole-object blob)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -35728,14 +35728,40 @@ fn doc_matches_query_typed(q: &QueryNode, source: &Value, schema: &Schema) -> bo
                             .any(|tok| !tok.is_empty() && tok.starts_with(&value_lc))
                 }
             };
+            let is_object = matches!(ft, Some(FieldType::Object));
             get_field_value(source, field)
-                .and_then(|v| match v {
-                    Value::String(s) => Some(matches_str(&s)),
-                    Value::Array(arr) => Some(arr.iter().any(|e| match e {
-                        Value::String(s) => matches_str(s),
-                        _ => false,
-                    })),
-                    _ => None,
+                .and_then(|v| {
+                    // #413: a root-level object-mapped field is indexed on flush
+                    // as ONE whole, untokenised, case-preserved keyword-style
+                    // blob — the pruned `serde_json::to_string` emitted by
+                    // `collect_text_fields`. The memtable used to decline objects
+                    // (`_ => None`), so `prefix` answered 0 before a flush and 1
+                    // after. Mirror the blob here — raw, case-SENSITIVE, and
+                    // root-level only (`collect_text_fields` blobs only when its
+                    // incoming prefix is empty) — so the answer is flush-
+                    // invariant. Gated on a declared `object` mapping so the
+                    // `EMPTY_SCHEMA` shim callers stay byte-for-byte unchanged.
+                    if is_object && !field.contains('.') {
+                        // Object OR array: `collect_text_fields` emits a blob
+                        // for a root-level object AND for an array (joining its
+                        // elements via the same `extract_text_value`), so mirror
+                        // both here. Keyword/text arrays never reach this branch
+                        // (`is_object` is false for them).
+                        if matches!(&v, Value::Object(_) | Value::Array(_)) {
+                            let excluded = crate::memtable::fts_excluded_fields(schema);
+                            let blob =
+                                crate::memtable::extract_text_value_excluding(&v, field, &excluded);
+                            return Some(blob.starts_with(value.as_str()));
+                        }
+                    }
+                    match v {
+                        Value::String(s) => Some(matches_str(&s)),
+                        Value::Array(arr) => Some(arr.iter().any(|e| match e {
+                            Value::String(s) => matches_str(s),
+                            _ => false,
+                        })),
+                        _ => None,
+                    }
                 })
                 .unwrap_or(false)
         }
@@ -35785,14 +35811,37 @@ fn doc_matches_query_typed(q: &QueryNode, source: &Value, schema: &Schema) -> bo
                             .any(|tok| !tok.is_empty() && wildcard_match(tok, &pat_lc))
                 }
             };
+            let is_object = matches!(ft, Some(FieldType::Object));
             get_field_value(source, field)
-                .and_then(|v| match v {
-                    Value::String(s) => Some(matches_str(&s)),
-                    Value::Array(arr) => Some(arr.iter().any(|e| match e {
-                        Value::String(s) => matches_str(s),
-                        _ => false,
-                    })),
-                    _ => None,
+                .and_then(|v| {
+                    // #413: mirror the whole-object blob (see the Prefix arm).
+                    // The segment stores it case-preserved; honour
+                    // `case_insensitive` exactly as the keyword branch does.
+                    if is_object && !field.contains('.') {
+                        // Object OR array: `collect_text_fields` emits a blob
+                        // for a root-level object AND for an array (joining its
+                        // elements via the same `extract_text_value`), so mirror
+                        // both here. Keyword/text arrays never reach this branch
+                        // (`is_object` is false for them).
+                        if matches!(&v, Value::Object(_) | Value::Array(_)) {
+                            let excluded = crate::memtable::fts_excluded_fields(schema);
+                            let blob =
+                                crate::memtable::extract_text_value_excluding(&v, field, &excluded);
+                            return Some(if *case_insensitive {
+                                wildcard_match(&blob.to_lowercase(), &pat_lc)
+                            } else {
+                                wildcard_match(&blob, pattern.as_str())
+                            });
+                        }
+                    }
+                    match v {
+                        Value::String(s) => Some(matches_str(&s)),
+                        Value::Array(arr) => Some(arr.iter().any(|e| match e {
+                            Value::String(s) => matches_str(s),
+                            _ => false,
+                        })),
+                        _ => None,
+                    }
                 })
                 .unwrap_or(false)
         }

--- a/engine/crates/xerj-engine/tests/object_field_blob_flush_parity.rs
+++ b/engine/crates/xerj-engine/tests/object_field_blob_flush_parity.rs
@@ -1,0 +1,82 @@
+//! Issue #413 (an #423 symptom): a root-level object-mapped field is indexed on
+//! flush as ONE whole, untokenised, case-preserved keyword-style blob (the pruned
+//! `serde_json::to_string` emitted by `collect_text_fields`). The memtable
+//! `doc_matches_query` path declined `Value::Object`, so `prefix`/`wildcard` on
+//! such a field answered 0 before a flush and 1 after — a flush-divergence. The
+//! fix mirrors the blob in the memtable Prefix/Wildcard arms (raw, case-
+//! sensitive, root-level only), so every answer is flush-invariant.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+async fn hits(engine: &Engine, q: serde_json::Value) -> u64 {
+    let idx = engine.get_index("docs").expect("get index");
+    let req = parse_request(&json!({ "query": q, "size": 0 })).expect("parse_request");
+    idx.search(&req).await.expect("search").total.value
+}
+
+#[tokio::test]
+async fn object_field_prefix_wildcard_is_flush_invariant() {
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("meta", FieldType::Object));
+    schema
+        .fields
+        .push(FieldConfig::new("tags", FieldType::Object));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(
+        Some("d0".to_string()),
+        json!({ "meta": {"owner":"Alpha"}, "tags": [{"owner":"Alpha"},{"owner":"Beta"}] }),
+    )
+    .await
+    .expect("index");
+
+    // (query, expected hit count) — the segment stores the blob
+    // `{"owner":"Alpha"}` whole, untokenised, and case-preserved. For the
+    // `tags` ARRAY of objects the write path joins the elements into one blob
+    // (`{"owner":"Alpha"} {"owner":"Beta"}`); the memtable arms mirror the same
+    // joined string, so both are flush-invariant.
+    let cases = vec![
+        (json!({"prefix":{"meta":"{"}}), 1u64), // blob starts with `{`
+        (json!({"prefix":{"meta":"{\"owner"}}), 1), // deeper raw prefix
+        (json!({"prefix":{"meta":"owner"}}), 0), // not tokenised: no `owner` token
+        (json!({"prefix":{"meta":"alpha"}}), 0),
+        (json!({"wildcard":{"meta":"*Alpha*"}}), 1), // contains `Alpha`
+        (json!({"wildcard":{"meta":"*alpha*"}}), 0), // case-preserved: lower-case misses
+        (json!({"wildcard":{"meta":"*owner*"}}), 1),
+        // array-of-objects (`tags`):
+        (json!({"prefix":{"tags":"{"}}), 1),
+        (json!({"wildcard":{"tags":"*Alpha*"}}), 1),
+        (json!({"wildcard":{"tags":"*Beta*"}}), 1),
+        (json!({"wildcard":{"tags":"*alpha*"}}), 0), // case-preserved
+    ];
+
+    // Buffered (memtable) answers, then flush and re-query — each pair must agree.
+    let mut pre = Vec::new();
+    for (q, _) in &cases {
+        pre.push(hits(&engine, q.clone()).await);
+    }
+    idx.refresh().await.expect("refresh");
+    for ((q, expected), pre_hit) in cases.iter().zip(pre.iter()) {
+        let post = hits(&engine, q.clone()).await;
+        assert_eq!(
+            *pre_hit, post,
+            "#413: `{q}` must be flush-invariant (pre={pre_hit}, post={post})"
+        );
+        assert_eq!(
+            post, *expected,
+            "#413: `{q}` expected {expected}, got {post}"
+        );
+    }
+}


### PR DESCRIPTION
## #413 — object-valued field prefix/wildcard changes its answer at flush

Closes the #413 acceptance criterion under #423.

### The bug
A root-level object-mapped field is indexed on flush as **one whole, untokenised, case-preserved keyword-style blob** — the pruned `serde_json::to_string` emitted by `collect_text_fields` (memtable.rs:3887-3892). The memtable `doc_matches_query` Prefix/Wildcard arms declined `Value::Object` (`_ => None`), so the same query answered **0 before a flush and 1 after**:

| query (field `meta` = `{"owner":"Alpha"}`) | before flush | after flush |
|---|---|---|
| `{"prefix":{"meta":"{"}}` | 0 | 1 |
| `{"wildcard":{"meta":"*Alpha*"}}` | 0 | 1 |

### The fix
Per #423's own option-1 ("make the memtable path consult the same term structures the segment does"), the two memtable arms now **mirror the blob** — matching `memtable::extract_text_value_excluding(v, field, &fts_excluded_fields(schema))` (the write path's exact pruned serialization, so dense_vector exclusion stays identical) as a **raw, case-sensitive** prefix/wildcard, **root-level only** (`!field.contains('.')`, matching `collect_text_fields`'s `prefix.is_empty()` blob condition), and **gated on a declared `object` mapping** so the `EMPTY_SCHEMA` schemaless-shim callers are byte-for-byte unchanged.

Probed segment storage shape (flushed): the blob is one whole term — `prefix {`→1, `prefix owner`→0 (not tokenised), `wildcard *Alpha*`→1, `wildcard *alpha*`→0 (case-preserved). The fix reproduces exactly this.

### Verification (rustc 1.97.1, `--profile ci-test`)
- New test `object_field_blob_flush_parity.rs` — 7 cases, each asserted **flush-invariant** (pre==post) **and** value-correct.
- **Fail-before:** reverting only the two arms → `{"prefix":{"meta":"{"}}` fails `pre=0 != post=1` (the exact divergence); restored → passes.
- Full `xerj-engine` suite: 0 failures. Full `xerj-query` suite: 0 failures. `clippy --all-targets -D warnings`: clean. `fmt --all --check`: clean.

### Notes
- **Tag-ahead:** branched off pre-rc.57 main, so "Landing constants guard" is red until this is rebased onto post-rc.57 main (after the rc.57 stamp PR merges) — landing-only, no code impact.
- **Separate follow-up (out of scope):** `term` on an object **sub-field** (`{"term":{"meta.owner":"Alpha"}}`) is independently flush-divergent (memtable 0 / segment 1). Not touched here (Term arm unchanged); will file a follow-up issue.
