### PR TITLE
fix(engine): #677 term on an object sub-field is flush-invariant (dotted-path source scan)

### DIFF
--- a/engine/crates/xerj-engine/src/memtable.rs
+++ b/engine/crates/xerj-engine/src/memtable.rs
@@ -1797,6 +1797,17 @@ impl ShardedFtsMemtable {
     /// refusal globally (`?` inside its loop); this makes the single-leaf
     /// wrappers behave the same way.
     fn dv_column_unusable(&self, field: &str) -> bool {
+        // #677: a dotted path (an object sub-field like `meta.owner`, or a
+        // `.keyword` multi-field) resolves through `get_field_value` /
+        // `get_nested_field` against the stored `_source`, NOT a faithful
+        // single-valued DV column — the same rule `terms_counts_columnar`
+        // states. Counting such a field via the column undercounts (0 while
+        // the buffered source matches → the #677 size:0-vs-size:5 split), so
+        // force the authoritative source scan. Always correct (the scan is the
+        // authority); only a bounded perf cost on dotted-field term counts.
+        if field.contains('.') {
+            return true;
+        }
         self.shards.iter().any(|s| {
             let g = s.read();
             g.doc_values.array_fields.contains(field)
@@ -3366,6 +3377,14 @@ impl FtsMemtable {
                     if self.doc_values.array_fields.contains(field.as_str()) {
                         return None;
                     }
+                    // #677: a dotted path (object sub-field / `.keyword`
+                    // multi-field) is not faithfully represented by a single
+                    // DV column — it resolves through `_source`. Bail to the
+                    // source scan, else a `term` on `meta.owner` counts 0 while
+                    // buffered but matches after flush (size:0 undercount).
+                    if field.contains('.') {
+                        return None;
+                    }
                     if let Some(col) = self.doc_values.keyword.get(field.as_str()) {
                         // Step 2: analyzed-text bailout via the insert-time
                         // cached flag instead of an O(N) per-query column
@@ -3394,6 +3413,10 @@ impl FtsMemtable {
                     lt,
                 } => {
                     if self.doc_values.array_fields.contains(field.as_str()) {
+                        return None;
+                    }
+                    // #677: dotted path → source scan (see the Term arm).
+                    if field.contains('.') {
                         return None;
                     }
                     let col = self.doc_values.numeric.get(field.as_str())?;
@@ -3486,6 +3509,12 @@ impl FtsMemtable {
                     if self.doc_values.array_fields.contains(field.as_str()) {
                         return None;
                     }
+                    // #677: dotted path (object sub-field / `.keyword`) → source
+                    // scan, so the count and filter paths agree (see the count
+                    // fn `doc_values_bool_hits`).
+                    if field.contains('.') {
+                        return None;
+                    }
                     if let Some(col) = self.doc_values.keyword.get(field.as_str()) {
                         if self
                             .doc_values
@@ -3509,6 +3538,10 @@ impl FtsMemtable {
                     lt,
                 } => {
                     if self.doc_values.array_fields.contains(field.as_str()) {
+                        return None;
+                    }
+                    // #677: dotted path → source scan (see the Term arm).
+                    if field.contains('.') {
                         return None;
                     }
                     let col = self.doc_values.numeric.get(field.as_str())?;

--- a/engine/crates/xerj-engine/tests/object_subfield_term_flush_parity.rs
+++ b/engine/crates/xerj-engine/tests/object_subfield_term_flush_parity.rs
@@ -25,7 +25,6 @@ async fn hits(engine: &Engine, q: serde_json::Value) -> u64 {
 }
 
 #[tokio::test]
-#[ignore = "#677: memtable term path does not resolve object sub-fields; un-ignored by the fix"]
 async fn term_on_object_subfield_is_flush_invariant() {
     let dir = TempDir::new().unwrap();
     let mut config = Config::default();
@@ -47,6 +46,12 @@ async fn term_on_object_subfield_is_flush_invariant() {
     idx.refresh().await.expect("refresh");
     let post = hits(&engine, q.clone()).await;
 
-    assert_eq!(pre, post, "#677: term on an object sub-field must be flush-invariant");
-    assert_eq!(post, 1, "#677: meta.owner is an indexed keyword sub-field (ES matches)");
+    assert_eq!(
+        pre, post,
+        "#677: term on an object sub-field must be flush-invariant"
+    );
+    assert_eq!(
+        post, 1,
+        "#677: meta.owner is an indexed keyword sub-field (ES matches)"
+    );
 }

--- a/engine/crates/xerj-engine/tests/object_subfield_term_flush_parity.rs
+++ b/engine/crates/xerj-engine/tests/object_subfield_term_flush_parity.rs
@@ -1,0 +1,52 @@
+//! Issue #677 (an #423 sibling of #413): `term` on an object **sub-field**
+//! changes its answer at flush. Field `meta` mapped `object`, document
+//! `{"meta":{"owner":"Alpha"}}`:
+//!
+//! | query | before flush | after flush |
+//! |---|---|---|
+//! | `{"term":{"meta.owner":"Alpha"}}` | 0 | 1 |
+//!
+//! The segment indexes `meta.owner` as its own term (via `collect_text_fields`
+//! recursion), so post-flush answers 1; the memtable's `term` path returns 0
+//! for the dotted sub-field. ES answers 1 consistently. Ignored until the fix
+//! makes the memtable term path resolve object sub-fields; the fix un-ignores it.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+async fn hits(engine: &Engine, q: serde_json::Value) -> u64 {
+    let idx = engine.get_index("docs").expect("get index");
+    let req = parse_request(&json!({ "query": q, "size": 0 })).expect("parse_request");
+    idx.search(&req).await.expect("search").total.value
+}
+
+#[tokio::test]
+#[ignore = "#677: memtable term path does not resolve object sub-fields; un-ignored by the fix"]
+async fn term_on_object_subfield_is_flush_invariant() {
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("meta", FieldType::Object));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(Some("d0".to_string()), json!({ "meta": {"owner":"Alpha"} }))
+        .await
+        .expect("index");
+
+    let q = json!({"term":{"meta.owner":"Alpha"}});
+    let pre = hits(&engine, q.clone()).await;
+    idx.refresh().await.expect("refresh");
+    let post = hits(&engine, q.clone()).await;
+
+    assert_eq!(pre, post, "#677: term on an object sub-field must be flush-invariant");
+    assert_eq!(post, 1, "#677: meta.owner is an indexed keyword sub-field (ES matches)");
+}


### PR DESCRIPTION
## #677 — `term` on an object sub-field changes its answer at flush

Closes #677 (an #423 sibling of the #413 prefix/wildcard fix).

### The bug
Field `meta` mapped `object`, doc `{"meta":{"owner":"Alpha"}}`:

| query | before flush | after flush |
|---|---|---|
| `{"term":{"meta.owner":"Alpha"}}` | **0** | **1** |

Probing size:0 vs size:5 pinpointed it: **matching is correct** (size:5 returns the doc, total=1 pre-flush) — it is a **size:0 count-only** undercount. The memtable's single-valued doc-values column can't faithfully represent a dotted path (`meta.owner` resolves through `_source`/`get_nested_field`, not a column — the same rule `terms_counts_columnar` already states), so the DV term-count answered 0 while the buffered source matched.

### The fix
Gate dotted-path term/range predicates to the **authoritative source scan** (always correct; the scan is the authority — only a bounded perf cost on dotted-field term counts), in every memtable path that counts/filters via the column:
- `dv_column_unusable` (covers `doc_values_term_query` / `doc_values_range_query` + the `try_shortcut_count` segment shortcut),
- `doc_values_bool_hits` (the size:0 + fused-bool count path) — Term and Range arms,
- `filtered_docs_arc_into` (the size>0 filter path) — Term and Range arms, so count and filter agree.

### Verification (rustc 1.97.1, `--profile ci-test`)
- New test `object_subfield_term_flush_parity.rs`: `term{meta.owner}` is flush-invariant (pre==post==1).
- **Fail-before:** reverting only the memtable gates → the test fails `pre=0 != post=1`; restored → passes.
- Full `xerj-engine` suite: **0 failures**. Full `xerj-query` suite: **0 failures**. `clippy --all-targets -D warnings`: clean. `fmt --all --check`: clean.
