### PR TITLE
fix(engine): #669 matched_queries (_name) uses the schema-aware matcher

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -18161,7 +18161,8 @@ impl Index {
             } else {
                 hit.source.clone()
             };
-            hit.matched_queries = collect_matched_queries(&request.query, &source_with_id);
+            hit.matched_queries =
+                collect_matched_queries(&request.query, &source_with_id, &dmq_schema);
         }
 
         // --- Apply search_after cursor (skip hits up to and including the cursor) ---
@@ -37685,20 +37686,31 @@ fn point_in_polygon(lat: f64, lon: f64, polygon: &[(f64, f64)]) -> bool {
 ///
 /// Recursively traverses the query tree, collecting the `name` of every `Named`
 /// query whose inner query matches the document.
-fn collect_matched_queries(q: &QueryNode, source: &Value) -> Vec<String> {
+fn collect_matched_queries(q: &QueryNode, source: &Value, schema: &Schema) -> Vec<String> {
     let mut names = Vec::new();
-    collect_matched_queries_inner(q, source, &mut names);
+    collect_matched_queries_inner(q, source, schema, &mut names);
     names
 }
 
-fn collect_matched_queries_inner(q: &QueryNode, source: &Value, names: &mut Vec<String>) {
+// #669: the `_name` / `matched_queries` channel must decide a named clause with
+// the SAME schema-aware matcher hit-SELECTION uses (`doc_matches_query_typed`
+// with the real index schema, post-#396/#667). The old 2-arg `doc_matches_query`
+// shim folded case for every field, so a named keyword `prefix`/`term` clause
+// could report a `_name` the hit set never granted (and disagree pre- vs
+// post-flush). Thread the schema through so the annotation matches selection.
+fn collect_matched_queries_inner(
+    q: &QueryNode,
+    source: &Value,
+    schema: &Schema,
+    names: &mut Vec<String>,
+) {
     match q {
         QueryNode::Named { name, query } => {
-            if doc_matches_query(query, source) {
+            if doc_matches_query_typed(query, source, schema) {
                 names.push(name.clone());
             }
             // Also recurse into the wrapped query in case it contains further Named nodes.
-            collect_matched_queries_inner(query, source, names);
+            collect_matched_queries_inner(query, source, schema, names);
         }
         QueryNode::Bool {
             must,
@@ -37713,21 +37725,21 @@ fn collect_matched_queries_inner(q: &QueryNode, source: &Value, names: &mut Vec<
                 .chain(must_not.iter())
                 .chain(filter.iter())
             {
-                collect_matched_queries_inner(sub, source, names);
+                collect_matched_queries_inner(sub, source, schema, names);
             }
         }
         QueryNode::Boosted { query, .. } | QueryNode::Constant { query, .. } => {
-            collect_matched_queries_inner(query, source, names);
+            collect_matched_queries_inner(query, source, schema, names);
         }
         QueryNode::DisMax { queries, .. } => {
             for sub in queries {
-                collect_matched_queries_inner(sub, source, names);
+                collect_matched_queries_inner(sub, source, schema, names);
             }
         }
         QueryNode::FunctionScore {
             query, functions, ..
         } => {
-            collect_matched_queries_inner(query, source, names);
+            collect_matched_queries_inner(query, source, schema, names);
             for f in functions {
                 // ES 8.9+: when the function entry itself carries
                 // `_name`, that name OVERRIDES any `_name` inside the
@@ -37738,9 +37750,9 @@ fn collect_matched_queries_inner(q: &QueryNode, source: &Value, names: &mut Vec<
                 let filter_matches = match &f.filter {
                     Some(filter) => {
                         if !filter_has_fn_name {
-                            collect_matched_queries_inner(filter, source, names);
+                            collect_matched_queries_inner(filter, source, schema, names);
                         }
-                        doc_matches_query(filter, source)
+                        doc_matches_query_typed(filter, source, schema)
                     }
                     None => true,
                 };
@@ -37754,14 +37766,14 @@ fn collect_matched_queries_inner(q: &QueryNode, source: &Value, names: &mut Vec<
         QueryNode::Boosting {
             positive, negative, ..
         } => {
-            collect_matched_queries_inner(positive, source, names);
-            collect_matched_queries_inner(negative, source, names);
+            collect_matched_queries_inner(positive, source, schema, names);
+            collect_matched_queries_inner(negative, source, schema, names);
         }
         QueryNode::Nested { query, .. } => {
-            collect_matched_queries_inner(query, source, names);
+            collect_matched_queries_inner(query, source, schema, names);
         }
         QueryNode::Pinned { organic, .. } => {
-            collect_matched_queries_inner(organic, source, names);
+            collect_matched_queries_inner(organic, source, schema, names);
         }
         _ => {}
     }

--- a/engine/crates/xerj-engine/tests/matched_queries_schema_aware.rs
+++ b/engine/crates/xerj-engine/tests/matched_queries_schema_aware.rs
@@ -1,0 +1,70 @@
+//! Issue #669 (follow-up to #396/#667): the `matched_queries` (`_name`) channel
+//! must decide a named clause with the SAME schema-aware matcher hit-SELECTION
+//! uses. `collect_matched_queries_inner` called the 2-arg schemaless
+//! `doc_matches_query` shim (fold-both), so a named keyword `prefix`/`term`
+//! clause could report a `_name` the hit set never granted, and disagree
+//! pre- vs post-flush. The fix threads the index schema through so the `_name`
+//! annotation matches selection.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+async fn matched(engine: &Engine, q: serde_json::Value) -> Vec<Vec<String>> {
+    let idx = engine.get_index("docs").expect("get index");
+    let req = parse_request(&json!({ "query": q, "size": 10 })).expect("parse_request");
+    idx.search(&req)
+        .await
+        .expect("search")
+        .hits
+        .iter()
+        .map(|h| h.matched_queries.clone())
+        .collect()
+}
+
+#[tokio::test]
+async fn matched_queries_name_is_schema_aware_and_flush_invariant() {
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("name", FieldType::Keyword));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(Some("d0".to_string()), json!({ "name": "Hello" }))
+        .await
+        .expect("index");
+
+    // A `function_score` whose function carries `_name` and a keyword-`prefix`
+    // FILTER. `match_all` makes the doc a hit; the function's `_name` "fp" is
+    // reported only if its filter matches. Keyword prefix is case-SENSITIVE, so
+    // "Hello" does not start with "hel" — the filter must NOT match and "fp"
+    // must NOT appear (the schemaless fold-shim wrongly folded and reported it).
+    let q = json!({
+        "function_score": {
+            "query": { "match_all": {} },
+            "functions": [
+                { "filter": { "prefix": { "name": "hel" } }, "weight": 2.0, "_name": "fp" }
+            ]
+        }
+    });
+
+    let pre = matched(&engine, q.clone()).await;
+    idx.refresh().await.expect("refresh");
+    let post = matched(&engine, q.clone()).await;
+
+    assert_eq!(pre, post, "#669: matched_queries must be flush-invariant");
+    assert_eq!(pre.len(), 1, "one hit (match_all)");
+    assert!(
+        !pre[0].contains(&"fp".to_string()),
+        "#669: keyword-prefix filter is case-sensitive; the function `_name` must agree with hit selection (no 'fp'): {:?}",
+        pre[0]
+    );
+}


### PR DESCRIPTION
## #669 — `matched_queries` (`_name`) used the schemaless fold-shim, disagreeing with schema-aware hit selection

Follow-up to #396/#667. After #667, memtable hit-SELECTION routes through `doc_matches_query_typed` with the real index schema (keyword `prefix`/`wildcard` are case-sensitive). But `collect_matched_queries_inner` (index.rs) still called the 2-arg schemaless `doc_matches_query` shim (fold-both), so the `_name` / `matched_queries` channel could report a name the hit set never granted — and differ pre- vs post-flush.

### Repro (rustc 1.97.1)
Field `name` mapped `keyword`, doc `{"name":"Hello"}`, a `function_score` whose function carries `_name:"fp"` over a keyword-`prefix` **filter** `{"prefix":{"name":"hel"}}`:

| | schemaless fold-shim (before) | schema-aware (after / ES) |
|---|---|---|
| filter `prefix name:"hel"` on `"Hello"` | folds → matches → reports `"fp"` | case-sensitive → no match → no `"fp"` |

`matched_queries` wrongly contained `"fp"`; hit selection never granted it.

### Fix
Thread the index schema (`dmq_schema = self.schema()`, already bound at the call site) through `collect_matched_queries` + `collect_matched_queries_inner`, and evaluate the named-clause leaf and the `function_score` filter with `doc_matches_query_typed` instead of the fold-shim — so the `_name` annotation matches hit selection on every field type and is flush-invariant.

### Verification
- New test `matched_queries_schema_aware.rs`: the function `_name` must NOT appear (keyword-prefix filter is case-sensitive), flush-invariant.
- **Fail-before:** reverting only the `index.rs` hunk → the test fails, `matched_queries` = `["fp"]`; restored → passes.
- Full `xerj-engine` + `xerj-query` suites: 0 failures. `clippy --all-targets -D warnings` clean. `fmt --all --check` clean.
