### PR TITLE
fix(query): #681 honor _name on the expanded prefix/wildcard form

### DIFF
--- a/engine/crates/xerj-engine/tests/name_on_prefix_wildcard.rs
+++ b/engine/crates/xerj-engine/tests/name_on_prefix_wildcard.rs
@@ -1,0 +1,68 @@
+//! Issue #681: `_name` on the expanded form of a `prefix`/`wildcard` clause
+//! (e.g. `{"prefix":{"name":{"value":"Hel","_name":"p"}}}`) was dropped by the
+//! parser (`parse_prefix`/`parse_wildcard` never called `maybe_named`), so a
+//! named prefix/wildcard clause never surfaced in `matched_queries`. The fix
+//! extracts `_name` and wraps the node, mirroring `parse_term`.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+async fn matched(engine: &Engine, q: serde_json::Value) -> Vec<Vec<String>> {
+    let idx = engine.get_index("docs").expect("get index");
+    let req = parse_request(&json!({ "query": q, "size": 10 })).expect("parse_request");
+    idx.search(&req)
+        .await
+        .expect("search")
+        .hits
+        .iter()
+        .map(|h| h.matched_queries.clone())
+        .collect()
+}
+
+#[tokio::test]
+async fn name_on_prefix_and_wildcard_surfaces_in_matched_queries() {
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("name", FieldType::Keyword));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(Some("d0".to_string()), json!({ "name": "Hello" }))
+        .await
+        .expect("index");
+
+    // A named `prefix` that matches ("Hel" prefixes "Hello") must report "p".
+    let pre = matched(
+        &engine,
+        json!({ "prefix": { "name": { "value": "Hel", "_name": "p" } } }),
+    )
+    .await;
+    assert_eq!(pre.len(), 1, "the prefix matches -> one hit");
+    assert!(
+        pre[0].contains(&"p".to_string()),
+        "#681: a named prefix must surface its `_name` in matched_queries: {:?}",
+        pre[0]
+    );
+
+    // A named `wildcard` that matches ("Hel*") must report "w".
+    let wc = matched(
+        &engine,
+        json!({ "wildcard": { "name": { "value": "Hel*", "_name": "w" } } }),
+    )
+    .await;
+    assert_eq!(wc.len(), 1, "the wildcard matches -> one hit");
+    assert!(
+        wc[0].contains(&"w".to_string()),
+        "#681: a named wildcard must surface its `_name` in matched_queries: {:?}",
+        wc[0]
+    );
+}

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -1264,13 +1264,22 @@ fn parse_prefix(params: &Value) -> Result<QueryNode> {
         .get("boost")
         .and_then(|v| v.as_f64())
         .map(|b| b as f32);
+    // #681: honor `_name` on the expanded form, like `parse_term`, so a named
+    // prefix clause surfaces in `matched_queries`.
+    let name = inner
+        .get("_name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
 
-    Ok(QueryNode::Prefix {
-        field,
-        value,
-        boost,
-        constant_score: true,
-    })
+    Ok(maybe_named(
+        QueryNode::Prefix {
+            field,
+            value,
+            boost,
+            constant_score: true,
+        },
+        name,
+    ))
 }
 
 fn parse_wildcard(params: &Value) -> Result<QueryNode> {
@@ -1303,17 +1312,25 @@ fn parse_wildcard(params: &Value) -> Result<QueryNode> {
         .get("boost")
         .and_then(|v| v.as_f64())
         .map(|b| b as f32);
+    // #681: honor `_name` on the expanded form (like `parse_term`).
+    let name = inner
+        .get("_name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
 
-    Ok(QueryNode::Wildcard {
-        field,
-        value,
-        boost,
-        constant_score: true,
-        case_insensitive: inner
-            .get("case_insensitive")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-    })
+    Ok(maybe_named(
+        QueryNode::Wildcard {
+            field,
+            value,
+            boost,
+            constant_score: true,
+            case_insensitive: inner
+                .get("case_insensitive")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+        },
+        name,
+    ))
 }
 
 fn parse_exists(params: &Value) -> Result<QueryNode> {


### PR DESCRIPTION
## #681 — `_name` on a `prefix`/`wildcard` clause was dropped by the parser

`parse_prefix` / `parse_wildcard` parsed the expanded field form (`{"prefix":{"name":{"value":"hel","_name":"p"}}}`) for `value`/`boost` but never read `_name` or called `maybe_named` — unlike `parse_term`. So a named prefix/wildcard clause parsed into an un-named node and never surfaced in `matched_queries`.

### Fix
Extract `_name` from the expanded object and wrap the node via `maybe_named` in both parsers, mirroring `parse_term`.

**Scope:** `prefix` + `wildcard`. Naming a `bool` clause (`_name` as a top-level sibling of `must`/`should`) is a separate mechanism and is left for a follow-up.

### Verification (rustc 1.97.1, `--profile ci-test`)
- New test `name_on_prefix_wildcard.rs`: a named `prefix` (`Hel` prefixes `Hello`) and a named `wildcard` (`Hel*`) that match must surface their `_name` in `matched_queries`.
- **Fail-before:** reverting only `parser.rs` → `matched_queries` is `[]` (the name is dropped); restored → passes.
- Full `xerj-query` + `xerj-engine` suites: 0 failures. `clippy --all-targets -D warnings` clean. `fmt --all --check` clean.

Combined with #669 (#680), a matching named prefix/wildcard is now both reported AND evaluated schema-aware / flush-invariant.
