### PR TITLE
fix(query): #681 honor _name on a bool clause (completes prefix/wildcard #682)

### DIFF
--- a/engine/crates/xerj-engine/tests/name_on_bool.rs
+++ b/engine/crates/xerj-engine/tests/name_on_bool.rs
@@ -1,0 +1,54 @@
+//! Issue #681 (bool half): `_name` on a `bool` clause (a top-level sibling of
+//! `must`/`should`/…) was silently dropped by `parse_bool` (it never read
+//! `_name` or wrapped the node), so a named bool never surfaced in
+//! `matched_queries`. The fix reads `_name` and wraps via `maybe_named`.
+
+use serde_json::json;
+use tempfile::TempDir;
+use xerj_common::config::Config;
+use xerj_common::types::{FieldConfig, FieldType, Schema};
+use xerj_engine::Engine;
+use xerj_query::parse_request;
+
+async fn matched(engine: &Engine, q: serde_json::Value) -> Vec<Vec<String>> {
+    let idx = engine.get_index("docs").expect("get index");
+    let req = parse_request(&json!({ "query": q, "size": 10 })).expect("parse_request");
+    idx.search(&req)
+        .await
+        .expect("search")
+        .hits
+        .iter()
+        .map(|h| h.matched_queries.clone())
+        .collect()
+}
+
+#[tokio::test]
+async fn name_on_bool_surfaces_in_matched_queries() {
+    let dir = TempDir::new().unwrap();
+    let mut config = Config::default();
+    config.server.data_dir = dir.path().to_str().unwrap().to_string();
+    let engine = Engine::new(config).expect("engine");
+
+    let mut schema = Schema::empty();
+    schema
+        .fields
+        .push(FieldConfig::new("name", FieldType::Keyword));
+    engine.create_index("docs", schema).expect("create");
+    let idx = engine.get_index("docs").expect("get");
+    idx.index_document(Some("d0".to_string()), json!({ "name": "Hello" }))
+        .await
+        .expect("index");
+
+    // A named `bool` that matches (via match_all) must report "b".
+    let m = matched(
+        &engine,
+        json!({ "bool": { "should": [{ "match_all": {} }], "_name": "b" } }),
+    )
+    .await;
+    assert_eq!(m.len(), 1, "the bool matches -> one hit");
+    assert!(
+        m[0].contains(&"b".to_string()),
+        "#681: a named bool must surface its `_name` in matched_queries: {:?}",
+        m[0]
+    );
+}

--- a/engine/crates/xerj-query/src/parser.rs
+++ b/engine/crates/xerj-query/src/parser.rs
@@ -2657,16 +2657,28 @@ fn parse_bool(params: &Value) -> Result<QueryNode> {
         .map(|b| b as f32)
         .filter(|b| *b != 1.0);
 
+    // #681: honor `_name` on a bool clause (a top-level sibling of
+    // must/should/must_not/filter), so a named bool surfaces in
+    // matched_queries when it matches. `parse_bool` ignores unknown keys, so
+    // this was silently dropped before.
+    let name = obj
+        .get("_name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
     if must.is_empty() && should.is_empty() && must_not.is_empty() && filter.is_empty() {
         // Empty bool == match_all; with a boost, ES scores it `boost`
         // per hit (constant-score semantics), like `match_all{boost}`.
-        return Ok(match boost {
-            Some(b) => QueryNode::Constant {
-                score: b,
-                query: Box::new(QueryNode::MatchAll),
+        return Ok(maybe_named(
+            match boost {
+                Some(b) => QueryNode::Constant {
+                    score: b,
+                    query: Box::new(QueryNode::MatchAll),
+                },
+                None => QueryNode::MatchAll,
             },
-            None => QueryNode::MatchAll,
-        });
+            name,
+        ));
     }
 
     let minimum_should_match = obj
@@ -2681,13 +2693,14 @@ fn parse_bool(params: &Value) -> Result<QueryNode> {
         filter,
         minimum_should_match,
     };
-    Ok(match boost {
+    let node = match boost {
         Some(b) => QueryNode::Boosted {
             boost: b,
             query: Box::new(node),
         },
         None => node,
-    })
+    };
+    Ok(maybe_named(node, name))
 }
 
 fn parse_constant_score(params: &Value) -> Result<QueryNode> {


### PR DESCRIPTION
## #681 (bool half) — `_name` on a `bool` clause was dropped by the parser

Completes #681. The prefix/wildcard half landed in #682; this is the `bool` clause.

`parse_bool` read `must`/`should`/`must_not`/`filter`/`boost`/`minimum_should_match` but never `_name`, and it ignores unknown keys — so `{"bool":{...,"_name":"b"}}` parsed into an un-named node and the name never surfaced in `matched_queries`.

### Fix
Read `_name` (a top-level sibling of the clause lists) and wrap both returns — the empty-bool (`match_all`/`Constant`) path and the main `Bool` node (outside the `boost` `Boosted` wrapper) — via `maybe_named`.

### Verification (rustc 1.97.1, `--profile ci-test`)
- New test `name_on_bool.rs`: a named bool that matches (via `match_all`) must surface `"b"` in `matched_queries`.
- **Fail-before:** reverting only `parser.rs` → `matched_queries` is `[]`; restored → passes.
- Full `xerj-query` + `xerj-engine` suites: 0 failures. `clippy --all-targets -D warnings` clean. `fmt --all --check` clean.
