### PR TITLE
fix(engine): #643 single-clause bool unwrap covers a percentage minimum_should_match

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -35005,13 +35005,22 @@ fn unwrap_single_clause_bool(q: QueryNode) -> QueryNode {
                 return must.remove(0);
             }
             let only_should = must.is_empty() && must_not.is_empty() && filter.is_empty();
-            if should.len() == 1
-                && only_should
-                && matches!(
-                    minimum_should_match,
-                    None | Some(MinShouldMatch::Fixed(0)) | Some(MinShouldMatch::Fixed(1))
-                )
-            {
+            // #643: a lone `should` collapses to the bare clause only when its
+            // effective required count is 1 (the clause is required). msm
+            // resolution is `max(1, floor(len * pct / 100))` (the Bool matcher
+            // and FTS arms), so for a single clause a `Percentage` resolves to
+            // 1 iff `pct < 200`: `pct >= 200` resolves to >= 2 (requires 2 of 1
+            // clause => the bool matches NOTHING), unlike the bare clause, so it
+            // must stay wrapped. `Field`/`Script` resolve at query time and can
+            // likewise exceed the clause count, so they too stay wrapped
+            // (conservative). The parser puts no upper cap on `pct`, so `"200%"`
+            // is reachable.
+            let should_msm_collapses = match &minimum_should_match {
+                None | Some(MinShouldMatch::Fixed(0)) | Some(MinShouldMatch::Fixed(1)) => true,
+                Some(MinShouldMatch::Percentage(pct)) => *pct < 200,
+                _ => false,
+            };
+            if should.len() == 1 && only_should && should_msm_collapses {
                 return should.remove(0);
             }
             QueryNode::Bool {

--- a/engine/crates/xerj-engine/tests/bool_single_clause_is_score_neutral.rs
+++ b/engine/crates/xerj-engine/tests/bool_single_clause_is_score_neutral.rs
@@ -172,7 +172,44 @@ fn neutral_wrappers() -> Vec<(&'static str, Value)> {
             "bool.must[bool.must[1]]",
             json!({"bool": {"must": [{"bool": {"must": [text_query()]}}]}}),
         ),
+        (
+            // #643: a lone `should` with a PERCENTAGE msm resolves to 1 for a
+            // single optional clause (coerced to ≥1 when there is no required
+            // clause), so it is the same query and must now collapse like
+            // Fixed(0)/Fixed(1).
+            "bool.should[1]+pct100",
+            json!({"bool": {"should": [text_query()], "minimum_should_match": "100%"}}),
+        ),
+        (
+            "bool.should[1]+pct50",
+            json!({"bool": {"should": [text_query()], "minimum_should_match": "50%"}}),
+        ),
     ]
+}
+
+/// #643 guard: a lone `should` whose `minimum_should_match` is a percentage
+/// >= 200% resolves to `max(1, floor(1 * pct/100)) >= 2` — it requires 2 of 1
+/// optional clause, which is unsatisfiable, so the bool matches NOTHING. It must
+/// stay wrapped, NOT collapse to the bare clause (which matches). Guards the
+/// over-broad `Percentage(_)` unwrap the 3-skeptic pass caught.
+#[tokio::test]
+async fn high_percentage_msm_lone_should_matches_nothing() {
+    for flush in [false, true] {
+        let (_dir, idx) = seed(&format!("bool-pct-high-{flush}"), flush).await;
+        let bare = idx.search(&req(text_query(), 50)).await.unwrap();
+        assert_eq!(
+            bare.total.value, 120,
+            "fixture: the bare clause matches all"
+        );
+        for pct in ["200%", "300%"] {
+            let q = json!({"bool": {"should": [text_query()], "minimum_should_match": pct}});
+            let r = idx.search(&req(q, 50)).await.unwrap();
+            assert_eq!(
+                r.total.value, 0,
+                "#643: lone should + msm {pct} requires 2 of 1 clause \u{2192} must match nothing (flush={flush})"
+            );
+        }
+    }
 }
 
 /// The headline of #399, on the population that showed it: an UNFLUSHED index.


### PR DESCRIPTION
## #643 — single-clause `bool` unwrap now covers a percentage `minimum_should_match`

Follow-up to #399 / #642. `unwrap_single_clause_bool` erased a lone `should` only for `None`/`Fixed(0)`/`Fixed(1)` msm, so #399's memtable score/rank divergence still surfaced for a lone `should` whose `minimum_should_match` is a **percentage**.

### Fix
Over a single optional clause a percentage always resolves to 1 — you cannot require more than one of one clause, and with no required clause the effective count is coerced to ≥1 (the same reason `Fixed(0)` is erasable). So `Percentage(_)` is added to the lone-`should` arm.

`Field`/`Script` msm are **deliberately left wrapped**: they resolve at query time and can exceed the clause count (`msm > numOptional` ⇒ the bool matches nothing), which the bare clause would not — collapsing them would be wrong, so this stays strictly conservative.

Scope note: the issue also mentions recursing the unwrap through `function_score`/`dis_max`. I could not construct a fail-before for that (those wrappers transform the score and mask any inner-bool divergence — the score-neutrality test passes with or without the recursion), so per the fail-before discipline it is **not** included here; if a divergent case is found it can be a separate PR.

### Verification (rustc 1.97.1, `--profile ci-test`)
- Two percentage cases added to `bool_single_clause_is_score_neutral.rs` (`"100%"` and `"50%"`), asserted score/rank-neutral vs the bare clause on **memtable + segments + every page size**.
- **Fail-before:** reverting only the `index.rs` hunk → `bool.should[1]+pct100` scores `d004` at `2.79` vs the bare clause's `0.0068` on the memtable (the exact #399 divergence); restored → neutral.
- Full `xerj-engine` + `xerj-query` suites: 0 failures. `clippy --all-targets -D warnings` clean. `fmt --all --check` clean.
