### PR TITLE
fix(autoindex): #673 prefix-scope correlation catalog ids (corr:/tcorr:)

### DIFF
--- a/engine/crates/xerj-autoindex/src/correlate.rs
+++ b/engine/crates/xerj-autoindex/src/correlate.rs
@@ -38,10 +38,15 @@ pub struct KeyCorr {
 }
 
 impl KeyCorr {
-    pub fn id(&self) -> String {
+    /// Catalog doc id, corpus-prefix-scoped (#673). The `autoindex-catalog`
+    /// index is shared across corpora, so a correlation keyed only by dataset
+    /// slugs (`corr:reports:orders:…`) would overwrite the same-slug
+    /// correlation from another corpus. Threading `prefix` — exactly as #416
+    /// did for `file:`/`ds:` ids — keeps them distinct.
+    pub fn id(&self, prefix: &str) -> String {
         format!(
-            "corr:{}:{}:{}:{}",
-            self.a_slug, self.b_slug, self.a_field, self.b_field
+            "corr:{}:{}:{}:{}:{}",
+            prefix, self.a_slug, self.b_slug, self.a_field, self.b_field
         )
     }
     pub fn to_value(&self) -> Value {
@@ -340,4 +345,52 @@ pub fn time_alignment(series: &[TimeSeries]) -> Vec<Value> {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_corr() -> KeyCorr {
+        KeyCorr {
+            a_slug: "reports".into(),
+            a_index: "ax-reports".into(),
+            a_field: "order_id".into(),
+            b_slug: "orders".into(),
+            b_index: "ax-orders".into(),
+            b_field: "id".into(),
+            kind: "keyword".into(),
+            a_set: 100,
+            b_set: 100,
+            overlap: 80,
+            containment: 0.8,
+            grade: "strong".into(),
+            examples: vec!["500001".into()],
+            confirmed: None,
+            confirm_details: Vec::new(),
+        }
+    }
+
+    /// #673: the `autoindex-catalog` index is shared across corpora, so a
+    /// correlation keyed only by dataset slugs must carry the corpus prefix in
+    /// its id — otherwise `(reports, orders)` in corpus A overwrites the
+    /// same-slug correlation in corpus B (silent cross-corpus data-loss).
+    #[test]
+    fn correlation_id_is_prefix_scoped_across_corpora() {
+        let c = sample_corr();
+        // Same correlation, different corpus prefix -> distinct ids (no overwrite).
+        assert_ne!(
+            c.id("ax-a"),
+            c.id("ax-b"),
+            "#673: same-slug correlations from two corpora must not collide"
+        );
+        // Idempotent within one corpus (a re-run upserts, does not duplicate).
+        assert_eq!(c.id("ax-a"), c.id("ax-a"));
+        // The prefix is actually in the id (not merely concatenated onto slugs).
+        assert!(
+            c.id("ax-a").starts_with("corr:ax-a:"),
+            "id was {:?}",
+            c.id("ax-a")
+        );
+    }
 }

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -5521,11 +5521,14 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     for c in &key_corrs {
         let mut v = c.to_value();
         v["run_id"] = json!(run_id);
-        push_doc(&c.id(), &v, &mut cat_buf);
+        push_doc(&c.id(&cfg.prefix), &v, &mut cat_buf);
     }
     for (i, tc) in time_corrs.iter().enumerate() {
+        // Prefix-scoped for the same cross-corpus reason as `corr:` above (#673):
+        // time correlations are keyed by dataset slugs and share the catalog.
         let id = format!(
-            "tcorr:{}:{}",
+            "tcorr:{}:{}:{}",
+            cfg.prefix,
             tc.get("a_dataset").and_then(|v| v.as_str()).unwrap_or(""),
             tc.get("b_dataset")
                 .and_then(|v| v.as_str())


### PR DESCRIPTION
Closes #673.

## Problem
The shared `autoindex-catalog` index keyed correlation docs by dataset slugs only:
- `corr:{a_slug}:{b_slug}:{a_field}:{b_field}` (`KeyCorr::id`, correlate.rs)
- `tcorr:{a_dataset}:{b_dataset}` (lib.rs time-correlation push)

#416/#672 scoped `file:`/`ds:`/`file-alias:` ids by the corpus `--prefix`, but these two id families stayed **global**. The moment server-side correlations run for two corpora that share dataset slugs, `(reports, orders)` in corpus A silently overwrites the same-slug correlation in corpus B — cross-corpus data-loss (the follow-up #673 raised from the #416 verification).

## Fix
Thread the corpus `--prefix` into both ids exactly as #416 did:
- `corr:{prefix}:{a_slug}:{b_slug}:{a_field}:{b_field}`
- `tcorr:{prefix}:{a_dataset}:{b_dataset}`

`KeyCorr::id(&self, prefix: &str)` — its only caller is the catalog push in `lib.rs` (passes `&cfg.prefix`).

### run:{id} deliberately left global
`run_id` is the globally-unique `tx_id` (`run-{second}-{pid}-{seq}` with an atomic per-process sequence; on the generation path `tx_id = {run_id}-g{gen}`), so `run:{id}` **cannot collide across corpora** — the scoping this PR adds to `corr:`/`tcorr:` fixes a real *slug*-keyed collision that `run:{id}` simply does not have. This tx_id global-uniqueness argument is load-bearing and holds on its own. Secondarily, `run:{id}` is a *read-contract* in the generation-catalog projection (two writer paths — lib.rs + generation_catalog.rs — plus exact-id test reads), so changing it would be a contract change for zero collision benefit. It is therefore left as-is by design. (Note: `execution.prefix` *is* in scope in the projection — used as `run_doc["prefix"]` at generation_catalog.rs:220 — so the reason to leave `run:` global is the uniqueness argument above, not any absence of the prefix.)

## Verification (rustc 1.97.1)
- New test `correlate::tests::correlation_id_is_prefix_scoped_across_corpora` (distinct across corpora, idempotent within one, prefix actually in the id).
- **Fail-before proven**: reverting only the format-string hunk makes both corpora produce `corr:reports:orders:order_id:id` → `assert_ne!` fails (exit 101).
- Full gate green: `fmt --all --check` / `clippy --workspace --all-targets -D warnings` / `build --workspace --profile ci-test` / `test -p xerj-autoindex` (full) — all exit 0. No regression (the `corr:reports:old` at generation_catalog_http_tests.rs:480 is a synthetic stale-id purge test, unaffected).