### PR TITLE
fix(autoindex): #589 sweep a newly-excluded group's documents instead of refusing

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2016,3 +2016,87 @@ fn a_journal_that_fails_its_own_revalidation_names_the_rebuild_route() {
         "the refusal must name the recovery route, not just the invariant: {rendered}"
     );
 }
+
+/// #589: `sweep_excluded_groups` actually deletes an excluded file's published
+/// documents (by `ax_file`, across the plan's dataset indices) and its catalog
+/// document (by `path`), while leaving every OTHER file's documents intact.
+/// Exercised over the real mock HTTP backend so the delete-by-query truly runs.
+#[test]
+fn sweep_excluded_groups_deletes_only_the_excluded_files_documents() {
+    let ep = HttpEndpoint::start();
+
+    // Seed two files' records in one dataset index, plus their catalog docs.
+    {
+        let mut st = ep.state.lock().unwrap();
+        let ds = "incremental-http-ds".to_string();
+        st.docs.insert(
+            (ds.clone(), "d1".into()),
+            json!({"ax_file": "key-excluded", "body": "secret"}),
+        );
+        st.docs.insert(
+            (ds.clone(), "d2".into()),
+            json!({"ax_file": "key-kept", "body": "kept"}),
+        );
+        st.docs.insert(
+            (catalog::CATALOG_INDEX.to_string(), "file:excluded".into()),
+            json!({"doc_kind": "file", "path": "secret.csv"}),
+        );
+        st.docs.insert(
+            (catalog::CATALOG_INDEX.to_string(), "file:kept".into()),
+            json!({"doc_kind": "file", "path": "kept.csv"}),
+        );
+    }
+
+    let es = Es::with_bulk_timeout(&ep.url, None, 30).expect("es client");
+
+    let mut plan = Plan::default();
+    plan.datasets.push(crate::state::PlanDataset {
+        slug: "ds".into(),
+        index: "incremental-http-ds".into(),
+        family: "csv".into(),
+        group: None,
+        specs: Vec::new(),
+        time_field: None,
+        semantic_field: None,
+        sampled_records: 1,
+        file_count: 1,
+    });
+
+    let excluded = vec![InventoryDeltaEntry {
+        file_key: "key-excluded".into(),
+        path: "secret.csv".into(),
+    }];
+
+    sweep_excluded_groups(&es, &plan, &excluded).expect("sweep");
+
+    let st = ep.state.lock().unwrap();
+    // The excluded file's dataset record is gone.
+    assert!(
+        !st.docs
+            .values()
+            .any(|d| d.get("ax_file").and_then(Value::as_str) == Some("key-excluded")),
+        "#589: the excluded file's indexed records must be swept"
+    );
+    // Its catalog document is gone.
+    assert!(
+        !st.docs
+            .iter()
+            .any(|((idx, _), d)| idx == catalog::CATALOG_INDEX
+                && d.get("path").and_then(Value::as_str) == Some("secret.csv")),
+        "#589: the excluded file's catalog document must be swept"
+    );
+    // Every other file is untouched (no over-deletion).
+    assert!(
+        st.docs
+            .values()
+            .any(|d| d.get("ax_file").and_then(Value::as_str) == Some("key-kept")),
+        "#589: a different file's records must NOT be swept"
+    );
+    assert!(
+        st.docs
+            .iter()
+            .any(|((idx, _), d)| idx == catalog::CATALOG_INDEX
+                && d.get("path").and_then(Value::as_str) == Some("kept.csv")),
+        "#589: a different file's catalog document must NOT be swept"
+    );
+}

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3068,11 +3068,23 @@ fn finish_generated_run(es: &Es, journal: &mut state::Journal, cfg: &IndexCfg) -
 /// KNOWN GAP (#589, next hunk): graph edges taught by the file remain in the
 /// edges index until it is swept too — the same limitation the refusal message
 /// already documents in `edges_note`.
-fn sweep_excluded_groups(es: &Es, prefix: &str, excluded: &[InventoryDeltaEntry]) -> Result<()> {
-    let corpus = format!("{prefix}-*");
+fn sweep_excluded_groups(es: &Es, plan: &Plan, excluded: &[InventoryDeltaEntry]) -> Result<()> {
+    // Exact dataset indices from the plan — the same resolution the replacement
+    // delete path uses (`ds_rt` → `rt.index`); a `{prefix}-*` wildcard would be
+    // untestable and could reach indices this corpus does not own.
+    let mut indices: Vec<&str> = plan.datasets.iter().map(|d| d.index.as_str()).collect();
+    indices.sort_unstable();
+    indices.dedup();
     for entry in excluded {
-        es.delete_by_query(&corpus, &json!({"term": {"ax_file": entry.file_key}}))
-            .with_context(|| format!("sweep indexed records for newly-excluded {}", entry.path))?;
+        for index in &indices {
+            es.delete_by_query(index, &json!({"term": {"ax_file": entry.file_key}}))
+                .with_context(|| {
+                    format!(
+                        "sweep indexed records for newly-excluded {} in {index}",
+                        entry.path
+                    )
+                })?;
+        }
         es.delete_by_query(
             catalog::CATALOG_INDEX,
             &json!({"term": {"path": entry.path}}),
@@ -3554,7 +3566,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         // continue, rather than leaving them live in the destination. Genuine
         // deletions above still refuse; never mutate under --dry-run.
         if !delta.excluded_content_groups.is_empty() && !cfg.dry_run {
-            sweep_excluded_groups(&es, &cfg.prefix, &delta.excluded_content_groups)
+            sweep_excluded_groups(&es, prior_plan, &delta.excluded_content_groups)
                 .context("sweep newly-excluded content groups")?;
         }
     }
@@ -3814,7 +3826,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         // #589: sweep documents left behind by a widened exclusion (see gate
         // above). Genuine deletions still refuse; never mutate under --dry-run.
         if !delta.excluded_content_groups.is_empty() && !cfg.dry_run {
-            sweep_excluded_groups(&es, &cfg.prefix, &delta.excluded_content_groups)
+            sweep_excluded_groups(&es, &plan, &delta.excluded_content_groups)
                 .context("sweep newly-excluded content groups")?;
         }
     }

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -2814,11 +2814,15 @@ impl UnsupportedInventoryDelta {
     /// Additions are not refused — they are skipped by the frozen plan exactly
     /// as before and `--fresh` rebuilds the plan in place to include them.
     fn refuses(&self) -> bool {
-        // Both categories still stay live with no reconcile behind them, so both
-        // still refuse the rerun (#439 splits them only to give the accurate
-        // recovery route — the excluded case gets swept, not refused, in a
-        // follow-up). Equivalent to the pre-split `!vanished.is_empty()`.
-        !self.deleted_content_groups.is_empty() || !self.excluded_content_groups.is_empty()
+        // #589: only a GENUINE deletion (source file gone from disk) refuses the
+        // rerun — its published documents would be left live with no file behind
+        // them and nothing else removes them. An EXCLUSION (file still on disk,
+        // newly matched by a widened ignore/hidden/`.xerjignore` rule) is data
+        // the exclusion must REMOVE, so it is SWEPT by `sweep_excluded_groups`
+        // and the run continues (#439's data-exposure headline). When a genuine
+        // deletion co-occurs the whole rerun is refused, and `into_error` still
+        // reports the excluded set too because it also stays live in that case.
+        !self.deleted_content_groups.is_empty()
     }
 
     fn into_error(self, targets: RefusalTargets) -> anyhow::Error {
@@ -3048,6 +3052,34 @@ fn finish_generated_run(es: &Es, journal: &mut state::Journal, cfg: &IndexCfg) -
         );
     }
     Ok(summary)
+}
+
+/// #589: sweep the documents an exclusion left behind. A file still on disk
+/// that a widened ignore/hidden/`.xerjignore` rule now skips must have its
+/// already-published documents removed — an exclusion that cannot remove data
+/// already in the index is the #439 data-exposure hole. Deletes the indexed
+/// records (by `ax_file`) across the corpus indices and the file's catalog
+/// document(s) (by logical `path`).
+///
+/// The caller sweeps only when there is NO genuine deletion in the same delta
+/// (a co-occurring deletion refuses the whole rerun, mutating nothing) and
+/// never under `--dry-run`.
+///
+/// KNOWN GAP (#589, next hunk): graph edges taught by the file remain in the
+/// edges index until it is swept too — the same limitation the refusal message
+/// already documents in `edges_note`.
+fn sweep_excluded_groups(es: &Es, prefix: &str, excluded: &[InventoryDeltaEntry]) -> Result<()> {
+    let corpus = format!("{prefix}-*");
+    for entry in excluded {
+        es.delete_by_query(&corpus, &json!({"term": {"ax_file": entry.file_key}}))
+            .with_context(|| format!("sweep indexed records for newly-excluded {}", entry.path))?;
+        es.delete_by_query(
+            catalog::CATALOG_INDEX,
+            &json!({"term": {"path": entry.path}}),
+        )
+        .with_context(|| format!("sweep catalog entry for newly-excluded {}", entry.path))?;
+    }
+    Ok(())
 }
 
 fn run_index(cfg: IndexCfg) -> Result<i32> {
@@ -3517,6 +3549,14 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         if delta.refuses() {
             return Err(delta.into_error(RefusalTargets::describe(&cfg, &state_dir, prior_plan)));
         }
+        // #589: a widened exclusion (file still on disk, newly ignored) is data
+        // the exclusion must remove — sweep the excluded group's documents and
+        // continue, rather than leaving them live in the destination. Genuine
+        // deletions above still refuse; never mutate under --dry-run.
+        if !delta.excluded_content_groups.is_empty() && !cfg.dry_run {
+            sweep_excluded_groups(&es, &cfg.prefix, &delta.excluded_content_groups)
+                .context("sweep newly-excluded content groups")?;
+        }
     }
     let mut journal = state::Journal::open_after_preflight(
         preflight,
@@ -3770,6 +3810,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         let delta = UnsupportedInventoryDelta::between(&cfg.root, &files, &keys, &plan);
         if delta.refuses() {
             return Err(delta.into_error(RefusalTargets::describe(&cfg, &state_dir, &plan)));
+        }
+        // #589: sweep documents left behind by a widened exclusion (see gate
+        // above). Genuine deletions still refuse; never mutate under --dry-run.
+        if !delta.excluded_content_groups.is_empty() && !cfg.dry_run {
+            sweep_excluded_groups(&es, &cfg.prefix, &delta.excluded_content_groups)
+                .context("sweep newly-excluded content groups")?;
         }
     }
 
@@ -6436,9 +6482,16 @@ mod inventory_delta_tests {
                 .collect::<Vec<_>>(),
             ["secret.csv"]
         );
-        // Its documents still stay live, so the rerun is still refused (#439's
-        // in-place sweep is a follow-up) — but with the accurate cause.
-        assert!(delta.refuses());
+        // #589: an excluded-only delta is now SWEPT, not refused — the rerun
+        // continues after `sweep_excluded_groups` removes its documents, so
+        // `refuses()` (deletion-only) is false here. `into_error`'s excluded
+        // wording still applies when a genuine deletion co-occurs (both sets
+        // stay live in that case), so it is still exercised below as a direct
+        // message-builder check.
+        assert!(
+            !delta.refuses(),
+            "#589: an excluded-only delta is swept, not refused"
+        );
         let error = delta.into_error(targets());
         let message = format!("{error:#}");
         assert!(message.contains("secret.csv"), "{message}");
@@ -6478,7 +6531,6 @@ mod inventory_delta_tests {
     /// `an_excluded_still_on_disk_group_is_not_reported_as_a_deletion` (the
     /// excluded-only case no longer produces a refusal).
     #[test]
-    #[ignore = "#589 WIP: excluded-only sweep not yet implemented"]
     fn an_excluded_only_delta_is_swept_not_refused() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("secret.csv"), "id,value\n1,live\n").unwrap();

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -6466,6 +6466,47 @@ mod inventory_delta_tests {
         assert_eq!(json["vanished_content_groups"].as_array().unwrap().len(), 1);
     }
 
+    /// #589 (fail-before, WIP): the purge half of #439. An exclusion (a file
+    /// still on disk that a widened ignore/hidden/`.xerjignore` rule now skips)
+    /// is data the exclusion must REMOVE from the index, not a reason to refuse
+    /// the whole rerun. With NO genuine deletion present, the reconcile must
+    /// PROCEED — sweeping the excluded group's published documents — unlike a
+    /// real deletion, which stays refused. Today `refuses()` conflates the two.
+    ///
+    /// Un-ignore when the sweep lands; that change also flips the
+    /// `assert!(delta.refuses())` in
+    /// `an_excluded_still_on_disk_group_is_not_reported_as_a_deletion` (the
+    /// excluded-only case no longer produces a refusal).
+    #[test]
+    #[ignore = "#589 WIP: excluded-only sweep not yet implemented"]
+    fn an_excluded_only_delta_is_swept_not_refused() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("secret.csv"), "id,value\n1,live\n").unwrap();
+        let mut plan = Plan::default();
+        plan.files.insert("secret".into(), assignment("secret.csv"));
+
+        // The walk yields nothing (the file is now excluded) though it is on disk.
+        let delta = UnsupportedInventoryDelta::between(root.path(), &[], &[], &plan);
+        assert!(
+            delta.deleted_content_groups.is_empty(),
+            "no genuine deletion — the file is still on disk"
+        );
+        assert_eq!(
+            delta
+                .excluded_content_groups
+                .iter()
+                .map(|e| e.path.as_str())
+                .collect::<Vec<_>>(),
+            ["secret.csv"],
+        );
+        // #589: an excluded-only delta must NOT refuse the rerun — the excluded
+        // group is swept from the destination and the run continues.
+        assert!(
+            !delta.refuses(),
+            "#589: an excluded-only delta must be swept, not refused"
+        );
+    }
+
     /// #439's headline case (CHANGELOG): a hidden NON-UTF-8 name still on disk.
     /// Its `rel` is a lossy `U+FFFD` rendering that matches no dirent, so a probe
     /// through `rel` would call it a deletion; the reversible `path_id` matches


### PR DESCRIPTION
Closes #589.

## Problem (the purge half of #439)
A file still on disk that a widened ignore/hidden/`.xerjignore` rule now skips lands in `excluded_content_groups`. `refuses()` conflated it with a genuine deletion and **refused the whole rerun**, so the file's already-published documents stayed **live and searchable** — an exclusion that cannot remove data already in the index (#439's data-exposure headline). #439 only *distinguished* the two causes and gave an accurate message; this PR does the sweep.

## Fix
- **`refuses()` now gates on genuine deletions only.** An excluded-only delta no longer refuses — the run proceeds and sweeps.
- **`sweep_excluded_groups`** deletes each excluded group's indexed records (`{term:{ax_file}}`) across the plan's **exact dataset indices** (`plan.datasets[].index`, the same resolution the replacement-delete path at lib.rs uses — not a `{prefix}-*` wildcard, which could reach indices this corpus does not own) and its catalog document (`{term:{path}}`).
- Wired at **both** resume gates, guarded by **`!dry_run`** (no remote mutation on a dry-run/refused attempt).
- **`into_error` is unchanged**: it still reports the excluded set when a **genuine deletion co-occurs** — that case still refuses the whole rerun, so the excluded documents also stay live and the wording is still accurate.

## Scope / known gap
Graph edges taught by the file are **not** swept in this PR — deferred to a follow-up. (Correction: per-file edge provenance *does* exist — `detect::invalidate_prior_edges` soft-invalidates edges by `{term:{src_file: rel}}`, and the excluded `InventoryDeltaEntry` carries that `rel` as `path` — so the follow-up can reuse that hook rather than build new provenance. `edges_note` documents that these edges "stay live until that index is deleted too" today.) The data-**exposure** that matters — searchable document *content*, keyed by `ax_file` — is fully swept; the residual is edge/path metadata naming an excluded file, lower-severity and tracked as a follow-up. Guardrail-covered: `.xerjignore` / `--no-default-ignores` widening classify as excluded the same way (via `UnsupportedInventoryDelta::between`).

## Verification (rustc 1.97.1)
- **Fail-before proven**: reverting only the `refuses()` hunk makes `an_excluded_only_delta_is_swept_not_refused` fail again (exit 101 — excluded-only refuses).
- **Decision** unit tests: the repro + the flipped sibling `an_excluded_still_on_disk_group_is_not_reported_as_a_deletion` (its comment re-read and updated).
- **Sweep** integration test over the mock HTTP backend: `sweep_excluded_groups_deletes_only_the_excluded_files_documents` seeds two files' records + catalog docs, sweeps one, asserts its records **and** catalog doc are removed by a real `delete_by_query` while the other file is untouched (no over-deletion).
- Full gate: `fmt --all --check` / `clippy --workspace --all-targets -D warnings` / `build --workspace --profile ci-test` / `test -p xerj-autoindex` (full) — all green.

## Note on 2 pre-existing flaky tests
Under heavy concurrent load one full-suite run flaked on `sync_executor::tests::gc_tombstone_crash_is_retryable_and_symlinks_are_refused` and `incremental_reconcile_http_tests::two_byte_identical_junk_files_commit_reconcile_and_survive_a_shrink`. Both **pass in isolation and on 4/4 subsequent full runs**; neither exercises the exclusion/sweep code path this PR touches. This is pre-existing parallelism sensitivity, not a regression from this change — flagged for transparency. If CI flakes on them, a re-run clears it.