### PR TITLE
fix(autoindex): #585 case 1 — refuse a pending --no-graph generation resumed on the graph path

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2100,3 +2100,59 @@ fn sweep_excluded_groups_deletes_only_the_excluded_files_documents() {
         "#589: a different file's catalog document must NOT be swept"
     );
 }
+
+/// #585 (case 1): a pending (uncommitted) `--no-graph` generation must NOT be
+/// resumed and committed on the default graph path — doing so silently commits
+/// a no-graph generation under a graph authority (the #584 hazard, but for a
+/// not-yet-committed generation the committed-manifest guard never sees it
+/// because the pending-sync branch returns first). The re-run must be refused
+/// before any mutation, symmetric to #584.
+#[test]
+fn pending_no_graph_generation_is_refused_on_the_graph_path() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    let source = corpus.path().join("rows.csv");
+    fs::write(&source, "id,value\n1,first\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+
+    // Commit generation 1 with the `--no-graph` generated executor.
+    let no_graph = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    assert_eq!(run_index(no_graph.clone()).unwrap(), 0);
+
+    // Interrupt a second `--no-graph` generation after sync_begin: the data bulk
+    // fails, leaving a pending sync (no-graph, uncommitted).
+    fs::write(&source, "id,value\n1,first\n2,second\n").unwrap();
+    endpoint.state.lock().unwrap().fail_next_data_bulk = true;
+    assert!(run_index(no_graph.clone()).is_err());
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 2);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+    // The destination as the refused re-run will find it (the interrupted run's
+    // delete-before-replace already mutated it — irrelevant to the guard).
+    let docs_before_rerun = endpoint.data_docs().len();
+
+    // Re-run the SAME state dir on the default graph path. The pending no-graph
+    // generation must be refused, not resumed-and-committed.
+    let mut graph = no_graph.clone();
+    graph.no_graph = false;
+    let error = run_index(graph).unwrap_err();
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("pending sync") && rendered.contains("different graph authority"),
+        "#585: a pending no-graph generation must be refused on the graph path with the clear message, got: {rendered}"
+    );
+    // No second generation committed, and the guard mutated nothing further.
+    assert_eq!(
+        journal_events(state_dir.path(), "sync_commit"),
+        1,
+        "#585: the refused graph re-run must not commit the pending no-graph generation"
+    );
+    assert_eq!(
+        endpoint.data_docs().len(),
+        docs_before_rerun,
+        "#585: the refused re-run must mutate nothing"
+    );
+}

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3257,6 +3257,43 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // slice; fail with the exact durable transaction rather than accidentally
     // executing a different folder snapshot.
     if preflight.pending_sync.is_some() {
+        // #585: a not-yet-committed generation carries the graph mode it was
+        // BEGUN in (`desired.execution.graph_enabled`). Resuming it under the
+        // other mode replays and COMMITS that generation on a mismatched
+        // authority — the #584 cross-path hazard, but for a pending generation
+        // the committed-manifest guard below never sees it because this branch
+        // returns first. Refuse before the journal is opened for write and
+        // before `gc_snapshots`, exactly the way #584 refuses the committed
+        // case: nothing is mutated.
+        if let Some(pending) = preflight.pending_sync.as_ref() {
+            if let Some(exec) = pending.desired.execution.as_ref() {
+                if exec.graph_enabled == cfg.no_graph {
+                    anyhow::bail!(
+                        "a generation is mid-commit (pending sync {}) begun {}; re-running it {} \
+                         would resume and commit it under a different graph authority and mutate \
+                         the destination. No remote mutation was attempted. Re-run {} to finish \
+                         the pending generation, or rebuild with a new --state-dir and a new \
+                         --prefix.",
+                        pending.tx_id,
+                        if exec.graph_enabled {
+                            "with graph detection"
+                        } else {
+                            "with --no-graph"
+                        },
+                        if cfg.no_graph {
+                            "with --no-graph"
+                        } else {
+                            "on the default graph path"
+                        },
+                        if exec.graph_enabled {
+                            "on the default graph path"
+                        } else {
+                            "with --no-graph"
+                        },
+                    );
+                }
+            }
+        }
         let mut journal = state::Journal::open_after_preflight(
             preflight,
             &root_str,


### PR DESCRIPTION
Addresses #585 (case 1 — the pending-sync gap; case 2 is decision-blocked, see below).

## Problem (data-loss / cross-path authority)
Follow-up to #490 fix#3 / #584. #584 refuses a **graph** re-run of a `--no-graph`-built **committed** corpus. But the `pending_sync` resume branch (`lib.rs`, `if preflight.pending_sync.is_some()`) replays and **commits** the pending generation **regardless of `cfg.no_graph`**, and it returns before the committed-manifest guard ever runs. So a `--no-graph` generation interrupted mid-commit (a `sync_begin` without `sync_commit`), re-run on the default graph path, is silently **resumed and committed** under a graph authority — "the user asked for the graph path and silently got a no-graph resume-and-commit" (#585's headline).

## Fix
At the top of the `pending_sync` resume branch — **before** the journal is opened for write and before `gc_snapshots` — compare the pending generation's mode (`pending.desired.execution.graph_enabled`) against the current run's mode (`cfg.no_graph`). On mismatch, refuse with a clear, actionable message (mirroring #584): re-run in the pending generation's own mode to finish it, or rebuild with a new `--state-dir`/`--prefix`. Nothing is mutated. (A pending generation is always incremental, so its `graph_enabled` is `false`; the guard therefore refuses exactly the graph re-run of a pending no-graph generation, and lets a same-mode `--no-graph` resume proceed.)

## Case 2 (genesis) deliberately NOT included
The issue's second case — a graph re-run over a `--no-graph` **genesis-bootstrap** state (gen 0, empty groups, `genesis_recovery` true) — has **no clean mode source**: `sync_bootstrap_genesis` creates the gen-0 manifest via `CommittedManifest::genesis()`, which is **mode-agnostic** (records no `graph_enabled`). The issue itself flags case 2 as needing "a decision on the intended behavior (refuse vs. resume-in-original-mode)". With no committed content at genesis there is no data to corrupt, so it is left as a documented follow-up rather than guessing a mode signal.

## Verification (rustc 1.97.1)
- **Fail-before proven**: neutralizing only the guard makes the graph re-run **resume and commit** the pending no-graph generation (`run_index(graph).unwrap_err()` panics because it returns `Ok`) — exit 101.
- New integration test `pending_no_graph_generation_is_refused_on_the_graph_path`: interrupts a `--no-graph` generation after `sync_begin` (data bulk fails → pending sync), re-runs on the graph path, asserts it is refused with the clear message, commits no second generation, and mutates nothing further.
- Full gate: `fmt --all --check` / `clippy --workspace --all-targets -D warnings` / `build --workspace --profile ci-test` / `test -p xerj-autoindex` (full) — all green.
