### PR TITLE
docs(engine): #421 item 2 — soften meta_sort_value's sort-vs-_seq_no agreement claim

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -13084,8 +13084,14 @@ impl Index {
     /// and `NumericComparator` compares those column values directly
     /// (`lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java:47-63`).
     /// xerj has no column for these fields, so it resolves them through the
-    /// SAME accessors that populate the response meta-fields — a hit's
-    /// `sort` value and its `_seq_no` / `_version` therefore agree.
+    /// SAME version-map accessors (`lookup_seq_no` / `lookup_version`) that
+    /// back the response meta-fields — so a hit's `sort` value equals its
+    /// `_seq_no` / `_version` whenever the lookup RESOLVES. It can only diverge
+    /// for a doc whose lookup returns `None` after it was collected (a
+    /// concurrent tombstone / version-map miss): this function then yields
+    /// `Value::Null` (so the request's `missing` policy governs the sort key),
+    /// while the response side applies its own `None` fallback — a narrow,
+    /// already-racing case that does not affect the ranking key computed here.
     ///
     /// Returns `None` for every other field name, so the caller falls
     /// through to the ordinary `_source` lookup.


### PR DESCRIPTION
Addresses #421 **item 2** (comment-only; no behaviour change).

## Problem
`meta_sort_value`'s doc comment claimed a hit's `sort` value and its `_seq_no`/`_version` **unconditionally agree**. They agree only when the version-map lookup resolves — the same overclaimed-without-proof shape #421's round 1 was rejected for.

## Fix
Soften to: they agree **whenever the lookup resolves**; for a doc whose `lookup_seq_no`/`lookup_version` returns `None` after it was collected (a concurrent tombstone / version-map miss), this function yields `Value::Null` (the request's `missing` policy then governs the sort key) while the response side applies its own `None` fallback — a narrow, already-racing case that does not affect the ranking key computed here.

Note: #421's original citation of `es_compat.rs`'s `unwrap_or(hit_idx)` positional fabrication is now partly stale — #566 changed the collapse  path to *omit* an unresolved `_seq_no` rather than fabricate a positional one — so the softened wording deliberately describes the divergence generically (`Null` here vs the response side's own `None` fallback) rather than pinning a specific line.

Comment-only. `fmt --all --check` / `clippy -p xerj-engine --all-targets -D warnings` clean.