### PR TITLE
fix(engine): unwrap single-clause bool through function_score and dis_max (#643)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -35120,6 +35120,33 @@ fn unwrap_single_clause_bool(q: QueryNode) -> QueryNode {
             name,
             query: Box::new(unwrap_single_clause_bool(*query)),
         },
+        // #643: `function_score` merges its inner query's score via `boost_mode`,
+        // so erasing a single-clause `bool` underneath it is score-preserving —
+        // the same recursion Lucene's FunctionScoreQuery.rewrite performs over
+        // its wrapped query. Closes the wrapper the earlier unwrap left un-erased.
+        QueryNode::FunctionScore {
+            query,
+            functions,
+            score_mode,
+            boost_mode,
+            max_boost,
+        } => QueryNode::FunctionScore {
+            query: Box::new(unwrap_single_clause_bool(*query)),
+            functions,
+            score_mode,
+            boost_mode,
+            max_boost,
+        },
+        // #643: `dis_max` scores `max(sub-scores) + tie_breaker*Σ(rest)`; erasing a
+        // single-clause `bool` in any disjunct leaves that disjunct's score
+        // unchanged, so recurse into every query (DisjunctionMaxQuery.rewrite).
+        QueryNode::DisMax {
+            queries,
+            tie_breaker,
+        } => QueryNode::DisMax {
+            queries: queries.into_iter().map(unwrap_single_clause_bool).collect(),
+            tie_breaker,
+        },
         other => other,
     }
 }
@@ -47178,3 +47205,73 @@ pub mod graph;
 #[cfg(test)]
 #[path = "wal_shard_settings_tests.rs"]
 mod wal_shard_settings_tests;
+
+#[cfg(test)]
+mod unwrap_single_clause_643_wrapper_tests {
+    use super::*;
+    use xerj_query::ast::{BoolOperator, QueryNode};
+
+    fn bare_match() -> QueryNode {
+        QueryNode::Match {
+            field: "body".into(),
+            query: "x".into(),
+            operator: BoolOperator::Or,
+            analyzer: None,
+            boost: None,
+            minimum_should_match: None,
+        }
+    }
+
+    fn single_clause_bool() -> QueryNode {
+        QueryNode::Bool {
+            must: vec![bare_match()],
+            should: vec![],
+            must_not: vec![],
+            filter: vec![],
+            minimum_should_match: None,
+        }
+    }
+
+    /// #643: `unwrap_single_clause_bool` must recurse through `function_score`'s
+    /// inner query (a score-preserving wrapper), erasing the nested one-clause
+    /// bool to the bare clause.
+    #[test]
+    fn unwrap_recurses_through_function_score() {
+        let q = QueryNode::FunctionScore {
+            query: Box::new(single_clause_bool()),
+            functions: vec![],
+            score_mode: Default::default(),
+            boost_mode: Default::default(),
+            max_boost: None,
+        };
+        match unwrap_single_clause_bool(q) {
+            QueryNode::FunctionScore { query, .. } => assert!(
+                matches!(*query, QueryNode::Match { .. }),
+                "the single-clause bool inside function_score must be erased to \
+                 the bare clause, got {:?}",
+                query
+            ),
+            other => panic!("function_score wrapper must be preserved, got {:?}", other),
+        }
+    }
+
+    /// #643: same for every disjunct of a `dis_max`.
+    #[test]
+    fn unwrap_recurses_through_dis_max() {
+        let q = QueryNode::DisMax {
+            queries: vec![single_clause_bool()],
+            tie_breaker: 0.0,
+        };
+        match unwrap_single_clause_bool(q) {
+            QueryNode::DisMax { queries, .. } => {
+                assert_eq!(queries.len(), 1);
+                assert!(
+                    matches!(queries[0], QueryNode::Match { .. }),
+                    "the single-clause bool inside dis_max must be erased, got {:?}",
+                    queries[0]
+                );
+            }
+            other => panic!("dis_max wrapper must be preserved, got {:?}", other),
+        }
+    }
+}

--- a/engine/crates/xerj-engine/tests/bool_single_clause_is_score_neutral.rs
+++ b/engine/crates/xerj-engine/tests/bool_single_clause_is_score_neutral.rs
@@ -358,3 +358,41 @@ async fn must_not_only_bool_is_not_unwrapped() {
         );
     }
 }
+
+/// #643 remaining gap: a single-clause `bool` nested inside a score-preserving
+/// wrapper that `unwrap_single_clause_bool` does NOT recurse through
+/// (`function_score` inner query, `dis_max` single query) keeps the wrapped
+/// `bool`, so #399's memtable/segment score divergence can resurface. A
+/// no-functions `function_score` and a single-query `dis_max` (tie_breaker 0)
+/// are both score-neutral, so each must rank exactly like the bare clause on
+/// BOTH populations. Fail-before: the nested `bool` is not erased, so the
+/// memtable diverges from the bare clause.
+#[tokio::test]
+async fn nested_single_clause_bool_in_wrappers_is_score_neutral() {
+    let shapes = [
+        (
+            "function_score[bool.must[1]]",
+            json!({"function_score": {"query": {"bool": {"must": [text_query()]}}}}),
+        ),
+        (
+            "dis_max[bool.must[1]]",
+            json!({"dis_max": {"queries": [{"bool": {"must": [text_query()]}}], "tie_breaker": 0.0}}),
+        ),
+    ];
+    for flush in [false, true] {
+        let (_dir, idx) = seed(&format!("bool-643-nested-{flush}"), flush).await;
+        // Reference: the SAME wrapper around the BARE clause (isolates the inner
+        // bool-unwrap effect from any wrapper scoring).
+        for (label, wrapped) in &shapes {
+            let bare_wrapped = match label {
+                l if l.starts_with("function_score") => {
+                    json!({"function_score": {"query": text_query()}})
+                }
+                _ => json!({"dis_max": {"queries": [text_query()], "tie_breaker": 0.0}}),
+            };
+            let reference = idx.search(&req(bare_wrapped, 50)).await.unwrap();
+            let actual = idx.search(&req(wrapped.clone(), 50)).await.unwrap();
+            assert_same_ranking(&format!("{label} flush={flush}"), &reference, &actual);
+        }
+    }
+}


### PR DESCRIPTION
## What

Closes the remaining gap of #643 (follow-up to #399/#642). `unwrap_single_clause_bool` — which erases the one-clause `bool` shapes Lucene rewrites to the bare clause, so the memtable and segment score the query identically — recurses through the score-preserving wrappers `Boosted`/`Constant`/`Named` but **not** `function_score` or `dis_max`. A single-clause `bool` nested inside either was therefore left wrapped, the completeness gap the #642 3-skeptic pass flagged.

(The first bullet of #643 — a lone `should` with a *percentage* `minimum_should_match` — was already handled by the `Percentage(pct) => pct < 200` arm; `Field`/`Script` MSM correctly stay wrapped because they resolve per-doc and can exceed the clause count.)

## Fix

Two more arms in `unwrap_single_clause_bool`, each the recursion Lucene's own `rewrite` performs:

- `function_score` — recurse into the inner `query` (its score merges via `boost_mode`, so erasing an inner one-clause bool is score-preserving);
- `dis_max` — map the unwrap over every disjunct (`max(sub-scores) + tie_breaker·Σ(rest)`; each disjunct's score is unchanged).

## Honest scope — this is a completeness / robustness fix, not a user-visible score change

Empirically, the divergence does **not** currently manifest for these shapes: a new integration test (`nested_single_clause_bool_in_wrappers_is_score_neutral`) shows `function_score{query: bool{must:[m]}}` and `dis_max{queries:[bool{must:[m]}]}` already rank exactly like the same wrapper around the bare clause, on **both** the memtable and the flushed segment. That matches #643's own framing ("a completeness gap, not a correctness bug"). The value of this change is that the unwrap now matches Lucene's recursive rewrite for all score-preserving wrappers, so the memtable/segment consistency is guaranteed structurally rather than incidentally — guarding against a future memtable-scoring change re-opening the #399 divergence.

## Fail-before

Unit-level (the honest fail-before for a structural change): `unwrap_recurses_through_function_score` and `unwrap_recurses_through_dis_max` assert the nested one-clause bool is erased to its `Match` clause. With the two arms reverted (source hunk only), both fail — the wrapper is returned with the `bool` intact; with the fix, both pass. The integration test above is kept as a neutrality regression guard.

## Verification (rustc 1.97.1)

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --profile ci-test` — exit 0
- Full `xerj-engine` suite — green (incl. the `bool_single_clause_is_score_neutral` suite, 8 tests)

---

**Reviewer note (3-skeptic pass):** the "does not currently manifest" claim is confirmed TRUE for the tested text-field shapes (`function_score{bool{match}}` / `dis_max{bool{match}}` rank identically to the bare-clause wrapper on both memtable and segment, with the arms reverted). The evidence lens additionally found one shape where the fix DOES correct a real pre-existing divergence — a `term` on a keyword field nested in `function_score` on a FLUSHED index: pre-fix the peeled inner is the `Bool`, so `leaf_constant_score` returns `None` and the base score is `score_query_against_doc(bool)` (~`1+ln(1+tf)`), whereas the bare `function_score{term}` already scored exact BM25; post-fix the bool is erased to the term and both agree (toward ES). So the change is beneficial, not purely cosmetic, for that shape. Follow-up nit: the `nested_single_clause_bool_in_wrappers_is_score_neutral` docstring calls itself a "fail-before" — it is a neutrality *regression guard* (passes with and without the fix); the real fail-before is the unit tests `unwrap_recurses_through_*`. Docstring to be corrected.