### PR TITLE
fix(autoindex): #585 case 2 — refuse a --no-graph genesis bootstrap continued on the graph path

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2156,3 +2156,61 @@ fn pending_no_graph_generation_is_refused_on_the_graph_path() {
         "#585: the refused re-run must mutate nothing"
     );
 }
+
+/// #585 (case 2): a `--no-graph` generation's genesis bootstrap (`sync_bootstrap`
+/// committed, interrupted before `sync_begin`) must NOT be continued on the
+/// default graph path either. Genesis carries no execution identity of its own
+/// (`validate_genesis` requires `execution: None`), so unlike case 1 the guard
+/// cannot compare a recorded mode — it instead relies on `sync_bootstrap` having
+/// actually replayed, which only `begin_non_graph_generation` ever writes, and
+/// only under `--no-graph`.
+#[test]
+fn no_graph_genesis_bootstrap_is_refused_on_the_graph_path() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(corpus.path().join("a.csv"), "id,value\n1,alpha\n").unwrap();
+    let endpoint = HttpEndpoint::start();
+    let mut no_graph = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    no_graph.snapshot_max_bytes = 1;
+
+    // Interrupt the very first --no-graph run between sync_bootstrap and
+    // sync_begin: generation 0 (genesis) is committed, nothing else is.
+    let error = run_index(no_graph.clone()).unwrap_err();
+    assert!(format!("{error:#}").contains("snapshot source footprint"));
+    assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 0);
+    assert_eq!(endpoint.data_docs().len(), 0);
+
+    // Re-run the SAME state dir on the default graph path. The pending
+    // --no-graph genesis bootstrap must be refused, not continued.
+    let mut graph = no_graph.clone();
+    graph.no_graph = false;
+    graph.snapshot_max_bytes = 64 << 30;
+    let error = run_index(graph).unwrap_err();
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("genesis bootstrap") && rendered.contains("different graph authority"),
+        "#585 case 2: a --no-graph genesis bootstrap must be refused on the graph path with the \
+         clear message, got: {rendered}"
+    );
+    // No mutation: nothing indexed, no new durable transaction beyond the
+    // original sync_bootstrap.
+    assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 0);
+    assert_eq!(endpoint.data_docs().len(), 0);
+
+    // Positive control: re-running in the SAME (--no-graph) mode continues
+    // the interrupted genesis normally.
+    no_graph.snapshot_max_bytes = 64 << 30;
+    assert_eq!(run_index(no_graph).unwrap(), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 1);
+    assert_eq!(endpoint.data_docs().len(), 1);
+}

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3356,6 +3356,35 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         finish_generated_progress(&pr, code, &summary);
         return Ok((code, Some(summary)));
     }
+    // #585 case 2: a --no-graph generation's genesis bootstrap (sync_bootstrap
+    // committed, nothing beyond generation 0 committed yet — no pending_sync,
+    // handled above, either) has no execution identity of its own to compare
+    // a mode against: `validate_genesis` requires `execution: None`, so
+    // unlike the pending-sync case above, genesis cannot carry
+    // `graph_enabled`. But the durable record that produced it is
+    // unambiguous — `preflight.no_graph_genesis` is `true` only when a
+    // `sync_bootstrap` record actually replayed, and the only caller of
+    // `sync_bootstrap_genesis` is `begin_non_graph_generation`, only under
+    // `cfg.no_graph`. Continuing that generation on the default graph path
+    // would proceed down the legacy `write_plan`/commit path below over the
+    // same state directory — the #584 cross-path hazard, for the one
+    // generation-0 case the committed-manifest guard cannot see either
+    // (`genesis_recovery` exempts it there on purpose, for genuinely legacy
+    // empty-plan journals that were never no-graph).
+    //
+    // `--fresh` is deliberately exempt, the same way `blocking_generation`
+    // above exempts genesis recovery: nothing has been committed past
+    // genesis, so discarding and rebuilding in the requested mode is safe.
+    if genesis_recovery && preflight.no_graph_genesis && !cfg.no_graph && !cfg.fresh {
+        anyhow::bail!(
+            "a --no-graph generation's genesis bootstrap is pending in {} (nothing beyond \
+             generation 0 committed); continuing it on the default graph path would proceed \
+             under a different graph authority and mutate the destination. No remote mutation \
+             was attempted. Re-run with --no-graph to finish the pending generation, or rebuild \
+             with a new --state-dir and a new --prefix.",
+            state_dir.join("journal.ndjson").display()
+        );
+    }
     // Totals are unknown until the walk returns, so this phase honestly
     // reports `pct=unknown` and proves liveness with the clock alone.
     pr.phase("walk", 0, 0);

--- a/engine/crates/xerj-autoindex/src/state.rs
+++ b/engine/crates/xerj-autoindex/src/state.rs
@@ -545,6 +545,7 @@ type PreflightReplay = (
     Option<crate::sync::CommittedManifest>,
     Option<crate::sync::PendingSync>,
     Vec<String>,
+    bool,
 );
 
 /// Read the last durable plan without locking, repairing, truncating or
@@ -560,7 +561,7 @@ fn read_plan_for_preflight(
     let file = match std::fs::File::open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok((None, None, None, Vec::new()));
+            return Ok((None, None, None, Vec::new(), false));
         }
         Err(error) => return Err(error.into()),
     };
@@ -569,6 +570,16 @@ fn read_plan_for_preflight(
     let mut committed_manifest: Option<crate::sync::CommittedManifest> = None;
     let mut pending_sync: Option<crate::sync::PendingSync> = None;
     let mut legacy_migration_reasons = Vec::new();
+    // #585 case 2: set (and never cleared) the moment a durable
+    // `sync_bootstrap` record replays. `begin_non_graph_generation` is the
+    // only caller of `sync_bootstrap_genesis`, and only under `cfg.no_graph`
+    // — so this is the one durable fact that tells a generation-0,
+    // empty-groups `committed_manifest` reached via generation-format
+    // records (an interrupted --no-graph genesis) apart from the same shape
+    // reached via a legacy graph-path `write_plan(Plan::default())` (an
+    // empty legacy plan, never no-graph). Genesis itself cannot carry this:
+    // `validate_genesis` requires `execution: None`.
+    let mut no_graph_genesis = false;
     let mut offset = 0u64;
     loop {
         let record_start = offset;
@@ -660,6 +671,7 @@ fn read_plan_for_preflight(
                 }
                 if kind == "sync_bootstrap" {
                     legacy_migration_reasons.clear();
+                    no_graph_genesis = true;
                 }
             }
             Some(kind) if kind.starts_with("sync_") => {
@@ -673,6 +685,7 @@ fn read_plan_for_preflight(
         committed_manifest,
         pending_sync,
         legacy_migration_reasons,
+        no_graph_genesis,
     ))
 }
 
@@ -688,6 +701,15 @@ pub struct JournalPreflight {
     /// the run is about to discard the journal anyway. The caller owns the
     /// decision to print it (autoindex honours `--quiet`).
     pub unreadable_plan: Option<String>,
+    /// #585 case 2: `true` once a durable `sync_bootstrap` record has
+    /// replayed. The only caller of `sync_bootstrap_genesis` is
+    /// `begin_non_graph_generation`, and only under `cfg.no_graph`, so this
+    /// is what lets a caller tell a generation-0/empty-groups
+    /// `committed_manifest` reached that shape via an interrupted --no-graph
+    /// genesis apart from the identical shape a legacy graph-path
+    /// `write_plan(Plan::default())` can also produce (never no-graph).
+    /// Meaningless unless `committed_manifest` is itself genesis-shaped.
+    pub no_graph_genesis: bool,
 }
 
 impl Journal {
@@ -729,26 +751,39 @@ impl Journal {
         };
         let journal_path = state_dir.join("journal.ndjson");
         let journal_exists = journal_path.exists();
-        let (plan, committed_manifest, pending_sync, legacy_migration_reasons, unreadable_plan) =
-            match read_plan_for_preflight(&journal_path, root, url, prefix) {
-                Ok((plan, committed, pending, reasons)) => {
-                    (plan, committed, pending, reasons, None)
-                }
-                // The journal is about to be deleted unread. Losing the plan here
-                // costs the removed-file gate its comparison basis, which is
-                // exactly what a full in-place rebuild accepts; the alternative is
-                // a state directory that no supported flag can recover.
-                //
-                // Every generated record is discarded with it, so the durable
-                // generation this run might otherwise have refused to overwrite is
-                // reported as absent rather than half-parsed. That is what keeps
-                // `--fresh` genuinely reachable here: the caller's generation
-                // refusal reads `committed_manifest`/`pending_sync`, and firing it
-                // off a partially-replayed journal would contradict the recovery
-                // this very error recommends.
-                Err(error) if fresh => (None, None, None, Vec::new(), Some(format!("{error:#}"))),
-                Err(error) => return Err(error),
-            };
+        let (
+            plan,
+            committed_manifest,
+            pending_sync,
+            legacy_migration_reasons,
+            no_graph_genesis,
+            unreadable_plan,
+        ) = match read_plan_for_preflight(&journal_path, root, url, prefix) {
+            Ok((plan, committed, pending, reasons, no_graph_genesis)) => {
+                (plan, committed, pending, reasons, no_graph_genesis, None)
+            }
+            // The journal is about to be deleted unread. Losing the plan here
+            // costs the removed-file gate its comparison basis, which is
+            // exactly what a full in-place rebuild accepts; the alternative is
+            // a state directory that no supported flag can recover.
+            //
+            // Every generated record is discarded with it, so the durable
+            // generation this run might otherwise have refused to overwrite is
+            // reported as absent rather than half-parsed. That is what keeps
+            // `--fresh` genuinely reachable here: the caller's generation
+            // refusal reads `committed_manifest`/`pending_sync`, and firing it
+            // off a partially-replayed journal would contradict the recovery
+            // this very error recommends.
+            Err(error) if fresh => (
+                None,
+                None,
+                None,
+                Vec::new(),
+                false,
+                Some(format!("{error:#}")),
+            ),
+            Err(error) => return Err(error),
+        };
         Ok(JournalPreflight {
             state_dir: state_dir.to_owned(),
             state_lock,
@@ -758,6 +793,7 @@ impl Journal {
             legacy_migration_reasons,
             journal_exists,
             unreadable_plan,
+            no_graph_genesis,
         })
     }
 


### PR DESCRIPTION
Closes #585 (case 2). Follow-up to #584 and #692 (case 1, merged).

## Background

#692 refused a **pending** (uncommitted) `--no-graph` generation resumed on the graph path, by comparing the pending sync's recorded `graph_enabled` against `cfg.no_graph`. It explicitly left out case 2 — a `--no-graph` generation's **genesis bootstrap** (`sync_bootstrap` committed, interrupted before `sync_begin`) continued on the graph path — because genesis has no execution identity of its own to compare a mode against (`validate_genesis` requires `execution: None`), and noted "no clean mode source".

## The mode source

There is one — it just isn't in the manifest. The *journal record* that produces a generation-0/empty-groups `committed_manifest` is unambiguous even though the resulting manifest shape is not:

- `sync_bootstrap_genesis` is called from exactly one place, `begin_non_graph_generation`, and only under `cfg.no_graph`. It appends a `{"kind": "sync_bootstrap", ...}` journal record.
- A legacy graph-path journal can independently reach the *identical* manifest shape via `write_plan(Plan::default())` (e.g. every file removed from an already-indexed folder) — but that writes a `{"kind": "plan", ...}` record, never `"sync_bootstrap"`.

So "did a durable `sync_bootstrap` record actually replay" is a real, durable fact that tells the two apart, even though the resulting `CommittedManifest` is byte-for-byte the same either way.

## Fix

- `state.rs` — journal replay (both the preflight-only pass and the authoritative one) now tracks whether a `sync_bootstrap` record has replayed, exposed as `JournalPreflight::no_graph_genesis`.
- `lib.rs` — the graph-path continuation is refused when `genesis_recovery && preflight.no_graph_genesis && !cfg.no_graph`, symmetric to case 1's guard and placed at the same point (before the journal is opened for write, before `gc_snapshots`) — nothing is mutated. `--fresh` is exempted, matching how `blocking_generation` already exempts genesis recovery from the `--fresh` refusal above it: nothing is committed past genesis, so discarding and rebuilding in the requested mode is safe.

## Testing

- New fail-before test `no_graph_genesis_bootstrap_is_refused_on_the_graph_path`: interrupts a `--no-graph` run between `sync_bootstrap` and `sync_begin` (via `snapshot_max_bytes`), re-runs the same state dir on the graph path (must refuse, mutate nothing), then re-runs in the same `--no-graph` mode as a positive control (must continue normally). Verified fail-before: with the `lib.rs` guard neutralized, the graph re-run silently succeeds (exit 0) instead of refusing.
- `cargo test -p xerj-autoindex --profile ci-test -- --test-threads=2`: 679 passed; the 19 failures are pre-existing environment issues (macOS non-UTF-8 filename handling + parallel-run ordering artifacts) that reproduce identically on unmodified `main` — confirmed via a clean-worktree run, unrelated to this change.
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `cargo check -p xerj-server --profile ci-test`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
