### PR TITLE
fix(autoindex): #346 - incremental reconcile compared a new document's raw family against the frozen "docs" label

### DIFF
--- a/engine/crates/xerj-autoindex/src/dataset.rs
+++ b/engine/crates/xerj-autoindex/src/dataset.rs
@@ -87,7 +87,15 @@ fn jaccard(a: &HashSet<&str>, b: &HashSet<&str>) -> f64 {
 /// single-record files? Self-describing structured formats only: CSV is
 /// tabular by nature, logs/jsonl are collections by nature, and sql groups
 /// carry a real table schema.
-fn demotable_family(f: Family) -> bool {
+///
+/// `pub(crate)`: `reconcile_plan::classify_new` mirrors this same shape test
+/// for an incrementally-added single file (#346 review) — it cannot reuse
+/// `cluster`'s aggregate demotion loop (multi-file membership depends on
+/// corpus order, which incremental reconcile deliberately does not
+/// replay), but a lone new file's OWN eligibility is exactly this
+/// predicate plus `members.len() == 1 <= DOC_DEMOTE_MAX_FILES`, which is
+/// unconditionally true for one file.
+pub(crate) fn demotable_family(f: Family) -> bool {
     matches!(f, Family::Json | Family::Yaml | Family::Xml)
 }
 

--- a/engine/crates/xerj-autoindex/src/reconcile_plan.rs
+++ b/engine/crates/xerj-autoindex/src/reconcile_plan.rs
@@ -164,10 +164,30 @@ pub(crate) fn reconcile_plan(
             let group = &sketch.group;
             let fields = document_fields.as_ref().unwrap_or(&sketch.fields);
             let slug = if let Some(owner) = retained {
+                // `FileAssignment.family` (the frozen per-FILE record) keeps
+                // the raw sniffed family — the same value `sniffed.family`
+                // recomputes here — so the two compare directly.
                 retained_slug(owner, group, sniffed.family.as_str(), fields, &datasets)
                     .with_context(|| format!("project retained file {}", file.rel))?
             } else {
-                classify_new(group, sniffed.family.as_str(), fields, &previous.datasets)
+                // #346: `PlanDataset.family` (the frozen DATASET's label) is
+                // a different value — a fresh plan's dataset construction
+                // collapses every "no data-derived name, no sub-file group"
+                // sketch's family to the literal `"docs"`
+                // (`dataset::cluster`'s own is-docs definition, mirrored
+                // here — see `lib.rs`'s `PlanDataset` build). Comparing the
+                // raw sniffed family against that frozen `"docs"` label
+                // instead made every incrementally-added document file
+                // (prose, markdown, one-off config, …) match zero frozen
+                // datasets and fail closed as "unsupported dataset/schema
+                // evolution" — even one byte-for-byte the same shape as the
+                // dataset it belongs to.
+                let family = if sketch.key_fields.is_empty() && group.is_none() {
+                    "docs"
+                } else {
+                    sniffed.family.as_str()
+                };
+                classify_new(group, family, fields, &previous.datasets)
                     .with_context(|| format!("project new file {}", file.rel))?
             };
             assignments.push((group.clone(), slug));
@@ -476,8 +496,15 @@ mod tests {
             }),
             sketches: vec![crate::GroupSketch {
                 group: None,
+                // A real jsonl sketch's `key_fields` is the record's own
+                // field names read out of the file — non-empty is what makes
+                // `dataset::cluster` (and, since #346, this module) treat it
+                // as schema'd data rather than a `"docs"` document. Every
+                // fixture in this module models structured jsonl content, so
+                // mirror that instead of the empty set a real document sketch
+                // would carry.
+                key_fields: fields.keys().cloned().collect(),
                 fields,
-                key_fields: std::collections::HashSet::new(),
                 records: 1,
             }],
             junk: None,
@@ -599,6 +626,42 @@ mod tests {
         );
         assert!(message.contains("a-tie"), "{message}");
         assert!(message.contains("z-tie"), "{message}");
+    }
+
+    /// #346: a fresh plan collapses every document-shaped cluster's family to
+    /// the literal `"docs"` (`lib.rs`'s `PlanDataset` build, mirroring
+    /// `dataset::cluster`'s own is-docs definition — no data-derived
+    /// `key_fields`, no sub-file `group`). A new file with that exact same
+    /// shape used to be compared against its RAW sniffed family instead,
+    /// matched zero frozen datasets, and aborted the whole run as
+    /// "unsupported dataset/schema evolution" — even though it was the same
+    /// shape as the dataset sitting right there.
+    #[test]
+    fn new_document_shaped_file_matches_the_frozen_docs_dataset() {
+        let previous = Plan {
+            datasets: vec![PlanDataset {
+                family: "docs".into(),
+                ..dataset("docs", vec![spec("body", "text"), spec("title", "text")])
+            }],
+            ..Plan::default()
+        };
+        let fields = HashMap::from([
+            ("body".into(), acc(&[json!("hello world")])),
+            ("title".into(), acc(&[json!("hello world")])),
+        ]);
+        let mut file_scan = scan(fields);
+        // A document sketch: no data-derived key fields, no sub-file group —
+        // the same shape `dataset::cluster` treats as "docs" on a fresh run.
+        file_scan.sketches[0].key_fields.clear();
+        let plan = reconcile_plan(
+            &inventory("new.txt", "unix:6e", "new"),
+            &previous,
+            vec![file_scan],
+            50,
+        )
+        .unwrap();
+        assert_eq!(plan.files["new"].assignments, vec![(None, "docs".into())]);
+        assert_eq!(plan.datasets[0].file_count, 1);
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/reconcile_plan.rs
+++ b/engine/crates/xerj-autoindex/src/reconcile_plan.rs
@@ -152,7 +152,26 @@ pub(crate) fn reconcile_plan(
         // renderer `build_phase_a` uses, exactly as the fresh path does, and
         // carry the committed `as_document` decision forward. Losing it would
         // index flattened records into a document mapping.
-        let as_document = retained.is_some_and(|owner| owner.as_document);
+        //
+        // A brand-new file gets no such carried-forward decision — it needs
+        // its OWN. #346 review: a fresh run's `dataset::cluster` demotes a
+        // `demotable_family` (Json/Yaml/Xml), group-less, single-record
+        // cluster of at most `DOC_DEMOTE_MAX_FILES` members into the scope's
+        // docs dataset. A lone new file's own membership is always
+        // `1 <= DOC_DEMOTE_MAX_FILES`, so its per-file eligibility is exactly
+        // that same shape test minus the membership cap. Without this, an
+        // incrementally-added one-off config file that a fresh run would
+        // happily fold into "docs" instead compared its raw structured
+        // fields (e.g. a JSON file's `host`/`port`) against nothing and
+        // failed closed — the exact shape the commit this comment replaces
+        // claimed to fix but did not.
+        let new_file_is_demoted = retained.is_none()
+            && scan.sketches.iter().any(|sk| {
+                sk.group.is_none()
+                    && sk.records == 1
+                    && crate::dataset::demotable_family(sniffed.family)
+            });
+        let as_document = retained.is_some_and(|owner| owner.as_document) || new_file_is_demoted;
         let document_fields = if as_document {
             Some(document_sample(&file.path, sniffed.gzip, sample))
         } else {
@@ -166,27 +185,35 @@ pub(crate) fn reconcile_plan(
             let slug = if let Some(owner) = retained {
                 // `FileAssignment.family` (the frozen per-FILE record) keeps
                 // the raw sniffed family — the same value `sniffed.family`
-                // recomputes here — so the two compare directly.
+                // recomputes here — so the two compare directly, whether or
+                // not the file is demoted (a demoted retained file's
+                // `FileAssignment.family` was never rewritten to "docs" at
+                // fresh-plan build time either — see `lib.rs`'s
+                // `PlanDataset` build).
                 retained_slug(owner, group, sniffed.family.as_str(), fields, &datasets)
                     .with_context(|| format!("project retained file {}", file.rel))?
             } else {
                 // #346: `PlanDataset.family` (the frozen DATASET's label) is
                 // a different value — a fresh plan's dataset construction
-                // collapses every "no data-derived name, no sub-file group"
-                // sketch's family to the literal `"docs"`
-                // (`dataset::cluster`'s own is-docs definition, mirrored
-                // here — see `lib.rs`'s `PlanDataset` build). Comparing the
-                // raw sniffed family against that frozen `"docs"` label
-                // instead made every incrementally-added document file
-                // (prose, markdown, one-off config, …) match zero frozen
-                // datasets and fail closed as "unsupported dataset/schema
-                // evolution" — even one byte-for-byte the same shape as the
-                // dataset it belongs to.
-                let family = if sketch.key_fields.is_empty() && group.is_none() {
-                    "docs"
-                } else {
-                    sniffed.family.as_str()
-                };
+                // collapses every document-shaped OR demoted sketch's family
+                // to the literal `"docs"` (`dataset::cluster`'s own is-docs
+                // and demotion rules, mirrored here and in
+                // `new_file_is_demoted` above). Comparing the raw sniffed
+                // family against that frozen `"docs"` label instead made
+                // every incrementally-added document file (prose, markdown,
+                // one-off config, …) match zero frozen datasets and fail
+                // closed as "unsupported dataset/schema evolution" — even
+                // one byte-for-byte the same shape as the dataset it belongs
+                // to. `new_file_is_demoted` is file-level (it drove
+                // `document_fields` above too); a direct document sketch
+                // (empty `key_fields`, no group) is docs-eligible on its own
+                // regardless of that flag.
+                let family =
+                    if new_file_is_demoted || (sketch.key_fields.is_empty() && group.is_none()) {
+                        "docs"
+                    } else {
+                        sniffed.family.as_str()
+                    };
                 classify_new(group, family, fields, &previous.datasets)
                     .with_context(|| format!("project new file {}", file.rel))?
             };
@@ -661,6 +688,80 @@ mod tests {
         )
         .unwrap();
         assert_eq!(plan.files["new"].assignments, vec![(None, "docs".into())]);
+        assert_eq!(plan.datasets[0].file_count, 1);
+    }
+
+    /// #346 review (3-skeptic pass, blocking finding): the fix above mirrors
+    /// only ONE of `dataset::cluster`'s two is-docs paths — the direct one
+    /// (empty `key_fields`, no group). The other is demotion (dataset.rs
+    /// ~180-193): a `demotable_family` (Json/Yaml/Xml), group-less,
+    /// single-record cluster folds into the docs dataset too, and such a
+    /// cluster has NON-empty `key_fields` by construction (it started as
+    /// structured data). A one-off `config.json` added incrementally to an
+    /// already-`docs`-indexed folder hits exactly this: real repro proved it
+    /// still aborted ("no frozen dataset accepts family json, group None,
+    /// and fields [...]") even after the fix above landed. This test pins
+    /// the actual on-disk document-rendering path (`document_sample`,
+    /// title/body from `extract_as_document`), not just the family label —
+    /// a real file is required because `as_document` re-samples from disk.
+    #[test]
+    fn new_one_off_config_file_demotes_into_the_frozen_docs_dataset() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_path = dir.path().join("config.json");
+        std::fs::write(&json_path, br#"{"host": "example.com", "port": 8080}"#).unwrap();
+
+        let previous = Plan {
+            datasets: vec![PlanDataset {
+                family: "docs".into(),
+                ..dataset("docs", vec![spec("body", "text"), spec("title", "text")])
+            }],
+            ..Plan::default()
+        };
+        // The family extractor's own (pre-demotion) view of the file: a
+        // single-record JSON object with real key fields — this is what
+        // made the OLD code treat it as data, not docs.
+        let raw_fields = HashMap::from([
+            ("host".into(), acc(&[json!("example.com")])),
+            ("port".into(), acc(&[json!(8080)])),
+        ]);
+        let scan = FileScan {
+            sniffed: Some(Sniffed {
+                family: Family::Json,
+                gzip: false,
+                binary_kind: None,
+                csv: None,
+                encoding: "utf-8",
+                logical_name: None,
+            }),
+            sketches: vec![crate::GroupSketch {
+                group: None,
+                key_fields: raw_fields.keys().cloned().collect(),
+                fields: raw_fields,
+                records: 1,
+            }],
+            junk: None,
+            pdf_spool: None,
+            pdf_spool_fallbacks: Vec::new(),
+        };
+        let inventory = Inventory {
+            files: vec![FileEntry {
+                path: json_path,
+                rel: "config.json".into(),
+                rel_id: "unix:63".into(),
+                is_symlink: false,
+                size: 10,
+            }],
+            keys: vec!["new".into()],
+            digests: vec!["digest-new".into()],
+            duplicates: vec![],
+        };
+        let plan = reconcile_plan(&inventory, &previous, vec![scan], 50).unwrap();
+        assert_eq!(plan.files["new"].assignments, vec![(None, "docs".into())]);
+        assert!(
+            plan.files["new"].as_document,
+            "a demoted new file must be indexed through the document renderer, not its raw \
+             family fields"
+        );
         assert_eq!(plan.datasets[0].file_count, 1);
     }
 


### PR DESCRIPTION
Addresses #346 (split out of #326 — the visibility/exit-code half of that finding was already fixed independently; this is the live defect a reviewer found still blocking the everyday "add a file, re-run" workflow, described in [this comment](https://github.com/xerj-org/xerj/issues/346#issuecomment-5298868471)).

## Problem

Re-running `xerj autoindex` over a folder with one new file added — the ordinary "keep my index matching the tree" action — aborts the whole run when the new file is a plain document (prose, markdown, one-off config):

```
xerj-done ok=false exit=1 reason=aborted
error: project new file f4.txt: no frozen dataset accepts family txt-prose, group None,
       and fields ["body", "title"]; this requires unsupported dataset/schema evolution
       (use a new prefix)
```

even when the new file is byte-for-byte the same shape as the dataset already sitting there. `--fresh` does not help either (it refuses to discard a committed generation). There is no documented recovery short of abandoning the index under a new `--prefix`.

## Root cause

Two different frozen fields get compared as if they were one.

- `PlanDataset.family` (the frozen **dataset's** label) is collapsed to the literal `"docs"` for every document-shaped cluster at fresh-plan build time (`lib.rs`, mirroring `dataset::cluster`'s own "is this a document" test: no data-derived `key_fields`, no sub-file `group`).
- `FileAssignment.family` (the frozen **per-file** record) keeps the file's raw sniffed family (e.g. `"txt-prose"`).

Confirmed directly from a live repro's journal — for the same run, `PlanDataset.family == "docs"` while `FileAssignment.family == "txt-prose"`.

`reconcile_plan.rs` has two comparisons: `retained_slug` (an already-known file) correctly compares raw-vs-raw against `FileAssignment.family`. `classify_new` (a brand-new file) compares against `PlanDataset.family`, but was passed the raw sniffed family too — so any incrementally-added document file matched **zero** frozen datasets, regardless of how well it actually fit.

## Fix

`classify_new`'s family argument is now normalized the same way `lib.rs` normalizes it at fresh-plan build time: `"docs"` when the sketch has no `key_fields` and no `group`, the file's raw family otherwise. `retained_slug` is untouched — its raw-to-raw comparison was already correct.

## Testing

- Reproduced live against a debug build (rc.18): a `--no-graph` corpus of 3 prose files, one 4th file added. Before the fix: abort, exit 1, 0 records reachable through any documented recovery. After: reconciles normally — generation 2 committed, 4 records live, exit 0 — and a further no-op re-run confirms without a spurious commit.
- The `reconcile_plan` unit-test fixtures shared a `scan()` helper that built jsonl (data-family) scans with an **empty** `key_fields` set — realistic for a document, not for structured data, and it happened to work before this fix only because `classify_new` never looked at `key_fields`/`group`. Corrected to derive `key_fields` from the fields under test, matching what a real jsonl sketch reports, and added a `#346`-specific test (`new_document_shaped_file_matches_the_frozen_docs_dataset`) for the document-shaped path the fixture couldn't previously exercise. Verified fail-before: with the normalization removed, that new test fails with the exact reported error text.
- `cargo test -p xerj-autoindex --profile ci-test -- --test-threads=2`: 675 passed; the 19 failures are pre-existing environment issues (macOS non-UTF-8 filename handling + parallel-run ordering artifacts) that reproduce identically on unmodified `main`.
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `cargo check -p xerj-server --profile ci-test`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
