### PR TITLE
ci(#456): pin every workflow action to a commit SHA, and the rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   CARGO_TERM_COLOR: always
 
+# #456: every `uses:` below is pinned to a commit SHA (with the resolved
+# tag/version as a trailing comment for humans), including `dtolnay/rust-
+# toolchain`, whose git ref IS the rustc version it installs. Before this,
+# `@stable` meant "whatever rustup resolves as stable on the day the job
+# runs" -- the compiler CI validates against could move with no commit, no
+# review, and nothing in the diff. Bumping any of these now takes an actual
+# PR, the same as bumping a Cargo dependency. `dtolnay/rust-toolchain@nightly`
+# (the fuzz job) is the one exception left floating: nightly drifting is the
+# point there, so only its ACTION ref is pinned, not what "nightly" resolves
+# to on the day the job runs.
 jobs:
   cla-config:
     name: CLA gate config
@@ -30,7 +40,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       # cla-bot reads .contributors straight off this repo; malformed JSON or a
       # missing bot exemption breaks the gate silently (it just flags everyone).
@@ -68,7 +78,7 @@ jobs:
     name: Reference-coding toolkit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Shell syntax
         run: |
@@ -100,7 +110,7 @@ jobs:
     name: Landing constants guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
         with:
           fetch-depth: 0
 
@@ -111,15 +121,15 @@ jobs:
     name: Format + Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           components: rustfmt, clippy
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
 
@@ -146,17 +156,17 @@ jobs:
     name: Dependency advisory audit (cargo-audit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
       # Cache the binary, not the advisory database — the database is the part
       # that must be fetched fresh on every run. Bump the `-vN` suffix to force
       # a cargo-audit upgrade (a very old binary can fail to read a newer
       # advisory-db schema).
       - name: Cache cargo-audit
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin/cargo-audit
           key: ci-cargo-audit-bin-v1
@@ -182,16 +192,16 @@ jobs:
     name: Fuzz harnesses (cargo-fuzz)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       # libFuzzer + the sanitizer runtimes are nightly-only.
       - name: Install Rust (nightly)
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly (pinned action ref; toolchain itself floats by design)
         with:
           components: rustfmt
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry/cache
@@ -219,7 +229,7 @@ jobs:
       # mean the failure is unreproducible.
       - name: Upload crashing inputs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fuzz-artifacts
           path: engine/fuzz/artifacts/
@@ -229,13 +239,13 @@ jobs:
     name: Build + Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
           # Single writer for the Linux [profile.ci-test] dependency cache.
@@ -308,13 +318,13 @@ jobs:
     name: Release build (fat LTO, all members link)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
 
@@ -326,15 +336,15 @@ jobs:
     name: ONNX feature compile + tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           components: clippy
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
 
@@ -358,13 +368,13 @@ jobs:
     name: API smoke + liveness + benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
           # Read-only consumer of build-test's ci-test dependency cache.
@@ -375,7 +385,7 @@ jobs:
           shared-key: ci-test-linux
           save-if: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
@@ -398,13 +408,13 @@ jobs:
     name: ES-compat YAML conformance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
           # Read-only consumer of build-test's ci-test dependency cache.
@@ -493,9 +503,9 @@ jobs:
     name: UX pipeline tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
@@ -515,12 +525,12 @@ jobs:
     name: Use-case harnesses (brain + MCP + autoindex)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Installer script lint (landing/get, landing/get.ps1)
         run: bash .github/scripts/installer-lint.sh
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
@@ -528,10 +538,10 @@ jobs:
         run: node .github/scripts/functions-get-test.mjs
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
           # Read-only consumer of build-test's ci-test dependency cache.
@@ -586,13 +596,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           workspaces: engine
 


### PR DESCRIPTION
Addresses #456.

## 1. The toolchain was not pinned

Nine jobs used `dtolnay/rust-toolchain@stable` and one used `@nightly`. That action's git **ref** is the mechanism that selects the installed rustc version — each version-named branch of the action repo bakes in a fixed `toolchain:` env value (confirmed by reading `action.yml` on the `1.97.1` branch); `stable` resolves to rustup's `stable` channel on the day the job runs. So the compiler CI validates against could move with no commit, no review, nothing in the diff.

Verified against the issue's own quoted 429 log: `dtolnay/rust-toolchain@stable` resolves to commit `4360b525...`, the exact SHA the issue's log shows being fetched (`gh api repos/dtolnay/rust-toolchain/commits/stable`).

## 2. Nothing was pinned by SHA

None of the ~38 `uses:` lines in `ci.yml` were pinned, so every job re-fetches whatever the tag currently points to.

## Fix

Every `uses:` in `ci.yml` now pins a commit SHA, with the resolved tag as a trailing comment for humans (GitHub's own supply-chain-hardening convention). `dtolnay/rust-toolchain@stable` → the SHA of that repo's `1.97.1` branch — the version already in use everywhere else in this tree (`rustc --version` locally, and "Compiles under 1.97.1" shows up in several recent commit messages). `dtolnay/rust-toolchain@nightly` (the fuzz job) keeps floating **on purpose** — nightly drift is the point there — so only its action ref is pinned, not what "nightly" resolves to on the day the job runs, matching the issue's explicit ask ("Keep `@nightly` where nightly is genuinely required").

Every other action (`actions/checkout`, `Swatinem/rust-cache`, `actions/cache`, `actions/upload-artifact`, `actions/setup-node`) is pinned the same way, at each one's current tag tip. Added a short comment above `jobs:` explaining the convention so a future bump is legible as a real PR rather than a mystery diff.

## Scope

Only `.github/workflows/ci.yml` — the file the issue measured and quoted from. The repo's other four workflow files also use unpinned tags but weren't part of the issue's own measurement, so widening beyond `ci.yml` is left to a follow-up rather than scope-creeping this fix.

## Not verified (same as the issue's own "Not verified" section)

Whether this actually reduces 429s in practice. Pinning by SHA doesn't change what gets fetched from `codeload.github.com` per job (the archive URL is already keyed by SHA even for a tag ref, as the issue's own log line shows), so this PR's confirmed effect is #1 (compiler drift) and general supply-chain hardening; its effect on #2's rate-limit fan-out is the same open question the issue left open — not something this PR claims to close.

## Verification

- Exact per-action `uses:` occurrence counts unchanged before/after the edit (14 checkout, 9 `rust-toolchain@stable`→`1.97.1`, 1 `@nightly`, 8 rust-cache, 2 cache, 1 upload-artifact, 3 setup-node).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
