### PR TITLE
ci: extend the default-parallelism gate to the full --workspace (#384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,23 +279,27 @@ jobs:
       # runner. It is cheap insurance and the place a wider, better-sized gate
       # (#384) can land -- not a claim that the class is now covered.
       #
-      # #384: widened from `-p xerj-engine --lib` to the full `--workspace --lib`
-      # now that the whole workspace's lib tests are *measured* green at default
-      # parallelism (6 ci-test-profile clean runs at this scope, 20 cores). This
-      # was blocked until #385: xerj-autoindex used to be red because
-      # `incremental_reconcile_http_tests` could reach the global
-      # `SNAPSHOT_FAILPOINT` without holding the `SNAPSHOT_TEST_LOCK` and steal
-      # another test's injected failure; the thread-local failpoint fix (merged)
-      # removed that defect, and re-measuring the widened scope is clean. A gate
-      # is worth nothing if it is merged red, so it goes in at the width it
-      # passes at; the integration targets (`tests/*.rs`) are the next,
-      # separately-measured step.
+      # #384: widened progressively — `-p xerj-engine --lib` -> `--workspace --lib`
+      # -> the full `--workspace` (all targets, INCLUDING the integration tests
+      # under `crates/*/tests/*.rs`) — now that every scope is *measured* green at
+      # default parallelism (6 clean `--workspace --lib` runs, then 4 clean full
+      # `--workspace` runs, ci-test profile, 20 cores). This was blocked until
+      # #385: xerj-autoindex used to be red because `incremental_reconcile_http_tests`
+      # could reach the global `SNAPSHOT_FAILPOINT` without holding the
+      # `SNAPSHOT_TEST_LOCK` and steal another test's injected failure; the
+      # thread-local failpoint fix (merged) removed that defect. The integration
+      # targets bind ports and share fixture dirs, so they are the likeliest to
+      # carry this class of defect (#384's own note) — but they passed every run
+      # here, and a hosted runner has FEWER cores than this 20-core box, so its
+      # default parallelism is strictly lower and less contended than what these
+      # runs already survived. A gate is worth nothing if it is merged red, so it
+      # goes in at the width it passes at.
       #
       # Reuses the binaries the step above already built: the added cost is test
       # runtime, not another compile.
-      - name: Workspace lib tests at default parallelism (contributor's `cargo test`)
+      - name: Workspace tests (all targets) at default parallelism (contributor's `cargo test`)
         working-directory: engine
-        run: cargo test --profile ci-test --workspace --lib
+        run: cargo test --profile ci-test --workspace
 
   # Fat LTO + codegen-units=1 + panic=abort over every workspace member is a
   # failure mode of its own (LTO ICEs, symbol collisions, panic-strategy


### PR DESCRIPTION
The remaining half of #384: extend the default-parallelism CI gate from `--workspace --lib` (merged in #716) to the full `--workspace` — all targets, so the **integration tests** (`crates/*/tests/*.rs`) run at default parallelism too. #384 flags these as the likeliest to carry the defect class (they bind ports + share fixture dirs).

**Measurement:** `cargo test --profile ci-test --workspace` at default parallelism (rustc 1.97.1, 20 cores) — **4 clean runs, 0 failed** across every suite. Crucially, hosted GitHub runners have **far fewer cores** than this 20-core box, so their default parallelism (`--test-threads = ncpu`) is strictly lower and *less* contended than what these runs already survived — the local measurement is a conservative upper bound on CI's concurrency.

**Verification:** this PR's own CI runs the full-`--workspace` gate at the new width — a gate merged red gets disabled, so if the integration suite flakes on the CI runner it shows here and this does not merge. Closes #384.