### PR TITLE
test(engine): #643 — cover the Percentage/Field/Script msm unwrap (gap 1)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -47305,7 +47305,7 @@ mod wal_shard_settings_tests;
 #[cfg(test)]
 mod unwrap_single_clause_643_wrapper_tests {
     use super::*;
-    use xerj_query::ast::{BoolOperator, QueryNode};
+    use xerj_query::ast::{BoolOperator, MinShouldMatch, QueryNode};
 
     fn bare_match() -> QueryNode {
         QueryNode::Match {
@@ -47325,6 +47325,18 @@ mod unwrap_single_clause_643_wrapper_tests {
             must_not: vec![],
             filter: vec![],
             minimum_should_match: None,
+        }
+    }
+
+    /// A `bool` whose only clause is a lone `should` with the given
+    /// `minimum_should_match` — the shape #643 gap 1 is about.
+    fn single_should_bool(msm: Option<MinShouldMatch>) -> QueryNode {
+        QueryNode::Bool {
+            must: vec![],
+            should: vec![bare_match()],
+            must_not: vec![],
+            filter: vec![],
+            minimum_should_match: msm,
         }
     }
 
@@ -47369,6 +47381,69 @@ mod unwrap_single_clause_643_wrapper_tests {
             }
             other => panic!("dis_max wrapper must be preserved, got {:?}", other),
         }
+    }
+
+    /// #643 (gap 1): a lone `should` whose `minimum_should_match` is a
+    /// `Percentage` that resolves to 1 is the clause-required shape Lucene
+    /// collapses to the bare clause, so it must unwrap exactly like
+    /// `Fixed(1)`/`None`. msm resolution is `max(1, floor(len * pct / 100))`,
+    /// so for the single clause (`len == 1`) every `pct < 200` resolves to 1
+    /// (`floor(1 * 199 / 100) == 1`, `max(1, 0) == 1` at `pct == 0`).
+    #[test]
+    fn unwrap_collapses_lone_should_with_percentage_msm_resolving_to_one() {
+        for pct in [0u32, 1, 50, 100, 150, 199] {
+            let unwrapped = unwrap_single_clause_bool(single_should_bool(Some(
+                MinShouldMatch::Percentage(pct),
+            )));
+            assert!(
+                matches!(unwrapped, QueryNode::Match { .. }),
+                "a lone should with {pct}% msm resolves to 1 required and must erase \
+                 to the bare clause, got {unwrapped:?}",
+            );
+        }
+    }
+
+    /// #643 (gap 1): a `Percentage` that resolves to >= 2 (`pct >= 200`, since
+    /// `floor(1 * 200 / 100) == 2`) requires 2 of the single clause — the bool
+    /// matches NOTHING, unlike the bare clause — so it must stay wrapped
+    /// (strictly conservative). The parser puts no upper cap on `pct`, so
+    /// `"200%"` is reachable.
+    #[test]
+    fn unwrap_keeps_lone_should_wrapped_when_percentage_msm_exceeds_the_clause_count() {
+        for pct in [200u32, 250, 400] {
+            let unwrapped = unwrap_single_clause_bool(single_should_bool(Some(
+                MinShouldMatch::Percentage(pct),
+            )));
+            assert!(
+                matches!(unwrapped, QueryNode::Bool { .. }),
+                "a lone should with {pct}% msm resolves to >= 2 over 1 clause (matches \
+                 nothing) and must stay wrapped, got {unwrapped:?}",
+            );
+        }
+    }
+
+    /// #643 (gap 1): `Field`/`Script` msm resolve only at query time (a per-doc
+    /// field value or a script result) and can exceed the clause count, so a
+    /// static rewrite cannot prove they resolve to 1 — they stay wrapped,
+    /// conservatively (the same `_ => false` fall-through as any un-erasable
+    /// shape).
+    #[test]
+    fn unwrap_keeps_lone_should_wrapped_for_query_time_msm() {
+        let field = unwrap_single_clause_bool(single_should_bool(Some(MinShouldMatch::Field(
+            "req".into(),
+        ))));
+        assert!(
+            matches!(field, QueryNode::Bool { .. }),
+            "a Field msm is unresolvable at rewrite time and must stay wrapped, got {field:?}",
+        );
+        let script = unwrap_single_clause_bool(single_should_bool(Some(MinShouldMatch::Script {
+            source: "params.num_terms".into(),
+            params: None,
+        })));
+        assert!(
+            matches!(script, QueryNode::Bool { .. }),
+            "a Script msm is unresolvable at rewrite time and must stay wrapped, got {script:?}",
+        );
     }
 }
 


### PR DESCRIPTION
## What

Closes #643 by adding the missing gap-1 test coverage. The issue's two conservative-unwrap gaps in `unwrap_single_clause_bool` are **both already implemented and correct** in the tree; the only remaining item was that gap 1 had no dedicated test.

## Why #643 is now fully addressed

- **gap 1 — `minimum_should_match` that resolves to 1** (`index.rs:35182-35184`): the code matches `Percentage(pct) => *pct < 200`. This is exactly right: msm resolves to `max(1, floor(len * pct / 100))`, so for the single `should` clause (`len == 1`) every `pct < 200` resolves to `1` (clause required → collapses to the bare clause), while `pct >= 200` resolves to `>= 2` (requires 2 of 1 clause → the bool matches nothing, so it must stay wrapped). `Field`/`Script` resolve only at query time and can exceed the clause count, so a static rewrite keeps them wrapped (the `_ => false` fall-through) — **correct by design; the issue's "resolve to an integer" direction is infeasible for these two**.
- **gap 2 — recursion through score-preserving wrappers** (`DisMax`, `FunctionScore`): already closed in #704, with `unwrap_recurses_through_{dis_max,function_score}`.

So the only true remainder was locking in gap 1 with a test.

## Tests added (`unwrap_single_clause_643_wrapper_tests`)

- `unwrap_collapses_lone_should_with_percentage_msm_resolving_to_one` — `0/1/50/100/150/199%` all erase to the bare clause;
- `unwrap_keeps_lone_should_wrapped_when_percentage_msm_exceeds_the_clause_count` — `200/250/400%` stay wrapped;
- `unwrap_keeps_lone_should_wrapped_for_query_time_msm` — `Field`/`Script` stay wrapped.

## Fail-before

Reverting only the `Some(MinShouldMatch::Percentage(pct)) => *pct < 200` arm (so `Percentage` falls through to `_ => false`) leaves the lone-`should` Percentage wrapped, and `unwrap_collapses_lone_should_with_percentage_msm_resolving_to_one` fails (`0% … got Bool { … }`). Restoring it → all pass.

## Verification (rustc 1.97.1)

- `cargo fmt --all --check` — clean
- `cargo clippy -p xerj-engine --all-targets -- -D warnings` — clean
- full `cargo test -p xerj-engine` (dev) — **1090 passed / 0 failed** (62 binaries; 23 pre-existing ignores)

Test-only change; no source behaviour is modified.

Closes #643.