### PR TITLE
fix(autoindex): #718 — offer --fresh in the genesis-guard recovery message + document the dry-run refusal

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2191,15 +2191,39 @@ fn no_graph_genesis_bootstrap_is_refused_on_the_graph_path() {
     let mut graph = no_graph.clone();
     graph.no_graph = false;
     graph.snapshot_max_bytes = 64 << 30;
-    let error = run_index(graph).unwrap_err();
+    let error = run_index(graph.clone()).unwrap_err();
     let rendered = format!("{error:#}");
     assert!(
         rendered.contains("genesis bootstrap") && rendered.contains("different graph authority"),
         "#585 case 2: a --no-graph genesis bootstrap must be refused on the graph path with the \
          clear message, got: {rendered}"
     );
+    // #718: the message must name every valid recovery route, including
+    // `--fresh` — the guard exempts it (nothing is committed past genesis), so
+    // omitting it hides a working recovery from the operator.
+    assert!(
+        rendered.contains("--fresh"),
+        "#718: the recovery message must offer --fresh, which the guard exempts, got: {rendered}"
+    );
     // No mutation: nothing indexed, no new durable transaction beyond the
     // original sync_bootstrap.
+    assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
+    assert_eq!(journal_events(state_dir.path(), "sync_begin"), 0);
+    assert_eq!(journal_events(state_dir.path(), "sync_commit"), 0);
+    assert_eq!(endpoint.data_docs().len(), 0);
+
+    // #718: `--dry-run` does not exempt the refusal. A graph-path dry run over
+    // the pending --no-graph genesis is refused the same way (there is no graph
+    // genesis projection to show), with the same recovery message, and mutates
+    // nothing — a dry run of a refused run is a refusal.
+    let mut graph_dry = graph;
+    graph_dry.dry_run = true;
+    let dry_error = run_index(graph_dry).unwrap_err();
+    let dry_rendered = format!("{dry_error:#}");
+    assert!(
+        dry_rendered.contains("genesis bootstrap") && dry_rendered.contains("--fresh"),
+        "#718: --dry-run over a genesis on the graph path is refused too, got: {dry_rendered}"
+    );
     assert_eq!(journal_events(state_dir.path(), "sync_bootstrap"), 1);
     assert_eq!(journal_events(state_dir.path(), "sync_begin"), 0);
     assert_eq!(journal_events(state_dir.path(), "sync_commit"), 0);

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3472,14 +3472,24 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     //
     // `--fresh` is deliberately exempt, the same way `blocking_generation`
     // above exempts genesis recovery: nothing has been committed past
-    // genesis, so discarding and rebuilding in the requested mode is safe.
+    // genesis, so discarding and rebuilding in the requested mode is safe —
+    // which is why `--fresh` is one of the recovery routes the message names.
+    //
+    // #718: this refusal is intentionally NOT gated on `!cfg.dry_run`, unlike
+    // the pending-sync projection above. A dry run previews the run that WOULD
+    // execute, but this graph-path run would itself be refused, and there is no
+    // graph-path genesis projection to show (the `--no-graph` dry-run
+    // projection further below is `!genesis_recovery`-gated). Bailing is
+    // therefore the honest preview, and it precedes every write, so `--dry-run`
+    // reaches it before anything is mutated.
     if genesis_recovery && preflight.no_graph_genesis && !cfg.no_graph && !cfg.fresh {
         anyhow::bail!(
             "a --no-graph generation's genesis bootstrap is pending in {} (nothing beyond \
              generation 0 committed); continuing it on the default graph path would proceed \
              under a different graph authority and mutate the destination. No remote mutation \
-             was attempted. Re-run with --no-graph to finish the pending generation, or rebuild \
-             with a new --state-dir and a new --prefix.",
+             was attempted. Re-run with --no-graph to finish the pending generation, re-run with \
+             --fresh to discard generation 0 and rebuild on the graph path, or rebuild with a new \
+             --state-dir and a new --prefix.",
             state_dir.join("journal.ndjson").display()
         );
     }


### PR DESCRIPTION
## What

Closes #718 — the two non-blocking polish items surfaced by the 3-skeptic review of #711 (#585 case 2). Both live in the genesis cross-path guard (`lib.rs`).

## Item 2 — `--fresh` missing from the recovery message

The guard exempts `--fresh` (`... && !cfg.fresh`) because nothing is committed past generation 0, so discarding and rebuilding in the requested (graph) mode is safe — the comment right above the guard already says so. But the `bail!` message named only two recovery routes (`--no-graph`, or a fresh `--state-dir`/`--prefix`), hiding a working recovery from the operator. Now it also offers **"re-run with `--fresh` to discard generation 0 and rebuild on the graph path."**

## Item 1 — the graph-path `--dry-run`-over-genesis refusal

The refusal is intentionally **not** gated on `!cfg.dry_run` (unlike the pending-sync projection above it). A dry run previews the run that *would* execute — but this graph-path run would itself be refused, and there is no graph-path genesis projection to show (the `--no-graph` dry-run projection further down is `!genesis_recovery`-gated). Bailing is therefore the honest preview, and it precedes every write. This is now documented in a comment and **locked by a test** (a `--dry-run` graph run over the pending genesis is refused with the same message and mutates nothing).

## Fail-before

The extended `no_graph_genesis_bootstrap_is_refused_on_the_graph_path` now asserts the message `contains("--fresh")` (both for the real run and the dry run). Reverting only the message's `--fresh` clause makes those assertions fail (`got: … Re-run with --no-graph … or rebuild with a new --state-dir …`).

## Verification (rustc 1.97.1)

- `cargo fmt --all --check` — clean
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings` — clean
- full `cargo test -p xerj-autoindex` (dev) — **715 passed / 0 failed** (verified green across 3 consecutive runs)
- ci-test: `cargo build --profile ci-test` — 0; genesis test — 1 passed / 0 failed

> Note: an earlier full-suite run showed a transient parallel flake in two unrelated tests (`two_byte_identical_junk_files_…`, `sync_executor::…gc_tombstone…`); both pass single-threaded and across 3 subsequent parallel runs, and clean `main` shows the same green — a pre-existing shared-state flake in the http_tests, not from this change (the guard bails at preflight before any failpoint/sync).

Closes #718.