### PR TITLE
fix(autoindex): #722 - the --no-graph generated pipeline never consumed as_document

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/mod.rs
+++ b/engine/crates/xerj-autoindex/src/extract/mod.rs
@@ -125,8 +125,24 @@ pub fn read_whole(path: &Path, gzip: bool, cap: u64) -> Result<Option<Vec<u8>>> 
 /// the text itself. Emits the same `title`/`body`/`section` vocabulary as
 /// every other document extractor (`FieldOrigin::Extractor`).
 pub fn extract_as_document(path: &Path, gzip: bool, sink: Sink) -> Result<ExtractStats> {
+    extract_as_document_with_name(path, path, gzip, sink)
+}
+
+/// [`extract_as_document`], but the title comes from `logical_path` rather
+/// than `content_path`. The `--no-graph` generated pipeline reads a
+/// SEALED SNAPSHOT — a real file on disk, but under its own ordinal name
+/// (`prepared/00000000`, …), not the source's — so deriving the title from
+/// `content_path` there produced `"00000000"` instead of the file's own
+/// name (#722). Mirrors `sniff::sniff_with_name`'s split for exactly the
+/// same reason.
+pub fn extract_as_document_with_name(
+    content_path: &Path,
+    logical_path: &Path,
+    gzip: bool,
+    sink: Sink,
+) -> Result<ExtractStats> {
     let mut stats = ExtractStats::default();
-    let Some(bytes) = read_whole(path, gzip, MAX_WHOLE_FILE)? else {
+    let Some(bytes) = read_whole(content_path, gzip, MAX_WHOLE_FILE)? else {
         stats.junk += 1;
         return Ok(stats);
     };
@@ -135,7 +151,7 @@ pub fn extract_as_document(path: &Path, gzip: bool, sink: Sink) -> Result<Extrac
         stats.junk += 1;
         return Ok(stats);
     }
-    let title = path
+    let title = logical_path
         .file_stem()
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| "untitled".into());

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -1602,8 +1602,36 @@ fn prepare_artifact(
     // generation because one line of one log file did not parse would make a
     // realistic corpus unindexable. The count is sealed into the artifact so
     // the generation, and then the catalog, can report it.
-    let stats = crate::extract::extract(snapshot_blob, &sniffed, None, &mut sink)
-        .with_context(|| format!("extract {} into durable preparation", source.rel))?;
+    //
+    // #722: `assignment.as_document` (a demoted one-off config file, #173)
+    // decides the record *shape*, the same precedence the legacy path's own
+    // phase-B dispatch gives it (`lib.rs`, `if fa.as_document { … }`) — the
+    // frozen dataset's mapping was built by re-sampling through
+    // `extract_as_document`, so that is the only extractor whose output may
+    // be compared against it. Before this, the durable/generated pipeline
+    // never checked the flag at all: a demoted file was correctly ROUTED
+    // into the docs dataset (`reconcile_plan`/`dataset::cluster` agree it
+    // belongs there) but its published fields still came from its raw
+    // family extractor, silently disagreeing with the mapping. `sniffed` is
+    // already sniffed from `snapshot_blob`, a real path on the sealed
+    // snapshot (not a byte blob), so the branch is exactly the legacy
+    // path's — no format change needed.
+    let stats = if assignment.as_document {
+        // `extract_as_document_with_name`, not `extract_as_document`:
+        // `snapshot_blob` is a real path, but to the SEALED SNAPSHOT under
+        // its own ordinal name, not the source file's — the title must come
+        // from `source.path` (the same split `sniff_with_name` above makes
+        // for the same reason).
+        crate::extract::extract_as_document_with_name(
+            snapshot_blob,
+            &source.path,
+            sniffed.gzip,
+            &mut sink,
+        )
+    } else {
+        crate::extract::extract(snapshot_blob, &sniffed, None, &mut sink)
+    }
+    .with_context(|| format!("extract {} into durable preparation", source.rel))?;
     if let Some(error) = sink_error {
         return Err(error);
     }
@@ -1917,6 +1945,67 @@ mod tests {
         assert_eq!(groups[0].expected_records_for("users"), Some(2));
         assert_eq!(groups[0].expected_records_for("orders"), Some(2));
         assert_eq!(groups[0].expected_records_for("absent"), Some(0));
+    }
+
+    /// #722: `assignment.as_document` was never read here at all — a demoted
+    /// one-off config file (#173) was correctly ROUTED into the docs dataset
+    /// (`reconcile_plan`/`dataset::cluster` agree) but published through its
+    /// raw family extractor, not `extract_as_document`, silently disagreeing
+    /// with the docs mapping the run itself built. A first, file-path-only
+    /// fix used `extract_as_document(snapshot_blob, …)` directly and derived
+    /// the title from `snapshot_blob`'s own name — the SEALED SNAPSHOT's
+    /// ordinal filename (`prepared/00000000`), not the source file's, so
+    /// every demoted document titled itself `"00000000"`. Pins both halves:
+    /// the record is document-shaped (`title`/`body`, not the source's raw
+    /// JSON keys) AND the title is the real source name.
+    #[test]
+    fn preparation_of_a_demoted_file_publishes_a_real_document_with_the_source_title() {
+        let _guard = SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let corpus = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        std::fs::write(
+            corpus.path().join("config.json"),
+            br#"{"host": "example.com", "port": 8080}"#,
+        )
+        .unwrap();
+        let inventory = inventory(corpus.path());
+        let mut plan = plan_for(&inventory);
+        let key = inventory.keys[0].clone();
+        plan.files.get_mut(&key).unwrap().as_document = true;
+
+        let snapshot = create_prepared_snapshot(
+            state.path(),
+            "tx-demoted-config",
+            &inventory,
+            &plan,
+            "test-preparation-v1",
+            u64::MAX,
+        )
+        .unwrap();
+
+        let prepared = snapshot.files[0].prepared.as_ref().unwrap();
+        assert_eq!(prepared.records, 1);
+        let root = state.path().join("sync-snapshots/tx-demoted-config");
+        let ndjson = std::fs::read_to_string(root.join(&prepared.relative_ndjson)).unwrap();
+        let document: Value = serde_json::from_str(ndjson.lines().nth(1).unwrap()).unwrap();
+        assert_eq!(
+            document["title"], "config",
+            "title must be the source file's own stem, not the sealed snapshot's ordinal \
+             filename: {document}"
+        );
+        assert!(
+            document["body"]
+                .as_str()
+                .unwrap()
+                .contains(r#""host": "example.com""#),
+            "body must be the decoded document text, not raw extracted JSON fields: {document}"
+        );
+        assert!(
+            document.get("host").is_none() && document.get("port").is_none(),
+            "a demoted file must not publish its raw family-extractor fields: {document}"
+        );
     }
 
     /// `snapshot_digest` covers the serialized `PreparedArtifact` and


### PR DESCRIPTION
Closes #722.

## Problem

A demoted one-off config file (#173: a small, group-less, single-record `Json`/`Yaml`/`Xml` file folded into a scope's `docs` dataset) is correctly **routed** into the `docs` dataset under `--no-graph` — `reconcile_plan` and `dataset::cluster` agree on that — but its **published content** still came from its raw family extractor, not `extract_as_document`, silently disagreeing with the `docs` mapping the run itself built.

Verified live before fixing, on a completely **fresh** (non-incremental) `--no-graph` run — one prose file + one one-off `config.json`:

```
generation 1 committed — 1 datasets, 2 records live
```

`config.json` lands in the `docs` index (`ax_dataset: "docs"`, `ax_locator: "doc"`) but its `_source` is:

```json
{"host": "example.com", "port": 8080, "ax_path": "config.json", ...}
```

instead of the `title`/`body` document shape the `docs` dataset's own mapping was inferred from.

## Root cause

The **legacy (graph-enabled) path**'s own phase-B extraction dispatch explicitly branches on `FileAssignment.as_document`:

```rust
let res = if fa.as_document {
    extract::extract_as_document(&f.path, sn.gzip, &mut sink)
} else if sn.family == Family::Pdf {
    ...
} else {
    extract::extract(&f.path, sn, ..., &mut sink)
};
```

`sync_executor.rs` — the **generated (`--no-graph`) pipeline**'s own extraction step — has exactly one extraction call site and it is unconditional: `crate::extract::extract(snapshot_blob, &sniffed, None, &mut sink)`. `as_document` is never referenced anywhere in `sync_executor.rs` outside test fixtures.

## Fix

1. `sync_executor.rs`'s `prepare_artifact` already has the file's `FileAssignment` in scope (`plan.files.get(content_id)`) — branch on `assignment.as_document` exactly the way `lib.rs`'s phase-B dispatch does. `snapshot_blob` is a real filesystem path (the sealed snapshot), not a byte blob, so **no signature refactor of the extractors was needed** — just the same branch, on the same field, on a real path.

2. That surfaced a second, narrower bug: naively calling `extract_as_document(snapshot_blob, ...)` derives the document's title from `snapshot_blob`'s own filename — the sealed snapshot's **ordinal** name (`prepared/00000000`), not the source file's — so every demoted document titled itself `"00000000"` instead of the real file's stem. `extract/mod.rs`'s `extract_as_document` is now a thin wrapper over a new `extract_as_document_with_name(content_path, logical_path, gzip, sink)`, mirroring `sniff::sniff_with_name`'s existing split for exactly the same reason (content from the snapshot blob, identity from the source path). `sync_executor.rs` calls the `_with_name` variant with `source.path` as the logical name.

## Testing

- New test `preparation_of_a_demoted_file_publishes_a_real_document_with_the_source_title` (`sync_executor.rs`) — a real `create_prepared_snapshot()` run over an `as_document: true` assignment for a real `config.json` on disk, reads the sealed NDJSON back, asserts `title == "config"` (not `"00000000"`), `body` contains the decoded JSON text, and the raw `host`/`port` fields are absent from the published record. Verified fail-before: with the `as_document` branch neutralized, the assertion fails exactly as the live repro did (no `title` key at all, raw `host`/`port` fields present).
- Verified live end-to-end after the fix (real server + CLI, `--no-graph`): `config.json` now publishes `{"title": "config", "body": "{\"host\": \"example.com\", \"port\": 8080}", ...}` under the `docs` index.
- `cargo test -p xerj-autoindex --profile ci-test -- --test-threads=2`: 680 passed; the 19 failures are pre-existing macOS environment issues (non-UTF-8 filenames + one unrelated data-assertion mismatch) that reproduce identically on unmodified `main`.
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `cargo check -p xerj-server --profile ci-test`: clean.

Found and filed (#722) while live-verifying #712 (fixing #346) — confirmed pre-existing and unrelated to that PR: reproduces identically on a completely fresh `--no-graph` run with no incremental reconcile involved at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
