### PR TITLE
fix(autoindex): #346 — surface files-skipped-after-plan-freeze distinctly, not below the noise floor

### DIFF
--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -823,6 +823,11 @@ fn a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it() {
     assert_eq!(code, 3);
     let report = report.unwrap();
     assert_eq!(report["files_junk"], 1, "{report}");
+    // #346: the file that appeared after the plan was frozen is surfaced
+    // DISTINCTLY as `skipped_appeared`, not just folded into `files_junk`, so a
+    // "make the index match the tree" re-run can see the index is incomplete
+    // instead of reading as an ordinary completed-with-junk success.
+    assert_eq!(report["skipped_appeared"], 1, "{report}");
     // `records_total` is the live server-side count (#195), so it still reports
     // the record the first run published. What must be zero is the run-local
     // counter: this rerun indexed nothing, because the frozen plan cannot

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -4473,6 +4473,15 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
              stay idempotent)",
         );
     }
+    // #346: the count of files that appeared after the resume plan was frozen
+    // (and so were skipped, never indexed) is surfaced DISTINCTLY below — in the
+    // run summary and the terminal `xerj-done` line — not just as a mid-stream
+    // note folded into the generic `junk_files` total. Folding it in leaves a
+    // "make the index match the tree" re-run reading as an ordinary
+    // completed-with-junk success while the index is in fact incomplete, which
+    // is the below-the-noise-floor reporting #346 is about. Captured here before
+    // `new_unplanned` is drained into `plan.junk_files`.
+    let skipped_appeared = new_unplanned.len();
     if resumed_with_plan {
         // Legacy journals predate intent-before-publication and may have live
         // partial records without either file_done or file_replace_start.
@@ -5933,6 +5942,13 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         run_doc["catalog_alias_sweep_failed_paths"] = json!(alias_sweep_failed);
         run_doc["catalog_alias_sweep_error"] = json!(error);
     }
+    // #346: present only when files appeared after the plan was frozen, so a
+    // healthy run document is unchanged and any reader finding this key knows
+    // the index is incomplete for that many files (distinct from unparseable
+    // `junk`).
+    if skipped_appeared > 0 {
+        run_doc["skipped_appeared"] = json!(skipped_appeared);
+    }
     push_doc(&format!("run:{run_id}"), &run_doc, &mut cat_buf);
 
     if !cat_buf.is_empty() {
@@ -6115,6 +6131,12 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             "catalog_alias_sweep_failures",
             alias_sweep_failed.len() as u64,
         ));
+    }
+    // #346: surface files-skipped-because-they-appeared-after-freeze on the
+    // terminal line, distinct from `junk_files`, so a re-run whose index is
+    // silently incomplete is visible instead of below the noise floor.
+    if skipped_appeared > 0 {
+        done_fields.push(("skipped_appeared", skipped_appeared as u64));
     }
     pr.finish(
         true,


### PR DESCRIPTION
## What

Closes **#346** (the *actual* one — "resume journal reports skipped files below the noise floor", split out of #326). Note: the earlier #712/#727 mis-referenced #346; this PR fixes the real defect.

A re-run over a changed tree records files that appeared *after* the resume plan was frozen as `skipped` junk and prints one mid-stream progress note (`autoindex: N file(s) appeared after the resume plan was frozen and were NOT indexed`). But that count was then folded into the generic `files_junk`/`junk_files` total — **indistinguishable from ordinary unparseable junk**. For a "make the index match the tree" workflow this reads as a routine `completed-with-junk` success while the index is in fact **incomplete**.

## Fix

Surface the count **distinctly**:
- capture `skipped_appeared` before `new_unplanned` is drained into `plan.junk_files`;
- only when `> 0`, emit it in the run summary document (`run_doc["skipped_appeared"]`) and on the terminal `xerj-done` line (`done_fields`).

A healthy run (no files appeared after freeze) is byte-unchanged — the key/field is absent. Exit code is untouched (already `3` / `completed-with-junk` via the junk count); per the issue, *surfacing the count* is the asked-for fix (vs. changing exit semantics, which would risk callers).

## Fail-before

The existing `a_rerun_after_an_added_file_succeeds_and_fresh_absorbs_it` (which indexes `first.csv`, adds `second.csv`, re-runs) now also asserts `report["skipped_appeared"] == 1`. Reverting only the `run_doc["skipped_appeared"]` hunk leaves the key absent (`Null`) and the assertion fails (`left: Null, right: 1`), while `files_junk` alone stays `1` — exactly the buried-below-noise-floor state.

## Verification (rustc 1.97.1, exact CI commands — no pipe masking)

- `cargo fmt --all --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo build -p xerj-autoindex --profile ci-test` — 0
- full `cargo test -p xerj-autoindex` — **716 passed / 0 failed on BOTH dev and ci-test profiles**

Closes #346.