### PR TITLE
ci: deploy landing/ to Cloudflare Pages from GitHub Actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,60 @@
+name: Deploy site (Cloudflare Pages)
+
+# Deploys the static site under landing/ to the "xerj" Cloudflare Pages project
+# on every push to main. Cloudflare serves landing/ verbatim (no build step);
+# wrangler uploads it directly. Auth is a scoped API token stored as the
+# CLOUDFLARE_API_TOKEN repo secret (needs the "Cloudflare Pages:Edit" permission)
+# plus CLOUDFLARE_ACCOUNT_ID. Both are configured in repo Settings → Secrets.
+#
+# This replaces reliance on Cloudflare's git integration with an explicit,
+# auditable deploy that only fires after CI/SEO gates on main have the chance to
+# run, and whose logs live in Actions.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'landing/**'
+      - 'wrangler.toml'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch: {}          # allow manual redeploy from the Actions tab
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false      # never abort a deploy mid-upload
+
+jobs:
+  deploy:
+    name: Publish landing/ to Cloudflare Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://xerj.org
+    steps:
+      - name: Check out the site
+        uses: actions/checkout@v4
+
+      - name: Guard — secrets must be present
+        run: |
+          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || [ -z "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID must be set in repo secrets."
+            exit 1
+          fi
+          [ -d landing ] || { echo "::error::landing/ not found — nothing to deploy."; exit 1; }
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Upload landing/ verbatim to the existing "xerj" project, tagged with
+          # the commit so a bad deploy is one rollback away in the CF dashboard.
+          command: >-
+            pages deploy landing
+            --project-name=xerj
+            --branch=main
+            --commit-dirty=true


### PR DESCRIPTION
Adds an explicit, auditable GitHub Actions deploy for the marketing site (`landing/`) to the existing **xerj** Cloudflare Pages project, replacing reliance on CF's git integration.

- Triggers on push to `main` touching `landing/` (+ manual `workflow_dispatch`).
- Uses `cloudflare/wrangler-action@v3` → `pages deploy landing --project-name=xerj`.
- Auth via repo secrets **CLOUDFLARE_API_TOKEN** (Pages:Edit) + **CLOUDFLARE_ACCOUNT_ID** — both already configured.
- Guard step fails loudly if a secret is missing or `landing/` is absent.

**Validated before merge:** a preview deploy from the same token succeeded (deploy-token-test.xerj.pages.dev, 170 files incl. Functions); production was not touched. Merging this triggers the first production deploy from Actions.