### PR TITLE
fix(autoindex): exclusion sweep purges a removed file's alias catalog docs (#693)

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2183,6 +2183,87 @@ fn sweep_excluded_groups_invalidates_the_excluded_files_edges() {
     );
 }
 
+/// #693: `sweep_excluded_groups` also purges the excluded file's `file-alias:`
+/// duplicate catalog docs. Those carry the DUPLICATE's own path (not the
+/// canonical `entry.path`), so the `path` term alone misses them — leaving an
+/// excluded file's alternate path/filename searchable. Deleting by `file_key`
+/// catches them, and cannot strand a live duplicate (a group is only excluded
+/// when no surviving file bears its key). Fail-before: without the `file_key`
+/// delete, the alias doc (path "dup.csv") survives the canonical-path sweep.
+#[test]
+fn sweep_excluded_groups_purges_the_excluded_files_alias_catalog_docs() {
+    let ep = HttpEndpoint::start();
+
+    {
+        let mut st = ep.state.lock().unwrap();
+        // Excluded file: a canonical `file:` doc plus a byte-identical
+        // `file-alias:` doc under a DIFFERENT path — both carry the same
+        // `file_key`.
+        st.docs.insert(
+            (catalog::CATALOG_INDEX.to_string(), "file:excluded".into()),
+            json!({"doc_kind": "file", "file_key": "key-excluded", "path": "canonical.csv"}),
+        );
+        st.docs.insert(
+            (catalog::CATALOG_INDEX.to_string(), "file-alias:ax:excluded".into()),
+            json!({"doc_kind": "file", "file_key": "key-excluded", "path": "dup.csv", "status": "duplicate"}),
+        );
+        // A different file's alias (distinct file_key) must survive.
+        st.docs.insert(
+            (catalog::CATALOG_INDEX.to_string(), "file-alias:ax:kept".into()),
+            json!({"doc_kind": "file", "file_key": "key-kept", "path": "kept-dup.csv", "status": "duplicate"}),
+        );
+    }
+
+    let es = Es::with_bulk_timeout(&ep.url, None, 30).expect("es client");
+    let mut plan = Plan::default();
+    plan.datasets.push(crate::state::PlanDataset {
+        slug: "ds".into(),
+        index: "incremental-http-ds".into(),
+        family: "csv".into(),
+        group: None,
+        specs: Vec::new(),
+        time_field: None,
+        semantic_field: None,
+        sampled_records: 1,
+        file_count: 1,
+    });
+    // entry.path is the CANONICAL rel — deliberately NOT the alias's "dup.csv".
+    let excluded = vec![InventoryDeltaEntry {
+        file_key: "key-excluded".into(),
+        path: "canonical.csv".into(),
+    }];
+
+    // 5-arg signature (post-#694): this test does not exercise edges, so pass
+    // `None`/`0` — only the catalog file_key sweep is under test here.
+    sweep_excluded_groups(&es, &plan, &excluded, None, 0).expect("sweep");
+
+    let st = ep.state.lock().unwrap();
+    // The excluded file's alias catalog doc is gone (the #693 fix).
+    assert!(
+        !st.docs
+            .iter()
+            .any(|((idx, _), d)| idx == catalog::CATALOG_INDEX
+                && d.get("path").and_then(Value::as_str) == Some("dup.csv")),
+        "#693: the excluded file's file-alias: catalog doc must be swept"
+    );
+    // Its canonical file doc is gone too.
+    assert!(
+        !st.docs
+            .iter()
+            .any(|((idx, _), d)| idx == catalog::CATALOG_INDEX
+                && d.get("file_key").and_then(Value::as_str) == Some("key-excluded")),
+        "#693: the excluded file's catalog docs (by file_key) must be swept"
+    );
+    // A different file's alias must NOT be swept (file_key is content-scoped).
+    assert!(
+        st.docs
+            .iter()
+            .any(|((idx, _), d)| idx == catalog::CATALOG_INDEX
+                && d.get("path").and_then(Value::as_str) == Some("kept-dup.csv")),
+        "#693: a different file's alias doc must NOT be swept"
+    );
+}
+
 /// #585 (case 1): a pending (uncommitted) `--no-graph` generation must NOT be
 /// resumed and committed on the default graph path — doing so silently commits
 /// a no-graph generation under a graph authority (the #584 hazard, but for a

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3198,6 +3198,19 @@ fn sweep_excluded_groups(
             &json!({"term": {"path": entry.path}}),
         )
         .with_context(|| format!("sweep catalog entry for newly-excluded {}", entry.path))?;
+        // #693: also purge the file's `file-alias:` duplicate catalog docs
+        // (`catalog::duplicate_file_doc`). Each carries the DUPLICATE's own
+        // `path`, so the `path` term above misses them, leaving an excluded
+        // file's alternate path/filename searchable. Both the main `file:` doc
+        // and every `file-alias:` doc carry `file_key`, and the delta classifies
+        // a content group as excluded ONLY when no surviving file bears its key
+        // (`UnsupportedInventoryDelta::between`: the `current_keys` guard), so a
+        // `file_key` term cannot strand a still-live byte-identical duplicate.
+        es.delete_by_query(
+            catalog::CATALOG_INDEX,
+            &json!({"term": {"file_key": entry.file_key}}),
+        )
+        .with_context(|| format!("sweep catalog aliases for newly-excluded {}", entry.path))?;
         // #694: soft-invalidate the edges this file taught. `invalidate_prior_edges`
         // tolerates a not-yet-created edges index (returns 0), so a graph run whose
         // edges index has not been ensured at this point is safe.


### PR DESCRIPTION
Closes #693 — the sibling #589 exclusion-sweep follow-up (alias/duplicate catalog residue).

## Problem
`sweep_excluded_groups` deleted the excluded file's content records (by `ax_file`) and its canonical `file:` catalog doc (by `path`), but left its **`file-alias:` duplicate catalog docs** (`catalog::duplicate_file_doc`) live. Each alias carries the **duplicate's own `path`**, not the canonical `entry.path`, so the `path` term missed them — an excluded file's alternate path/filename stayed searchable in the catalog. (Metadata residue only: the content records were already swept by #589, so no document content was exposed.)

## Fix
Both the main `file:` doc and every `file-alias:` doc carry **`file_key`** (`catalog.rs`). A content group is classified excluded **only when no surviving file bears its key** — `UnsupportedInventoryDelta::between` skips a group whose key is still in `current_keys` — so deleting catalog docs by `{term:{file_key}}` **cannot strand a still-live byte-identical duplicate**. Added that delete alongside the existing `path` delete; the tested #589 main-doc sweep is left unchanged.

## Test / fail-before
`sweep_excluded_groups_purges_the_excluded_files_alias_catalog_docs`: the excluded file's alias (seeded under a **different** path, `dup.csv`) is swept, while another file's alias (distinct `file_key`) survives (`file_key` is content-scoped — no over-deletion). **Fail-before** (file_key delete reverted): the alias doc survives the canonical-path sweep — the assertion discriminates the fix. The mock `delete_by_query` already handles an arbitrary `{term}` field, so no harness change was needed.

## Verification (rustc 1.97.1)
- `cargo fmt --all --check` → exit 0
- `cargo clippy -p xerj-autoindex --all-targets -- -D warnings` → clean
- `cargo test -p xerj-autoindex` (full suite, ci-test) → **706 lib + integration, 0 failed**

Sibling of #732 (#694, graph edges) — both touch `sweep_excluded_groups` at distinct points; whichever lands second takes a trivial rebase. No `:9200` conformance run touched.