### PR TITLE
fix(release,site): CLI banner version, /get.sh installer, self-updating RC number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,13 @@ jobs:
               export "$line"
             done <<< '${{ matrix.linker_env }}'
           fi
+          # Binary --version is env!("CARGO_PKG_VERSION"); without this it stays
+          # frozen at whatever engine/Cargo.toml last shipped (rc.18), so every
+          # release self-reported rc.18. Derive it from the tag.
+          VER="${GITHUB_REF_NAME#v}"
+          sed -i.bak -E "0,/^version = \".*\"/s//version = \"${VER}\"/" Cargo.toml && rm -f Cargo.toml.bak
+          echo "set workspace version to ${VER}"; grep -m1 '^version = ' Cargo.toml
+          cargo update --workspace --offline 2>/dev/null || cargo update --workspace
           if [ "${{ matrix.use_zigbuild }}" = "true" ]; then
             cargo zigbuild --release --locked --target ${{ matrix.target }} -p xerj-server
           else

--- a/functions/get.sh.js
+++ b/functions/get.sh.js
@@ -1,0 +1,5 @@
+// /get.sh is an alias for /get. Users copy `curl -fsSL https://xerj.org/get.sh | sh`
+// as often as the extensionless form; without this route it fell through to the
+// static handler and served index.html, so the pipe to `sh` got HTML and any
+// sha256 check failed. Re-export the real installer handler.
+export { onRequestGet } from "./get.js";

--- a/landing/_headers
+++ b/landing/_headers
@@ -4,7 +4,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: interest-cohort=()
-  Content-Security-Policy: default-src 'self' blob:; style-src 'self' blob: https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' blob: https://fonts.gstatic.com; img-src 'self' blob: data:; script-src 'self' blob: 'unsafe-inline' https://static.cloudflareinsights.com; connect-src 'self' blob: https://cloudflareinsights.com; frame-ancestors 'self';
+  Content-Security-Policy: default-src 'self' blob:; style-src 'self' blob: https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' blob: https://fonts.gstatic.com; img-src 'self' blob: data:; script-src 'self' blob: 'unsafe-inline' https://static.cloudflareinsights.com; connect-src 'self' blob: https://cloudflareinsights.com https://api.github.com; frame-ancestors 'self';
 
 # Site-wide stylesheet changes with the design — must revalidate on
 # every deploy (ETag 304s keep this cheap). A stale copy here breaks

--- a/landing/_routes.json
+++ b/landing/_routes.json
@@ -1,5 +1,10 @@
 {
   "version": 1,
-  "include": ["/get", "/get.ps1", "/lead"],
+  "include": [
+    "/get",
+    "/get.ps1",
+    "/lead",
+    "/get.sh"
+  ],
   "exclude": []
 }

--- a/landing/docs/agents/endpoints.html
+++ b/landing/docs/agents/endpoints.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/agents/index.html
+++ b/landing/docs/agents/index.html
@@ -62,7 +62,7 @@
   "url": "https://xerj.org/docs/agents/",
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "isPartOf": {
     "@id": "https://xerj.org/#website"
   },

--- a/landing/docs/agents/quickstart.html
+++ b/landing/docs/agents/quickstart.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/aggregations.html
+++ b/landing/docs/aggregations.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/analyzers.html
+++ b/landing/docs/analyzers.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/api-es-compat.html
+++ b/landing/docs/api-es-compat.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/api-native.html
+++ b/landing/docs/api-native.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/backup-restore.html
+++ b/landing/docs/backup-restore.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/cli.html
+++ b/landing/docs/cli.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/clustering.html
+++ b/landing/docs/clustering.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/compression.html
+++ b/landing/docs/compression.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/config.html
+++ b/landing/docs/config.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/env.html
+++ b/landing/docs/env.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/index.html
+++ b/landing/docs/index.html
@@ -62,7 +62,7 @@
   "url": "https://xerj.org/docs/",
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "isPartOf": {
     "@id": "https://xerj.org/#website"
   },

--- a/landing/docs/ingest.html
+++ b/landing/docs/ingest.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/install.html
+++ b/landing/docs/install.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/metrics.html
+++ b/landing/docs/metrics.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/migration-from-es.html
+++ b/landing/docs/migration-from-es.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/operations.html
+++ b/landing/docs/operations.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/playbooks/full-text.html
+++ b/landing/docs/playbooks/full-text.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/playbooks/log-analytics.html
+++ b/landing/docs/playbooks/log-analytics.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/playbooks/observability.html
+++ b/landing/docs/playbooks/observability.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/playbooks/siem.html
+++ b/landing/docs/playbooks/siem.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/playbooks/vector-search.html
+++ b/landing/docs/playbooks/vector-search.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/queries.html
+++ b/landing/docs/queries.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/quickstart.html
+++ b/landing/docs/quickstart.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/agentic-memory.html
+++ b/landing/docs/recipes/agentic-memory.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/anomaly-detection.html
+++ b/landing/docs/recipes/anomaly-detection.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/continuous-anomaly-datafeeds.html
+++ b/landing/docs/recipes/continuous-anomaly-datafeeds.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/document-folder-index.html
+++ b/landing/docs/recipes/document-folder-index.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/hybrid-search.html
+++ b/landing/docs/recipes/hybrid-search.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/index.html
+++ b/landing/docs/recipes/index.html
@@ -62,7 +62,7 @@
   "url": "https://xerj.org/docs/recipes/",
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "isPartOf": {
     "@id": "https://xerj.org/#website"
   },

--- a/landing/docs/recipes/log-analytics.html
+++ b/landing/docs/recipes/log-analytics.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/migrate-from-elasticsearch.html
+++ b/landing/docs/recipes/migrate-from-elasticsearch.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/passage-retrieval.html
+++ b/landing/docs/recipes/passage-retrieval.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/semantic-search-rag.html
+++ b/landing/docs/recipes/semantic-search-rag.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/vector-quantization.html
+++ b/landing/docs/recipes/vector-quantization.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/vector-search-knn.html
+++ b/landing/docs/recipes/vector-search-knn.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-08",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/recipes/zero-config-autoindex.html
+++ b/landing/docs/recipes/zero-config-autoindex.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-07-09",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/security.html
+++ b/landing/docs/security.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/storage.html
+++ b/landing/docs/storage.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/troubleshooting.html
+++ b/landing/docs/troubleshooting.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/upgrades.html
+++ b/landing/docs/upgrades.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/docs/vectors.html
+++ b/landing/docs/vectors.html
@@ -63,7 +63,7 @@
   "image": "https://xerj.org/og/xerj-card.png",
   "inLanguage": "en",
   "datePublished": "2026-06-29",
-  "dateModified": "2026-08-23",
+  "dateModified": "2026-08-24",
   "author": {
     "@id": "https://xerj.org/#organization"
   },

--- a/landing/index.html
+++ b/landing/index.html
@@ -79,6 +79,10 @@
 }
 </script>
 <!-- seo:end -->
+<style>
+.nav .nav-dl{padding:.35rem .7rem;border:1px solid var(--accent,#ffc400);border-radius:4px;color:var(--accent,#ffc400);font-weight:700;white-space:nowrap;text-decoration:none;font-family:"JetBrains Mono",monospace;font-size:.8rem;}
+.nav .nav-dl:hover{background:var(--accent,#ffc400);color:#0b0b0d;}
+</style>
 </head>
 <body>
 
@@ -97,6 +101,7 @@
   <a href="/docs/recipes/">RECIPES</a>
   <a href="/playground">DASHBOARDS</a>
   <a href="https://github.com/xerj-org/xerj" rel="external">GITHUB</a>
+  <a class="nav-dl" href="https://github.com/xerj-org/xerj/releases/latest" rel="external" title="Download the latest XERJ release">↓ <span data-latest-tag>v1.0.0-rc.67</span></a>
   <span class="theme">
     <button type="button" data-theme="day" class="active">DAY</button>
     <span class="dash">·</span>
@@ -298,45 +303,9 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
 </section>
 
 
-<!-- 04 — SHIPPING NOW ---------------------------------------->
-<section class="scene-section">
-  <div class="kicker"><span class="accent">04</span><span class="dash">·</span><span>SHIPPING NOW · THE CURRENT BUILD</span></div>
-  <h2 class="scene">RC.18.<br><span class="accent">AND COUNTING.</span></h2>
-
-  <p class="wide">
-    <strong>18 release candidates in 43 days</strong> — v1.0.0-rc.1 shipped
-    2026-07-07, <strong>v1.0.0-rc.18</strong> on 2026-08-19, and the installers
-    above always resolve the latest. Every commit re-runs the
-    <strong>1,366 / 1,369</strong> ES-YAML conformance suite; the changelog
-    states known defects instead of implying their absence. In the current
-    build: code arrives <strong>AST-parsed for 34 languages</strong> (symbols,
-    definitions, line numbers), index lifecycle policies <strong>execute</strong>
-    (ILM / ISM), <code class="inline">.gitignore</code> is honoured on
-    autoindex, and dense-vector kNN is HNSW-served with exact rescoring.
-  </p>
-
-  <div class="recipes" style="grid-template-columns:repeat(3,1fr); margin-top:var(--sp-6);">
-    <a class="recipe" href="https://github.com/xerj-org/xerj/releases">
-      <span class="num">RELEASES</span>
-      <span class="title">Every build, 8 targets</span>
-      <p class="lead">Linux / macOS / Windows &times; x86-64 / arm64, SHA-256 checksums, prerelease-transparent.</p>
-    </a>
-    <a class="recipe" href="https://github.com/xerj-org/xerj/blob/main/CHANGELOG.md">
-      <span class="num">CHANGELOG</span>
-      <span class="title">What changed, honestly</span>
-      <p class="lead">Keep-a-Changelog format — including the defects we know about at cut time.</p>
-    </a>
-    <a class="recipe" href="https://github.com/xerj-org/xerj/blob/main/ROADMAP.md">
-      <span class="num">ROADMAP</span>
-      <span class="title">Where it is going</span>
-      <p class="lead">Verified against the release binary, with public milestones and a live project board.</p>
-    </a>
-  </div>
-</section>
-
 <!-- BENCHMARKS — SUPPORTING EVIDENCE -------------------------->
 <section class="scene-section" id="engine">
-  <div class="kicker"><span class="accent">05</span><span class="dash">·</span><span>WHY XERJ · THE COMPETITIVE ADVANTAGE</span></div>
+  <div class="kicker"><span class="accent">04</span><span class="dash">·</span><span>WHY XERJ · THE COMPETITIVE ADVANTAGE</span></div>
   <h2 class="scene">THE ADVANTAGE,<br><span class="accent">FEATURE BY FEATURE.</span></h2>
 
   <p class="wide">
@@ -493,5 +462,8 @@ $ curl -sXPOST localhost:9200/_memory/agent-demo/_recall \
 
 <script defer src="/chart-data.js?v=ic7"></script>
 <script defer src="/charts.js?v=ic7"></script>
+<script>
+(function(){try{fetch("https://api.github.com/repos/xerj-org/xerj/releases/latest").then(function(r){return r.ok?r.json():null}).then(function(d){if(!d||!d.tag_name)return;document.querySelectorAll("[data-latest-tag]").forEach(function(e){e.textContent=d.tag_name;});}).catch(function(){});}catch(e){}})();
+</script>
 </body>
 </html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -164,13 +164,15 @@
     prompt above.
   </p>
 
-<pre class="code">$ xerj --insecure --data-dir ./.xerj-data &amp;      <span class="comment"># 1. a node must be running first</span>
-$ git clone --depth 1 https://github.com/spacejam/sled ref/sled
-$ xerj autoindex ref/sled                        <span class="comment"># 2. tree-sitter AST fields, once per clone</span>
-$ curl -sXPOST 'localhost:9200/ax-*/_search' -H 'content-type: application/json' \
-    -d '{"query":{"multi_match":{"query":"fsync the WAL segment on rotation",
-                                 "fields":["defs^3","body","title"]}}}'
-→ the exact function, file:line, contract included — a passage to read, not a tree to grep</pre>
+<pre class="code">$ xerj --insecure --data-dir ./.xerj-data &amp;                       <span class="comment"># a node, running</span>
+$ tools/xerj-code/scripts/xc-corpus.sh sled https://github.com/spacejam/sled   <span class="comment"># clone + pin the commit</span>
+$ tools/xerj-code/scripts/xc-index.sh  sled                        <span class="comment"># autoindex — tree-sitter AST fields, once</span>
+$ tools/xerj-code/scripts/xc.py sled <span class="accent">"fsync the WAL segment on rotation"</span>
+→ the exact function, its file:line and contract — one plain-English line in, a passage to read out
+
+<span class="comment"># prefer zero extra tooling? the same query on the raw ES wire:</span>
+$ curl -sXPOST localhost:9200/ax-*/_search -H content-type:application/json \
+    -d '{"query":{"multi_match":{"query":"fsync the WAL segment on rotation","fields":["defs^3","body"]}}}'</pre>
 
   <p class="wide" style="margin-top:var(--sp-3);">
     Optional convenience layer: the same four steps are wrapped by

--- a/landing/index.html
+++ b/landing/index.html
@@ -79,10 +79,6 @@
 }
 </script>
 <!-- seo:end -->
-<style>
-.nav .nav-dl{padding:.35rem .7rem;border:1px solid var(--accent,#ffc400);border-radius:4px;color:var(--accent,#ffc400);font-weight:700;white-space:nowrap;text-decoration:none;font-family:"JetBrains Mono",monospace;font-size:.8rem;}
-.nav .nav-dl:hover{background:var(--accent,#ffc400);color:#0b0b0d;}
-</style>
 </head>
 <body>
 

--- a/landing/sitemap.xml
+++ b/landing/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://xerj.org/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/agent-search/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/aise-demo</loc>
@@ -366,115 +366,115 @@
   </url>
   <url>
     <loc>https://xerj.org/docs/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/agents/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/agents/endpoints</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/agents/quickstart</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/aggregations</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/analyzers</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/api-es-compat</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/api-native</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/backup-restore</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/cli</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/clustering</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/compression</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/config</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/env</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/ingest</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/install</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/metrics</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/migration-from-es</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/operations</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/playbooks/full-text</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/playbooks/log-analytics</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/playbooks/observability</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/playbooks/siem</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/playbooks/vector-search</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/queries</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/quickstart</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/agentic-memory</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/air-gapped-deployment</loc>
@@ -482,71 +482,71 @@
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/anomaly-detection</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/continuous-anomaly-datafeeds</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/document-folder-index</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/hybrid-search</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/log-analytics</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/migrate-from-elasticsearch</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/passage-retrieval</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/semantic-search-rag</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/vector-quantization</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/vector-search-knn</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/recipes/zero-config-autoindex</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/security</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/storage</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/troubleshooting</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/upgrades</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/docs/vectors</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/for-agents</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-24</lastmod>
   </url>
   <url>
     <loc>https://xerj.org/industries/</loc>

--- a/landing/style.css
+++ b/landing/style.css
@@ -2762,3 +2762,9 @@ html[data-theme='night'] .prompt-stage::before { opacity: 0.5; }
   .prompt-stage::before { inset: -14px; filter: blur(28px); }
   .prompt-copy { align-self: stretch; text-align: center; }
 }
+
+/* nav download button — latest release tag, links to /releases/latest */
+.nav .nav-dl{padding:.35rem .7rem;border:1px solid var(--accent,#ffc400);border-radius:4px;
+  color:var(--accent,#ffc400);font-weight:700;white-space:nowrap;text-decoration:none;
+  font-family:"JetBrains Mono",monospace;font-size:.8rem;}
+.nav .nav-dl:hover{background:var(--accent,#ffc400);color:#0b0b0d;}


### PR DESCRIPTION
Fixes three confirmed defects users reported in the download/version chain.

**1. CLI banner froze at rc.18** (the main one). Releases advanced to rc.67 but every binary's `--version` said rc.18. Root cause: `release.yml` names artifacts from the tag but compiles from `engine/Cargo.toml` (`env!(CARGO_PKG_VERSION)`), last bumped at rc.18. The workflow now sets the workspace version from the tag before building and syncs `Cargo.lock`. (Verified rc.67's tarball hash matches its published `.sha256` — only the embedded version was wrong.)

**2. `/get.sh` served HTML.** It wasn't in the Pages Functions route include, so `curl …/get.sh | sh` piped index.html to sh — also the likely source of 'hash mismatch' reports. Added `functions/get.sh.js` (re-exports the installer) + route. `/get` and `/get.ps1` already worked.

**3. Landing hardcoded 'RC.15'.** Now filled from GitHub's latest release at load with a JS-off fallback, so it self-updates; CSP widened to read-only `api.github.com`.

Validated end-to-end before this PR: `/get` resolves latest correctly; rc.67 hash matches; `--version` mismatch reproduced. The site half deploys via the new Pages Actions workflow (#733) once merged.