### PR TITLE
fix(release): hotfix the 3 defects #735 merged (version stamp + /get.sh)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,12 +157,26 @@ jobs:
             done <<< '${{ matrix.linker_env }}'
           fi
           # Binary --version is env!("CARGO_PKG_VERSION"); without this it stays
-          # frozen at whatever engine/Cargo.toml last shipped (rc.18), so every
-          # release self-reported rc.18. Derive it from the tag.
-          VER="${GITHUB_REF_NAME#v}"
-          sed -i.bak -E "0,/^version = \".*\"/s//version = \"${VER}\"/" Cargo.toml && rm -f Cargo.toml.bak
-          echo "set workspace version to ${VER}"; grep -m1 '^version = ' Cargo.toml
-          cargo update --workspace --offline 2>/dev/null || cargo update --workspace
+          # frozen at whatever engine/Cargo.toml last shipped (rc.18). Stamp it
+          # from the tag — but ONLY on a v-tag: this matrix also runs on main
+          # pushes / workflow_dispatch as a cross-compile canary, where
+          # GITHUB_REF_NAME is a branch name and `version = "main"` would make
+          # cargo reject the manifest and fail the build.
+          case "${GITHUB_REF_NAME}" in
+            v[0-9]*)
+              VER="${GITHUB_REF_NAME#v}"
+              # perl, not `sed 0,/re/`: the address-0 form is a GNU extension and
+              # the macOS legs run BSD sed, which errors on it and (being non-final
+              # in `sed && rm`) leaves the version unchanged. This rewrites only the
+              # first `version = "..."` line, the [workspace.package] version.
+              perl -0777 -i -pe 's/^version = "[^"]*"/version = "'"$VER"'"/m' Cargo.toml
+              echo "set workspace version to ${VER}"; grep -m1 '^version = ' Cargo.toml
+              cargo update --workspace --offline 2>/dev/null || cargo update --workspace
+              ;;
+            *)
+              echo "ref ${GITHUB_REF_NAME} is not a version tag; leaving engine/Cargo.toml version as-is (canary build)"
+              ;;
+          esac
           if [ "${{ matrix.use_zigbuild }}" = "true" ]; then
             cargo zigbuild --release --locked --target ${{ matrix.target }} -p xerj-server
           else

--- a/functions/get.js
+++ b/functions/get.js
@@ -112,6 +112,7 @@ function platform(ua) {
 /** Which script this request is for. Anything else is not ours to serve. */
 function scriptFor(pathname) {
   if (pathname === '/get') return 'get';
+  if (pathname === '/get.sh') return 'get'; // alias: same shell installer
   if (pathname === '/get.ps1') return 'get.ps1';
   return null;
 }

--- a/functions/get.sh.js
+++ b/functions/get.sh.js
@@ -2,4 +2,4 @@
 // as often as the extensionless form; without this route it fell through to the
 // static handler and served index.html, so the pipe to `sh` got HTML and any
 // sha256 check failed. Re-export the real installer handler.
-export { onRequestGet } from "./get.js";
+export { onRequestGet, onRequestHead } from "./get.js";


### PR DESCRIPTION
#735 merged at its old head before the rework commit landed (GitHub PR-head webhook lag), so the 3 blocking defects a review caught went to main. Same fix, re-applied.

- release.yml stamped the version on main/dispatch canary runs too (VER=main → cargo rejects → build fails). Gated to v-tags.
- GNU-only `sed 0,/re/` no-opd on the macOS BSD-sed legs → mac binaries shipped rc.18. Replaced with perl.
- `/get.sh` returned 404 (scriptFor never mapped it). Now maps to the installer; get.sh.js re-exports onRequestHead too.

Verified by the 3-skeptic re-review of the original rework (0 blocking); this is the identical diff cherry-picked onto main. Follow-ups: #740 (static /get.sh twin).