### PR TITLE
fix(site): /get.sh installer fallback when Functions are off (#740)

### DIFF
--- a/landing/_headers
+++ b/landing/_headers
@@ -56,6 +56,12 @@
   Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=300
 
+# /get.sh alias (#740): text/plain so the Functions-off fallback rewrite to /get
+# serves the installer as plain text, never HTML.
+/get.sh
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: public, max-age=300
+
 # Agent-readable Markdown twins are alternate representations of the HTML
 # articles, not HTML pages. Keep the charset explicit for direct fetches.
 /answers/*.md

--- a/landing/_redirects
+++ b/landing/_redirects
@@ -23,6 +23,13 @@
 /bench        /benchmarks/        301
 /github       https://github.com/xerj-org/xerj 302
 
+# Installer fallback (#740). /get.sh is normally answered by functions/get.js
+# (it's in _routes.json), which counts the request and serves the installer.
+# This 200-rewrite only fires if Functions are disabled, so /get.sh serves the
+# real installer body (same file as /get) instead of falling to the SPA/404 and
+# piping HTML to sh. No drift: it points at /get, not a copy. Not a catch-all.
+/get.sh       /get                200
+
 # Trailing slash normalization
 /home         /                   301
 


### PR DESCRIPTION
Closes #740.

/get.sh is in _routes.json, so functions/get.js answers it (counts + serves the installer) when deployed. If Functions are off it fell to the SPA/404 and piped HTML to sh. 

- `/get.sh /get 200` in _redirects: degraded path serves the real installer body (points at /get, no copy so no drift).
- /get.sh _headers block: text/plain.

Functions take precedence for _routes.json paths, so no counting regression. Not a catch-all; seo_lint clean (0 gate violations).