### PR TITLE
docs(feedback): report v1.0.0-rc.67 artifact verification

### DIFF
--- a/user-feedback/16-agent-field-reports/2026-08-25-release-artifact-verification.md
+++ b/user-feedback/16-agent-field-reports/2026-08-25-release-artifact-verification.md
@@ -1,0 +1,13 @@
+# Release artifact verification (2026-08-25)
+
+**Agent:** Codex (GPT-5)  ·  **XERJ:** published `v1.0.0-rc.67` reports `xerj v1.0.0-rc.18`  ·  **Platform:** macOS arm64
+
+**Pointed at:** All eight archives in the latest GitHub release; no user corpus was indexed.
+
+**Used it for:** Ran `scripts/verify-release.sh v1.0.0-rc.67`, including the host-native boot, document index, search, and aggregation smoke test.
+
+**Verdict:** The native artifact booted and completed its smoke workflow, and every archive passed checksum and content checks. I would not use this release because every target reports `1.0.0-rc.18` instead of the release tag. Current `main` contains a tag-version stamping step, so I would re-run this verification after the next release.
+
+**Numbers:** `bash scripts/verify-release.sh v1.0.0-rc.67` -> 8 archives checksum-clean; 9 failed checks, all caused by the version mismatch; native smoke operations passed. `cargo build --release -j 32 -p xerj-server` on current `main` -> passed in 6m 41s.
+
+**Filed alongside:** no separate issue; the version-stamping change is already present on current `main`.


### PR DESCRIPTION
Written by an AI coding agent (Codex / GPT-5), run by @Nicolas0315.

Adds the required field report only. It records the reproducible published-artifact version mismatch: every v1.0.0-rc.67 archive reports v1.0.0-rc.18, although archive checks and the host-native smoke workflow passed.

Verified:
- bash scripts/verify-release.sh v1.0.0-rc.67 -> 8 archives present, checksum-clean and unpackable; 9 failures caused by the version mismatch; native boot/index/search/aggregation smoke operations passed.
- cargo build --release -j 32 -p xerj-server on current main -> passed in 6m 41s.
- The committed diff contains one new 13-line Markdown field report and nothing else.

Assumed:
- The current tag-version stamping step will prevent the mismatch on a future tag; that release has not yet been produced.

Not run:
- ES-YAML conformance suite, because this adds no engine code or documentation claim.