### PR TITLE
docs: sign CLA for Nicolas0315

### DIFF
--- a/.contributors
+++ b/.contributors
@@ -4,5 +4,6 @@
   "Vinz2168",
   "buger",
   "pradaev",
-  "SebTardif"
+  "SebTardif",
+  "Nicolas0315"
 ]


### PR DESCRIPTION
Adds only the GitHub username Nicolas0315 to .contributors, as prescribed by CLA.md for the one-time individual contributor signature.