### PR TITLE
fix(autoindex): exclusion sweep invalidates inbound graph edges (#736 sweep half)

### DIFF
--- a/engine/crates/xerj-autoindex/src/detect/mod.rs
+++ b/engine/crates/xerj-autoindex/src/detect/mod.rs
@@ -655,17 +655,22 @@ pub fn ensure_brain_meta(
     Ok(())
 }
 
-/// Soft-invalidate every live edge taught by `rel` (replacement hook, §6.6.3).
-/// Runs BEFORE any of this run's edges for that file are written, so the
-/// `src_file` + no-`invalid_at` query can only match prior-generation edges.
+/// Soft-invalidate every live edge whose keyword `field` equals `value`.
 /// Each pass re-indexes its hits with `invalid_at = expired_at = now` and
 /// refreshes, so repeat-until-empty converges; the pass bound turns a broken
-/// endpoint into an error instead of an infinite loop.
-pub fn invalidate_prior_edges(es: &Es, edges_index: &str, rel: &str, now_ms: i64) -> Result<u64> {
+/// endpoint into an error instead of an infinite loop. Callers pass `src_file`
+/// (edges a file taught) or `dst` (edges pointing at a file's anchor node).
+pub fn invalidate_edges_by_field(
+    es: &Es,
+    edges_index: &str,
+    field: &str,
+    value: &str,
+    now_ms: i64,
+) -> Result<u64> {
     const MAX_PASSES: usize = 1_000;
     let query = json!({
         "query": {"bool": {
-            "filter": [{"term": {"src_file": rel}}],
+            "filter": [{"term": {field: value}}],
             "must_not": [{"exists": {"field": "invalid_at"}}]
         }},
         "size": 1000,
@@ -715,8 +720,9 @@ pub fn invalidate_prior_edges(es: &Es, edges_index: &str, rel: &str, now_ms: i64
         let outcome = es.bulk(body).context("invalidate prior edges")?;
         if outcome.server_errors > 0 || outcome.item_errors > 0 {
             return Err(anyhow!(
-                "edge invalidation for {} was partial: {}",
-                rel,
+                "edge invalidation for {}={} was partial: {}",
+                field,
+                value,
                 outcome
                     .first_server_error
                     .or(outcome.first_error)
@@ -727,8 +733,15 @@ pub fn invalidate_prior_edges(es: &Es, edges_index: &str, rel: &str, now_ms: i64
         es.refresh(edges_index)?;
     }
     Err(anyhow!(
-        "edge invalidation for {rel} still found live edges after {MAX_PASSES} passes"
+        "edge invalidation for {field}={value} still found live edges after {MAX_PASSES} passes"
     ))
+}
+
+/// Soft-invalidate every live edge a file taught (`src_file` == `rel`). The
+/// replacement hook (§6.6.3): runs before this run rewrites the file's edges,
+/// so it only matches prior generations. Also reused by the exclusion sweep.
+pub fn invalidate_prior_edges(es: &Es, edges_index: &str, rel: &str, now_ms: i64) -> Result<u64> {
+    invalidate_edges_by_field(es, edges_index, "src_file", rel, now_ms)
 }
 
 #[cfg(test)]

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2431,6 +2431,89 @@ fn sweep_excluded_groups_deletes_a_legacy_main_doc_by_id() {
     );
 }
 
+/// #736: the sweep also soft-invalidates INBOUND edges — ones a surviving file
+/// taught that point AT the excluded file's anchor node (`dst`). Without it they
+/// stay live, pointing at a node that is gone. An edge to a different node stays
+/// live. Fail-before: with the dst-side invalidation reverted, the inbound edge
+/// keeps no `invalid_at`.
+#[test]
+fn sweep_excluded_groups_invalidates_inbound_edges() {
+    let ep = HttpEndpoint::start();
+    let edges = ".xerj-memory-testbrain-edges";
+    // The excluded file anchors in dataset slug "ds"; edges point at this id.
+    let anchor = crate::ids::doc_id("ds", "key-excluded", "file");
+
+    {
+        let mut st = ep.state.lock().unwrap();
+        st.saw_dataset_mapping_update = true;
+        st.saw_catalog_mapping_update = true;
+        // A surviving file's edge INTO the excluded file's anchor.
+        st.docs.insert(
+            (edges.to_string(), "edge-inbound".to_string()),
+            json!({"src_file": "survivor.csv", "dst": anchor, "kind": "samedir"}),
+        );
+        // A surviving file's edge to some OTHER node must stay live.
+        st.docs.insert(
+            (edges.to_string(), "edge-other".to_string()),
+            json!({"src_file": "survivor.csv", "dst": "other-node-id", "kind": "samedir"}),
+        );
+    }
+
+    let es = Es::with_bulk_timeout(&ep.url, None, 30).expect("es client");
+    let mut plan = Plan::default();
+    plan.datasets.push(crate::state::PlanDataset {
+        slug: "ds".into(),
+        index: "incremental-http-ds".into(),
+        family: "csv".into(),
+        group: None,
+        specs: Vec::new(),
+        time_field: None,
+        semantic_field: None,
+        sampled_records: 1,
+        file_count: 1,
+    });
+    // plan.files carries the excluded file's slug so the dst anchor resolves.
+    plan.files.insert(
+        "key-excluded".to_string(),
+        crate::state::FileAssignment {
+            rel: "secret.csv".into(),
+            path_id: String::new(),
+            is_symlink: None,
+            family: "csv".into(),
+            gzip: false,
+            content_digest: None,
+            assignments: vec![(None, "ds".into())],
+            as_document: false,
+        },
+    );
+    let excluded = vec![InventoryDeltaEntry {
+        file_key: "key-excluded".into(),
+        path: "secret.csv".into(),
+    }];
+
+    let now_ms = 1_724_500_000_000i64;
+    sweep_excluded_groups(&es, "ax", &plan, &excluded, Some(edges), now_ms).expect("sweep");
+
+    let st = ep.state.lock().unwrap();
+    let inbound = st
+        .docs
+        .get(&(edges.to_string(), "edge-inbound".to_string()))
+        .expect("inbound edge present (soft-invalidated, not deleted)");
+    assert_eq!(
+        inbound.get("invalid_at").and_then(Value::as_i64),
+        Some(now_ms),
+        "#736: an inbound edge to the excluded file's anchor must be invalidated"
+    );
+    let other = st
+        .docs
+        .get(&(edges.to_string(), "edge-other".to_string()))
+        .expect("other edge present");
+    assert!(
+        other.get("invalid_at").is_none(),
+        "#736: an edge to a different node must NOT be invalidated"
+    );
+}
+
 /// #585 (case 1): a pending (uncommitted) `--no-graph` generation must NOT be
 /// resumed and committed on the default graph path — doing so silently commits
 /// a no-graph generation under a graph authority (the #584 hazard, but for a

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3249,6 +3249,26 @@ fn sweep_excluded_groups(
         if let Some(edges) = edges_index {
             detect::invalidate_prior_edges(es, edges, &entry.path, now_ms)
                 .with_context(|| format!("sweep graph edges for newly-excluded {}", entry.path))?;
+            // #736: also soft-invalidate INBOUND edges — ones a surviving file
+            // taught that point AT this now-removed file's anchor node. Without
+            // this they stay live, pointing at a `dst` whose node is gone. The
+            // edge's `dst` is the target file's anchor doc id
+            // `ids::doc_id(slug, file_key, "file")`; a file can anchor in more
+            // than one dataset, so invalidate for every slug the frozen plan
+            // assigned it. Same soft-invalidate as the src side (bi-temporal).
+            if let Some(fa) = plan.files.get(&entry.file_key) {
+                for (_, slug) in &fa.assignments {
+                    let anchor =
+                        crate::ids::doc_id(slug, &entry.file_key, detect::FILE_CARD_LOCATOR);
+                    detect::invalidate_edges_by_field(es, edges, "dst", &anchor, now_ms)
+                        .with_context(|| {
+                            format!(
+                                "sweep inbound graph edges for newly-excluded {}",
+                                entry.path
+                            )
+                        })?;
+                }
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
Addresses the exclusion-sweep half of #736.

`sweep_excluded_groups` invalidated only the edges a removed file **taught** (`src_file`). Edges a surviving file taught that point **at** the removed file's anchor node (`dst`) stayed live, dangling at a node that is gone. Now also soft-invalidate those.

The edge `dst` is the target file's anchor doc id `ids::doc_id(slug, file_key, "file")`, computed from the frozen plan's slug(s) for the excluded key (a file can anchor in several datasets). Same bi-temporal soft-invalidate as the src side — **no edge schema change** (`dst` is already a keyword).

Refactored `invalidate_prior_edges` → `invalidate_edges_by_field(field, value)`; `invalidate_prior_edges` is now a `src_file` wrapper, byte-identical for the replacement + #694 callers.

## Test
`sweep_excluded_groups_invalidates_inbound_edges`: an inbound edge to the excluded anchor is invalidated, an edge to another node stays live. Fail-before proven (dst-side reverted → inbound edge keeps no `invalid_at`). Full xerj-autoindex suite 711/0, fmt/clippy clean, rustc 1.97.1.

The replacement-invalidation dst-side (a file whose content changed, old anchor orphaned) is a separate code path, so **#736 stays open** for it.