### PR TITLE
fix(engine): fold the proxy endpoint into the embedder identity (#533)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -29033,6 +29033,15 @@ const EMBEDDING_IDENTITY_FILE: &str = "embedding_identity.json";
 /// proxy endpoint or neural model — which is the half a mode check cannot see.
 const EMBEDDING_EXECUTION_FILE: &str = "embedding_execution.json";
 
+/// On-disk record version for `embedding_execution.json`. Distinct from the
+/// wire `EmbeddingExecutionIdentity.version` (the API contract, pinned == 1 by
+/// the autoindex client). Bumped to 2 by #533: the proxy identity_sha256 now
+/// folds in the endpoint, so a v1 record's hash was produced by a different
+/// algorithm — `validate_embedding_execution` treats a version delta as
+/// "unknown" (grandfather + re-record), never a mismatch, so upgrading does not
+/// brick a populated proxy index; a later change under v2 is still detected.
+const PERSISTED_EMBEDDING_EXECUTION_VERSION: u32 = 2;
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct PersistedEmbeddingExecution {
     version: u32,
@@ -29239,11 +29248,13 @@ pub(crate) fn embedding_execution_identity(
     };
     let canonical = format!("{CONTRACT};backend={backend};{material}");
     Ok(crate::engine::EmbeddingExecutionIdentity {
-        // #533: v2 folds the proxy endpoint into the identity material. A
-        // persisted v1 record is grandfathered by `validate_embedding_execution`
-        // (a version delta is treated as "unknown", not a mismatch) so upgrading
-        // does not brick an already-populated proxy index.
-        version: 2,
+        // This is the WIRE/API version the autoindex client pins on
+        // (esclient.rs requires == 1); it is NOT the on-disk migration marker.
+        // #533 folds the proxy endpoint into `material` (moving identity_sha256)
+        // without changing this contract; the on-disk record version is bumped
+        // separately (PERSISTED_EMBEDDING_EXECUTION_VERSION) so a populated proxy
+        // index is grandfathered, not bricked, on upgrade.
+        version: 1,
         backend: backend.to_string(),
         identity_sha256: format!("{:x}", Sha256::digest(canonical.as_bytes())),
         dimensions,
@@ -29426,7 +29437,7 @@ fn validate_embedding_execution(
                     path.display()
                 )))
             })?;
-        if persisted.version != current.version {
+        if persisted.version != PERSISTED_EMBEDDING_EXECUTION_VERSION {
             version_upgraded = true;
         } else if persisted.identity_sha256 != current.identity_sha256 && has_documents {
             return Err(EngineError::Common(xerj_common::XerjError::embedding(
@@ -29444,7 +29455,7 @@ fn validate_embedding_execution(
         write_file_atomic(
             &path,
             &serde_json::to_vec_pretty(&PersistedEmbeddingExecution {
-                version: current.version,
+                version: PERSISTED_EMBEDDING_EXECUTION_VERSION,
                 backend: current.backend.clone(),
                 identity_sha256: current.identity_sha256.clone(),
             })?,

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -29422,12 +29422,16 @@ fn validate_embedding_execution(
 ) -> Result<()> {
     let path = index_dir.join(EMBEDDING_EXECUTION_FILE);
     let current = embedding_execution_identity(cfg)?;
-    // #533: when the persisted record is from an OLDER identity version, the
-    // `identity_sha256` was computed by a different algorithm (e.g. v1 hashed a
-    // proxy without its endpoint), so a hash delta can't be told apart from a
-    // real embedder change. Grandfather it once — do not refuse — and re-record
-    // at the current version below, so a LATER change under the new algorithm is
-    // detected. Only a SAME-version hash delta is a genuine embedder change.
+    // #533 migration guard. A genuine embedder change over a POPULATED index is
+    // refused. Two signals:
+    //  - a backend-NAME change (e.g. lexical -> proxy) is unambiguous at ANY
+    //    version — no hash comparison needed, so it is refused even across a
+    //    version bump;
+    //  - a hash delta is a real change only WITHIN the same on-disk version.
+    //    Across an OLDER record the hash was produced by a different algorithm
+    //    (v1 hashed a proxy without its endpoint), so it can't be compared and
+    //    is grandfathered — the record is then re-recorded at the current
+    //    version below, so a LATER change under v2 is still detected.
     let mut version_upgraded = false;
     if path.exists() {
         let persisted: PersistedEmbeddingExecution = serde_json::from_slice(&std::fs::read(&path)?)
@@ -29437,9 +29441,11 @@ fn validate_embedding_execution(
                     path.display()
                 )))
             })?;
-        if persisted.version != PERSISTED_EMBEDDING_EXECUTION_VERSION {
-            version_upgraded = true;
-        } else if persisted.identity_sha256 != current.identity_sha256 && has_documents {
+        let older_record = persisted.version < PERSISTED_EMBEDDING_EXECUTION_VERSION;
+        let genuine_change = has_documents
+            && (persisted.backend != current.backend
+                || (!older_record && persisted.identity_sha256 != current.identity_sha256));
+        if genuine_change {
             return Err(EngineError::Common(xerj_common::XerjError::embedding(
                 format!(
                     "index {} holds vectors produced by embedding backend {:?} but this server resolves embedding.mode={:?} to backend {:?}. Query vectors from one embedder scored against document vectors from another are silently wrong rather than visibly wrong: the widths can agree, so no dimension check fires, and the scores stay plausible while the ranking degrades toward noise. Restore the previous embedding configuration, or reindex into a new index under this one.",
@@ -29450,6 +29456,7 @@ fn validate_embedding_execution(
                 ),
             )));
         }
+        version_upgraded = older_record;
     }
     if new_index || !has_documents || version_upgraded {
         write_file_atomic(
@@ -29744,6 +29751,39 @@ mod embedding_identity_tests {
         };
         validate_embedding_execution(index_dir, &swapped, false, true)
             .expect_err("#533: after re-baselining, a v2 endpoint change must be refused");
+    }
+
+    /// #533: the version-delta grandfather must NOT mask a genuine BACKEND change
+    /// — a lexical->proxy swap is a different embedder regardless of hash, so a
+    /// populated index whose v1 record names a different backend is still refused
+    /// on the first upgraded reopen (the hash is uncomparable across versions,
+    /// but the backend name is not).
+    #[test]
+    fn a_version_delta_still_refuses_a_backend_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path();
+        let path = index_dir.join(EMBEDDING_EXECUTION_FILE);
+        // Legacy v1 record: the index holds LEXICAL vectors.
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&PersistedEmbeddingExecution {
+                version: 1,
+                backend: "lexical".into(),
+                identity_sha256: "legacy-lexical-sha".into(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        // Reopen the POPULATED index under a proxy config → backend "proxy".
+        let proxy = xerj_common::config::EmbeddingConfig {
+            mode: "proxy".into(),
+            default_endpoint: "https://a.example/v1".into(),
+            default_model: "text-embedding-x".into(),
+            ..Default::default()
+        };
+        validate_embedding_execution(index_dir, &proxy, false, true).expect_err(
+            "#533: a version delta must NOT grandfather a lexical->proxy backend change",
+        );
     }
 
     #[cfg(feature = "onnx-experimental")]

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -29219,7 +29219,15 @@ pub(crate) fn embedding_execution_identity(
             None,
         ),
         "proxy" => (
-            format!("proxy-unpinned.v1;configured-model={}", cfg.default_model),
+            // #533: the endpoint is part of the embedder identity — the same
+            // model name behind a different `default_endpoint` is a DIFFERENT
+            // embedder, and omitting it let the endpoint change silently past the
+            // #434 guard (a missed detection). `api_key` is deliberately left out
+            // (a rotated key over the same endpoint+model is the same embedder).
+            format!(
+                "proxy-unpinned.v1;configured-model={};endpoint={}",
+                cfg.default_model, cfg.default_endpoint
+            ),
             false,
             Some(
                 "the remote provider does not attest immutable model assets; semantic resume is unsafe"
@@ -29231,7 +29239,11 @@ pub(crate) fn embedding_execution_identity(
     };
     let canonical = format!("{CONTRACT};backend={backend};{material}");
     Ok(crate::engine::EmbeddingExecutionIdentity {
-        version: 1,
+        // #533: v2 folds the proxy endpoint into the identity material. A
+        // persisted v1 record is grandfathered by `validate_embedding_execution`
+        // (a version delta is treated as "unknown", not a mismatch) so upgrading
+        // does not brick an already-populated proxy index.
+        version: 2,
         backend: backend.to_string(),
         identity_sha256: format!("{:x}", Sha256::digest(canonical.as_bytes())),
         dimensions,
@@ -29399,6 +29411,13 @@ fn validate_embedding_execution(
 ) -> Result<()> {
     let path = index_dir.join(EMBEDDING_EXECUTION_FILE);
     let current = embedding_execution_identity(cfg)?;
+    // #533: when the persisted record is from an OLDER identity version, the
+    // `identity_sha256` was computed by a different algorithm (e.g. v1 hashed a
+    // proxy without its endpoint), so a hash delta can't be told apart from a
+    // real embedder change. Grandfather it once — do not refuse — and re-record
+    // at the current version below, so a LATER change under the new algorithm is
+    // detected. Only a SAME-version hash delta is a genuine embedder change.
+    let mut version_upgraded = false;
     if path.exists() {
         let persisted: PersistedEmbeddingExecution = serde_json::from_slice(&std::fs::read(&path)?)
             .map_err(|e| {
@@ -29407,7 +29426,9 @@ fn validate_embedding_execution(
                     path.display()
                 )))
             })?;
-        if persisted.identity_sha256 != current.identity_sha256 && has_documents {
+        if persisted.version != current.version {
+            version_upgraded = true;
+        } else if persisted.identity_sha256 != current.identity_sha256 && has_documents {
             return Err(EngineError::Common(xerj_common::XerjError::embedding(
                 format!(
                     "index {} holds vectors produced by embedding backend {:?} but this server resolves embedding.mode={:?} to backend {:?}. Query vectors from one embedder scored against document vectors from another are silently wrong rather than visibly wrong: the widths can agree, so no dimension check fires, and the scores stay plausible while the ranking degrades toward noise. Restore the previous embedding configuration, or reindex into a new index under this one.",
@@ -29419,11 +29440,11 @@ fn validate_embedding_execution(
             )));
         }
     }
-    if new_index || !has_documents {
+    if new_index || !has_documents || version_upgraded {
         write_file_atomic(
             &path,
             &serde_json::to_vec_pretty(&PersistedEmbeddingExecution {
-                version: 1,
+                version: current.version,
                 backend: current.backend.clone(),
                 identity_sha256: current.identity_sha256.clone(),
             })?,
@@ -29627,6 +29648,91 @@ mod embedding_identity_tests {
         };
         validate_embedding_execution(index_dir, &proxy_without_endpoint, false, true)
             .expect("a proxy that falls back to lexical must not be refused");
+    }
+
+    /// #533: the proxy `default_endpoint` is part of the embedder identity. Same
+    /// model behind a different endpoint is a different embedder; before this it
+    /// slipped past the #434 guard (a missed detection).
+    #[test]
+    fn proxy_endpoint_is_part_of_the_execution_identity() {
+        let a = xerj_common::config::EmbeddingConfig {
+            mode: "proxy".into(),
+            default_endpoint: "https://a.example/v1".into(),
+            default_model: "text-embedding-x".into(),
+            ..Default::default()
+        };
+        let b = xerj_common::config::EmbeddingConfig {
+            default_endpoint: "https://b.example/v1".into(),
+            ..a.clone()
+        };
+        let id_a = embedding_execution_identity(&a).unwrap();
+        let id_b = embedding_execution_identity(&b).unwrap();
+        assert_eq!(id_a.backend, "proxy");
+        assert_ne!(
+            id_a.identity_sha256, id_b.identity_sha256,
+            "#533: same model + different endpoint must be distinct identities"
+        );
+
+        // End to end: a populated proxy index reopened under a swapped endpoint
+        // (same identity version, different sha) is refused.
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path();
+        validate_embedding_execution(index_dir, &a, true, false).unwrap();
+        let err = validate_embedding_execution(index_dir, &b, false, true)
+            .expect_err("#533: a swapped proxy endpoint over a populated index must be refused");
+        assert!(format!("{err}").contains("holds vectors produced by embedding backend"));
+    }
+
+    /// #533 migration: a record persisted at version 1 (before the endpoint was
+    /// folded in) must be grandfathered — not refused — on upgrade, then
+    /// re-recorded at the current version so a LATER change IS detected.
+    #[test]
+    fn a_version_1_record_is_grandfathered_then_rebaselined() {
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path();
+        let path = index_dir.join(EMBEDDING_EXECUTION_FILE);
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&PersistedEmbeddingExecution {
+                version: 1,
+                backend: "proxy".into(),
+                identity_sha256: "legacy-v1-sha-without-endpoint".into(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let proxy = xerj_common::config::EmbeddingConfig {
+            mode: "proxy".into(),
+            default_endpoint: "https://a.example/v1".into(),
+            default_model: "text-embedding-x".into(),
+            ..Default::default()
+        };
+        // Populated index, v1 record, v2 current → grandfathered (not refused).
+        validate_embedding_execution(index_dir, &proxy, false, true)
+            .expect("#533: a v1 record must be grandfathered, not refused, on upgrade");
+
+        // Re-baselined to v2 with the current identity.
+        let rewritten: PersistedEmbeddingExecution =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(
+            rewritten.version, 2,
+            "#533: the record must be re-recorded at v2"
+        );
+        assert_eq!(
+            rewritten.identity_sha256,
+            embedding_execution_identity(&proxy)
+                .unwrap()
+                .identity_sha256
+        );
+
+        // After re-baselining, a LATER endpoint change under v2 IS detected.
+        let swapped = xerj_common::config::EmbeddingConfig {
+            default_endpoint: "https://b.example/v1".into(),
+            ..proxy.clone()
+        };
+        validate_embedding_execution(index_dir, &swapped, false, true)
+            .expect_err("#533: after re-baselining, a v2 endpoint change must be refused");
     }
 
     #[cfg(feature = "onnx-experimental")]


### PR DESCRIPTION
Closes #533 (part 2 of #522).

`embedding_execution_identity` for a `proxy` backend hashed the model name but **not** `default_endpoint`, so swapping the proxy endpoint under the same model name did not move `identity_sha256` — a changed embedder the #434 guard fails to detect (a missed detection, not a false refusal). Querying one embedder's vectors against another's is silently wrong.

- Include `default_endpoint` in the proxy identity material (`api_key` stays out — a rotated key over the same endpoint+model is the same embedder).
- **Migration:** this changes the hash for existing proxy indices, so bump the identity version to 2 and grandfather v1 records — `validate_embedding_execution` treats a persisted-vs-current version delta as "unknown" (not a mismatch) and re-records at the current version, so upgrade does not brick a populated proxy index and a **later** endpoint change under v2 is still detected. A same-version hash delta is still a genuine embedder change → refused.

## Tests
- `proxy_endpoint_is_part_of_the_execution_identity`: same model + different endpoint → distinct identity, and a populated proxy index reopened under a swapped endpoint is refused.
- `a_version_1_record_is_grandfathered_then_rebaselined`: a v1 record is not refused on upgrade, is re-recorded at v2, and a later v2 endpoint change IS refused.

Fail-before proven (revert the endpoint fold-in → different endpoints hash identical). Full xerj-engine suite green, fmt/clippy clean, rustc 1.97.1. Unit-level — no `:9200`.