### PR TITLE
fix(ci): resolve the merge before it lands + hoist tree-sitter (#352)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,28 @@ jobs:
         working-directory: engine
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  # #352: #327 (tree-sitter 0.25) and #317 (0.26) were each green on their own
+  # head, but tree-sitter declares `links = "tree-sitter"` so only one version
+  # may exist — the MERGE was a hard resolution failure that took out build,
+  # test, clippy and every release job at once, and stayed red long enough that
+  # ~every open PR inherited it. No gate caught it because each branch resolved
+  # its own head, never the merge. This resolves the merge in a few seconds, no
+  # compile: `actions/checkout` gives refs/pull/N/merge by default on a
+  # pull_request, so this runs against the merged tree. `--locked` also fails on
+  # Cargo.lock drift.
+  workspace-resolves:
+    name: Workspace resolves (links + lockfile)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
+
+      - name: cargo metadata (resolves the merge; fails on a links conflict or lock drift)
+        working-directory: engine
+        run: cargo metadata --locked --format-version 1 >/dev/null
+
   # XERJ's security pitch is "no JVM, so none of the Log4Shell class of supply
   # chain CVEs" — which is only worth anything if somebody is actually watching
   # the 660-odd crates we do depend on. This job is that somebody. It was

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -109,6 +109,13 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 tempfile = "3"
 # Benchmarking
 criterion = { version = "0.5", features = ["html_reports"] }
+# AST parsing. Only tree-sitter CORE is hoisted here: it declares
+# `links = "tree-sitter"`, so two crates pinning different core versions is a
+# hard resolution failure that takes out the whole workspace at once, not a
+# duplicate-dep warning (#352: #327 pinned 0.25, #317 moved to 0.26, and the
+# merge stopped resolving). One pin, one version. Per-crate grammar pins stay
+# local; the `workspace-resolves` CI gate catches any links crate that drifts.
+tree-sitter = "0.26"
 
 [profile.release]
 opt-level = 3

--- a/engine/crates/xerj-autoindex/Cargo.toml
+++ b/engine/crates/xerj-autoindex/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { workspace = true, features = ["blocking"] }
 # Core 0.26: forced by tree-sitter-perl 1.1.2, the only #295 grammar with a
 # hard (`links`) core dep — same story as the c-sharp 0.24→0.25 bump. Every
 # other grammar binds through tree-sitter-language and does not care.
-tree-sitter = "0.26"
+tree-sitter = { workspace = true }
 tree-sitter-python = "0.23"
 tree-sitter-c = "0.23"
 tree-sitter-rust = "0.23"

--- a/engine/crates/xerj-engine/Cargo.toml
+++ b/engine/crates/xerj-engine/Cargo.toml
@@ -54,7 +54,7 @@ rustc-hash = { workspace = true }
 # (`xerj-autoindex/src/extract/code.rs`) — this module re-parses at RESPONSE
 # time rather than depending on that crate (autoindex depends on the engine,
 # not the other way around; a reverse dependency would be circular). ---
-tree-sitter = "0.26"
+tree-sitter = { workspace = true }
 tree-sitter-python = "0.23"
 tree-sitter-c = "0.23"
 tree-sitter-rust = "0.23"


### PR DESCRIPTION
Closes #352.

Two green PRs merged into a tree that would not resolve: #327 pinned tree-sitter 0.25, #317 moved to 0.26, and tree-sitter is a `links` crate so only one version may exist. The merge was a hard resolution failure — build, test, clippy and every release job at once — and no gate caught it because CI only ever resolved each PR head, never the merge.

**New `workspace-resolves` job**: `cargo metadata --locked` against the merge ref (`actions/checkout` gives `refs/pull/N/merge` by default on pull_request). Seconds, no compile. Fails on any `links` conflict or Cargo.lock drift. Verified it catches the exact #352 failure — reintroducing a 0.25 pin gives `cargo metadata` exit 101 with "package tree-sitter links to the native library tree-sitter, but it conflicts...".

**Hoist tree-sitter core** into `[workspace.dependencies]`; both crates use `{ workspace = true }`. Structural belt-and-suspenders so the highest-frequency recurrence can't happen. Behaviour-identical: same version (0.26.12), Cargo.lock unchanged, both crates build.

Grammar pins stay per-crate — the guard covers those if they ever drift. Prevention idea credited to @buger in the #351 review notes.