### PR TITLE
fix(autoindex): #739 - sweep a legacy file-alias: catalog doc by id (alias half)

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2431,6 +2431,77 @@ fn sweep_excluded_groups_deletes_a_legacy_main_doc_by_id() {
     );
 }
 
+/// #739 (alias half): a `file-alias:` catalog doc written by a pre-#737
+/// binary has NO `prefix` field either, so it survives both the #737
+/// prefix-scoped alias sweep AND the #693 term-scoped one on the first
+/// upgraded run — the residual the main-doc fix (#739 above) left open. The
+/// frozen `plan.duplicate_files` still carries the alias's `rel`/`path_id`,
+/// so the sweep can reconstruct its exact `_id` and delete it directly.
+#[test]
+fn sweep_excluded_groups_deletes_a_legacy_alias_doc_by_id() {
+    let ep = HttpEndpoint::start();
+    let legacy_alias_id = catalog::duplicate_file_id("ax", "legacy-key", "alias.csv", "pid1");
+    let sibling_alias_id = catalog::duplicate_file_id("bx", "legacy-key", "alias.csv", "pid1");
+
+    {
+        let mut st = ep.state.lock().unwrap();
+        // Legacy alias docs: no `prefix` field (pre-#737). Corpus "ax"
+        // excludes the canonical file; corpus "bx" holds a same-key alias
+        // under its own (differently prefix-encoded) id.
+        st.docs.insert(
+            (catalog::CATALOG_INDEX.to_string(), legacy_alias_id.clone()),
+            json!({"doc_kind": "file", "path": "alias.csv"}),
+        );
+        st.docs.insert(
+            (catalog::CATALOG_INDEX.to_string(), sibling_alias_id.clone()),
+            json!({"doc_kind": "file", "path": "alias.csv"}),
+        );
+    }
+
+    let es = Es::with_bulk_timeout(&ep.url, None, 30).expect("es client");
+    let mut plan = Plan::default();
+    plan.datasets.push(crate::state::PlanDataset {
+        slug: "ds".into(),
+        index: "incremental-http-ds".into(),
+        family: "csv".into(),
+        group: None,
+        specs: Vec::new(),
+        time_field: None,
+        semantic_field: None,
+        sampled_records: 1,
+        file_count: 1,
+    });
+    plan.duplicate_files.push(crate::state::DuplicateFile {
+        file_key: "legacy-key".into(),
+        rel: "alias.csv".into(),
+        path_id: "pid1".into(),
+        is_symlink: None,
+        duplicate_of: "legacy.csv".into(),
+        bytes: 0,
+    });
+    let excluded = vec![InventoryDeltaEntry {
+        file_key: "legacy-key".into(),
+        path: "legacy.csv".into(),
+    }];
+
+    sweep_excluded_groups(&es, "ax", &plan, &excluded, None, 0).expect("sweep");
+
+    let st = ep.state.lock().unwrap();
+    // ax's legacy alias doc is swept by its reconstructed id, even without a
+    // `prefix` field.
+    assert!(
+        !st.docs
+            .contains_key(&(catalog::CATALOG_INDEX.to_string(), legacy_alias_id)),
+        "#739: the excluding corpus's legacy file-alias: doc must be swept by id"
+    );
+    // The sibling corpus's same-key legacy alias doc survives (different id).
+    assert!(
+        st.docs
+            .contains_key(&(catalog::CATALOG_INDEX.to_string(), sibling_alias_id)),
+        "#739: a sibling corpus's legacy file-alias: doc must NOT be swept"
+    );
+}
+
 /// #736: the sweep also soft-invalidates INBOUND edges — ones a surviving file
 /// taught that point AT the excluded file's anchor node (`dst`). Without it they
 /// stay live, pointing at a node that is gone. An edge to a different node stays

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3231,18 +3231,33 @@ fn sweep_excluded_groups(
         // the first upgraded run. Delete the main `file:` doc by its exact,
         // prefix-encoded `_id` too: it catches legacy and current docs alike and
         // is inherently corpus-scoped (a sibling corpus's id differs), so it
-        // cannot strand or over-delete. (Legacy `file-alias:` ids can't be
-        // reconstructed here without the per-alias path_ids — a smaller residual.)
-        es.delete_by_query(
-            catalog::CATALOG_INDEX,
-            &json!({"ids": {"values": [catalog::file_id(prefix, &entry.file_key)]}}),
-        )
-        .with_context(|| {
-            format!(
-                "sweep catalog file doc by id for newly-excluded {}",
-                entry.path
-            )
-        })?;
+        // cannot strand or over-delete.
+        //
+        // Legacy `file-alias:` docs get the same treatment: `plan` is the
+        // FROZEN plan (the state before this run), so `duplicate_files` still
+        // carries every alias's `rel`/`path_id` for a content group being
+        // excluded now — the same lookup `catalog::duplicate_file_id` needs,
+        // and the same shape `stale_alias_ids` above already reconstructs ids
+        // from elsewhere in this file. Building each alias's exact id closes
+        // the residual the main-doc fix (above) left open: a pre-#737
+        // `file-alias:` doc has no `prefix` either, so it also survives the
+        // #693 term-scoped alias sweep on the first upgraded run.
+        let mut ids = vec![catalog::file_id(prefix, &entry.file_key)];
+        ids.extend(
+            plan.duplicate_files
+                .iter()
+                .filter(|alias| alias.file_key == entry.file_key)
+                .map(|alias| {
+                    catalog::duplicate_file_id(prefix, &alias.file_key, &alias.rel, &alias.path_id)
+                }),
+        );
+        es.delete_by_query(catalog::CATALOG_INDEX, &json!({"ids": {"values": ids}}))
+            .with_context(|| {
+                format!(
+                    "sweep catalog file/alias docs by id for newly-excluded {}",
+                    entry.path
+                )
+            })?;
         // #694: soft-invalidate the edges this file taught. `invalidate_prior_edges`
         // tolerates a not-yet-created edges index (returns 0), so a graph run whose
         // edges index has not been ensured at this point is safe.


### PR DESCRIPTION
Closes #739.

#743 already fixed the "main-doc half": a `file:` catalog doc written by a pre-#737 binary has no `prefix` field, so it survives the #737 prefix-scoped sweep on the first upgraded run — fixed by also deleting it by its exact prefix-encoded `_id`.

The same gap exists on the `file-alias:` side, and was called out explicitly as the residual left open by #743: a pre-#737 alias doc also has no `prefix` field, so it survives both the #737 prefix-scoped delete and the #693 term-scoped alias delete.

## Fix

`sweep_excluded_groups` already receives `prior_plan` (the frozen plan). `Plan.duplicate_files` still carries every alias's `rel`/`path_id` for a content group being excluded now — the exact inputs `catalog::duplicate_file_id` needs to reconstruct an alias's id, the same pattern this file already uses elsewhere (`stale_alias_ids`). This reconstructs each matching alias's id and folds it into the same `ids`-delete the main-doc fix added, so one `delete_by_query` now sweeps the main doc and every legacy alias doc for the excluded file_key.

## Testing

- Added `sweep_excluded_groups_deletes_a_legacy_alias_doc_by_id`, mirroring the existing `sweep_excluded_groups_deletes_a_legacy_main_doc_by_id`: a pre-#737 (no `prefix`) alias doc in the excluding corpus is swept by id, while a sibling corpus's same-key legacy alias doc (different id) survives.
- Fail-before verified: stashed the `lib.rs` fix and confirmed the new test fails; restored and it passes.
- `cargo test -p xerj-autoindex --lib` — 690 passed. The 19 failures present are pre-existing on a clean `main` checkout too (unrelated `failure_resume_http_tests`/`inventory_delta_tests`/`sync_executor` — likely the parallelism flakiness tracked in #751), not introduced by this change.

## Provenance
- [x] Read #739, #743, and the code both touch before writing this fix
- [x] `cargo build -p xerj-autoindex`
- [x] `cargo test -p xerj-autoindex --lib sweep_excluded_groups` — 7/7 passed
- [x] Fail-before verified the new test against the reverted fix
- [x] `cargo test -p xerj-autoindex --lib` — confirmed the 19 failures are pre-existing on `main`, not from this change

Claude-Session: https://claude.ai/code/session_01DgiP3zVSST92nyxLmTkM4h
