### PR TITLE
fix(autoindex): cap section records per file + flag truncation (#381)

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/docx.rs
+++ b/engine/crates/xerj-autoindex/src/extract/docx.rs
@@ -2,7 +2,7 @@
 //! Collects w:t runs, breaks paragraphs on w:p, records Heading-styled
 //! paragraphs as headings. One document record (sectioned at 32KB).
 
-use super::{emit_document, ExtractStats, Sink};
+use super::{emit_document, ExtractStats, Sink, MAX_RECORDS_PER_FILE};
 use anyhow::{Context, Result};
 use quick_xml::events::Event;
 use quick_xml::Reader;
@@ -138,7 +138,14 @@ fn extract_bounded(
                     .unwrap_or_else(|| "untitled".into())
             })
     });
-    emit_document(&title, &headings, body, sink, &mut stats);
+    emit_document(
+        &title,
+        &headings,
+        body,
+        MAX_RECORDS_PER_FILE,
+        sink,
+        &mut stats,
+    );
     Ok(stats)
 }
 

--- a/engine/crates/xerj-autoindex/src/extract/html.rs
+++ b/engine/crates/xerj-autoindex/src/extract/html.rs
@@ -5,7 +5,8 @@
 //! document record {title, headings, body}.
 
 use super::{
-    emit_document, sanitize_field_name, ExtractStats, FieldOrigin, RawRecord, Sink, MAX_WHOLE_FILE,
+    emit_document, sanitize_field_name, ExtractStats, FieldOrigin, RawRecord, Sink,
+    MAX_RECORDS_PER_FILE, MAX_WHOLE_FILE,
 };
 use anyhow::Result;
 use serde_json::{Map, Value};
@@ -92,7 +93,14 @@ pub fn extract(path: &Path, gzip: bool, sink: Sink) -> Result<ExtractStats> {
     } else {
         doc.title.trim().to_string()
     };
-    emit_document(&title, &doc.headings, doc.body.trim(), sink, &mut stats);
+    emit_document(
+        &title,
+        &doc.headings,
+        doc.body.trim(),
+        MAX_RECORDS_PER_FILE,
+        sink,
+        &mut stats,
+    );
     Ok(stats)
 }
 

--- a/engine/crates/xerj-autoindex/src/extract/mod.rs
+++ b/engine/crates/xerj-autoindex/src/extract/mod.rs
@@ -67,6 +67,10 @@ pub struct RawRecord {
 pub struct ExtractStats {
     pub records: u64,
     pub junk: u64,
+    /// Set when a per-file record cap (`MAX_RECORDS_PER_FILE`) stopped the
+    /// split before the whole body was emitted (#381). Carried out so the
+    /// truncation is reported, never silent.
+    pub truncated: bool,
 }
 
 /// Sink returns false to stop extraction early (sampling).
@@ -86,6 +90,18 @@ pub const MAX_WHOLE_FILE: u64 = 64 << 20; // whole-file parse cap (json/html/yam
 /// comfortably inside the 512-token limit of the built-in neural embedder, so
 /// a section maps to one vector without truncation.
 pub const SECTION_CHARS: usize = 2 << 10;
+
+/// Hard cap on section records one file may emit (#381).
+///
+/// A magic-less printable byte payload (a raw texture, a packed `.bytes` asset)
+/// decodes under the text fallback, classifies as prose and is sectioned in
+/// full — one record per `SECTION_CHARS`, so the 16 MiB txt read cap becomes
+/// ~8k noise records with no ceiling of its own. This bounds that; the drop is
+/// surfaced via `ExtractStats.truncated`, so a genuinely large *legitimate*
+/// document is reported and never silently cut. A resource guard keyed off
+/// record count only — never off byte statistics, which is what deleted CJK
+/// text worldwide and was removed in #371.
+pub const MAX_RECORDS_PER_FILE: usize = 4 << 10; // 4096
 
 /// Characters of the previous section repeated at the start of the next, so an
 /// answer spanning a boundary stays retrievable from both sides.
@@ -155,7 +171,14 @@ pub fn extract_as_document_with_name(
         .file_stem()
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| "untitled".into());
-    emit_document(&title, &[], text.trim(), sink, &mut stats);
+    emit_document(
+        &title,
+        &[],
+        text.trim(),
+        MAX_RECORDS_PER_FILE,
+        sink,
+        &mut stats,
+    );
     Ok(stats)
 }
 
@@ -506,6 +529,7 @@ pub fn emit_document(
     title: &str,
     headings: &[String],
     body: &str,
+    max_records: usize,
     sink: Sink,
     stats: &mut ExtractStats,
 ) -> bool {
@@ -518,17 +542,33 @@ pub fn emit_document(
         let Some(prev) = pending.replace(sec) else {
             return true;
         };
+        // #381: bound noise from a misclassified payload. Stopping the split
+        // (not just the sink) also stops paying to section the rest of the body.
+        if next >= max_records {
+            stats.truncated = true;
+            return false;
+        }
         let i = next;
         next += 1;
         stats.records += 1;
         alive = sink(section_record(title, headings, i, true, prev));
         alive
     });
+    // A sink that stopped early (sampling) sets `alive = false`; the cap leaves
+    // it true and sets `truncated` instead. Distinguish so a capped run still
+    // reports success and does NOT emit the over-cap `pending` tail section.
     if !alive {
         return false;
     }
+    if stats.truncated {
+        return true;
+    }
     match pending {
         Some(last) => {
+            if next >= max_records {
+                stats.truncated = true;
+                return true;
+            }
             stats.records += 1;
             sink(section_record(title, headings, next, next > 0, last))
         }
@@ -771,7 +811,14 @@ mod section_tests {
                 got.push((r.locator.clone(), r.fields.contains_key("section")));
                 true
             };
-            assert!(emit_document("t", &[], body, &mut sink, &mut stats));
+            assert!(emit_document(
+                "t",
+                &[],
+                body,
+                MAX_RECORDS_PER_FILE,
+                &mut sink,
+                &mut stats
+            ));
             assert_eq!(stats.records as usize, got.len());
             got
         }
@@ -801,10 +848,61 @@ mod section_tests {
             "t",
             &[],
             &doc(60, 300),
+            MAX_RECORDS_PER_FILE,
             &mut sink,
             &mut stats
         ));
         assert_eq!(got, vec!["s0".to_string(), "s1".to_string()]);
         assert_eq!(stats.records, 2);
+    }
+
+    /// #381: a body that sections into far more chunks than the cap yields
+    /// exactly the cap and REPORTS the truncation — it is never silent.
+    #[test]
+    fn emit_document_caps_records_and_reports_truncation() {
+        let mut got = Vec::new();
+        let mut stats = ExtractStats::default();
+        let mut sink = |r: RawRecord| {
+            got.push(r.locator.clone());
+            true
+        };
+        // doc(60, 300) sections into well more than 3 chunks.
+        assert!(emit_document(
+            "t",
+            &[],
+            &doc(60, 300),
+            3,
+            &mut sink,
+            &mut stats
+        ));
+        assert_eq!(got.len(), 3, "record count must be bounded by the cap");
+        assert_eq!(stats.records, 3);
+        assert!(stats.truncated, "truncation must be reported, not silent");
+    }
+
+    /// A document within the cap indexes in full and is not flagged truncated.
+    #[test]
+    fn emit_document_under_the_cap_is_not_truncated() {
+        let mut n = 0usize;
+        let mut stats = ExtractStats::default();
+        let mut sink = |_r: RawRecord| {
+            n += 1;
+            true
+        };
+        let body = doc(60, 300); // ~9 sections, well under the cap
+        assert!(emit_document(
+            "t",
+            &[],
+            &body,
+            MAX_RECORDS_PER_FILE,
+            &mut sink,
+            &mut stats
+        ));
+        assert!(!stats.truncated);
+        assert_eq!(stats.records as usize, n);
+        assert!(
+            n > 1 && n < MAX_RECORDS_PER_FILE,
+            "sanity: multi-section but under the cap, got {n}"
+        );
     }
 }

--- a/engine/crates/xerj-autoindex/src/extract/txt.rs
+++ b/engine/crates/xerj-autoindex/src/extract/txt.rs
@@ -22,7 +22,7 @@
 //! caller can jump straight to the source — the old per-line record only
 //! carried an opaque byte locator.
 
-use super::{emit_document, ExtractStats, FieldOrigin, RawRecord, Sink};
+use super::{emit_document, ExtractStats, FieldOrigin, RawRecord, Sink, MAX_RECORDS_PER_FILE};
 use anyhow::Result;
 use serde_json::{Map, Value};
 use std::path::Path;
@@ -62,7 +62,14 @@ pub fn extract_prose(path: &Path, gzip: bool, sink: Sink) -> Result<ExtractStats
                 .map(|s| s.to_string_lossy().to_string())
                 .unwrap_or_else(|| "untitled".into())
         });
-    emit_document(&title, &[], text.trim(), sink, &mut stats);
+    emit_document(
+        &title,
+        &[],
+        text.trim(),
+        MAX_RECORDS_PER_FILE,
+        sink,
+        &mut stats,
+    );
     Ok(stats)
 }
 

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -4749,6 +4749,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // Records the backend refused in a bulk response (invocation-local: no
     // journal record exists for a document that was never accepted).
     let rejected_records = AtomicU64::new(0);
+    // Files whose section stream hit the per-file record cap (#381): the tail
+    // was dropped, so it is surfaced after the run rather than silently lost.
+    let truncated_files = AtomicU64::new(0);
     let bulk_errors = Mutex::new(Vec::<String>::new());
     let graph: Option<GraphRt> = if cfg.no_graph {
         None
@@ -5255,6 +5258,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                         match res {
                             Ok(stats) => {
                                 file_junk += stats.junk;
+                                if stats.truncated {
+                                    truncated_files.fetch_add(1, Ordering::Relaxed);
+                                }
                             }
                             Err(e) => {
                                 send_err = Some(format!("extract {}: {e}", f.rel));
@@ -5830,6 +5836,17 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         }});
         cat_buf.extend_from_slice(action.to_string().as_bytes());
         cat_buf.push(b'\n');
+    }
+
+    // #381: the per-file record cap dropped a file's tail. Report it (never
+    // silent) so a genuinely large legitimate document is visible, not guessed.
+    let truncated = truncated_files.load(Ordering::Relaxed);
+    if truncated > 0 {
+        pr.note(&format!(
+            "{truncated} file(s) hit the per-file record cap ({}) and were truncated; \
+             split the input or raise the cap if the dropped tail matters (#381)",
+            extract::MAX_RECORDS_PER_FILE
+        ));
     }
 
     // dataset docs

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -595,6 +595,7 @@ fn finish_generated_progress(pr: &Progress, code: i32, summary: &Value) {
     );
 }
 
+#[allow(clippy::too_many_arguments)] // cutover threads the whole run context
 fn begin_non_graph_generation(
     es: &Es,
     journal: &mut state::Journal,
@@ -602,6 +603,7 @@ fn begin_non_graph_generation(
     cfg: &IndexCfg,
     root_identity: &str,
     inventory: &content::Inventory,
+    pr: &Progress,
     plan: Plan,
 ) -> Result<()> {
     anyhow::ensure!(
@@ -630,6 +632,22 @@ fn begin_non_graph_generation(
         &preparation_contract,
         cfg.snapshot_max_bytes,
     )?;
+    // #381: the per-file record cap dropped a file's tail during preparation.
+    // The generated path seals before the graph worker loop runs, so report it
+    // here rather than at the shared post-run summary.
+    let truncated = snapshot
+        .files
+        .iter()
+        .filter_map(|f| f.prepared.as_ref())
+        .filter(|p| p.truncated)
+        .count();
+    if truncated > 0 {
+        pr.note(&format!(
+            "{truncated} file(s) hit the per-file record cap ({}) and were truncated; \
+             split the input or raise the cap if the dropped tail matters (#381)",
+            extract::MAX_RECORDS_PER_FILE
+        ));
+    }
     let chunker_identity = prepared_records_identity(cfg)?;
     let semantic = plan
         .datasets
@@ -3847,6 +3865,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             &cfg,
             &root_str,
             &inventory,
+            &pr,
             plan,
         )?;
         let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);
@@ -4512,6 +4531,7 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             &cfg,
             &root_str,
             &inventory,
+            &pr,
             plan,
         )?;
         let mut backend = sync_executor::EsSyncBackend::new(&es, &state_dir, cfg.bulk_mb << 20);

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -59,6 +59,12 @@ pub struct PreparedArtifact {
     /// never published, so no read-back count sees it.
     #[serde(default)]
     pub junk: u64,
+    /// The per-file record cap (#381) stopped this file's section stream before
+    /// the whole body was emitted. Skip-serialized when false so a non-truncated
+    /// artifact hashes exactly as before (a truncating file already differs by
+    /// design — it seals fewer records).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
     /// Per-dataset breakdown of `records`, keyed by the dataset each record was
     /// written under. One file can feed several datasets — a SQL dump is one
     /// file and N tables — so the flat total is not comparable to any single
@@ -1645,6 +1651,7 @@ fn prepare_artifact(
         passages,
         vectors,
         junk: stats.junk,
+        truncated: stats.truncated,
         records_by_dataset,
         bytes,
         digest: stream_digest(&path, "axp1")?,


### PR DESCRIPTION
First hunk of #381 (draft — see remaining step below).

A magic-less printable byte payload (a raw texture, a packed `.bytes` asset) decodes under the text fallback, classifies as prose and is sectioned in full — one record per `SECTION_CHARS`, so a large blob expands into thousands of noise records with no ceiling of its own (the `16 MiB` txt read cap alone still allows ~8k).

This caps `emit_document` at `MAX_RECORDS_PER_FILE` (4096, tunable) and sets `ExtractStats.truncated` so the drop is carried out for reporting — never silent. Keyed off record count only, never byte statistics (those deleted CJK text worldwide and were removed in #371).

Verify:
- fail-before: with the cap hunk removed, `emit_document_caps_records_and_reports_truncation` fails (`left: 9, right: 3`).
- fail-after: capped to the limit + `truncated` set; a document under the cap is unchanged and not flagged.
- `cargo test -p xerj-autoindex` 713 passed; clippy `--all-targets -D warnings` clean; both profiles build (1.97.1).

Remaining (why draft): surface `truncated` on the progress meter along the existing `ExtractStats` → sketch → `reconcile_plan` path (the `#378` `shadowed_junk_entries` precedent), so a genuinely large legitimate document reports its truncation to the user. Not mergeable until that lands — a set-but-unsurfaced flag would still be silent.