### PR TITLE
fix(autoindex): #765 warn when XERJ_URL is set but --url was not passed

### DIFF
--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -385,12 +385,38 @@ pub fn help_text_with(feedback: bool) -> String {
     )
 }
 
+/// A startup note for the case where `XERJ_URL` is set but the run did not pass
+/// `--url`. `autoindex` resolves its endpoint from `--url` only (default
+/// `http://localhost:9200`); `XERJ_URL` is honored by `xerj search` but not
+/// here, on purpose, so a stale variable can't silently redirect a write. Silent
+/// is the trap though, so name the mismatch and how to act on it. `None` when
+/// `--url` was passed, or `XERJ_URL` is unset or empty.
+pub(crate) fn xerj_url_ignored_note(xerj_url: Option<&str>, url_explicit: bool) -> Option<String> {
+    if url_explicit {
+        return None;
+    }
+    let value = xerj_url?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "XERJ_URL={value} is set but ignored here: autoindex takes its endpoint from --url only \
+         (default http://localhost:9200). Pass --url {value} to target it."
+    ))
+}
+
 pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
     let mut it = args.into_iter().peekable();
     let mut folder: Option<PathBuf> = None;
     let mut sub: Option<String> = None;
 
     let mut url = "http://localhost:9200".to_string();
+    // `xerj autoindex` takes its endpoint from `--url` ONLY, unlike `xerj
+    // search` which honors `XERJ_URL`. Ignoring the env var here is deliberate:
+    // a write must not be redirected by a stale variable. But silent is a trap
+    // (it cost a multi-session mis-target debug), so we track whether --url was
+    // actually passed and warn when XERJ_URL is set and it was not.
+    let mut url_explicit = false;
     let mut api_key = std::env::var("XERJ_API_KEY").ok().filter(|s| !s.is_empty());
     // Set only when the key was discovered on disk, so output can reference the
     // file instead of echoing the secret.
@@ -431,7 +457,10 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
 
     while let Some(arg) = it.next() {
         match arg.as_str() {
-            "--url" => url = it.next().ok_or("--url needs a value")?,
+            "--url" => {
+                url = it.next().ok_or("--url needs a value")?;
+                url_explicit = true;
+            }
             "--api-key" => api_key = it.next(),
             "--workers" => {
                 // Refused, not clamped: `--workers 0` used to become 1 and
@@ -775,6 +804,12 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
                 );
             }
             let plan = crate::resources::plan(workers, pdf_workers, bulk_mb);
+            let mut resource_notes = plan.notes;
+            if let Some(note) =
+                xerj_url_ignored_note(std::env::var("XERJ_URL").ok().as_deref(), url_explicit)
+            {
+                resource_notes.push(note);
+            }
             Ok(Cmd::Index(Box::new(IndexCfg {
                 root,
                 url,
@@ -783,7 +818,7 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
                 workers: plan.index_workers,
                 scan_workers: plan.scan_threads,
                 pdf_workers: plan.pdf_workers,
-                resource_notes: plan.notes,
+                resource_notes,
                 pdf_timeout_secs,
                 bulk_mb,
                 bulk_timeout_secs,
@@ -921,6 +956,35 @@ mod tests {
 
     fn err(args: &[&str]) -> String {
         parse(args.iter().map(|s| s.to_string()).collect()).expect_err("must be refused")
+    }
+
+    /// `xerj autoindex` reads its endpoint from `--url` only; setting `XERJ_URL`
+    /// (which `xerj search` honors) and forgetting `--url` used to silently hit
+    /// the loopback default with no word to the operator. The note fires exactly
+    /// on that mismatch and nowhere else.
+    #[test]
+    fn xerj_url_ignored_note_fires_only_on_the_mismatch() {
+        use super::xerj_url_ignored_note as note;
+
+        // XERJ_URL set, --url absent: warn, and say what and how.
+        let n = note(Some("http://es.internal:9200"), false)
+            .expect("a set-but-ignored XERJ_URL must be surfaced");
+        assert!(
+            n.contains("http://es.internal:9200") && n.contains("--url") && n.contains("ignored"),
+            "the note must echo the value, name --url, and say it is ignored: {n}"
+        );
+
+        // --url was passed: it wins, no note (env is genuinely irrelevant).
+        assert!(
+            note(Some("http://es.internal:9200"), true).is_none(),
+            "an explicit --url means XERJ_URL was not ignored; no note"
+        );
+        // Nothing set, or set to blank: nothing to warn about.
+        assert!(note(None, false).is_none(), "unset XERJ_URL: no note");
+        assert!(
+            note(Some("   "), false).is_none(),
+            "blank XERJ_URL: no note"
+        );
     }
 
     /// #240 §1/§2: `--workers` capped itself at 8 for no recorded reason and

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -80,6 +80,10 @@ pub struct MapCfg {
     pub prefix: String,
     pub json: bool,
     pub dataset: Option<String>,
+    /// A startup note when `XERJ_URL` was set but ignored (endpoint comes from
+    /// `--url` only). `map` reads the catalog, so a stale var shows the wrong
+    /// node's map without a word — same trap as the index path, read side.
+    pub xerj_url_note: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -88,6 +92,9 @@ pub struct StatusCfg {
     pub api_key: Option<String>,
     pub prefix: String,
     pub state_dir: Option<PathBuf>,
+    /// See [`MapCfg::xerj_url_note`]: `status` queries the same endpoint, so a
+    /// set-but-ignored `XERJ_URL` would report the wrong node's progress.
+    pub xerj_url_note: Option<String>,
 }
 
 #[derive(Debug)]
@@ -749,6 +756,12 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
         }
     }
 
+    // `--url` is the only endpoint source for every subcommand; XERJ_URL is
+    // ignored on purpose (a stale var must not redirect a write). Computed once
+    // so index, map, and status all surface the same mismatch note.
+    let xerj_url_note =
+        xerj_url_ignored_note(std::env::var("XERJ_URL").ok().as_deref(), url_explicit);
+
     match (sub.as_deref(), folder) {
         (Some("map"), _) | (Some("status"), _) if max_minutes_explicit || approve_explicit => {
             Err(format!(
@@ -782,6 +795,7 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
             prefix,
             json,
             dataset,
+            xerj_url_note,
         })),
         (Some("status"), _) if bulk_timeout_explicit => {
             Err("--bulk-timeout-secs applies only to indexing, not `autoindex status`".into())
@@ -791,6 +805,7 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
             api_key,
             prefix,
             state_dir,
+            xerj_url_note,
         })),
         (None, Some(root)) => {
             // A flag that is accepted and does nothing is the shape this repo
@@ -805,9 +820,7 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
             }
             let plan = crate::resources::plan(workers, pdf_workers, bulk_mb);
             let mut resource_notes = plan.notes;
-            if let Some(note) =
-                xerj_url_ignored_note(std::env::var("XERJ_URL").ok().as_deref(), url_explicit)
-            {
+            if let Some(note) = xerj_url_note {
                 resource_notes.push(note);
             }
             Ok(Cmd::Index(Box::new(IndexCfg {

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -6494,6 +6494,9 @@ fn format_str(sn: Option<&Sniffed>) -> String {
 // ─── map subcommand ──────────────────────────────────────────────────────
 
 fn run_map(cfg: MapCfg) -> Result<i32> {
+    if let Some(note) = &cfg.xerj_url_note {
+        eprintln!("autoindex: {note}");
+    }
     let es = Es::new(&cfg.url, cfg.api_key.clone())?;
     es.ping()?;
     let fetch = |query: Value, size: usize, sort: Option<Value>| -> Result<Vec<Value>> {
@@ -6755,6 +6758,9 @@ pub fn fetch_catalog_summary(url: &str, api_key: Option<String>) -> Result<Catal
 // ─── status subcommand ───────────────────────────────────────────────────
 
 fn run_status(cfg: StatusCfg) -> Result<i32> {
+    if let Some(note) = &cfg.xerj_url_note {
+        eprintln!("autoindex: {note}");
+    }
     // journals
     let dirs: Vec<std::path::PathBuf> = match &cfg.state_dir {
         Some(d) => vec![d.clone()],


### PR DESCRIPTION
Closes #765.

`xerj autoindex` resolves its endpoint from `--url` only, defaulting to `http://localhost:9200`. It ignores `XERJ_URL` (which `xerj search` honors) on purpose, so a stale env var can't silently redirect a write. But silent is the trap: setting `XERJ_URL` and forgetting `--url` quietly targeted the loopback default with no word to the operator (this cost a multi-session mis-target debug).

Fix keeps the safety (still `--url` only, env never selects the endpoint) and removes the silence: track whether `--url` was actually passed, and when `XERJ_URL` is set and it was not, surface a startup note that echoes the ignored value and says how to act on it (`Pass --url <value>`).

Covers all three subcommands: `index` rides the existing `resource_notes` channel (prints at run start, also in `--json`); `map` and `status` carry the note on their cfg and print it before they connect (both read the same endpoint, so a stale var shows the wrong node's map/progress too). The note is computed once in `parse()`.

Logic is a pure helper (`xerj_url_ignored_note`), unit-tested across all branches (set+no-url -> note names value/--url/ignored; explicit --url -> none; unset/blank -> none).

Not E2E-run on purpose: the note only fires when `--url` is absent, which by construction targets `:9200`, so exercising it would hit the reference node. Verified via the unit test plus the pre-existing `resource_notes` -> `pr.note` print path.

fmt/clippy(--all-targets -D warnings)/build all green under 1.97.1; full xerj-autoindex suite 722 lib + integration all pass (both dev and ci-test).