### PR TITLE
ci(#751): bound Build+Test hangs (step-6 + job-level timeout) so main isn't stuck for hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,19 @@ jobs:
   build-test:
     name: Build + Test
     runs-on: ubuntu-latest
+    # #751's second-order damage is the whole job hanging against GitHub's 6h
+    # default while main's `cancel-in-progress: false` never auto-cancels — main
+    # then sits ~4h with no CI verdict. The step-6 `timeout-minutes: 12` below
+    # bounds the one documented hang (step 6, default parallelism) precisely and
+    # fast. This job-level cap is defense-in-depth: it bounds ANY hang in the job
+    # (setup, cache, a future test race the step timeout would not cover) to
+    # 50 min instead of the 6h default. It is deliberately generous because
+    # step 5 (build + threads=2 tests) can legitimately take ~36 min on a loaded
+    # 2-4 vCPU runner — a slow compile, not a hang (measured: step 5 built for
+    # ~36 min then step 6 ran and passed) — so a tighter cap would false-fail
+    # slow-but-healthy runs. Neither cap fixes the root race (#751 stays open for
+    # the bisect + port/fixture serialisation).
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,16 @@ jobs:
       #
       # Reuses the binaries the step above already built: the added cost is test
       # runtime, not another compile.
+      # #751: this step intermittently hangs on the 2-4 vCPU hosted runner (a
+      # port/fixture race at low thread count — normal ~2.3 min, observed hanging
+      # 18-28 min). Because main's `cancel-in-progress: false` never auto-cancels,
+      # a hang leaves the whole run stuck for hours with no completed signal, so
+      # main commits never get a CI verdict. Bound it: a hang now fails the step
+      # in 12 min (5x normal, well under the observed hangs) so the run completes
+      # and `gh run rerun --failed` can recover. This does NOT fix the root race —
+      # #751 stays open for the bisect + port/fixture serialisation.
       - name: Workspace tests (all targets) at default parallelism (contributor's `cargo test`)
+        timeout-minutes: 12
         working-directory: engine
         run: cargo test --profile ci-test --workspace
 


### PR DESCRIPTION
Partial fix for #751 (mitigation, not the root fix — issue stays open).

`Build + Test` intermittently hangs on the 2-4 vCPU hosted runner (port/fixture race at low thread count). Because main uses `cancel-in-progress: false` by design, a hung job sits against GitHub's 6h default and leaves main ~4h with no completed CI verdict — the damaging second-order effect the issue calls out.

Two bounds, neither of which fixes the root race:

1. `timeout-minutes: 12` on step 6 (`Workspace tests at default parallelism`) — precise, fast bound for the one documented step-6 hang (normal ~2.3 min, seen 18-28 min).
2. `timeout-minutes: 50` on the whole `build-test` job — defense-in-depth. Bounds ANY hang in the job (setup, cache, a future test race the step timeout would not cover) to 50 min instead of the 6h default. Kept generous on purpose: step 5 (build + threads=2 tests) can legitimately take ~36 min on a loaded runner — a slow compile, not a hang (measured on a recent run: step 5 built ~36 min, then step 6 ran and passed) — so a tighter cap would false-fail slow-but-healthy runs.

Root race still needs the bisect + port/fixture serialisation from the issue, so #751 stays open. YAML validated (both timeouts attach to the right scope; run commands unchanged).