### PR TITLE
fix(autoindex): #768 deliver the XERJ_URL wrong-node warning so --quiet can't silence it

### DIFF
--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -32,6 +32,13 @@ pub struct IndexCfg {
     pub pdf_workers: usize,
     /// What the machine forced on this run, printed once at start-up.
     pub resource_notes: Vec<String>,
+    /// #768: the `XERJ_URL`-ignored safety note (set when `XERJ_URL` is present
+    /// but `--url` was not passed). Carried separately from `resource_notes`
+    /// because it is a safety warning, not routine progress chatter: it is
+    /// emitted with an unconditional `eprintln` (so `--quiet` does not silence a
+    /// "you may be writing to the wrong node" message) and mirrored into the
+    /// `--json` result, matching how `map`/`status` deliver the same note.
+    pub xerj_url_note: Option<String>,
     pub pdf_timeout_secs: u64,
     pub bulk_mb: usize,
     pub bulk_timeout_secs: u64,
@@ -819,10 +826,6 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
                 );
             }
             let plan = crate::resources::plan(workers, pdf_workers, bulk_mb);
-            let mut resource_notes = plan.notes;
-            if let Some(note) = xerj_url_note {
-                resource_notes.push(note);
-            }
             Ok(Cmd::Index(Box::new(IndexCfg {
                 root,
                 url,
@@ -831,7 +834,11 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
                 workers: plan.index_workers,
                 scan_workers: plan.scan_threads,
                 pdf_workers: plan.pdf_workers,
-                resource_notes,
+                resource_notes: plan.notes,
+                // #768: delivered by run_index via unconditional eprintln (not the
+                // --quiet-suppressible resource_notes surface) and mirrored into
+                // --json, so a wrong-node warning is never silently dropped.
+                xerj_url_note,
                 pdf_timeout_secs,
                 bulk_mb,
                 bulk_timeout_secs,
@@ -997,6 +1004,21 @@ mod tests {
         assert!(
             note(Some("   "), false).is_none(),
             "blank XERJ_URL: no note"
+        );
+    }
+
+    /// #768: the index cfg carries the XERJ_URL-ignored note on its own field
+    /// (delivered by an unconditional eprintln, so --quiet cannot silence a
+    /// wrong-node warning) rather than folding it into the --quiet-suppressible
+    /// resource_notes. An explicit --url means the env var was not ignored, so
+    /// there is nothing to warn about — deterministic regardless of the
+    /// environment the test runs in.
+    #[test]
+    fn index_suppresses_the_xerj_url_note_when_url_is_explicit() {
+        let cfg = index(&["data", "--url", "http://es.internal:9200"]);
+        assert!(
+            cfg.xerj_url_note.is_none(),
+            "an explicit --url means XERJ_URL was not ignored; no note"
         );
     }
 

--- a/engine/crates/xerj-autoindex/src/cli.rs
+++ b/engine/crates/xerj-autoindex/src/cli.rs
@@ -34,10 +34,11 @@ pub struct IndexCfg {
     pub resource_notes: Vec<String>,
     /// #768: the `XERJ_URL`-ignored safety note (set when `XERJ_URL` is present
     /// but `--url` was not passed). Carried separately from `resource_notes`
-    /// because it is a safety warning, not routine progress chatter: it is
-    /// emitted with an unconditional `eprintln` (so `--quiet` does not silence a
-    /// "you may be writing to the wrong node" message) and mirrored into the
-    /// `--json` result, matching how `map`/`status` deliver the same note.
+    /// because it is a safety warning, not routine progress chatter: the index
+    /// path emits it through `pr.warn` (which, unlike `pr.note`, is not silenced
+    /// by `--quiet`/`Surface::Silent`, yet stays a well-formed event on
+    /// `--progress json`) and mirrors it into the `--json` result. `map`/`status`
+    /// carry the same note but `eprintln` it, having no progress surface.
     pub xerj_url_note: Option<String>,
     pub pdf_timeout_secs: u64,
     pub bulk_mb: usize,
@@ -835,9 +836,10 @@ pub fn parse(args: Vec<String>) -> Result<Cmd, String> {
                 scan_workers: plan.scan_threads,
                 pdf_workers: plan.pdf_workers,
                 resource_notes: plan.notes,
-                // #768: delivered by run_index via unconditional eprintln (not the
-                // --quiet-suppressible resource_notes surface) and mirrored into
-                // --json, so a wrong-node warning is never silently dropped.
+                // #768: delivered by run_index via pr.warn (not the
+                // --quiet-suppressible resource_notes/pr.note surface) and
+                // mirrored into --json, so a wrong-node warning is never silently
+                // dropped, yet stays a well-formed event on --progress json.
                 xerj_url_note,
                 pdf_timeout_secs,
                 bulk_mb,
@@ -1008,11 +1010,10 @@ mod tests {
     }
 
     /// #768: the index cfg carries the XERJ_URL-ignored note on its own field
-    /// (delivered by an unconditional eprintln, so --quiet cannot silence a
-    /// wrong-node warning) rather than folding it into the --quiet-suppressible
-    /// resource_notes. An explicit --url means the env var was not ignored, so
-    /// there is nothing to warn about — deterministic regardless of the
-    /// environment the test runs in.
+    /// (delivered by `pr.warn`, which `--quiet` cannot silence, rather than
+    /// folding it into the --quiet-suppressible resource_notes). An explicit
+    /// --url means the env var was not ignored, so there is nothing to warn
+    /// about — deterministic regardless of the environment the test runs in.
     #[test]
     fn index_suppresses_the_xerj_url_note_when_url_is_explicit() {
         let cfg = index(&["data", "--url", "http://es.internal:9200"]);

--- a/engine/crates/xerj-autoindex/src/detect/e2e.rs
+++ b/engine/crates/xerj-autoindex/src/detect/e2e.rs
@@ -266,6 +266,7 @@ fn cfg(root: &Path, state_dir: &Path, url: &str) -> IndexCfg {
         scan_workers: 1,
         pdf_workers: 1,
         resource_notes: Vec::new(),
+        xerj_url_note: None,
         pdf_timeout_secs: 30,
         bulk_mb: 8,
         bulk_timeout_secs: 300,

--- a/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/failure_resume_http_tests.rs
@@ -587,6 +587,7 @@ fn cfg(root: &Path, state_dir: &Path, url: &str) -> IndexCfg {
         scan_workers: 1,
         pdf_workers: 1,
         resource_notes: Vec::new(),
+        xerj_url_note: None,
         pdf_timeout_secs: 30,
         bulk_mb: 64,
         bulk_timeout_secs: 3_600,

--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -481,6 +481,7 @@ fn cfg(root: &Path, state_dir: &Path, url: &str, semantic: bool) -> IndexCfg {
         scan_workers: 1,
         pdf_workers: 1,
         resource_notes: Vec::new(),
+        xerj_url_note: None,
         pdf_timeout_secs: 30,
         bulk_mb: 1,
         bulk_timeout_secs: 30,

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -1636,6 +1636,7 @@ mod phase_a_grouping_tests {
             scan_workers: 1,
             pdf_workers: 1,
             resource_notes: Vec::new(),
+            xerj_url_note: None,
             pdf_timeout_secs: 10,
             bulk_mb: 1,
             bulk_timeout_secs: 10,
@@ -3530,6 +3531,13 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // The very first statement of the function, deliberately: `started` must
     // be when this invocation began, not when its summary was built.
     let invocation_started = chrono::Utc::now();
+    // #768: the wrong-node warning is a safety signal, not progress chatter, so
+    // it goes to stderr unconditionally (surviving --quiet, which silences the
+    // resource_notes/pr.note surface) and before any endpoint I/O — the same
+    // delivery map/status use. It is also mirrored into the --json result below.
+    if let Some(note) = &cfg.xerj_url_note {
+        eprintln!("autoindex: {note}");
+    }
     // Fix the phase-A pool width BEFORE anything parallel starts: hashing and
     // sniffing are the CPU-bound phase, and they used to take every core no
     // matter what the caller asked for (#240 §2).
@@ -6250,6 +6258,9 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
         "bulk_concurrency_final": es.bulk_concurrency_limit(),
         "bulk_congestion_events": es.bulk_congestion_events(),
         "resource_notes": cfg.resource_notes,
+        // #768: mirror the wrong-node warning here too (null when it did not
+        // fire), so a --json consumer sees the same safety signal stderr does.
+        "xerj_url_note": cfg.xerj_url_note,
         "semantic": !cfg.no_semantic,
         "pdf_extraction_reuse": pdf_spool_budget.report(),
     });

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3531,13 +3531,6 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
     // The very first statement of the function, deliberately: `started` must
     // be when this invocation began, not when its summary was built.
     let invocation_started = chrono::Utc::now();
-    // #768: the wrong-node warning is a safety signal, not progress chatter, so
-    // it goes to stderr unconditionally (surviving --quiet, which silences the
-    // resource_notes/pr.note surface) and before any endpoint I/O — the same
-    // delivery map/status use. It is also mirrored into the --json result below.
-    if let Some(note) = &cfg.xerj_url_note {
-        eprintln!("autoindex: {note}");
-    }
     // Fix the phase-A pool width BEFORE anything parallel starts: hashing and
     // sniffing are the CPU-bound phase, and they used to take every core no
     // matter what the caller asked for (#240 §2).
@@ -3564,6 +3557,16 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             .unwrap_or_else(|| progress::default_interval(surface)),
     );
     let ticker = pr.spawn_ticker();
+    // #768: the wrong-node warning is a safety signal, not routine progress, so
+    // it goes out FIRST and through `pr.warn` — which, unlike `pr.note`, is not
+    // silenced by `--quiet`/`Surface::Silent` (a "you may be writing to the
+    // wrong node" message must still reach the operator) yet stays a well-formed
+    // event on `--progress json` instead of a bare line. It is emitted before
+    // any endpoint I/O below, and mirrored into the --json result. map/status
+    // deliver the same note; they have no progress surface, so they `eprintln`.
+    if let Some(note) = &cfg.xerj_url_note {
+        pr.warn(&format!("autoindex: {note}"));
+    }
     // One throughput meter for the whole run: both phase-A routes (the legacy
     // scan and the generated route's `project_reconcile_plan`) feed it, so the
     // estimate is built from whatever this invocation actually parsed.

--- a/engine/crates/xerj-autoindex/src/progress.rs
+++ b/engine/crates/xerj-autoindex/src/progress.rs
@@ -558,6 +558,33 @@ impl Progress {
         }
     }
 
+    /// Like [`Self::note`] but for a safety warning that must not be silenced.
+    /// A "you may be writing to the wrong node" message (#768) still has to reach
+    /// the operator under [`Surface::Silent`] (`--quiet` / `--progress none`),
+    /// where routine notes are dropped, so this does NOT early-return there — it
+    /// writes a plain line to stderr instead. On [`Surface::Json`] it stays a
+    /// well-formed `{"event":"warning",…}` object rather than a bare line, so a
+    /// `--progress json` consumer's one-object-per-line stderr contract holds.
+    pub fn warn(&self, message: &str) {
+        let message = &sanitize(message, SAFE_NOTE_MAX);
+        match self.surface {
+            Surface::Silent | Surface::Plain => self.sink.write(format!("{message}\n").as_bytes()),
+            Surface::Json => {
+                let line = serde_json::json!({"event": "warning", "message": message});
+                self.sink.write(format!("{line}\n").as_bytes());
+            }
+            Surface::Tty => {
+                let mut state = self.state.lock().unwrap();
+                let mut out = clear_tty(state.tty_width);
+                state.tty_width = 0;
+                drop(state);
+                out.push_str(message);
+                out.push('\n');
+                self.sink.write(out.as_bytes());
+            }
+        }
+    }
+
     /// Render one progress line now.
     pub fn tick(&self) {
         self.emit();
@@ -1358,6 +1385,51 @@ mod tests {
 
     fn captured(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
         String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
+
+    /// #768: a safety warning must reach the operator even under `--quiet`
+    /// (`Surface::Silent`), where a routine `note` is dropped — and on
+    /// `--progress json` it must stay a well-formed event, not a bare line that
+    /// corrupts the one-object-per-line stderr contract.
+    #[test]
+    fn warn_pierces_quiet_and_stays_json_on_the_json_surface() {
+        // Silent: a plain `note` emits nothing, but `warn` still reaches stderr.
+        let (progress, buffer) = Progress::capture(Surface::Silent, Duration::from_secs(3600));
+        progress.note("routine: suppressed under --quiet");
+        assert_eq!(
+            captured(&buffer),
+            "",
+            "a note must stay silent under --quiet"
+        );
+        progress.warn("autoindex: XERJ_URL=http://h:9200 is set but ignored");
+        let out = captured(&buffer);
+        assert!(
+            out.contains("XERJ_URL=http://h:9200 is set but ignored"),
+            "warn must pierce --quiet: {out:?}"
+        );
+        assert!(
+            !out.trim_start().starts_with('{'),
+            "Silent warn is a plain line, not JSON"
+        );
+
+        // Json: `warn` is a well-formed {"event":"warning",...} object, one per
+        // line — never a bare line that would break a --progress json consumer.
+        let (progress, buffer) = Progress::capture(Surface::Json, Duration::from_secs(3600));
+        progress.warn("autoindex: XERJ_URL is set but ignored");
+        let out = captured(&buffer);
+        for line in out.lines().filter(|l| !l.trim().is_empty()) {
+            let v: serde_json::Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("non-JSON line {line:?}: {e}"));
+            assert_eq!(
+                v.get("event").and_then(|e| e.as_str()),
+                Some("warning"),
+                "{line}"
+            );
+        }
+        assert!(
+            out.contains("XERJ_URL is set but ignored"),
+            "message must survive: {out:?}"
+        );
     }
 
     #[test]

--- a/engine/crates/xerj-server/src/brain.rs
+++ b/engine/crates/xerj-server/src/brain.rs
@@ -565,6 +565,10 @@ fn index_cfg(cfg: &BrainCfg, brain: &str, api_key: Option<String>) -> IndexCfg {
         scan_workers: plan.scan_threads,
         pdf_workers: plan.pdf_workers,
         resource_notes: plan.notes,
+        // #768: the XERJ_URL-vs-`--url` mismatch is a CLI-parse concern; the
+        // brain path takes its endpoint from BrainCfg directly and never reads
+        // the env var, so there is no ignored-XERJ_URL warning to carry here.
+        xerj_url_note: None,
         pdf_timeout_secs: 120,
         bulk_mb: BULK_MB,
         bulk_timeout_secs: 300,


### PR DESCRIPTION
Closes #768. Follow-up to #765/#766 (surfaced by that PR's skeptic pass).

#765 warns when `XERJ_URL` is set but `--url` was not passed (endpoint is `--url` only, so a stale var silently mis-targets, e.g. the loopback default). On the index path that note rode `resource_notes` -> `pr.note`, which `--quiet` silences (`Surface::Silent`) — so `xerj autoindex <dir> --quiet` with `XERJ_URL` set and no `--url` surfaced NOTHING, re-opening under `--quiet` the exact silent mis-write the warning prevents. map/status already `eprintln` unconditionally.

Fix — treat it as a safety signal delivered consistently:
- New `Progress::warn`: like `pr.note` but NOT silenced by `Surface::Silent` (a wrong-node warning must pierce `--quiet`), and on `--progress json` a well-formed `{"event":"warning",...}` object rather than a bare line (the surface is contractually one JSON object per line). The index path emits the note through `pr.warn`, before any endpoint I/O.
- Carried on `IndexCfg.xerj_url_note` (the field map/status already have) and mirrored into the `--json` result (`"xerj_url_note"`, null when it did not fire).

No `--json` compat break: the #765 note only landed on main today (post-rc.69), unreleased.

Tests: pure helper `xerj_url_ignored_note` unchanged (4-branch unit test); `index_suppresses_the_xerj_url_note_when_url_is_explicit` (explicit --url -> None, env-independent); `warn_pierces_quiet_and_stays_json_on_the_json_surface` (Silent -> plain line reaches stderr; Json -> well-formed event) — the safety-critical delivery is now tested without `:9200`.

Two defects the #769 skeptic pass caught and this PR now fixes: (1) a missed 5th `IndexCfg` constructor in `xerj-server/src/brain.rs` (E0063 workspace build break — `-p xerj-autoindex` never compiled it); (2) the bare `eprintln` polluting `--progress json` (now `pr.warn`). Verified workspace-wide under 1.97.1: fmt / `clippy --workspace --all-targets -D warnings` / `cargo check --workspace` clean; full xerj-autoindex suite 725 lib + integration pass (dev + ci-test). Not E2E-run: the note only fires with `--url` absent, which by construction targets `:9200`.