### PR TITLE
test(engine): #421 bind the build_doc_value_columns underscore-skip invariant

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -382,6 +382,35 @@ mod collection_publication_fail_closed_tests {
         );
     }
 
+    /// #421 "Also unresolved": `sorted_shadow_for`'s correctness rests on
+    /// `build_doc_value_columns` skipping `_`-prefixed source keys — `_seq_no`,
+    /// `_id`, `_source` and friends are envelope bookkeeping, not user data, and
+    /// must never be shadowed into a doc-value column from `_source` (a meta
+    /// field is resolved from the version map, never from a source column). That
+    /// invariant lived only in a comment (index.rs, the `starts_with('_')` skip)
+    /// with no test binding it to `sorted_shadow_for`. Pin it: a source doc
+    /// carrying `_`-prefixed keys must yield NO column for them, so removing the
+    /// skip fails here instead of silently shadowing meta-fields.
+    #[test]
+    fn build_doc_value_columns_skips_underscore_prefixed_source_keys() {
+        let doc = json!({"_seq_no": 5, "_id": "abc", "title": "hello", "count": 42});
+        let skip = std::collections::HashSet::new();
+        let cols = super::build_doc_value_columns([Some(&doc)].into_iter(), &skip);
+        assert!(
+            !cols.keys().any(|k| k.starts_with('_')),
+            "#421: no `_`-prefixed source key may become a doc-value column (got {:?})",
+            cols.keys().collect::<Vec<_>>()
+        );
+        // Sanity so the assertion above is not vacuously true: real user fields
+        // DO get shadowed, so the function did build columns — it just excluded
+        // the meta keys.
+        assert!(
+            cols.contains_key("title") && cols.contains_key("count"),
+            "user fields must be shadowed into columns (got {:?})",
+            cols.keys().collect::<Vec<_>>()
+        );
+    }
+
     async fn assert_flush_publication_blocks_reader_then_finishes(inject_error: bool) {
         let dir = tempfile::tempdir().unwrap();
         let mut config = Config::default();


### PR DESCRIPTION
Addresses the second of #421's "Also unresolved" hardening notes (does not close #421).

The issue flags: `sorted_shadow_for`'s correctness "rests on `build_doc_value_columns` skipping `_`-prefixed source keys, an invariant in a different function with no test binding the two." Meta-fields (`_seq_no`, `_id`, `_source`, ...) are envelope bookkeeping resolved from the version map, and must never be shadowed into a doc-value column from `_source` — otherwise a meta-sort/agg could read a stale source-derived column. The skip (`if field.starts_with(_) { continue }` in `build_doc_value_columns`) enforced it but lived only in a comment.

This adds a pure-function `#[test]`: a source doc carrying `_seq_no`/`_id` (plus real user fields) must yield NO column for the `_`-prefixed keys, while the user fields DO get columns (so the assertion is not vacuous). Removing the skip now fails here instead of silently shadowing meta-fields.

Fail-before proven: replacing the `starts_with(_)` guard with `if false` makes the test FAIL (`_`-prefixed keys get columns, 0 passed/1 failed); restored, it passes (dev, 0.01s). fmt clean; clippy validating. Test-only change — no production code touched, so no behavior/regression risk; CI runs the full workspace suite + clippy.

Context: #421 items 1 (meta-aware `memtable_primary_key_rejects`) and 2 (`meta_sort_value` comment) are on main; item 3 (conformance) was run (search/ 449/0/2, CI conformance job green); the `_id` sort-value invariant was bound in #772 (merged). This binds the second "Also unresolved" invariant; only the pre-existing `painless_script_limits` stack overflow remains.