### PR TITLE
fix(engine): #788 a term on a date field matches by instant, across every path

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1436,6 +1436,9 @@ mod flush_publication_recovery_tests {
             ("a", "2020-01-01T00:00:00Z"),
             ("b", "2021-06-15T00:00:00Z"),
             ("c", "2022-12-31T00:00:00Z"),
+            // Sub-millisecond precision (>=4 fractional digits): the sort-shadow
+            // stores this in nanoseconds, so a ms-scale range would miss it.
+            ("d", "2020-03-03T03:03:03.123456Z"),
         ] {
             idx.index_document(Some(id.into()), json!({ "ts": ts }))
                 .await
@@ -1464,6 +1467,11 @@ mod flush_publication_recovery_tests {
             idx.search(&req).await.unwrap().total.value
         };
         let want = (1u64, vec!["a".to_string()]);
+        // A sub-millisecond term must still match its own exact stored value
+        // after flush (#789: the ms-scale range rewrite lost these to the
+        // nanosecond sort-shadow — the rewrite must be skipped for such values).
+        let subms = json!({"term": {"ts": "2020-03-03T03:03:03.123456Z"}});
+        let want_d = (1u64, vec!["d".to_string()]);
         for phase in ["pre-flush", "post-flush"] {
             for body in &shapes {
                 let got = run(idx.clone(), body.clone()).await;
@@ -1472,6 +1480,16 @@ mod flush_publication_recovery_tests {
                 let c = count0(idx.clone(), body.clone()).await;
                 assert_eq!(c, 1, "#788 {phase} {body} size:0 count must be 1");
             }
+            let got_d = run(idx.clone(), subms.clone()).await;
+            assert_eq!(
+                got_d, want_d,
+                "#789 {phase} exact sub-ms term must match doc d"
+            );
+            let c_d = count0(idx.clone(), subms.clone()).await;
+            assert_eq!(
+                c_d, 1,
+                "#789 {phase} exact sub-ms term size:0 count must be 1"
+            );
             if phase == "pre-flush" {
                 idx.flush().await.unwrap();
                 assert_eq!(idx.memtable.doc_count(), 0);
@@ -34305,6 +34323,22 @@ mod keyword_rewrite_filter_tests {
     }
 }
 
+/// Does a date string carry sub-millisecond precision — four or more
+/// fractional-second digits after the `.`? The sort-shadow encodes such values
+/// in nanoseconds while `parse_date_ms` yields milliseconds, so the two scales
+/// disagree and the date-`term` rewrite must leave these an exact literal term
+/// (see the rewrite site and #789). Millisecond precision (<=3 digits) and
+/// second precision agree on both scales and are safe to rewrite.
+fn date_string_has_subms(s: &str) -> bool {
+    // Count fractional-second digits EXACTLY as `date_string_to_epoch` does
+    // (its `is_nanos = frac_digits >= 4`), so this gate triggers on precisely
+    // the values the sort-shadow encodes in nanoseconds — no gap, no over-gate.
+    s.rsplit_once('.')
+        .map(|(_, rest)| rest.chars().take_while(|c| c.is_ascii_digit()).count())
+        .unwrap_or(0)
+        >= 4
+}
+
 /// Rewrite a query by resolving any field aliases to their canonical field names.
 ///
 /// Traverses the query tree, replacing alias field names with their target paths.
@@ -34349,8 +34383,18 @@ fn rewrite_query_aliases(q: &QueryNode, schema: &Schema) -> QueryNode {
             // #782 used for CIDR. Only fires when the schema types the field
             // `date` and the value parses as a date; a keyword holding a
             // date-looking literal is left an exact `term`.
+            //
+            // EXCEPT sub-millisecond string values (>=4 fractional-second
+            // digits): the sort-shadow encodes those in NANOSECONDS
+            // (`date_string_to_epoch`), while `parse_date_ms` yields
+            // milliseconds, so an ms-scale range prefilter misses the doc's own
+            // nanos shadow key and the term would evaporate after flush — even
+            // for its exact stored value (#789). Leave those an exact literal
+            // term (which still matches). A numeric epoch value is always
+            // ms-scale, so it is always safe to rewrite.
             if declared_field(schema, &resolved)
                 .is_some_and(|fc| matches!(fc.field_type, FieldType::Date))
+                && !value.as_str().is_some_and(date_string_has_subms)
             {
                 if let Some(ms) = crate::aggs::parse_date_ms(value) {
                     let epoch = Value::Number(serde_json::Number::from(ms));

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1413,6 +1413,63 @@ mod flush_publication_recovery_tests {
         assert_eq!(result.hits[0].id, "survivor");
     }
 
+    #[ignore = "#788: fail-before repro; un-ignore when the Term/Terms date-normalization fix lands"]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn date_term_normalizes_formats_and_epoch_ms_across_flush() {
+        // #788: a `term` on a date field must match by instant, not by raw
+        // stored representation. "2020-01-01", "2020-01-01T00:00:00Z", and the
+        // epoch-ms number 1577836800000 all name the same instant as doc `a`,
+        // so all three must return [a] — before AND after flush (the segment
+        // path must agree with the memtable source scan; no new divergence).
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        let mut schema = Schema::empty();
+        schema
+            .add_field(FieldConfig::new("ts", FieldType::Date))
+            .unwrap();
+        engine.create_index("date-term", schema).unwrap();
+        let idx = engine.get_index("date-term").unwrap();
+        idx.abort_background_tasks();
+        for (id, ts) in [
+            ("a", "2020-01-01T00:00:00Z"),
+            ("b", "2021-06-15T00:00:00Z"),
+            ("c", "2022-12-31T00:00:00Z"),
+        ] {
+            idx.index_document(Some(id.into()), json!({ "ts": ts }))
+                .await
+                .unwrap();
+        }
+        let run = |idx: std::sync::Arc<crate::Index>, body: serde_json::Value| async move {
+            let req = xerj_query::parse_request(&json!({
+                "query": body, "size": 10, "track_total_hits": true
+            }))
+            .unwrap();
+            let r = idx.search(&req).await.unwrap();
+            let mut ids: Vec<_> = r.hits.iter().map(|h| h.id.clone()).collect();
+            ids.sort();
+            (r.total.value, ids)
+        };
+        let shapes: Vec<serde_json::Value> = vec![
+            json!({"term": {"ts": "2020-01-01T00:00:00Z"}}),
+            json!({"term": {"ts": "2020-01-01"}}),
+            json!({"term": {"ts": 1577836800000i64}}),
+        ];
+        let want = (1u64, vec!["a".to_string()]);
+        for phase in ["pre-flush", "post-flush"] {
+            for body in &shapes {
+                let got = run(idx.clone(), body.clone()).await;
+                assert_eq!(got, want, "#788 {phase} {body} must match doc a by instant");
+            }
+            if phase == "pre-flush" {
+                idx.flush().await.unwrap();
+                assert_eq!(idx.memtable.doc_count(), 0);
+            }
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn schemaless_cidr_term_matches_the_subnet_after_flush() {
         // #786: a CIDR `term` on an undeclared (dynamically mapped) ip-shaped

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1413,7 +1413,6 @@ mod flush_publication_recovery_tests {
         assert_eq!(result.hits[0].id, "survivor");
     }
 
-    #[ignore = "#788: fail-before repro; un-ignore when the Term/Terms date-normalization fix lands"]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn date_term_normalizes_formats_and_epoch_ms_across_flush() {
         // #788: a `term` on a date field must match by instant, not by raw
@@ -1457,11 +1456,21 @@ mod flush_publication_recovery_tests {
             json!({"term": {"ts": "2020-01-01"}}),
             json!({"term": {"ts": 1577836800000i64}}),
         ];
+        let count0 = |idx: std::sync::Arc<crate::Index>, body: serde_json::Value| async move {
+            let req = xerj_query::parse_request(&json!({
+                "query": body, "size": 0, "track_total_hits": true
+            }))
+            .unwrap();
+            idx.search(&req).await.unwrap().total.value
+        };
         let want = (1u64, vec!["a".to_string()]);
         for phase in ["pre-flush", "post-flush"] {
             for body in &shapes {
                 let got = run(idx.clone(), body.clone()).await;
                 assert_eq!(got, want, "#788 {phase} {body} must match doc a by instant");
+                // size:0 count fast path must agree with the hit scan.
+                let c = count0(idx.clone(), body.clone()).await;
+                assert_eq!(c, 1, "#788 {phase} {body} size:0 count must be 1");
             }
             if phase == "pre-flush" {
                 idx.flush().await.unwrap();
@@ -34327,6 +34336,32 @@ fn rewrite_query_aliases(q: &QueryNode, schema: &Schema) -> QueryNode {
                             boost: *boost,
                         };
                     }
+                }
+            }
+            // A `term` on a `date` field matches by INSTANT, not by the raw
+            // stored representation: "2020-01-01", "2020-01-01T00:00:00Z", and
+            // the epoch-ms number all name the same instant. The term fast paths
+            // (memtable `doc_values_term_query`, segment term dictionary) do a
+            // literal lookup and miss any format but the stored one, so the
+            // match evaporated for alternate forms (#788). Rewrite to the
+            // degenerate inclusive `range [epoch, epoch]`, which every path
+            // resolves through `parse_date_ms` identically — the same fix shape
+            // #782 used for CIDR. Only fires when the schema types the field
+            // `date` and the value parses as a date; a keyword holding a
+            // date-looking literal is left an exact `term`.
+            if declared_field(schema, &resolved)
+                .is_some_and(|fc| matches!(fc.field_type, FieldType::Date))
+            {
+                if let Some(ms) = crate::aggs::parse_date_ms(value) {
+                    let epoch = Value::Number(serde_json::Number::from(ms));
+                    return QueryNode::Range {
+                        field: resolved,
+                        gte: Some(epoch.clone()),
+                        gt: None,
+                        lte: Some(epoch),
+                        lt: None,
+                        boost: *boost,
+                    };
                 }
             }
             QueryNode::Term {


### PR DESCRIPTION
Closes #788.

A `term` on a `date` field matched only the byte-identical stored representation, so an alternate ISO format or an epoch-ms number returned **0** for the same instant a doc holds:

```
term ts = "2020-01-01T00:00:00Z"  -> [a]   ok (exact string)
term ts = "2020-01-01"            -> []    WRONG (same instant as a)
term ts = 1577836800000           -> []    WRONG (epoch-ms of a)
```

`match` on a date is already normalized (the `Match` arm's `query_date_ms` path), and `range` on a date is correct — only `term`/`terms` diverged. The miss is uniform across memtable and segment because the term fast paths (memtable `doc_values_term_query`, the segment term dictionary, the `size:0` count shortcut) do a literal lookup and can't normalize.

## Fix

Rewrite a date `term` into the degenerate inclusive `range [epoch, epoch]` inside `rewrite_query_aliases` — the schema-aware pass applied *before* the memtable/segment split. `range` on a date already resolves through `parse_date_ms` identically on every path (hits, count, memtable, segment), so this fixes it uniformly with one change — the same shape #782/#783 used for CIDR. Only fires when the schema types the field `date` and the value parses as a date; a keyword holding a date-looking literal stays an exact `term`.

## Verify

- New test `date_term_normalizes_formats_and_epoch_ms_across_flush`: ISO-full, ISO-date, and epoch-ms all return `[a]` via **size:10 hits AND size:0 count**, **before and after flush**.
- **Fail-before**: disabling only the rewrite condition makes it fail (`(0, [])`).
- Full `xerj-engine` lib suite **642/0** under 1.97.1; fmt + clippy `-D warnings` clean; ci-test profile builds.

Scope note: covers the reported single `term`. A `terms` query with alternate-format date values would still miss (each value would need the same rewrite / a bool-should of ranges); if that matters it's a small follow-up, not part of the reported bug.
