### PR TITLE
fix(engine): #797 must_not-only prefix/wildcard drops all docs after flush (pure-negative FTS projection)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1659,6 +1659,62 @@ mod flush_publication_recovery_tests {
         }
     }
 
+    #[ignore = "#797 WIP: fail-before repro — must_not-only prefix/wildcard drops all docs after flush"]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mustnot_only_prefix_keeps_nonmatching_docs_after_flush() {
+        // #797: a bool with ONLY a must_not (no must/should/filter) containing a
+        // prefix/wildcard leaf returns zero hits after flush — the segment
+        // planner lets the negative leaf drive candidate generation, so the
+        // non-matching docs never enter the set. `term` is unaffected. Base set
+        // must be all docs, must_not subtracting only its matches.
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        let mut schema = Schema::empty();
+        schema
+            .add_field(FieldConfig::new("k", FieldType::Keyword))
+            .unwrap();
+        engine.create_index("mn797", schema).unwrap();
+        let idx = engine.get_index("mn797").unwrap();
+        idx.abort_background_tasks();
+        for (id, k) in [("1", "apple"), ("2", "Application"), ("3", "banana")] {
+            idx.index_document(Some(id.into()), json!({ "k": k }))
+                .await
+                .unwrap();
+        }
+        let run = |idx: std::sync::Arc<crate::Index>, q: serde_json::Value| async move {
+            let req = xerj_query::parse_request(
+                &json!({"query": q, "size": 10, "track_total_hits": true}),
+            )
+            .unwrap();
+            let r = idx.search(&req).await.unwrap();
+            let mut ids: Vec<_> = r.hits.iter().map(|h| h.id.clone()).collect();
+            ids.sort();
+            (r.total.value, ids)
+        };
+        // must_not-ONLY [prefix "ap"] (case-sensitive keyword) excludes apple(1);
+        // Application(2) + banana(3) must remain, pre AND post flush.
+        let want = (2u64, vec!["2".to_string(), "3".to_string()]);
+        for phase in ["pre", "post"] {
+            for q in [
+                json!({"bool": {"must_not": [{"prefix": {"k": "ap"}}]}}),
+                json!({"bool": {"must_not": [{"wildcard": {"k": "app*"}}]}}),
+            ] {
+                assert_eq!(
+                    run(idx.clone(), q.clone()).await,
+                    want,
+                    "#797 {phase} {q}: must_not-only prefix/wildcard keeps non-matching docs"
+                );
+            }
+            if phase == "pre" {
+                idx.flush().await.unwrap();
+                assert_eq!(idx.memtable.doc_count(), 0);
+            }
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn mustnot_prefix_on_keyword_stays_case_sensitive_after_flush() {
         // #794: a prefix/wildcard inside bool.must_not case-folded on the segment

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1659,7 +1659,6 @@ mod flush_publication_recovery_tests {
         }
     }
 
-    #[ignore = "#797 WIP: fail-before repro — must_not-only prefix/wildcard drops all docs after flush"]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn mustnot_only_prefix_keeps_nonmatching_docs_after_flush() {
         // #797: a bool with ONLY a must_not (no must/should/filter) containing a
@@ -1679,7 +1678,10 @@ mod flush_publication_recovery_tests {
         engine.create_index("mn797", schema).unwrap();
         let idx = engine.get_index("mn797").unwrap();
         idx.abort_background_tasks();
-        for (id, k) in [("1", "apple"), ("2", "Application"), ("3", "banana")] {
+        // Data is case-fold-invariant for prefix "ap"/"app*": only "apple"
+        // starts with it under ANY casing, so the correct answer does not
+        // depend on the separate #794 keyword-prefix case-sensitivity fix.
+        for (id, k) in [("1", "apple"), ("2", "grape"), ("3", "banana")] {
             idx.index_document(Some(id.into()), json!({ "k": k }))
                 .await
                 .unwrap();
@@ -1694,8 +1696,9 @@ mod flush_publication_recovery_tests {
             ids.sort();
             (r.total.value, ids)
         };
-        // must_not-ONLY [prefix "ap"] (case-sensitive keyword) excludes apple(1);
-        // Application(2) + banana(3) must remain, pre AND post flush.
+        // must_not-ONLY [prefix "ap"] excludes apple(1); grape(2) + banana(3)
+        // must remain, pre AND post flush (before the fix, post-flush dropped
+        // ALL docs → (0, []) via the pure-negative FTS projection).
         let want = (2u64, vec!["2".to_string(), "3".to_string()]);
         for phase in ["pre", "post"] {
             for q in [
@@ -41886,7 +41889,15 @@ fn query_node_to_fts_with_keyword_fields(
                 // — not projectable; fall back to the stored-doc scan.
                 Some(_) => return None,
             }
-            let mut projected_any = false;
+            // #797: a bool that projects NO positive (must/should/filter)
+            // clause must NOT become a pure-negative FTS bool. FTS (like
+            // Lucene) requires a positive clause to enumerate a base set, so a
+            // `must_not`-only projection matches NOTHING — whereas the true
+            // answer is "all docs minus the must_not matches". Track whether a
+            // positive clause projected; if none did, decline so the stored
+            // scan (whose base is all docs) answers, exactly as a `must_not`-
+            // only keyword `term` (which never projects) already does.
+            let mut projected_positive = false;
             // CRITICAL: if a `must` child can't be projected to FTS we
             // CANNOT lift just the projectable subset — the bool would
             // become more permissive than the original query.  Return
@@ -41900,7 +41911,7 @@ fn query_node_to_fts_with_keyword_fields(
                     keyword_fields,
                 )?;
                 bool_q = bool_q.must(fq);
-                projected_any = true;
+                projected_positive = true;
             }
             // `filter` children constrain the hit set exactly like `must` but
             // contribute NOTHING to `_score` (`BooleanClause.isScoring()` is
@@ -41931,7 +41942,7 @@ fn query_node_to_fts_with_keyword_fields(
                     keyword_fields,
                 ) {
                     bool_q = bool_q.filter(fq);
-                    projected_any = true;
+                    projected_positive = true;
                 }
             }
             for sub in should {
@@ -41947,7 +41958,7 @@ fn query_node_to_fts_with_keyword_fields(
                     keyword_fields,
                 )?;
                 bool_q = bool_q.should(fq);
-                projected_any = true;
+                projected_positive = true;
             }
             // `must_not` children that don't project are similar: dropping
             // a must_not relaxes the filter, which is wrong.
@@ -41963,10 +41974,9 @@ fn query_node_to_fts_with_keyword_fields(
                     keyword_fields,
                 ) {
                     bool_q = bool_q.must_not(fq);
-                    projected_any = true;
                 }
             }
-            if !projected_any {
+            if !projected_positive {
                 return None;
             }
             Some(FtsQuery::Bool(Box::new(bool_q)))


### PR DESCRIPTION
Closes #797.

A `bool` with **only** a `must_not` (no `must`/`should`/`filter`) and a projectable keyword leaf (`prefix`/`wildcard`) returned zero hits after flush; the doc set was non-empty and pre-flush was correct.

## Root cause
`query_node_to_fts_with_keyword_fields` projected the bool to a **pure-negative** FTS bool (`must_not:[prefix]`, no positive clause). FTS — like Lucene — needs a positive clause to enumerate a base set, so a pure-negative bool matches **nothing** → `seg_hits` empty. And because the leaf *did* project, `bool_has_nonprojectable_nonscoring` was false, so `residual_gate` was off and the empty FTS result was treated as authoritative. `term` must_not-only was unaffected only incidentally. Traced: `needs_fts=true, residual_gate=false`, post-flush `seg_total=0 seg_hits_len=0`.

## Fix
Track whether a **positive** (`must`/`should`/`filter`) clause projected. If none did, decline the projection (return `None`) so the stored-doc scan answers over the full doc set — the same path a must_not-only keyword `term` (which never projects) already takes. Positive bools with a non-projectable `must_not` are unchanged (they keep the FTS path + the existing `residual_gate` re-test).

## Verification (rustc 1.97.1, unit harness — no :9200)
Test data is case-fold-invariant (only "apple" starts with "ap"), so it is independent of the separate #794 keyword-prefix case-sensitivity fix.
- Fail-before: `bool{must_not:[prefix "ap"]}` over `apple/grape/banana` → `(0,[])` post-flush; with the fix `(2,["2","3"])`, pre- and post-flush (same for `wildcard "app*"`).
- Full `xerj-engine` lib suite 645/0
- `cargo fmt --all --check` clean; `clippy -p xerj-engine --all-targets -D warnings` clean