### PR TITLE
fix(engine): #797 a must_not-only bool with prefix/wildcard falls back to the doc scan after flush

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1498,6 +1498,62 @@ mod flush_publication_recovery_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mustnot_only_prefix_or_wildcard_bool_excludes_correctly_after_flush() {
+        // #797: a `bool` with ONLY a `must_not` (no must/should/filter)
+        // containing a `prefix` or `wildcard` silently returned zero results
+        // after flush. With no positive driver, ES semantics say the base
+        // set is ALL docs, must_not subtracting matches — `term` in the same
+        // position already got this right; `prefix`/`wildcard` didn't
+        // because the FTS bool evaluator has no notion of "every doc in this
+        // segment" and built its candidate set from the (empty) `should`
+        // union instead.
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        let mut schema = Schema::empty();
+        schema
+            .add_field(FieldConfig::new("k", FieldType::Keyword))
+            .unwrap();
+        engine.create_index("mustnot-only", schema).unwrap();
+        let idx = engine.get_index("mustnot-only").unwrap();
+        idx.abort_background_tasks();
+        for (id, k) in [("1", "apple"), ("2", "Application"), ("3", "banana")] {
+            idx.index_document(Some(id.into()), json!({ "k": k }))
+                .await
+                .unwrap();
+        }
+        let run = |idx: std::sync::Arc<crate::Index>, body: serde_json::Value| async move {
+            let req = xerj_query::parse_request(&json!({
+                "query": body, "size": 10, "track_total_hits": true
+            }))
+            .unwrap();
+            let r = idx.search(&req).await.unwrap();
+            let mut ids: Vec<_> = r.hits.iter().map(|h| h.id.clone()).collect();
+            ids.sort();
+            (r.total.value, ids)
+        };
+        // Case-sensitive prefix "ap" excludes only "apple" ("Application"
+        // starts with "Ap", not "ap"), so the expected survivors are 2 and 3.
+        let want = (2u64, vec!["2".to_string(), "3".to_string()]);
+        let shapes: Vec<serde_json::Value> = vec![
+            json!({"bool": {"must_not": [{"prefix": {"k": "ap"}}]}}),
+            json!({"bool": {"must_not": [{"wildcard": {"k": "ap*"}}]}}),
+        ];
+        for phase in ["pre-flush", "post-flush"] {
+            for body in &shapes {
+                let got = run(idx.clone(), body.clone()).await;
+                assert_eq!(got, want, "#797 {phase} {body} must exclude only apple");
+            }
+            if phase == "pre-flush" {
+                idx.flush().await.unwrap();
+                assert_eq!(idx.memtable.doc_count(), 0);
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn schemaless_cidr_term_matches_the_subnet_after_flush() {
         // #786: a CIDR `term` on an undeclared (dynamically mapped) ip-shaped
         // field matches in the memtable (the value-driven source scan expands
@@ -41813,6 +41869,20 @@ fn query_node_to_fts_with_keyword_fields(
             filter,
             minimum_should_match,
         } => {
+            // #797: with no positive driver (must/filter/should all empty),
+            // ES semantics say the base set is ALL docs, with must_not
+            // subtracting matches. The FTS bool evaluator has no notion of
+            // "every doc in this segment" — it only ever sees clause hits —
+            // so its "no required clauses" branch builds the candidate set
+            // from the (here, empty) `should` union instead of all docs,
+            // silently returning zero. Decline this projection so a
+            // must_not-only bool falls back to the stored-doc scan, which
+            // already implements "all docs minus must_not" correctly via
+            // `doc_matches_query_typed` (the pre-flush memtable path proves
+            // it).
+            if must.is_empty() && filter.is_empty() && should.is_empty() && !must_not.is_empty() {
+                return None;
+            }
             let mut bool_q = FtsBool::new();
             // `minimum_should_match` changes MATCHING, not just scoring, and
             // the FTS bool evaluator (`execute_bool`) enforces it — dropping


### PR DESCRIPTION
Closes #797.

A `bool` with **only** a `must_not` (no `must`/`should`/`filter`) containing a `prefix` or `wildcard` silently returned zero results after flush. Pre-flush was correct; `term` in the same position was already fine post-flush too — only `prefix`/`wildcard` diverged, and only after flush.

## Root cause

`query_node_to_fts_with_keyword_fields` happily projects a must_not-only bool into an FTS `Bool` query (`must_not` populated, everything else empty). That FTS query then runs through `xerj-fts`'s `execute_bool`, whose "no required clauses" branch unconditionally sets the candidate set to the `should`-clause union — but `should` is *also* empty here (must_not-only), so the candidate set silently becomes empty instead of "all docs". ES semantics say a bool with no positive driver starts from all docs, with `must_not` subtracting matches; `execute_bool` has no notion of "every doc in this segment" to fall back on — it only ever sees clause hits.

`term` never hit this because a plain term leaf doesn't need the FTS term-dictionary path (doc-values lookup suffices), so a term-only must_not bool never reaches the buggy FTS combinator in the first place; `prefix` and `wildcard` require the term-dictionary walk, which forces the whole bool through `query_node_to_fts_with_keyword_fields`.

## Fix

Decline the projection (return `None`) for a bool with `must`/`filter`/`should` all empty and a non-empty `must_not`. Every `QueryNode::Bool` already flags `is_doc_scan_query`, so declining just routes it to the existing stored-doc scan (`doc_matches_query_typed`), which already gets "all docs minus must_not" right — proven by the pre-flush memtable path using the same matcher.

## Tests

`mustnot_only_prefix_or_wildcard_bool_excludes_correctly_after_flush` (`flush_publication_recovery_tests`), same style as the existing single-term tests: real `Engine`/`Index`, both `prefix` and `wildcard` shapes, pre- and post-flush, `size:10` hits + ids.

Fail-before verified by disabling the new guard: fails post-flush with `(0, [])` instead of `(2, ["2","3"])`.

xerj-engine lib suite 642/644 (2 pre-existing, unrelated `snapshot_path_security_tests` failures on macOS, reproduce identically on `upstream/main` without this change — `/tmp -> /private/tmp` symlink resolution); fmt clean; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4vw8pibaJgnX5eD1TtUJE
