### PR TITLE
fix(metrics): #804 wire xerj_bytes_written_total to the segment flush path

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1498,6 +1498,40 @@ mod flush_publication_recovery_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn flush_increments_the_bytes_written_metric() {
+        // #804: `xerj_bytes_written_total` was registered but nothing ever
+        // incremented it, so it stayed 0 regardless of write volume. This is
+        // the one call site in the whole binary that installs a `Metrics`
+        // instance (`OnceLock`, set-once-per-process) — assert `after >
+        // before` rather than an exact delta, since other tests' concurrent
+        // flushes may also land on this now-shared counter once installed.
+        let metrics = std::sync::Arc::new(xerj_common::metrics::Metrics::new().unwrap());
+        crate::set_engine_metrics(metrics.clone());
+        let before = metrics.bytes_written.get();
+
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine
+            .create_index("bytes-written", Schema::empty())
+            .unwrap();
+        let idx = engine.get_index("bytes-written").unwrap();
+        idx.abort_background_tasks();
+        idx.index_document(Some("a".into()), json!({ "f": "x" }))
+            .await
+            .unwrap();
+        idx.flush().await.unwrap();
+
+        let after = metrics.bytes_written.get();
+        assert!(
+            after > before,
+            "#804 a flush must increment xerj_bytes_written_total: before={before} after={after}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn schemaless_cidr_term_matches_the_subnet_after_flush() {
         // #786: a CIDR `term` on an undeclared (dynamically mapped) ip-shaped
         // field matches in the memtable (the value-driven source scan expands
@@ -26565,6 +26599,15 @@ async fn do_flush_shard(
             )));
         }
     };
+    // #804: `xerj_bytes_written_total` was registered but nothing ever
+    // incremented it, so it stayed 0 regardless of write volume. A flush is
+    // the actual byte-producing event on this path; `meta.size_bytes` is the
+    // freshly-written `.seg` file's own size (set from the encoded buffer
+    // length in `SegmentWriter::finish`), so this is one real, non-double-
+    // counted number per flush — not an estimate.
+    if let Some(m) = crate::engine_metrics() {
+        m.bytes_written.inc_by(meta.size_bytes);
+    }
     if prof {
         eprintln!(
             "XERJ_PROF flush-total shard={} docs={} drain_us={} prep_us={} finalize_us={} total_us={}",


### PR DESCRIPTION
Closes #804.

`xerj_bytes_written_total` was registered ("Total bytes written to segment files (uncompressed)") but nothing ever incremented it, so it stayed 0 regardless of write volume. Reported against the shipped `rc.4` binary (aarch64-apple-darwin), tested natively rather than a self-built image specifically to rule out build drift. Grepping the whole engine for anything that increments it returned nothing outside `metrics.rs` itself.

## Fix

Increment it by `meta.size_bytes` at the point `do_flush_shard` obtains the freshly-published `SegmentMeta` — that's the actual byte-producing event on this path, and `size_bytes` is set from the encoded `.seg` buffer's own length in `SegmentWriter::finish`, so this is one real, non-double-counted number per flush, not an estimate.

**Scope note — deliberately not merge output:** a merge rewrites bytes an earlier flush already counted, so folding it in would inflate this "bytes written" ingest-volume metric with compaction churn — the same separation ES's own metrics keep between indexing and merge byte counts.

**Known gap:** the sidecar files a flush's own `build_fts` step writes afterward (doc-values column, FTS postings) aren't part of `size_bytes`, so this under-counts the true bytes-on-disk per flush. Worth a follow-up if that gap matters in practice, but this already turns the metric from "always 0" into a real, monotonically correct-for-what-it-tracks number.

## Tests

`flush_increments_the_bytes_written_metric` (`flush_publication_recovery_tests`): installs a fresh `Metrics` via the process-global `set_engine_metrics` (`OnceLock`, set once per binary — this is the only call site in the crate), indexes one doc, flushes, asserts the counter went up. Asserts `after > before` rather than an exact delta since, once installed, other tests' concurrent flushes in the same test binary may also land on this now-shared counter.

Fail-before verified by disabling the increment: fails with `before=0 after=0` instead of `after > 0`.

Also checked the related report in the same issue (`xerj_docs_indexed_total` undercounting on rc.4): on current main the single-doc paths already call `record_doc_indexed` (`es_compat.rs`) alongside the bulk tally, so that one looks already addressed since rc.4 — not touched here.

xerj-engine lib suite 644/646 (2 pre-existing, unrelated `snapshot_path_security_tests` failures on macOS, reproduce identically on `upstream/main` without this change — `/tmp -> /private/tmp` symlink resolution); fmt clean; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4vw8pibaJgnX5eD1TtUJE
