### PR TITLE
fix(metrics): #804 wire xerj_bytes_written_total (was registered but never incremented)

### DIFF
--- a/engine/crates/xerj-common/src/metrics.rs
+++ b/engine/crates/xerj-common/src/metrics.rs
@@ -122,7 +122,7 @@ impl Metrics {
 
         let bytes_written = IntCounter::with_opts(Opts::new(
             "xerj_bytes_written_total",
-            "Total bytes written to segment files (uncompressed)",
+            "Total on-disk bytes written to segment (.seg) files by flush and merge",
         ))
         .map_err(|e| XerjError::internal(format!("metrics: {e}")))?;
 
@@ -354,6 +354,18 @@ impl Metrics {
         self.docs_indexed_by_index
             .with_label_values(&[index])
             .inc_by(n);
+    }
+
+    /// Record `n` on-disk bytes written to a segment (.seg) file — called
+    /// once per segment finalized by flush or merge with the sealed segment's
+    /// `size_bytes`. A no-op when `n == 0`. (#804: the counter was registered
+    /// but never incremented, so it read a flat zero regardless of write
+    /// volume.)
+    pub fn record_bytes_written(&self, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.bytes_written.inc_by(n);
     }
 
     /// Drop the per-index label series for `index` (RC4-W4 item 5).

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1891,6 +1891,40 @@ mod flush_publication_recovery_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bytes_written_metric_increments_on_flush() {
+        // #804: xerj_bytes_written_total was registered but never incremented,
+        // so it read a flat zero regardless of write volume. Flush now records
+        // each sealed segment's on-disk size via engine_metrics().
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        // Idempotent OnceLock: installs a handle if none yet, else reads the
+        // existing one. Either way the post-flush delta must be positive.
+        crate::set_engine_metrics(std::sync::Arc::new(
+            xerj_common::metrics::Metrics::new().unwrap(),
+        ));
+        let m = crate::engine_metrics().expect("engine metrics installed");
+        let before = m.bytes_written.get();
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        engine.create_index("bw804", Schema::empty()).unwrap();
+        let idx = engine.get_index("bw804").unwrap();
+        idx.abort_background_tasks();
+        for i in 0..5 {
+            idx.index_document(Some(format!("{i}")), json!({ "body": "some text content" }))
+                .await
+                .unwrap();
+        }
+        idx.flush().await.unwrap();
+        assert_eq!(idx.memtable.doc_count(), 0);
+        let after = m.bytes_written.get();
+        assert!(
+            after > before,
+            "#804: bytes_written must increase after a flush, got {before} -> {after}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn portable_field_flush_keeps_baseline_data_dir_format() {
         let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
@@ -10048,6 +10082,10 @@ impl Index {
                             return None;
                         }
                     };
+                    // #804: count the merge-written segment's on-disk bytes.
+                    if let Some(m) = crate::engine_metrics() {
+                        m.record_bytes_written(merged_meta.size_bytes);
+                    }
 
                     // Build FTS side-cars using the parallel per-field builder.
                     // We pre-built `fts_input` during the byte-copy pass above,
@@ -26403,6 +26441,11 @@ async fn do_flush_shard(
         .filter(|hook| hook.target_memtable == test_target)
         .and_then(|hook| hook.before_blocking_spawn.as_ref().map(Arc::clone));
     let build_fts = move |meta: &xerj_storage::segment::SegmentMeta| -> xerj_storage::Result<()> {
+        // #804: count the flush-written segment's on-disk bytes (the sealed
+        // `.seg` whose `size_bytes` this closure receives).
+        if let Some(m) = crate::engine_metrics() {
+            m.record_bytes_written(meta.size_bytes);
+        }
         #[cfg(test)]
         let test_callback = test_hook
             .as_ref()


### PR DESCRIPTION
Closes #804. Reported by Vincenzo Lombardo (Seacom Srl) against the shipped `rc.4` binary: `xerj_bytes_written_total` stays at `0` regardless of write volume.

## Root cause
`metrics.rs` registers the `IntCounter` but there is **no increment call site** anywhere in the engine — the metric is exported, documented as "Total bytes written to segment files", and always zero. Anyone graphing write throughput gets a flat line with no indication it is unimplemented.

## Fix
The engine already exposes a process-wide metrics handle via `engine_metrics()` (a no-op when unset, e.g. unit tests). Both segment-producing paths finalize a `SegmentMeta` (which carries `size_bytes` = the sealed `.seg` on-disk size) in engine code:
- **flush** — `do_flush_shard`s `build_fts` closure receives the sealed `meta`;
- **merge** — `merge_pass_locked`s `writer.finish()` returns `merged_meta`.

Record `size_bytes` at both via a new `Metrics::record_bytes_written(n)` helper. Also corrected the help text: the value is the on-disk `.seg` size, not "uncompressed" (dropped the misleading qualifier).

Chose to WIRE it (the issues preferred option) rather than drop it — a working write-throughput counter is worth more than a removed one.

## Verification (rustc 1.97.1)
- New test `bytes_written_metric_increments_on_flush`: installs a metrics handle, indexes 5 docs + flushes, asserts the counter strictly increases. Fail-before (both increments removed) → `0 -> 0`, test fails.
- `xerj-common` suite 91/0; `xerj-engine` lib suite 649/0.
- `cargo fmt --all --check` clean; `clippy -p xerj-engine -p xerj-common --all-targets -D warnings` clean.

Note: counts the main `.seg` file (`size_bytes`); FTS/DV sidecar files are not included — a defensible "segment files" reading and a huge improvement over always-zero. The related `xerj_docs_indexed_total` undercount the reporter saw on rc.4 was already addressed on main (single-doc paths call `record_doc_indexed`); left as-is.