### PR TITLE
fix(test): #804 bytes_written metric test is OnceLock-order-robust (#828)

### DIFF
--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1500,13 +1500,18 @@ mod flush_publication_recovery_tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn flush_increments_the_bytes_written_metric() {
         // #804: `xerj_bytes_written_total` was registered but nothing ever
-        // incremented it, so it stayed 0 regardless of write volume. This is
-        // the one call site in the whole binary that installs a `Metrics`
-        // instance (`OnceLock`, set-once-per-process) — assert `after >
-        // before` rather than an exact delta, since other tests' concurrent
-        // flushes may also land on this now-shared counter once installed.
-        let metrics = std::sync::Arc::new(xerj_common::metrics::Metrics::new().unwrap());
-        crate::set_engine_metrics(metrics.clone());
+        // incremented it, so it stayed 0 regardless of write volume. The
+        // handle is a process-wide `OnceLock` (set-once) and MORE THAN ONE
+        // test installs one (`bytes_written_metric_increments_on_flush`), so
+        // whichever runs first wins the race and a locally-constructed
+        // `Metrics` may never be the one `engine_metrics()` (and thus flush)
+        // increments — reading it gave a flat 0 under high-core parallelism.
+        // Read the INSTALLED handle instead, and assert `after > before`
+        // rather than an exact delta since concurrent flushes share it.
+        crate::set_engine_metrics(std::sync::Arc::new(
+            xerj_common::metrics::Metrics::new().unwrap(),
+        ));
+        let metrics = crate::engine_metrics().expect("engine metrics installed");
         let before = metrics.bytes_written.get();
 
         let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;


### PR DESCRIPTION
Closes #828.

`flush_increments_the_bytes_written_metric` (index.rs:1501) fails under high-core local `cargo test -p xerj-engine --lib` (passes in isolation; passes in CI at lower parallelism — #818/#822/#803 all merged green).

Cause: `ENGINE_METRICS` is a set-once `OnceLock` and TWO tests install a handle — this one and `bytes_written_metric_increments_on_flush`. This test read its own locally-constructed `Metrics`; when the sibling wins the race, `set_engine_metrics` here is a no-op, flush increments the other instance, and the local counter stays 0 → `after==before` → fail.

Fix: read the INSTALLED handle via `crate::engine_metrics()` (as the sibling already does). No production change.

Verified 1.97.1: full xerj-engine lib **652/0** twice (was 651 passed / 1 failed on main); fmt clean; clippy --all-targets -D warnings clean.