### PR TITLE
docs(query): match_phrase slop is in-order only, not transpositions (#830)

### DIFF
--- a/engine/crates/xerj-query/src/ast.rs
+++ b/engine/crates/xerj-query/src/ast.rs
@@ -413,7 +413,10 @@ pub enum QueryNode {
         minimum_should_match: Option<MinShouldMatch>,
     },
 
-    /// Ordered phrase match with optional slop (token transpositions allowed).
+    /// Ordered phrase match with optional slop. `slop` admits forward gaps
+    /// between the in-order tokens ONLY — it does NOT admit transpositions
+    /// (reorderings), a known divergence from Lucene's SloppyPhraseMatcher
+    /// (see #830 and `index.rs::phrase_walk`).
     MatchPhrase {
         field: String,
         query: String,

--- a/engine/crates/xerj-query/src/planner.rs
+++ b/engine/crates/xerj-query/src/planner.rs
@@ -62,7 +62,8 @@ pub enum ExecutionPlan {
         field: String,
         tokens: Vec<String>,
         require_all: bool,
-        /// Phrase mode — tokens must appear in order (with `slop` transpositions).
+        /// Phrase mode — tokens must appear IN ORDER, with `slop` forward gaps
+        /// permitted between them (NOT transpositions/reorderings; see #830).
         phrase: bool,
         slop: u32,
         cost: f64,


### PR DESCRIPTION
Part of #830 (doc-accuracy half).

The `MatchPhrase` doc comment (ast.rs) and the planner Phrase-mode comment (planner.rs) both claimed `slop` allows "token transpositions". That's inaccurate: `phrase_walk` — and the segment-side `phrase_positions_match` it deliberately mirrors — admit forward gaps only, in-order. This is a documented known divergence from Lucene's SloppyPhraseMatcher (index.rs ~36906, "KNOWN DIVERGENCE FROM ES ... in-order only").

Corrects both comments to state in-order-only and point at #830. **No behavior change** (doc comments only). The behavioral gap (implementing transpositions in both evaluators, flush-invariant) stays tracked in #830.

Verified 1.97.1: fmt clean, clippy -p xerj-query --all-targets -D warnings clean.