### PR TITLE
fix(aggs): terms _key ordering is numeric on numeric fields (#839)

### DIFF
--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -3911,6 +3911,16 @@ pub(crate) fn typed_term_key(key: &str) -> (Value, Option<String>) {
 /// `["10", "100", "2"]`. Which keys count as numeric mirrors `typed_term_key`
 /// exactly: an `i64`, or a finite `f64` (non-finite / bool / date stay lexical).
 fn cmp_term_key(a: &str, b: &str) -> std::cmp::Ordering {
+    // Both keys are exact integers -> compare as i64 losslessly. Snowflake IDs
+    // and epoch-nanos exceed f64's 2^53 exact range, so widening to f64 (the
+    // fallback below) would collapse distinct long keys to the same float and
+    // mis-order them. ES orders a long field by exact value.
+    if let (Ok(x), Ok(y)) = (a.parse::<i64>(), b.parse::<i64>()) {
+        return x.cmp(&y);
+    }
+    // Otherwise order numerically when both parse as a finite number (covers
+    // floats and int/float mixes), else byte/lexicographic -- mirroring
+    // typed_term_key's numeric-key notion (non-finite/bool/date/keyword lexical).
     fn as_num(s: &str) -> Option<f64> {
         if let Ok(n) = s.parse::<i64>() {
             return Some(n as f64);
@@ -13857,6 +13867,32 @@ mod tests {
         ];
         let r = run_aggs(&json!({ "m": { "missing": { "field": "f" } } }), &docs);
         assert_eq!(r["m"]["doc_count"].as_u64(), Some(4), "got {r:?}");
+    }
+
+    #[test]
+    fn cmp_term_key_orders_longs_beyond_f64_range_exactly() {
+        use std::cmp::Ordering;
+        // Snowflake IDs / epoch-nanos exceed f64's 2^53 exact range. `cmp_term_key`
+        // must compare such keys by exact i64 value: a lossy i64->f64 widening
+        // collapses distinct longs to the same float and returns Equal (then the
+        // stable sort leaves them in arbitrary hash order — a wrong, unstable
+        // result vs ES). f64 rounding is monotonic, so the defect only ever
+        // shows as this Equal-collapse, which is why it is asserted directly.
+        assert_eq!(
+            cmp_term_key("9007199254740992", "9007199254740993"), // 2^53, 2^53+1
+            Ordering::Less,
+            "adjacent longs past 2^53 must not collapse to Equal"
+        );
+        assert_eq!(
+            cmp_term_key("1500000000000000002", "1500000000000000001"), // snowflake scale
+            Ordering::Greater
+        );
+        // Small ints, negatives, floats and int/float mixes stay numeric; a
+        // non-numeric key stays lexical.
+        assert_eq!(cmp_term_key("2", "10"), Ordering::Less);
+        assert_eq!(cmp_term_key("-5", "-2"), Ordering::Less);
+        assert_eq!(cmp_term_key("9.5", "10"), Ordering::Less);
+        assert_eq!(cmp_term_key("banana", "apple"), Ordering::Greater);
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -3904,6 +3904,28 @@ pub(crate) fn typed_term_key(key: &str) -> (Value, Option<String>) {
 /// other path is resolved against the bucket's precomputed sub-aggs and
 /// compared as a floating-point metric value (missing → -inf for asc,
 /// +inf for desc so gaps sort last).
+/// Order two terms-agg `_key`s the way ES does: NUMERICALLY when both keys are
+/// numbers, otherwise by byte/lexicographic order. XERJ already types numeric
+/// keys by value in `typed_term_key` (emitting `10` as JSON `10`, not `"10"`),
+/// so the ordering must match — otherwise `[2, 10, 100]` sorts as
+/// `["10", "100", "2"]`. Which keys count as numeric mirrors `typed_term_key`
+/// exactly: an `i64`, or a finite `f64` (non-finite / bool / date stay lexical).
+fn cmp_term_key(a: &str, b: &str) -> std::cmp::Ordering {
+    fn as_num(s: &str) -> Option<f64> {
+        if let Ok(n) = s.parse::<i64>() {
+            return Some(n as f64);
+        }
+        match s.parse::<f64>() {
+            Ok(f) if f.is_finite() => Some(f),
+            _ => None,
+        }
+    }
+    match (as_num(a), as_num(b)) {
+        (Some(x), Some(y)) => x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal),
+        _ => a.cmp(b),
+    }
+}
+
 fn cmp_terms_by_orders(
     a: &(String, u64, Option<Value>),
     b: &(String, u64, Option<Value>),
@@ -3912,12 +3934,12 @@ fn cmp_terms_by_orders(
     use std::cmp::Ordering;
     if orders.is_empty() {
         // ES default: count desc, key asc.
-        return b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0));
+        return b.1.cmp(&a.1).then_with(|| cmp_term_key(&a.0, &b.0));
     }
     for (path, asc) in orders {
         let ord = match path.as_str() {
             "_count" => a.1.cmp(&b.1),
-            "_key" => a.0.cmp(&b.0),
+            "_key" => cmp_term_key(&a.0, &b.0),
             other => {
                 let va = lookup_agg_metric(a.2.as_ref(), other);
                 let vb = lookup_agg_metric(b.2.as_ref(), other);
@@ -3930,7 +3952,7 @@ fn cmp_terms_by_orders(
         }
     }
     // Final tiebreaker on key.
-    a.0.cmp(&b.0)
+    cmp_term_key(&a.0, &b.0)
 }
 
 /// Resolve a dotted/`>`-separated path against a sub-aggregation result

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -1971,6 +1971,78 @@ mod flush_publication_recovery_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn terms_agg_numeric_key_order_is_numeric_not_lexicographic() {
+        // A terms agg on a numeric field must order `_key` (and break count
+        // ties) NUMERICALLY, like ES — not by the lexicographic string form of
+        // the number. Before the fix the comparator did `key_a.cmp(&key_b)` on
+        // the raw string keys, so [2, 10, 100] sorted as ["10","100","2"], even
+        // though the bucket keys are emitted as JSON numbers.
+        let _fault_test = FLUSH_FAULT_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.server.data_dir = dir.path().to_string_lossy().into_owned();
+        let engine = crate::Engine::new(config).unwrap();
+        let mut schema = Schema::empty();
+        schema
+            .add_field(FieldConfig::new("n", FieldType::Long))
+            .unwrap();
+        engine.create_index("ntk", schema).unwrap();
+        let idx = engine.get_index("ntk").unwrap();
+        idx.abort_background_tasks();
+        // counts: 10->2, 2->1, 100->1.
+        for (id, n) in [("a", 10), ("b", 10), ("c", 2), ("d", 100)] {
+            idx.index_document(Some(id.into()), json!({ "n": n }))
+                .await
+                .unwrap();
+        }
+        let run = |idx: std::sync::Arc<crate::Index>, order: serde_json::Value| async move {
+            let terms = if order.is_null() {
+                json!({"field":"n","size":10})
+            } else {
+                json!({"field":"n","size":10,"order":order})
+            };
+            let req = xerj_query::parse_request(
+                &json!({"query":{"match_all":{}},"size":0,"aggs":{"byn":{"terms":terms}}}),
+            )
+            .unwrap();
+            let r = idx.search(&req).await.unwrap();
+            r.aggs
+                .as_ref()
+                .and_then(|a| a["byn"]["buckets"].as_array())
+                .map(|bs| {
+                    bs.iter()
+                        .filter_map(|b| b["key"].as_i64())
+                        .collect::<Vec<i64>>()
+                })
+                .unwrap_or_default()
+        };
+        for phase in ["mem", "seg"] {
+            // order _key asc: 2 < 10 < 100 numerically (lexically "10" < "2").
+            assert_eq!(
+                run(idx.clone(), json!({"_key":"asc"})).await,
+                vec![2i64, 10, 100],
+                "_key asc numeric ({phase})"
+            );
+            // order _key desc.
+            assert_eq!(
+                run(idx.clone(), json!({"_key":"desc"})).await,
+                vec![100i64, 10, 2],
+                "_key desc numeric ({phase})"
+            );
+            // default order = count desc, then _key ASC numerically: 10 (count
+            // 2) first, then 2 before 100 (lexically "100" < "2" would flip it).
+            assert_eq!(
+                run(idx.clone(), serde_json::Value::Null).await,
+                vec![10i64, 2, 100],
+                "default tie-break numeric ({phase})"
+            );
+            if phase == "mem" {
+                idx.flush().await.unwrap();
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn mustnot_only_prefix_keeps_nonmatching_docs_after_flush() {
         // #797: a bool with ONLY a must_not (no must/should/filter) containing a
         // prefix/wildcard leaf returns zero hits after flush — the segment


### PR DESCRIPTION
Fixes #839.

A `terms` agg on a numeric field ordered `_key` (and broke `_count` ties) by the lexicographic string form of the number, so `[2, 10, 100]` came out `[10, 100, 2]` - even though the bucket keys are emitted as JSON numbers.

Root cause: `cmp_terms_by_orders` compared keys with `key_a.cmp(&key_b)` on the raw `String` keys at three sites (default tie-break, `_key`, final tiebreak). Keys are number-strings and `typed_term_key` already types them back to numbers, so the sort must agree.

Fix: a `cmp_term_key` helper orders keys numerically when both parse as a number (i64, or finite f64 - mirroring `typed_term_key` exactly), else lexicographically. Keyword/bool/date/non-finite keys stay lexical.

Test `terms_agg_numeric_key_order_is_numeric_not_lexicographic` (mem+seg): `_key` asc/desc and the default count-tie break. Fail-before (string cmp) -> `_key` asc = `[10,100,2]`; after -> `[2,10,100]`.

Full `cargo test -p xerj-engine` green (lib 655/0 + integration), fmt + clippy -D warnings clean, ci-test profile builds. 1.97.1.