### PR TITLE
fix(autoindex): anchor C++ enumerator capture, no function-local leak (#820 item 2)

### DIFF
--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -816,6 +816,7 @@ const CPP_Q: &str = r#"
 (translation_unit (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))
 (namespace_definition body: (declaration_list (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
 (field_declaration_list (field_declaration type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
+(linkage_specification body: (declaration_list (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
 (field_declaration (storage_class_specifier) @_s declarator: (field_identifier) @const (#eq? @_s "static"))
 "#;
 
@@ -1891,9 +1892,10 @@ mod tests {
         assert!(has(&s, "fn", "function"));
     }
 
-    /// #820 item 2: the `enumerator` pattern must be anchored to top-level /
-    /// namespace / class scope — a FUNCTION-LOCAL enum's values are not a
-    /// cross-file symbol and must not leak into `defs`.
+    /// #820 item 2: the `enumerator` pattern must be anchored to file-scope
+    /// (top-level / namespace / class / `extern "C"` linkage block) — a
+    /// FUNCTION-LOCAL enum's values are not a cross-file symbol and must not
+    /// leak into `defs`.
     #[test]
     fn cpp_function_local_enum_does_not_leak() {
         let s = syms(
@@ -1901,12 +1903,17 @@ mod tests {
             "enum Top { TA, TB };\n\
              namespace n { enum Ns { NA, NB }; }\n\
              class K { enum Member { MA, MB }; };\n\
+             extern \"C\" { enum Linkage { GA, GB }; }\n\
              void f() { enum Local { LA, LB }; }\n",
         );
-        // Top-level / namespace / class enumerators stay captured.
+        // File-scope enumerators (top-level / namespace / class / extern "C")
+        // stay captured.
         assert!(has(&s, "TA", "const"), "got {s:?}");
         assert!(has(&s, "NA", "const"), "got {s:?}");
         assert!(has(&s, "MA", "const"), "got {s:?}");
+        // `extern "C"` is a linkage_specification block, a common interop-header
+        // shape — its file-scope enum must be captured, not dropped (#841 gate).
+        assert!(has(&s, "GA", "const"), "got {s:?}");
         // Function-local enumerators must NOT leak.
         assert!(!has(&s, "LA", "const"), "got {s:?}");
         assert!(!has(&s, "LB", "const"), "got {s:?}");

--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -814,13 +814,12 @@ const CPP_Q: &str = r#"
 (namespace_definition body: (declaration_list (declaration declarator: (init_declarator declarator: (identifier) @const))))
 (namespace_definition body: (declaration_list (declaration declarator: (init_declarator declarator: (pointer_declarator declarator: (identifier) @const)))))
 (translation_unit (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))
+(translation_unit (_ (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
 (namespace_definition body: (declaration_list (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
-(field_declaration_list (field_declaration type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
+(namespace_definition body: (declaration_list (_ (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))))
+(field_declaration_list (_ (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
 (linkage_specification body: (declaration_list (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
-(translation_unit (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
-(namespace_definition body: (declaration_list (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))))
-(field_declaration_list (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
-(linkage_specification body: (declaration_list (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))))
+(linkage_specification body: (declaration_list (_ (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))))
 (field_declaration (storage_class_specifier) @_s declarator: (field_identifier) @const (#eq? @_s "static"))
 "#;
 
@@ -1909,8 +1908,12 @@ mod tests {
              class K { enum Member { MA, MB }; };\n\
              extern \"C\" { enum Linkage { GA, GB }; }\n\
              typedef enum { TDA, TDB } TdColor;\n\
+             enum WithVar { WVA, WVB } gvar;\n\
+             enum { ANONA = 1, ANONB = 2 } dims;\n\
+             namespace m { enum NsVar { NVA } nvinst; }\n\
              void f() { enum Local { LA, LB }; }\n\
-             void g() { typedef enum { LTA, LTB } LocTd; }\n",
+             void g() { typedef enum { LTA, LTB } LocTd; }\n\
+             void h() { enum LVar { LVA } lvi; }\n",
         );
         // File-scope enumerators (top-level / namespace / class / extern "C")
         // stay captured.
@@ -1924,10 +1927,19 @@ mod tests {
         // enum_specifier sits under a type_definition, so it needs its own
         // scope anchors, else its values are dropped (#841 gate 2).
         assert!(has(&s, "TDA", "const"), "got {s:?}");
-        // Function-local enumerators must NOT leak — plain OR typedef'd.
+        // An enum with an INLINE variable declarator (`enum E {..} v;`) — and
+        // the idiomatic anonymous-constant form (`enum { A, B } v;`) — wraps the
+        // enum_specifier in a `declaration` node, so file-scope anchors must
+        // allow that wrapper (#841 gate 3, the #500 "constants indexed nowhere").
+        assert!(has(&s, "WVA", "const"), "got {s:?}");
+        assert!(has(&s, "ANONA", "const"), "got {s:?}");
+        assert!(has(&s, "NVA", "const"), "got {s:?}");
+        // Function-local enumerators must NOT leak — plain, typedef'd, OR with
+        // an inline declarator.
         assert!(!has(&s, "LA", "const"), "got {s:?}");
         assert!(!has(&s, "LB", "const"), "got {s:?}");
         assert!(!has(&s, "LTA", "const"), "got {s:?}");
+        assert!(!has(&s, "LVA", "const"), "got {s:?}");
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -817,6 +817,10 @@ const CPP_Q: &str = r#"
 (namespace_definition body: (declaration_list (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
 (field_declaration_list (field_declaration type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
 (linkage_specification body: (declaration_list (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
+(translation_unit (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
+(namespace_definition body: (declaration_list (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))))
+(field_declaration_list (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
+(linkage_specification body: (declaration_list (type_definition type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))))
 (field_declaration (storage_class_specifier) @_s declarator: (field_identifier) @const (#eq? @_s "static"))
 "#;
 
@@ -1904,7 +1908,9 @@ mod tests {
              namespace n { enum Ns { NA, NB }; }\n\
              class K { enum Member { MA, MB }; };\n\
              extern \"C\" { enum Linkage { GA, GB }; }\n\
-             void f() { enum Local { LA, LB }; }\n",
+             typedef enum { TDA, TDB } TdColor;\n\
+             void f() { enum Local { LA, LB }; }\n\
+             void g() { typedef enum { LTA, LTB } LocTd; }\n",
         );
         // File-scope enumerators (top-level / namespace / class / extern "C")
         // stay captured.
@@ -1914,9 +1920,14 @@ mod tests {
         // `extern "C"` is a linkage_specification block, a common interop-header
         // shape — its file-scope enum must be captured, not dropped (#841 gate).
         assert!(has(&s, "GA", "const"), "got {s:?}");
-        // Function-local enumerators must NOT leak.
+        // `typedef enum { .. } Name;` is the pervasive C/C++ header idiom — the
+        // enum_specifier sits under a type_definition, so it needs its own
+        // scope anchors, else its values are dropped (#841 gate 2).
+        assert!(has(&s, "TDA", "const"), "got {s:?}");
+        // Function-local enumerators must NOT leak — plain OR typedef'd.
         assert!(!has(&s, "LA", "const"), "got {s:?}");
         assert!(!has(&s, "LB", "const"), "got {s:?}");
+        assert!(!has(&s, "LTA", "const"), "got {s:?}");
     }
 
     #[test]

--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -813,7 +813,9 @@ const CPP_Q: &str = r#"
 (translation_unit (declaration declarator: (init_declarator declarator: (pointer_declarator declarator: (identifier) @const))))
 (namespace_definition body: (declaration_list (declaration declarator: (init_declarator declarator: (identifier) @const))))
 (namespace_definition body: (declaration_list (declaration declarator: (init_declarator declarator: (pointer_declarator declarator: (identifier) @const)))))
-(enumerator name: (identifier) @const)
+(translation_unit (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const))))
+(namespace_definition body: (declaration_list (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
+(field_declaration_list (field_declaration type: (enum_specifier body: (enumerator_list (enumerator name: (identifier) @const)))))
 (field_declaration (storage_class_specifier) @_s declarator: (field_identifier) @const (#eq? @_s "static"))
 "#;
 
@@ -1887,6 +1889,27 @@ mod tests {
         // Function-local stays out (anchored to unit / namespace scope).
         assert!(!has(&s, "local", "const"), "got {s:?}");
         assert!(has(&s, "fn", "function"));
+    }
+
+    /// #820 item 2: the `enumerator` pattern must be anchored to top-level /
+    /// namespace / class scope — a FUNCTION-LOCAL enum's values are not a
+    /// cross-file symbol and must not leak into `defs`.
+    #[test]
+    fn cpp_function_local_enum_does_not_leak() {
+        let s = syms(
+            "cpp",
+            "enum Top { TA, TB };\n\
+             namespace n { enum Ns { NA, NB }; }\n\
+             class K { enum Member { MA, MB }; };\n\
+             void f() { enum Local { LA, LB }; }\n",
+        );
+        // Top-level / namespace / class enumerators stay captured.
+        assert!(has(&s, "TA", "const"), "got {s:?}");
+        assert!(has(&s, "NA", "const"), "got {s:?}");
+        assert!(has(&s, "MA", "const"), "got {s:?}");
+        // Function-local enumerators must NOT leak.
+        assert!(!has(&s, "LA", "const"), "got {s:?}");
+        assert!(!has(&s, "LB", "const"), "got {s:?}");
     }
 
     #[test]


### PR DESCRIPTION
Advances #820 (item 2 of the four const-capture precision nits).

The C++ `enumerator` pattern was unanchored, so a function-local enum leaked its values as `const` symbols into the cross-file retrieval surface:
```cpp
void f() { enum E { LX, LY }; }   // LX, LY wrongly captured as const
```

Fix: anchor the enumerator to the three scopes the other C++ const patterns use - `translation_unit`, `namespace_definition` body, and class `field_declaration_list` (the exact parent shapes were read off the tree-sitter parse, not guessed). Function-local enums (under `compound_statement`) no longer match.

Test `cpp_function_local_enum_does_not_leak`: top-level / namespace / class enumerators stay captured, function-local excluded. Fail-before (unanchored) leaks LX/LY; after, clean. Existing `cpp_constants` unchanged (no recall loss). Full `cargo test -p xerj-autoindex` green (733/0), `all_queries_compile` passes, fmt + clippy -D warnings clean, ci-test builds. 1.97.1.

Items 1 (class-static const) and 4 (Python bare annotation) of #820 are already fixed+tested on main; item 3 is a labeling refinement. This closes the recall-affecting remainder.