### PR TITLE
fix(aggs): missing agg counts empty/only-null arrays as missing (#844)

### DIFF
--- a/engine/crates/xerj-engine/src/aggs.rs
+++ b/engine/crates/xerj-engine/src/aggs.rs
@@ -7264,8 +7264,11 @@ fn run_missing(params: &Value, docs: &[Value]) -> Value {
     } else {
         docs.iter()
             .filter(|doc| {
-                let v = get_nested_field(doc, field);
-                v.is_null()
+                // A doc is "missing" the field iff it has no non-null value —
+                // the exact complement of `exists` (#792/#793 value_present):
+                // absent, null, `[]` and `[null]` all count as missing, so
+                // `is_null()` alone (which kept `[]`/`[null]`) undercounted.
+                !crate::index::value_present(get_nested_field(doc, field))
             })
             .count()
     };
@@ -13816,6 +13819,22 @@ mod tests {
             rd["mn"]["value_as_string"].is_string(),
             "date min_as_string: {rd:?}"
         );
+    }
+
+    #[test]
+    fn missing_agg_counts_empty_and_null_arrays() {
+        // ES `missing` agg counts docs with NO value: absent, null, [] and
+        // [null] all count as missing; a real value does not. This is the
+        // exact complement of `exists` (#792/#793 value_present).
+        let docs = vec![
+            json!({ "f": 5 }),      // present
+            json!({ "f": null }),   // missing
+            json!({ "f": [] }),     // missing (empty array)
+            json!({ "f": [null] }), // missing (only-null array)
+            json!({ "other": 1 }),  // missing (absent)
+        ];
+        let r = run_aggs(&json!({ "m": { "missing": { "field": "f" } } }), &docs);
+        assert_eq!(r["m"]["doc_count"].as_u64(), Some(4), "got {r:?}");
     }
 
     #[test]

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -37240,7 +37240,7 @@ fn doc_matches_query(q: &QueryNode, source: &Value) -> bool {
 /// `[null]` are NOT present; `[null, "x"]` is (it has a non-null element).
 /// Scalars and objects are present (object sub-field recursion is a separate
 /// concern the dense/declared paths already handle).
-fn value_present(v: &Value) -> bool {
+pub(crate) fn value_present(v: &Value) -> bool {
     match v {
         Value::Null => false,
         Value::Array(a) => a.iter().any(value_present),


### PR DESCRIPTION
Fixes #844.

The `missing` agg counted a doc as present whenever `get_nested_field` wasn't JSON null, so `[]` and `[null]` (no value in ES) were wrongly counted present. That's the complement of the #792/#793 `exists` fix — leaving `exists` and `missing` to disagree on the same doc (a `f:[]` doc was both 'not exists' and 'not missing').

Repro: docs {f:5},{f:null},{f:[]},{f:[null]},{other:1} -> missing doc_count XERJ 2, ES 4.

Fix: `run_missing` counts `!crate::index::value_present(...)` — the exact helper #793 added for `exists`, now `pub(crate)` for a single source of truth. absent/null/[]/[null] all count as missing.

Test `missing_agg_counts_empty_and_null_arrays` (aggs.rs module, no index.rs anchor). Fail-before proven (is_null -> 2 vs 4). Full `cargo test -p xerj-engine` green (CARGO_EXIT=0, 62 bins, 0 failed), fmt+clippy -D clean, ci-test builds. 1.97.1.