### PR TITLE
fix(es-compat): GET /_doc _source_includes/excludes honor nested paths (#850)

### DIFF
--- a/engine/crates/xerj-api/src/es_compat.rs
+++ b/engine/crates/xerj-api/src/es_compat.rs
@@ -3205,29 +3205,11 @@ fn apply_get_doc_source_filter(source: Value, params: &GetDocParams) -> Value {
         return source;
     }
 
-    // Re-use the same filter_object logic from the search path.
-    filter_source_object(&source, &includes, &excludes)
-}
-
-/// Filter a JSON object by includes/excludes lists (with trailing `*` wildcard support).
-fn filter_source_object(source: &Value, includes: &[String], excludes: &[String]) -> Value {
-    let obj = match source.as_object() {
-        Some(o) => o,
-        None => return source.clone(),
-    };
-    let mut result = serde_json::Map::new();
-    for (k, v) in obj {
-        let keep = if includes.is_empty() {
-            true
-        } else {
-            includes.iter().any(|inc| source_field_matches(k, inc))
-        };
-        let excluded = excludes.iter().any(|exc| source_field_matches(k, exc));
-        if keep && !excluded {
-            result.insert(k.clone(), v.clone());
-        }
-    }
-    Value::Object(result)
+    // Project through the SAME faithful ES `_source` automaton the search path
+    // uses (`xerj_engine::filter_object`), so dotted/nested includes+excludes
+    // and `*` globs behave identically. The old local top-level-only filter
+    // dropped nested includes entirely and no-oped nested excludes (#850).
+    xerj_engine::filter_object(&source, &includes, &excludes)
 }
 
 fn source_field_matches(field: &str, pattern: &str) -> bool {
@@ -3235,6 +3217,54 @@ fn source_field_matches(field: &str, pattern: &str) -> bool {
         field.starts_with(prefix)
     } else {
         field == pattern
+    }
+}
+
+#[cfg(test)]
+mod get_doc_source_filter_tests {
+    use super::*;
+    use serde_json::json;
+
+    // #850: GET /_doc `_source_includes`/`_source_excludes` must support
+    // dotted/nested paths (and `*` globs), like search — the old top-level-only
+    // filter dropped a nested include entirely and no-oped a nested exclude.
+    #[test]
+    fn get_doc_source_filter_handles_nested_paths() {
+        let src = || json!({ "user": { "name": "x", "age": 5 }, "id": 1 });
+
+        // Nested include keeps only the requested leaf under its parent.
+        let inc = apply_get_doc_source_filter(
+            src(),
+            &GetDocParams {
+                source_includes: Some("user.name".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(inc, json!({ "user": { "name": "x" } }), "nested include");
+
+        // Nested exclude removes just that leaf, keeps siblings + other keys.
+        let exc = apply_get_doc_source_filter(
+            src(),
+            &GetDocParams {
+                source_excludes: Some("user.age".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            exc,
+            json!({ "user": { "name": "x" }, "id": 1 }),
+            "nested exclude"
+        );
+
+        // Top-level literal include is unchanged from before.
+        let top = apply_get_doc_source_filter(
+            src(),
+            &GetDocParams {
+                source_includes: Some("id".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(top, json!({ "id": 1 }), "top-level include");
     }
 }
 
@@ -17991,7 +18021,7 @@ async fn build_update_get_field(
             let filtered = if includes.is_empty() && excludes.is_empty() {
                 source
             } else {
-                filter_source_object(&source, &includes, &excludes)
+                xerj_engine::filter_object(&source, &includes, &excludes)
             };
             json!({ "found": true, "_source": filtered })
         }

--- a/engine/crates/xerj-engine/src/index.rs
+++ b/engine/crates/xerj-engine/src/index.rs
@@ -27940,7 +27940,12 @@ fn generated_embedding_companion_fields(schema: &Schema) -> HashSet<String> {
 /// Supports dotted field paths: `include.field1` matches the nested
 /// `{"include": {"field1": ...}}` structure. If `includes` is empty,
 /// all fields are kept before exclusions are applied.
-fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Value {
+/// Faithful ES `_source` include/exclude projection over a single JSON value:
+/// dotted paths and `*` globs that span `.` at any depth, includes then
+/// excludes (#602). Exposed so the document-GET path (`_source_includes` /
+/// `_source_excludes` on `GET /_doc`) projects identically to search instead
+/// of the old top-level-only filter that dropped nested includes.
+pub fn filter_object(source: &Value, includes: &[String], excludes: &[String]) -> Value {
     let obj = match source.as_object() {
         Some(o) => o,
         None => return source.clone(),

--- a/engine/crates/xerj-engine/src/lib.rs
+++ b/engine/crates/xerj-engine/src/lib.rs
@@ -49,8 +49,8 @@ mod bounded_ingest_resources_tests;
 pub use cluster_state::{ClusterStateBlockKind, ClusterStateBootStatus};
 pub use engine::{EmbeddingExecutionIdentity, Engine, HealthStatus, IndexInfo};
 pub use index::{
-    detect_log_format, resolve_date_math, resolve_field_alias, EnrichTable, FieldEncodingInfo,
-    Index, IndexResponse, IndexStats, LogFormat,
+    detect_log_format, filter_object, resolve_date_math, resolve_field_alias, EnrichTable,
+    FieldEncodingInfo, Index, IndexResponse, IndexStats, LogFormat,
 };
 // Second-brain graph expansion (bounded columnar traversal over an edges
 // index). Lives under `index` for private-field access; re-exported at the


### PR DESCRIPTION
Fixes #850.

`GET /{index}/_doc/{id}?_source_includes=user.name` only filtered TOP-LEVEL _source keys — `apply_get_doc_source_filter` called a local `filter_source_object` matching each top-level key with exact/trailing-`*` only, never descending. So `_source_includes=user.name` returned `{}` (dropped nested data) and `_source_excludes=user.age` no-oped (left it in). GET /_doc diverged from search, which routes through the engine's faithful ES _source automaton — the code even commented it should reuse it.

Fix: route both `apply_get_doc_source_filter` call sites through `xerj_engine::filter_object` (now `pub` + re-exported), and drop the top-level-only `filter_source_object`. `source_field_matches` (used elsewhere) kept.

Test `get_doc_source_filter_handles_nested_paths` (nested include keeps the leaf; nested exclude removes just it; top-level unchanged). Fail-before proven (nested include -> {}). Full `cargo test -p xerj-api -p xerj-engine` green (CARGO_EXIT=0, 122 bins, 0 failed), fmt + clippy -D clean, ci-test builds. 1.97.1.