### PR TITLE
chore: add MavenRain to .contributors (CLA signature)

### DIFF
--- a/.contributors
+++ b/.contributors
@@ -5,5 +5,6 @@
   "buger",
   "pradaev",
   "SebTardif",
-  "Nicolas0315"
+  "Nicolas0315",
+  "MavenRain"
 ]


### PR DESCRIPTION
Signs CLA.md per cla-bot on #865.