### PR TITLE
fix(autoindex): invalidate the edges of a superseded anchor node (#736)

### DIFF
--- a/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
+++ b/engine/crates/xerj-autoindex/src/incremental_reconcile_http_tests.rs
@@ -2703,6 +2703,185 @@ fn sweep_excluded_groups_invalidates_inbound_edges() {
     );
 }
 
+/// #736 (replacement half): a run that SUPERSEDES a file's anchor node must
+/// soft-invalidate the edges pointing AT the old anchor, not only the edges the
+/// old generation taught.
+///
+/// The reachable trigger is `--fresh`. An ordinary resume maps every file back
+/// onto its planned key (`select_resume_plan_keys`), so an in-place edit keeps
+/// its `file_key` and its anchor id — nothing is superseded and the inbound
+/// edges keep pointing at a live node. `--fresh` discards the plan and rebuilds
+/// every key from current content, so an edited file gets a NEW key and a NEW
+/// anchor, while `cleanup_required` (the journal's record of what is live) has
+/// just been wiped with the journal — so before this fix the run invalidated
+/// nothing at all, and every edge a surviving file taught into the old anchor
+/// stayed live and searchable, pointing at a superseded node.
+///
+/// Fail-before: with the superseded-anchor invalidation reverted, the two
+/// `a.md → old b anchor` edges come back with no `invalid_at` and the first
+/// assertion fires.
+#[test]
+fn fresh_run_invalidates_inbound_edges_to_a_superseded_anchor() {
+    let _guard = HTTP_E2E_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _replay_guard = sync_executor::REPLAY_FAILPOINT_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let corpus = tempfile::tempdir().unwrap();
+    let state_dir = tempfile::tempdir().unwrap();
+    fs::write(
+        corpus.path().join("a.md"),
+        "# A\n\nSee [[b]] for the details of the target document.\n",
+    )
+    .unwrap();
+    fs::write(
+        corpus.path().join("b.md"),
+        "# B\n\nThe target document says one thing.\n",
+    )
+    .unwrap();
+    let endpoint = HttpEndpoint::start();
+    let mut config = cfg(corpus.path(), state_dir.path(), &endpoint.url, false);
+    config.no_graph = false;
+    config.brain = Some("testbrain".into());
+    assert_eq!(run_index(config.clone()).unwrap(), 0);
+    let edges_index = detect::edges_index_name("testbrain");
+
+    // Anchor ids are read off the published file cards (`ax_locator: "file"`),
+    // so the test never has to recompute `ids::doc_id` itself.
+    let anchors_of = |path: &str| -> Vec<String> {
+        let st = endpoint.state.lock().unwrap();
+        let mut ids: Vec<String> = st
+            .docs
+            .iter()
+            .filter(|((index, _), doc)| {
+                index != catalog::CATALOG_INDEX
+                    && doc.get("ax_locator").and_then(Value::as_str) == Some("file")
+                    && doc.get("ax_path").and_then(Value::as_str) == Some(path)
+            })
+            .map(|((_, id), _)| id.clone())
+            .collect();
+        ids.sort();
+        ids
+    };
+    let edges_of = |predicate: &dyn Fn(&Value) -> bool| -> Vec<(String, Value)> {
+        let st = endpoint.state.lock().unwrap();
+        let mut rows: Vec<(String, Value)> = st
+            .docs
+            .iter()
+            .filter(|((index, _), doc)| *index == edges_index && predicate(doc))
+            .map(|((_, id), doc)| (id.clone(), doc.clone()))
+            .collect();
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        rows
+    };
+
+    let old_b_anchor = {
+        let mut found = anchors_of("b.md");
+        assert_eq!(found.len(), 1, "run 1 publishes exactly one b.md file card");
+        found.pop().unwrap()
+    };
+    // The inbound edges the fix has to reach: taught by the SURVIVING file a.md,
+    // pointing at b.md's anchor. Asserted before the change so a corpus that
+    // stopped producing them could never make this test vacuously pass.
+    let inbound_before = edges_of(&|doc| {
+        doc.get("src_file").and_then(Value::as_str) == Some("a.md")
+            && doc.get("dst").and_then(Value::as_str) == Some(old_b_anchor.as_str())
+    });
+    assert!(
+        !inbound_before.is_empty(),
+        "#736: the fixture must actually teach a.md → b.md edges"
+    );
+    // a.md's other edges (its own card → section chain) must survive untouched:
+    // a.md is byte-identical across the two runs, and #868's skip means an
+    // unchanged file must neither re-teach nor lose its edges.
+    let a_internal_before: Vec<String> = edges_of(&|doc| {
+        doc.get("src_file").and_then(Value::as_str) == Some("a.md")
+            && doc.get("dst").and_then(Value::as_str) != Some(old_b_anchor.as_str())
+    })
+    .into_iter()
+    .map(|(id, _)| id)
+    .collect();
+    assert!(
+        !a_internal_before.is_empty(),
+        "#736: the fixture must have edges that the sweep MUST NOT touch"
+    );
+
+    // Edit b.md, then rebuild in place with --fresh: b.md's content key, and so
+    // its anchor node id, is superseded.
+    fs::write(
+        corpus.path().join("b.md"),
+        "# B\n\nThe target document now says something completely different today.\n",
+    )
+    .unwrap();
+    let mut fresh = config.clone();
+    fresh.fresh = true;
+    assert_eq!(run_index(fresh).unwrap(), 0);
+
+    let new_b_anchor = {
+        let found = anchors_of("b.md");
+        let fresh_ids: Vec<&String> = found.iter().filter(|id| **id != old_b_anchor).collect();
+        assert_eq!(
+            fresh_ids.len(),
+            1,
+            "--fresh must publish a new b.md file card after the edit, got {found:?}"
+        );
+        fresh_ids[0].clone()
+    };
+    assert_ne!(
+        new_b_anchor, old_b_anchor,
+        "the fixture must actually supersede b.md's anchor"
+    );
+
+    // The bug: every live edge pointing at the superseded anchor.
+    let inbound_after =
+        edges_of(&|doc| doc.get("dst").and_then(Value::as_str) == Some(old_b_anchor.as_str()));
+    assert_eq!(
+        inbound_after.len(),
+        inbound_before.len(),
+        "#736: prior edges are soft-invalidated, never deleted — the bi-temporal \
+         record must still be there for `as_of`"
+    );
+    for (id, doc) in &inbound_after {
+        assert!(
+            doc.get("invalid_at").is_some(),
+            "#736: edge {id} still points at b.md's superseded anchor {old_b_anchor} \
+             and was left live: {doc}"
+        );
+    }
+    // The old generation's own outbound edges go too — same root cause, same
+    // pass: `src_file == b.md` was never invalidated under --fresh either.
+    for (id, doc) in
+        edges_of(&|doc| doc.get("src").and_then(Value::as_str) == Some(old_b_anchor.as_str()))
+    {
+        assert!(
+            doc.get("invalid_at").is_some(),
+            "#736: edge {id} is taught BY b.md's superseded anchor and was left live: {doc}"
+        );
+    }
+
+    // …and the graph is still a graph: a.md links to the NEW anchor, live.
+    let inbound_new = edges_of(&|doc| {
+        doc.get("src_file").and_then(Value::as_str) == Some("a.md")
+            && doc.get("dst").and_then(Value::as_str) == Some(new_b_anchor.as_str())
+            && doc.get("invalid_at").is_none()
+    });
+    assert!(
+        !inbound_new.is_empty(),
+        "#736: the re-run must re-teach a.md → b.md against the new anchor"
+    );
+    // #868: the unchanged file's unrelated edges are untouched.
+    for id in &a_internal_before {
+        let st = endpoint.state.lock().unwrap();
+        let doc = st
+            .docs
+            .get(&(edges_index.clone(), id.clone()))
+            .unwrap_or_else(|| panic!("#868: a.md's edge {id} must survive the re-run"));
+        assert!(
+            doc.get("invalid_at").is_none(),
+            "#868: byte-identical a.md's own edge {id} must stay live: {doc}"
+        );
+    }
+}
+
 /// #585 (case 1): a pending (uncommitted) `--no-graph` generation must NOT be
 /// resumed and committed on the default graph path — doing so silently commits
 /// a no-graph generation under a graph authority (the #584 hazard, but for a

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -3447,6 +3447,40 @@ fn graph_edges_index(cfg: &IndexCfg) -> Option<String> {
         .map(|()| detect::edges_index_name(&brain))
 }
 
+/// #736: every graph ANCHOR node a plan owns — `ids::doc_id(slug, file_key,
+/// FILE_CARD_LOCATOR)` for each dataset the file is assigned to — paired with
+/// that file's `rel`. Sorted and deduped so two calls are directly comparable.
+///
+/// The anchor is the node every cross-file edge points AT (`EdgeDraft::dst` is
+/// `CorpusFile::anchor_doc_id` in every detector that links two files), so the
+/// anchor set is exactly the set of edge endpoints a plan can own.
+///
+/// The graph phase compares the PRIOR plan's anchors against this run's. An
+/// anchor the prior plan owned and this one does not is SUPERSEDED — its node
+/// belongs to a generation this run replaced — so the edges pointing at it
+/// (`dst`) and the edges that generation taught (`src_file`) must both be
+/// soft-invalidated. A file whose key and dataset assignments are unchanged
+/// appears in both sets and is therefore never touched, which is what keeps the
+/// #868 byte-identical skip honest: an unchanged file neither re-teaches nor
+/// loses its edges.
+fn plan_anchor_nodes(plan: &Plan) -> Vec<(String, String)> {
+    let mut anchors: Vec<(String, String)> = plan
+        .files
+        .iter()
+        .flat_map(|(key, assignment)| {
+            assignment.assignments.iter().map(move |(_, slug)| {
+                (
+                    crate::ids::doc_id(slug, key, detect::FILE_CARD_LOCATOR),
+                    assignment.rel.clone(),
+                )
+            })
+        })
+        .collect();
+    anchors.sort();
+    anchors.dedup();
+    anchors
+}
+
 /// Catalog doc id for a time correlation, corpus-prefix-scoped (#673): the
 /// `autoindex-catalog` index is shared across corpora, so a time correlation
 /// keyed only by dataset slugs would overwrite the same-slug correlation from
@@ -4121,6 +4155,18 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
             .context("sweep newly-excluded content groups")?;
         }
     }
+    // #736: snapshot the PRIOR plan's anchor nodes HERE, before the journal is
+    // opened. `--fresh` deletes `journal.ndjson` inside `open_after_preflight`,
+    // taking the prior plan with it — and `--fresh` is precisely the path that
+    // supersedes a changed file's anchor, because it rebuilds every key from
+    // current content instead of mapping each file onto its planned key the way
+    // `select_resume_plan_keys` does on an ordinary resume. Only a run that can
+    // write edges has any to invalidate, so `--no-graph` (and an unusable brain
+    // name) pays nothing here.
+    let prior_anchor_nodes: Vec<(String, String)> = match preflight.plan.as_ref() {
+        Some(prior) if graph_edges_index(&cfg).is_some() => plan_anchor_nodes(prior),
+        _ => Vec::new(),
+    };
     let mut journal = state::Journal::open_after_preflight(
         preflight,
         &root_str,
@@ -4969,12 +5015,49 @@ pub fn run_index_report(cfg: IndexCfg) -> Result<(i32, Option<Value>)> {
                 .filter(|&&i| cleanup_required.contains(&keys[i]))
                 .map(|&i| files[i].rel.as_str())
                 .collect();
+            // #736: `cleanup_required` is the journal's own record of what is
+            // already live, so it is EMPTY after `--fresh` wiped the journal —
+            // and `--fresh` is the one path that gives a content-changed file a
+            // new `file_key`, hence a new anchor node. Nothing above notices, so
+            // the prior generation's edges stayed live: the ones the old anchor
+            // taught (`src_file`) AND the ones a surviving file taught pointing
+            // AT it (`dst`), which is the inbound half #736 was filed for. An
+            // ordinary resume supersedes no anchor (`select_resume_plan_keys`
+            // preserves the planned key across an in-place edit), so this set is
+            // empty there and the resume behaviour is unchanged.
+            let live_anchors: std::collections::HashSet<String> = plan_anchor_nodes(&plan)
+                .into_iter()
+                .map(|(anchor, _)| anchor)
+                .collect();
+            let superseded: Vec<&(String, String)> = prior_anchor_nodes
+                .iter()
+                .filter(|(anchor, _)| !live_anchors.contains(anchor))
+                .collect();
+            replaced_rels.extend(superseded.iter().map(|(_, rel)| rel.as_str()));
             replaced_rels.sort_unstable();
             replaced_rels.dedup();
             for rel in replaced_rels {
                 invalidated +=
                     detect::invalidate_prior_edges(&es, &edges_index, rel, created_at_ms)
                         .with_context(|| format!("invalidate prior edges taught by {rel}"))?;
+            }
+            // The inbound half. Keyed on the SUPERSEDED anchor only — never on a
+            // surviving file — so an unchanged file's edges are left exactly as
+            // they are (#868). This runs before any edge this run writes, and
+            // this run's edges name the NEW anchor, so it can only ever match
+            // prior generations. Same soft-invalidate as the src side: the
+            // bi-temporal record survives for `as_of` time travel.
+            for (anchor, rel) in superseded {
+                invalidated += detect::invalidate_edges_by_field(
+                    &es,
+                    &edges_index,
+                    "dst",
+                    anchor,
+                    created_at_ms,
+                )
+                .with_context(|| {
+                    format!("invalidate inbound edges to the superseded anchor node of {rel}")
+                })?;
             }
         }
 


### PR DESCRIPTION
Finishes the second half of #736. [#746](https://github.com/xerj-org/xerj/pull/746) closed the exclusion-sweep half — a widened ignore rule now soft-invalidates the INBOUND edges a surviving file taught into the removed file's anchor, not only the OUTBOUND edges the removed file taught. The issue stayed open for the replacement-invalidation half.

## What I found first

The half the issue describes ("a file whose CONTENT changed → new `file_key` → the OLD anchor is orphaned") **does not happen on the ordinary resume path**, and the previous attempt on this branch was right to refuse to claim it did. `select_resume_plan_keys` (`engine/crates/xerj-autoindex/src/lib.rs:2455`) maps every current file back onto its planned key by `path_id`/`rel`, so an in-place edit keeps its `file_key` and therefore its anchor doc id. Measured on a two-file corpus (`a.md` wikilinks `b.md`), editing `b.md` and re-running without `--fresh`:

```
resume run 1   nodes: a.md anchor a2f4…, b.md anchor 6b7b… (key axf2-61d4…-29)
resume run 2   nodes: UNCHANGED — b.md keeps key axf2-61d4…-29 and anchor 6b7b…
               b.md's own prior edge invalidated, re-taught; a.md → 6b7b… still
               live and still pointing at a LIVE node
```

So that path needed no fix and this PR does not change it.

## The path that is actually broken: `--fresh`

The graph phase's replacement invalidation (`lib.rs:5013`) builds `replaced_rels` from `cleanup_required`, which is the **journal's** record of what is already live (`journal.done` + `journal.pending_replacements`, `lib.rs:4775`). `--fresh` deletes `journal.ndjson` inside `Journal::open_after_preflight` — so on that path `cleanup_required` is empty and the loop invalidates **nothing at all**. And `--fresh` is simultaneously the one path that *does* supersede an anchor: it discards the plan and rebuilds every key from current content instead of mapping each file onto its planned key. New key → new anchor id `ids::doc_id(slug, file_key, "file")` → every edge naming the OLD anchor is left live, on both sides.

Same fixture, edit `b.md`, re-run with `--fresh` (edges dumped from the stateful HTTP fixture):

```
run 1   b.md anchor 6b7b8c63…
        a.md  -> 6b7b8c63…   wikilink   live
        a.md  -> 6b7b8c63…   samedir    live
        6b7b8c63… -> 0f5be977…  sequence (b.md's own)   live
run 2   b.md anchor 3fb3b18b… (new); a.md -> 3fb3b18b… written
        all three run-1 edges STILL LIVE, naming the superseded anchor
```

## The fix

`plan_anchor_nodes` (`lib.rs:3466`) projects a plan to the anchor nodes it owns — `(ids::doc_id(slug, key, FILE_CARD_LOCATOR), rel)` per file per dataset assignment. That set is exactly the set of edge endpoints a plan can own: `EdgeDraft::dst` is `CorpusFile::anchor_doc_id` in every detector that links two files (`wikilink`/`mdlink`/`href`/`pathcite`/`cratecite`/`samedir`/`sharedterm`); `sequence` is the one detector with a non-anchor `dst`, and it is intra-file, so the `src_file` side already covers it.

- The **prior** plan's projection is snapshotted at `lib.rs:4166`, before the journal is opened — `--fresh` destroys the prior plan there. Skipped entirely when the run cannot write edges (`--no-graph`, unusable brain name), so those runs pay nothing.
- The graph phase diffs it against this run's plan. An anchor the prior plan owned and this one does not is **superseded**: its rel joins `replaced_rels` (the `src_file` side, `lib.rs:5039`) and its anchor id is invalidated on the `dst` side (`lib.rs:5050`).
- Same bi-temporal soft-invalidate as the rest of the path — `invalid_at`/`expired_at` stamped, nothing deleted, `as_of` time travel intact. No edge schema change; `dst` is already a keyword.

**#868 byte-identical skip.** The dst sweep keys on the *superseded anchor*, never on a surviving file. An unchanged file's key and slug are in both projections, so it is not in the diff and neither re-teaches nor loses a single edge. On an ordinary resume the diff is empty and behaviour is bit-for-bit unchanged. Excluded files that #746 already swept *are* in the diff, where re-invalidation finds no live edges — a no-op backstop.

## Test and fail-before

`fresh_run_invalidates_inbound_edges_to_a_superseded_anchor` (`incremental_reconcile_http_tests.rs:2724`) drives two real `run_index` invocations against the stateful HTTP fixture, reads `b.md`'s anchor off its published file card (rather than recomputing an id), and asserts: no live edge names the superseded anchor on either side; the prior edges are still **present** (soft-invalidated, not deleted); `a.md` links the NEW anchor, live; and every one of byte-identical `a.md`'s unrelated edges is untouched. It also asserts the fixture really produces inbound edges before the edit, so it can never pass vacuously.

Fail-before proven by `git stash`ing `lib.rs` and re-running:

```
#736: edge 51a03e29… still points at b.md's superseded anchor 6b7b8c63…
and was left live: {"type":"wikilink","src_file":"a.md","dst":"6b7b8c63…", …}
```

## Gates

- `cargo fmt --all --check` — clean.
- `cargo clippy --release -j 8 -p xerj-autoindex --all-targets -- -D warnings` — clean.
- `cargo test --release -j 8 -p xerj-autoindex --lib` — **736 passed, 0 failed**; `--tests` (the four integration binaries) all green. Full crate suite ran in ~11s, so nothing was skipped for time.
- One flake seen on the first `--lib` run and **not** caused by this change: `unchanged_reindex_skips_the_parse_and_stays_byte_identical` uses the process-global `SCAN_FILE_PARSED` counter under `HTTP_E2E_LOCK`, but the 65 tests in `failure_resume_http_tests` take a *different* lock (`FAILPOINT_TEST_LOCK`) and bump that counter concurrently. It passes alone and passed on the immediate re-run. Pre-existing; flagged, not touched here.

## Deliberately not fixed here

`--fresh` also leaves the superseded generation's **documents** live — the run-2 dump above has 6 node docs where the corpus has 4 — so the old anchor is a stale duplicate rather than a missing node. Invalidating its edges is right either way (the graph stops returning the superseded generation), but the orphaned documents are a delete path, not an edge path, and want their own issue.

Closes #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
