### PR TITLE
fix(autoindex): stop opening directories as files — `--no-graph` was dead on Windows (#482)

### DIFF
--- a/.github/scripts/autoindex-fd-smoke.sh
+++ b/.github/scripts/autoindex-fd-smoke.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# Per-platform regression guard for the autoindex "Too many open files" crash.
+# Per-platform runtime gate for `xerj autoindex`. Two regressions live here:
+#
+#   1. the "Too many open files" (EMFILE) crash — described below;
+#   2. #482, the `--no-graph` ERROR_ACCESS_DENIED abort on Windows — described
+#      at its own section further down.
+#
+# Both exist because nothing in CI used to RUN the binary on macOS/Windows.
 #
 # The crash: `xerj autoindex` on a large repo infers hundreds of datasets =>
 # hundreds of indices. Before the fix each index pinned one WAL file descriptor
@@ -93,10 +99,66 @@ if [ "${CREATED:-0}" -lt 300 ]; then
   FAIL=1
 fi
 
+# ── the `--no-graph` generated path (#482) ─────────────────────────────────
+# The default (graph) path above never touches `sync-snapshots/`. `--no-graph`
+# does: it seals a durable source snapshot under the state directory and
+# fsyncs the directories it just published. Sealing used `File::open(dir)
+# .sync_all()`, a Unix-only idiom that returns ERROR_ACCESS_DENIED (os error
+# 5) on EVERY Windows call, so `xerj autoindex <folder> --no-graph` aborted on
+# Windows right after the journal was written, before one document was
+# indexed — reported against rc.17 and invisible to this job because it only
+# ever ran the graph path.
+#
+# Two runs, on purpose. The first exercises the seal (create_snapshot_inner);
+# the second exercises snapshot GC over an existing `sync-snapshots/`
+# directory, which was a second, unconditional open of the same kind — so
+# once a Windows user had run `--no-graph` once, EVERY later run over that
+# state directory died too.
+NG_CORPUS="$ROOT/nograph"
+mkdir -p "$NG_CORPUS"
+printf '# beacon report\n\nA short markdown note mentioning a trojan.\n' > "$NG_CORPUS/t.md"
+printf 'ng_id,ng_name,ng_val\n1,alpha,10\n2,beta,20\n' > "$NG_CORPUS/rows.csv"
+NG_STATE="$ROOT/nograph-state"
+
+for attempt in 1 2; do
+  "$BIN" autoindex "$NG_CORPUS" --no-graph --max-minutes 0 \
+    --state-dir "$NG_STATE" --prefix ng > "$DATA/ng-$attempt.log" 2>&1
+  NGRC=$?
+  echo "autoindex --no-graph (run $attempt) exit=$NGRC"
+  tail -20 "$DATA/ng-$attempt.log" || true
+  if [ "$NGRC" != "0" ] && [ "$NGRC" != "3" ]; then
+    echo "::error::--no-graph autoindex run $attempt exited $NGRC (expected 0 or 3) on $(uname -s)"
+    FAIL=1
+  fi
+  # The localised Windows message ("Acceso denegado", "Zugriff verweigert", …)
+  # is why this matches the os error NUMBER and not the text.
+  if grep -qiE 'os error 5([^0-9]|$)' "$DATA/ng-$attempt.log" "$DATA/server.log"; then
+    echo "::error::--no-graph run $attempt hit os error 5 (ACCESS_DENIED) — #482 regression"
+    FAIL=1
+  fi
+done
+
+# A silent no-op must not pass. The seal is the operation that aborted, so
+# assert its output exists: a sealed snapshot directory holding a manifest.
+SEALED="$(find "$NG_STATE/sync-snapshots" -name manifest.json 2>/dev/null | head -1)"
+if [ -z "$SEALED" ]; then
+  echo "::error::--no-graph sealed no snapshot manifest under $NG_STATE/sync-snapshots"
+  FAIL=1
+else
+  echo "sealed snapshot manifest: $SEALED"
+fi
+NG_CREATED="$(curl -s 'localhost:9200/_cat/indices?h=index' 2>/dev/null | grep -cE '(^|[[:space:]])ng-' || true)"
+echo "ng-* indices created: $NG_CREATED"
+if [ "${NG_CREATED:-0}" -lt 1 ]; then
+  echo "::error::--no-graph created no ng-* index"
+  FAIL=1
+fi
+
 kill "$SPID" 2>/dev/null || true
 if [ "$FAIL" = 0 ]; then
-  echo "AUTOINDEX FD SMOKE PASSED on $(uname -s) ($CREATED datasets, no EMFILE)"
+  echo "AUTOINDEX SMOKE PASSED on $(uname -s) ($CREATED datasets, no EMFILE; \
+--no-graph sealed and reconciled, no ACCESS_DENIED)"
 else
-  echo "AUTOINDEX FD SMOKE FAILED on $(uname -s)"
+  echo "AUTOINDEX SMOKE FAILED on $(uname -s)"
   exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     separate work: it has to prove the #825 union/sum contract with tombstones
     present, and is not attempted here.
 
+- **`xerj autoindex --no-graph` no longer aborts with `Access denied
+  (os error 5)` on Windows**
+  ([#482](https://github.com/xerj-org/xerj/issues/482)). The durable-snapshot
+  path fsynced the directories it had just published with
+  `File::open(dir)?.sync_all()?`. That is a Unix-only idiom: on Windows
+  `File::open` on a *directory* returns `ERROR_ACCESS_DENIED` (os error 5) on
+  every call, because `std` cannot pass `FILE_FLAG_BACKUP_SEMANTICS`. So the
+  first such call — sealing the source snapshot, immediately after the journal
+  was written and before a single document was indexed — killed the run with a
+  context-free, locale-dependent io error (`Acceso denegado. (os error 5)` in
+  the report). A second, unconditional open of the same kind in snapshot GC
+  then failed *every later run* over that state directory, whether or not
+  `--no-graph` was passed again. `xerj-autoindex` now routes directory
+  durability through `xerj_common::fsio::fsync_dir`, which has carried the
+  documented `#[cfg(windows)]` shim since the same mistake stopped the server
+  creating any index at boot; the surrounding filesystem calls also carry
+  context now, so a future failure names the operation instead of only its
+  errno. This costs Windows no durability it had: the code it replaces flushed
+  nothing there — it returned `Err` and ended the run. Windows keeps the
+  engine-wide posture that directory-namespace changes carry no durability
+  claim; file contents inside a snapshot are still fsynced. The
+  windows-latest `autoindex-fd-smoke` CI job now runs the reported
+  `--no-graph` flow twice over one state directory, which is what would have
+  caught this: the job existed, but only ever ran the default graph path,
+  which never touches `sync-snapshots/`.
+
 - **A code symbol's retrievable unit is the whole declaration, not the single
   physical line the name sits on**
   ([#500](https://github.com/xerj-org/xerj/issues/500)). Promoting each

--- a/engine/crates/xerj-autoindex/src/sync_executor.rs
+++ b/engine/crates/xerj-autoindex/src/sync_executor.rs
@@ -841,7 +841,10 @@ pub fn gc_snapshots(state_dir: &Path, journal: &Journal) -> Result<()> {
     let entries = match std::fs::read_dir(&root) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error.into()),
+        Err(error) => {
+            return Err(anyhow::Error::from(error)
+                .context(format!("list snapshot directory {}", root.display())));
+        }
     };
     let mut entries = entries.collect::<std::io::Result<Vec<_>>>()?;
     entries.sort_by_key(|entry| entry.file_name());
@@ -855,7 +858,6 @@ pub fn gc_snapshots(state_dir: &Path, journal: &Journal) -> Result<()> {
             entry.path().display()
         );
     }
-    let directory = File::open(&root)?;
     for entry in entries.into_iter().take(SNAPSHOT_GC_BATCH_SIZE) {
         let metadata = entry.file_type()?;
         if !metadata.is_dir() {
@@ -874,16 +876,23 @@ pub fn gc_snapshots(state_dir: &Path, journal: &Journal) -> Result<()> {
                 "snapshot tombstone already exists: {}",
                 tombstone.display()
             );
-            std::fs::rename(entry.path(), &tombstone)?;
-            directory.sync_all()?;
+            std::fs::rename(entry.path(), &tombstone).with_context(|| {
+                format!(
+                    "rename snapshot {} to tombstone {}",
+                    entry.path().display(),
+                    tombstone.display()
+                )
+            })?;
+            sync_dir(&root)?;
             #[cfg(test)]
             if GC_FAIL_AFTER_RENAME.swap(false, std::sync::atomic::Ordering::SeqCst) {
                 anyhow::bail!("injected snapshot GC crash after durable tombstone rename");
             }
             tombstone
         };
-        std::fs::remove_dir_all(&tombstone)?;
-        directory.sync_all()?;
+        std::fs::remove_dir_all(&tombstone)
+            .with_context(|| format!("remove snapshot tombstone {}", tombstone.display()))?;
+        sync_dir(&root)?;
     }
     Ok(())
 }
@@ -1762,9 +1771,22 @@ fn write_synced_json(path: &Path, value: &impl Serialize) -> Result<()> {
     Ok(())
 }
 
+/// fsync a directory so the entries created or renamed inside it survive
+/// power loss.
+///
+/// #482: this used to be `File::open(path)?.sync_all()?` — a Unix-only idiom.
+/// On Windows `File::open` on a *directory* fails with `ERROR_ACCESS_DENIED`
+/// (os error 5) on **every** call, because `std` cannot pass
+/// `FILE_FLAG_BACKUP_SEMANTICS`, so sealing a source snapshot aborted the
+/// whole `--no-graph` run before a single document was indexed. Exactly the
+/// same mistake had already been found and fixed once in
+/// [`xerj_common::fsio::fsync_dir`]; route through it instead of re-deriving
+/// it here. Its Windows body is a documented no-op that makes no durability
+/// claim — which costs Windows nothing, because the code it replaces flushed
+/// nothing either: it returned `Err` and killed the run.
 fn sync_dir(path: &Path) -> Result<()> {
-    File::open(path)?.sync_all()?;
-    Ok(())
+    xerj_common::fsio::fsync_dir(path)
+        .with_context(|| format!("fsync snapshot directory {}", path.display()))
 }
 
 #[cfg(test)]
@@ -2918,5 +2940,91 @@ mod tests {
         assert_eq!(backend.validations, 0);
         assert_eq!(journal.committed_manifest.as_ref().unwrap().generation, 0);
         assert!(journal.pending_sync.is_some());
+    }
+}
+
+/// Issue #482 regression guard.
+///
+/// The durable-snapshot path (`--no-graph`) fsyncs four directories per seal
+/// plus two per GC step. `File::open` applied to a *directory* is a Unix-only
+/// idiom: on Windows it returns `ERROR_ACCESS_DENIED` (os error 5) for every
+/// call, because `std` cannot pass `FILE_FLAG_BACKUP_SEMANTICS`. Each of
+/// those sites was therefore an unconditional abort of the whole run on that
+/// platform. The engine had already learned this once —
+/// `xerj_common::fsio::fsync_dir` carries the `#[cfg(windows)]` shim and the
+/// write-up — and this module re-derived the broken form anyway.
+///
+/// The fix is `#[cfg(windows)]`-shaped, so no behavioural test compiled for
+/// Unix can tell fixed code from unfixed. The behavioural coverage is the
+/// windows-latest `autoindex-fd-smoke` job, which since this change runs the
+/// reported `--no-graph` flow. This guard is what keeps the idiom from coming
+/// back on the platform the unit suite is never compiled for.
+#[cfg(test)]
+mod windows_directory_open_guard {
+    /// The body of the `fn` whose signature line starts with `header`,
+    /// brace-matched out of this file's own source at compile time.
+    fn function_body(source: &str, header: &str) -> String {
+        let start = source
+            .find(header)
+            .unwrap_or_else(|| panic!("signature moved: {header}"))
+            + header.len();
+        let mut depth = 1usize;
+        for (offset, ch) in source[start..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return source[start..start + offset].to_string();
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("unbalanced braces after {header}");
+    }
+
+    /// Every directory this module makes durable, named by the binding the
+    /// code passes around. None of them may reach `File::open`.
+    const DIRECTORY_BINDINGS: [&str; 6] = [
+        "&root",
+        "&staging",
+        "&blobs",
+        "&prepared_dir",
+        "&final_dir",
+        "&snapshot_dir",
+    ];
+
+    #[test]
+    fn no_directory_is_opened_as_a_file() {
+        const SRC: &str = include_str!("sync_executor.rs");
+        for binding in DIRECTORY_BINDINGS {
+            // Assembled, never written out literally, so this test's own
+            // source can never satisfy the search it performs.
+            let forbidden = format!("File::open({binding})");
+            assert!(
+                !SRC.contains(&forbidden),
+                "#482: `{forbidden}` opens a directory as a file. That call returns \
+                 ERROR_ACCESS_DENIED (os error 5) on Windows every single time and \
+                 aborts the run. Use `sync_dir`, which routes through \
+                 `xerj_common::fsio::fsync_dir`."
+            );
+        }
+    }
+
+    #[test]
+    fn sync_dir_delegates_to_the_platform_aware_shim() {
+        const SRC: &str = include_str!("sync_executor.rs");
+        let body = function_body(SRC, "fn sync_dir(path: &Path) -> Result<()> {");
+        assert!(
+            body.contains("xerj_common::fsio::fsync_dir(path)"),
+            "#482: `sync_dir` must delegate to `xerj_common::fsio::fsync_dir`, whose \
+             Windows body is a documented no-op; body was:\n{body}"
+        );
+        assert!(
+            !body.contains("File::open"),
+            "#482: `sync_dir` re-derived the Unix-only `File::open(dir).sync_all()` \
+             idiom, which fails with os error 5 on every Windows call; body was:\n{body}"
+        );
     }
 }


### PR DESCRIPTION
`xerj autoindex --no-graph` has never worked on Windows. Not on the reporter's
machine, not on any machine: the generated path aborts unconditionally on that
platform, and a second site then bricks the state directory for every later
run, `--no-graph` or not.

## Root cause

The durable-snapshot path made directories durable like this:

```rust
fn sync_dir(path: &Path) -> Result<()> {
    File::open(path)?.sync_all()?;      // sync_executor.rs:1765 (pre-fix)
    Ok(())
}
```

and `gc_snapshots` held the same kind of handle across its loop:

```rust
let directory = File::open(&root)?;     // sync_executor.rs:858 (pre-fix)
```

`File::open` applied to a **directory** is a Unix-only idiom. On Windows it
returns `ERROR_ACCESS_DENIED` (os error 5) on *every* call, because `std`
cannot pass `FILE_FLAG_BACKUP_SEMANTICS` when opening the handle. Not a race,
not a permission quirk on the reporter's box, not locale — every call, always.

This repo had already found and fixed exactly this bug once:
`engine/crates/xerj-common/src/fsio.rs:33-49` carries the `#[cfg(windows)]`
`fsync_dir` shim and the write-up, including the note that before it "the
server could not create an index — it aborted at boot with `create
.xerj_users: I/O error: Access is denied. (os error 5)`". `sync_executor.rs`
re-derived the broken form anyway.

## Why CI was green, and why the report was right

`create_prepared_snapshot` has one production caller,
`begin_non_graph_generation` (`lib.rs:882`), which asserts `cfg.no_graph`. The
seal — and every `sync_dir` in it — runs **only** under `--no-graph`. The
existing `autoindex-fd-smoke` job boots the server and autoindexes 400
datasets on ubuntu / macOS / windows, and it has been green throughout,
because it only ever ran the *default* graph path, which never touches
`sync-snapshots/`.

On the reported command (`xerj autoindex <folder> --max-minutes 0 --no-graph`):

1. journal opened, `run` + `sync_bootstrap` records written → `journal.ndjson`
2. `.autoindex.lock` taken
3. `create_snapshot_inner` → `create_dir_all(sync-snapshots)`, the dir appears
4. staging dir created, blobs copied (instant for a one-file corpus)
5. `sync_dir(&blobs)` → `ERROR_ACCESS_DENIED`
6. a bare `?`, with no `.context()` anywhere on the way out, so the top-level
   printer shows only the io error's own localised text

which is exactly what #482 describes: journal written (483 B), `.autoindex.lock`
present, `sync-snapshots/` present, `wall=0.0s`, `reason=aborted`, and a
context-free `Acceso denegado. (os error 5)`.

The **second** site is worse. `gc_snapshots` runs unconditionally right after
every journal open (`lib.rs:4239`, `4399`, `4628`), graph path included, and
its `File::open(&root)` sat *after* the `read_dir` NotFound early-return. So
the moment a Windows user ran `--no-graph` once, that state directory was
bricked: every later run over it — with or without `--no-graph` — died at the
same os error 5, with nothing to fix it but deleting the state directory.

Both sites are in the tag the reporter ran:
`git show v1.0.0-rc.17:engine/crates/xerj-autoindex/src/sync_executor.rs` has
`let directory = File::open(&root)?;` at line 785 and
`File::open(path)?.sync_all()?;` at line 1654, and rc.17's
`create_prepared_snapshot` is likewise gated behind `--no-graph`. They arrived
in `14567df5` (2026-08-03), an ancestor of rc.17 (2026-08-15). This is not a
fix for a lookalike.

## The fix

- `sync_dir` delegates to `xerj_common::fsio::fsync_dir`
  (`sync_executor.rs:1774-1790`). That shim's non-Windows body is the same
  two calls this deletes (`File::open` then `sync_all`), so Unix behaviour is
  unchanged apart from the added error context.
- `gc_snapshots` no longer holds a directory handle; it calls `sync_dir(&root)`
  at the two points that used `directory.sync_all()` (`sync_executor.rs:886`,
  `895`).
- The surrounding filesystem calls gained `.context()`, so the next failure
  here names the operation rather than only its errno.

**Durability, stated plainly.** `fsio::fsync_dir` is a no-op on Windows and
makes no durability claim there; Win32 has no directory-flush primitive
(`FlushFileBuffers` is undefined for directory handles). This costs Windows
nothing it had: the code being replaced flushed nothing on that platform
either — it returned `Err` and killed the run. File contents inside a snapshot
are still fsynced (`copy_synced`, `write_synced_json`, `prepare_artifact`).
Windows keeps the engine-wide posture that a directory-*namespace* change
carries no durability claim, the same as every other `fsync_dir` call site.
Unix durability is unchanged.

## Test proof

**Platform coverage (commit 1, pushed first on purpose).**
`.github/scripts/autoindex-fd-smoke.sh` now also runs the reported `--no-graph`
flow twice over one state directory — run 1 exercises the seal, run 2
exercises `gc_snapshots` over an existing `sync-snapshots/`. It asserts exit
0/3, no `os error 5` in either log (matched on the **number**, because the
reporter's Windows is Spanish), a sealed `manifest.json` on disk, and at least
one `ng-*` index. That commit was pushed alone and the windows-latest job ran
against unfixed code:

[Run 33397991091, job 99507055527](https://github.com/xerj-org/xerj/actions/runs/33397991091/job/99507055527)
— the default graph run in the *same job* had just finished clean, which is
exactly why this was invisible until now:

```
xerj-done ok=true exit=0 reason=completed wall=621.1s files=400 records=1600 datasets=400 ...
autoindex --no-graph (run 1) exit=1
xerj-done ok=false exit=1 reason=aborted wall=1.1s
error: Access is denied. (os error 5)
##[error]--no-graph autoindex run 1 exited 1 (expected 0 or 3) on MINGW64_NT-10.0-26100
##[error]--no-graph run 1 hit os error 5 (ACCESS_DENIED) — #482 regression
autoindex --no-graph (run 2) exit=1
xerj-done ok=false exit=1 reason=aborted wall=0.3s
error: Access is denied. (os error 5)
##[error]--no-graph autoindex run 2 exited 1 (expected 0 or 3) on MINGW64_NT-10.0-26100
##[error]--no-graph run 2 hit os error 5 (ACCESS_DENIED) — #482 regression
##[error]--no-graph sealed no snapshot manifest under .../nograph-state/sync-snapshots
ng-* indices created: 0
##[error]--no-graph created no ng-* index
AUTOINDEX SMOKE FAILED on MINGW64_NT-10.0-26100
```

`Access is denied. (os error 5)` is the English-locale form of the reporter's
`Acceso denegado. (os error 5)`. ubuntu-latest and macos-latest passed the same
new block on the same commit, so the gate is not simply broken — the platform
is.

**After**, with the fix commit on top —
[run 33400179956, job 99514409460](https://github.com/xerj-org/xerj/actions/runs/33400179956/job/99514409460):

```
autoindex --no-graph (run 1) exit=0
autoindex --no-graph (run 2) exit=0
sealed snapshot manifest: .../nograph-state/sync-snapshots/run-...-g1/manifest.json
ng-* indices created: 2
AUTOINDEX SMOKE PASSED on MINGW64_NT-10.0-26100 (400 datasets, no EMFILE; --no-graph sealed and reconciled, no ACCESS_DENIED)
```

Same runner OS, same script, same command; the only change is this PR's second
commit.

**Unit guards (commit 2).** Two source guards in
`sync_executor::windows_directory_open_guard`. I reverted only the two
production hunks, left the guards in place, and watched them fail:

```
test ...::sync_dir_delegates_to_the_platform_aware_shim ... FAILED
test ...::no_directory_is_opened_as_a_file ... FAILED
#482: `File::open(&root)` opens a directory as a file. That call returns
ERROR_ACCESS_DENIED (os error 5) on Windows every single time ...
test result: FAILED. 0 passed; 2 failed
```

and pass with the fix restored (`ok. 2 passed; 0 failed`). They are source
guards deliberately: the fix is `#[cfg(windows)]`-shaped, so nothing compiled
for Unix can tell fixed code from unfixed, and CI compiles the unit suite on
ubuntu only.

**Local reproduction of the mechanism** (this box is Linux; no Windows
available). I built the binary with `sync_dir` forced to return os error 5 —
what Windows does there unconditionally — and ran the extended smoke against a
private port:

```
xerj-done ok=false exit=1 reason=aborted wall=0.5s
error: Input/output error (os error 5)
::error::--no-graph autoindex run 1 exited 1 (expected 0 or 3) on Linux
::error::--no-graph run 1 hit os error 5 (ACCESS_DENIED) — #482 regression
::error::--no-graph sealed no snapshot manifest under .../sync-snapshots
ng-* indices created: 0
AUTOINDEX SMOKE FAILED on Linux
```

state directory left behind: `.autoindex.lock` (0 B), `journal.ndjson`
(524 B), `sync-snapshots/` present and empty — against the report's
`.autoindex.lock`, `journal.ndjson` 483 B, `sync-snapshots/`. Same artefacts,
same shape; the byte count differs only by run-id and path lengths, and the
message text differs because errno 5 is `EIO` on Linux and `ACCESS_DENIED` on
Windows. With the real fix the same smoke prints `AUTOINDEX SMOKE PASSED on
Linux`, both `--no-graph` runs at exit 0, a sealed `manifest.json`, 2 `ng-*`
indices. That simulation is evidence for the mechanism, not a substitute for
the platform — the authoritative check is the windows-latest job above.

## What I did not verify

- I did not run the reporter's rc.17 Windows binary; I verified by source that
  the same two calls are in that tag and that the reported flow reaches them.
- I cannot rule out a *second*, unrelated Windows problem on their machine.
  What is certain is that this one fires first, unconditionally, at the point
  they describe.
- The issue's secondary note about the default gRPC port (8081) colliding with
  local HTTP bridges is untouched here — it is a docs question, not this bug.

## Gates

`cargo fmt --all --check` clean. `cargo clippy --release -j 8 -p xerj-autoindex
--all-targets -- -D warnings` clean. Full `xerj-autoindex` suite: 755 + 8 + 1 +
1 + 4 passed, 0 failed, 2 ignored.

Closes #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
