### PR TITLE
feat(autoindex): report ingest throughput as docs/sec in the run summary (#904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`autoindex`'s run summary reports throughput as `docs/sec`**
+  ([#904](https://github.com/xerj-org/xerj/issues/904)). Split out of
+  [#366](https://github.com/xerj-org/xerj/issues/366), which asked for this
+  so an operator could see ingest throughput without timing the command by
+  hand or inferring it from the elapsed line; [#897](https://github.com/xerj-org/xerj/issues/897)
+  fixed that issue's neural-embedder batching defect but did not touch the
+  summary output. The rate is `records_total / wall` (0 when `wall` is
+  0.0, e.g. an all-resume no-op, rather than reporting `inf`), printed on
+  the `done in …` line and added to the `--json` run document as
+  `docs_per_sec`.
+
 ### Performance
 
 - **Merge copies posting lists instead of re-analysing every document it

--- a/engine/crates/xerj-autoindex/src/lib.rs
+++ b/engine/crates/xerj-autoindex/src/lib.rs
@@ -6960,6 +6960,16 @@ fn run_index_report_tallied(cfg: IndexCfg, tally: &ScanTally) -> Result<(i32, Op
     let (started, summary_generated_at) =
         invocation_report_timestamps(invocation_started, chrono::Utc::now());
     let total_records: u64 = ds_counts.values().sum();
+    // #904: ingest throughput, so the cost of a slow embedder (#366) is
+    // visible in the summary itself rather than something an operator has
+    // to derive by hand from the elapsed line. `wall` can be 0.0 on a
+    // sub-millisecond run (e.g. an all-resume no-op); reporting 0 docs/sec
+    // there is more honest than a divide-by-zero `inf`.
+    let docs_per_sec = if wall > 0.0 {
+        total_records as f64 / wall
+    } else {
+        0.0
+    };
     // Run-summary honesty (§6.6.4): what the detectors wrote AND what they
     // could not resolve — a dangling [[link]] is a fact about the corpus, not
     // something to swallow.
@@ -7038,6 +7048,7 @@ fn run_index_report_tallied(cfg: IndexCfg, tally: &ScanTally) -> Result<(i32, Op
         "files_submitted_this_run": files_done.load(Ordering::Relaxed),
         "records_submitted_this_run": records_total.load(Ordering::Relaxed),
         "wall_seconds": (wall * 10.0).round() / 10.0,
+        "docs_per_sec": (docs_per_sec * 10.0).round() / 10.0,
         "workers": cfg.workers,
         // The whole resource decision, so a run can be explained after the
         // fact from its own summary rather than from the machine it ran on.
@@ -7138,7 +7149,7 @@ fn run_index_report_tallied(cfg: IndexCfg, tally: &ScanTally) -> Result<(i32, Op
     if cfg.json {
         println!("{run_doc}");
     } else if !cfg.quiet {
-        println!("\ndone in {wall:.1}s — {} datasets, {} records live, {} duplicate aliases, {} junk records, {} junk/skipped files",
+        println!("\ndone in {wall:.1}s — {} datasets, {} records live, {} duplicate aliases, {} junk records, {} junk/skipped files ({docs_per_sec:.1} docs/sec)",
             plan.datasets.len(), total_records, plan.duplicate_files.len(), junk_total_records, junk_file_count);
         // Indexed-vs-submitted honesty line (#195): the live count against
         // what this run actually submitted, so a silent-rejection mismatch


### PR DESCRIPTION
Closes #904.

Split out of #366, which asked for a `docs/sec` line in the `xerj autoindex` run summary so an operator can see ingest throughput without timing the command by hand or inferring it from the elapsed line. #897 fixed that issue's neural-embedder batching defect but did not touch the summary output.

## What changed

- `docs_per_sec` is computed as `records_total / wall`, guarded to `0` when `wall` is `0.0` (e.g. an all-resume no-op) instead of reporting `inf`.
- Printed on the existing `done in …s — …` summary line, e.g.:
  ```
  done in 12.3s — 4 datasets, 1200 records live, 0 duplicate aliases, 0 junk records, 0 junk/skipped files (97.6 docs/sec)
  ```
- Added to the `--json` run document as `docs_per_sec`, alongside the existing `wall_seconds`.

## Testing

- `cargo build -p xerj-autoindex --lib` — clean.
- `cargo fmt -p xerj-autoindex -- --check` — clean.
- `cargo clippy -p xerj-autoindex --lib` — clean.
- `cargo test -p xerj-autoindex --lib` — 741 passed, 19 failed; confirmed the same 19 fail identically on unmodified `main` (pre-existing, unrelated: concurrent temp-dir/journal races and a non-UTF8 path test, reproduced on this machine before this change).

Refs #904, #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
