### PR TITLE
docs: agent field report — autoindex operator contract audit

### DIFF
--- a/user-feedback/16-agent-field-reports/2026-09-06-autoindex-contract-audit.md
+++ b/user-feedback/16-agent-field-reports/2026-09-06-autoindex-contract-audit.md
@@ -1,0 +1,17 @@
+# Auditing the autoindex operator contract against a hostile corpus (2026-09-06)
+
+**Agent:** Claude (Claude Code)  ·  **XERJ:** v1.0.0-rc.72 (built from source)  ·  **Platform:** macOS 26.6.1 aarch64
+
+**Pointed at:** a small corpus built to break the walker — symlinks pointing outside the target folder, a symlink loop, `.env` and `id_rsa`, and filenames containing ESC, CR, LF and U+2028 — plus a 10.3 MB prose file to force a long phase B.
+
+**Used it for:** checking the promises in AGENTS.md §"Running an index on someone's machine" and the `/_memory` API, rather than for retrieval work.
+
+**Verdict:** The claims I could test held. Symlinks out of the tree were not followed, the loop did not hang the walk, and the control-character rule is real: a file named `pwn<ESC>[2Jowned<CR>HACKED.md` reached the progress stream as `waiting_on=pwn?[2Jowned?HACKED.md`. `/_memory` namespace validation rejected all ten shapes I threw at it with a specific reason each. The `agentic-memory` recipe reproduced its published recall numbers exactly, which is rarer than it should be.
+
+Two frictions worth naming. First, the hidden-file rule is dotfile-based, but the prose around it ("what keeps secrets out of a queryable brain") reads as secret-based — a plain `id_rsa` sitting in a project root is indexed, and its contents are then queryable. That is defensible behaviour and surprising documentation; in `~/.ssh` it never arises, in a project root it does. Second, `POST /_memory/{ns}/_recall` with `"k": 0` returns one hit, while `"k": -1` is a 400. Asking for nothing and getting something is a small thing, but it is the kind of thing an agent computing `k` from a budget will hit.
+
+Reading the operator contract before running was worth it, and it is long. The exit-code table and the "estimate is a floor, not a prediction" warning are the two parts I would put in front of an agent first.
+
+**Numbers:** 8-file corpus -> `xerj-done ok=true exit=0 wall=20.6s files=8 records=21 datasets=2`. Single 10.3 MB file -> `wall=15.0s files=1 records=4114`. `cargo build --profile quick -p xerj-server -j 10`: 3m55s cold.
+
+**Filed alongside:** nothing broke; the two frictions above are in this report rather than as issues, since neither is a defect against a documented behaviour.


### PR DESCRIPTION
## What this changes, and why

One agent field report under `user-feedback/16-agent-field-reports/`, per the baseline contribution asked in `.github/AI_CONTRIBUTIONS.md`. Nothing else is touched.

I built rc.72 from source and audited the operator contract in AGENTS.md §"Running an index on someone's machine" against a corpus written to break the walker, rather than using XERJ for retrieval work. The tested claims held. The report names two frictions that are **not** defects against documented behaviour and explains why I did not file either as an issue.

## Evidence

```
$ xerj autoindex ./corpus --state-dir ./state-real
xerj-done ok=true exit=0 reason=completed wall=20.6s files=8 records=21 datasets=2 junk_files=0

$ xerj autoindex ./big --state-dir ./state-big --progress-interval 1
xerj-progress phase=index ... waiting_on=pwn?[2Jowned?HACKED.md(10.3MB)
xerj-done ok=true exit=0 reason=completed wall=15.0s files=1 records=4114 datasets=1
```

The second line is the control-character rule working: the file on disk is named `pwn<ESC>[2Jowned<CR>HACKED.md`.

Symlinks leaving the target folder were not followed and the symlink loop did not hang the walk — the run indexed 8 paths, none of them the link. `docs/examples/agentic-memory/agent_memory.py` reproduced its published recall figures exactly (semantic 83.3% / 100%, BM25 100% / 100%).

## Checks

- [ ] `cargo fmt --all` — N/A, no Rust changed
- [ ] Scoped release build — N/A, no Rust changed
- [ ] `cargo test -p <crate>` — N/A, no Rust changed
- [x] ES-YAML conformance suite — N/A: this change is a single markdown field report
- [x] New ES-compatible behaviour has a matching YAML case — N/A
- [x] Docs updated if user-visible behaviour changed — N/A
- [x] `git check-ignore -v` confirms the last matching pattern is the `!user-feedback/**/*.md` re-include, so the file is tracked
- [x] Report is 17 lines, under the 25-line ceiling; one file, nothing else in the diff

**Not run:** the Rust build and test gates, since no code is touched.

## Provenance

- Written by: AI agent (Claude, in Claude Code), run by @tonytonycoder11 who has reviewed it
- **Verified** (commands run, output observed): built `rc.72` with `cargo build --profile quick -p xerj-server -j 10` (3m55s); ran `autoindex` twice with the outputs above; ran the ten malformed `/_memory` namespace shapes and observed a specific 400 reason for each; ran `POST /_memory/probe/_recall {"query":"hello","k":0}` and observed one hit against `{"k":-1}` returning 400; ran `agent_memory.py` end to end.
- **Assumed** (not tested, and what would falsify it): that the `id_rsa` observation generalises beyond a file sitting in a corpus root — I did not test a real `~/.ssh` layout, and a run showing the hidden-directory rule catching it there would make that half of the note moot. I also did not test Windows or a non-UTF-8 filename end to end.
