### PR TITLE
Convert 12 AM to hour 0 in the 12-hour (`h`/`a`) date format

### DIFF
--- a/engine/crates/xerj-query/src/dates.rs
+++ b/engine/crates/xerj-query/src/dates.rs
@@ -841,10 +841,16 @@ fn parse_pattern_with(toks: &[PatTok], value: &str, text: TextMatch) -> Option<D
     if st.i != value.len() {
         return None; // ES: "unparsed text found at index N"
     }
-    if st.has_ampm && st.pm {
+    if st.has_ampm {
         if let Some(h) = st.parts.hour {
-            if h < 12 {
-                st.parts.hour = Some(h + 12);
+            if st.pm {
+                // PM: 12 o'clock stays 12; 1-11 shift to 13-23.
+                if h < 12 {
+                    st.parts.hour = Some(h + 12);
+                }
+            } else if h == 12 {
+                // AM: 12 o'clock is hour 0 (midnight); 1-11 are unchanged.
+                st.parts.hour = Some(0);
             }
         }
     }
@@ -2451,5 +2457,26 @@ mod ignored_metadata_field_oracle {
             crate::parse_request(&body).is_err(),
             "an unrepresentable range bound must be a 400, not an abort"
         );
+    }
+}
+
+#[cfg(test)]
+mod ampm_twelve_hour_tests {
+    use super::{compile_formats, resolve_date_bound_str};
+
+    fn resolve(value: &str) -> Option<String> {
+        let fmts = compile_formats("hh:mm a").unwrap();
+        resolve_date_bound_str(value, false, Some(&fmts)).unwrap()
+    }
+
+    #[test]
+    fn twelve_hour_clock_converts_to_24h_like_elasticsearch() {
+        // java.time `h` (clock-hour-of-am-pm) with the `a` marker:
+        // AM 12 -> 00, AM 1-11 unchanged, PM 12 -> 12, PM 1-11 -> +12.
+        assert_eq!(resolve("12:30 AM").as_deref(), Some("1970-01-01T00:30:00.000Z"));
+        assert_eq!(resolve("01:30 AM").as_deref(), Some("1970-01-01T01:30:00.000Z"));
+        assert_eq!(resolve("11:30 AM").as_deref(), Some("1970-01-01T11:30:00.000Z"));
+        assert_eq!(resolve("12:30 PM").as_deref(), Some("1970-01-01T12:30:00.000Z"));
+        assert_eq!(resolve("01:30 PM").as_deref(), Some("1970-01-01T13:30:00.000Z"));
     }
 }


### PR DESCRIPTION
## What this changes, and why

In the 12-hour date format (`h` + `a`, e.g. `format: "hh:mm a"`), the AM/PM post-processing in `parse_pattern_with` (`crates/xerj-query/src/dates.rs`) only adjusts the **PM** side (1–11 → +12). An **AM hour of 12** is left as `12` instead of wrapping to `0`.

This contradicts the token's own docstring — *"AM/PM marker (`a`); shifts a 12-hour value"* — and java.time's `h` (clock-hour-of-am-pm) semantics that ES 8.13 follows: with an `a` marker, **AM 12 → 0**, **PM 12 → 12**, PM 1–11 → +12.

Consequences:
- `gte: "12:30 AM"` under `format: "hh:mm a"` resolves to `1970-01-01T12:30` instead of `00:30`.
- A midnight-hour range `{"range":{"t":{"gte":"12:00 AM","lt":"01:00 AM","format":"hh:mm a"}}}` builds an **inverted** `12:00 <= t < 01:00` bound, so **every document in the midnight hour is silently dropped**.

The fix adds the missing AM branch (12 → 0; 1–11 unchanged). PM behaviour is byte-for-byte unchanged.

## Evidence

```
# Before the fix — new regression test fails on the AM-12 case:
$ cargo test -p xerj-query twelve_hour_clock_converts
assertion `left == right` failed
  left: Some("1970-01-01T12:30:00.000Z")
 right: Some("1970-01-01T00:30:00.000Z")
test result: FAILED. 0 passed; 1 failed

# After the fix — passes (AM 12→00:30, AM 01→01:30, AM 11→11:30, PM 12→12:30, PM 01→13:30):
$ cargo test -p xerj-query
test result: ok. 187 passed; 0 failed   # was 186; +1 new test, no regression

$ cargo fmt -p xerj-query -- --check    # clean
$ cargo clippy -p xerj-query            # no warnings
$ cargo build --release -p xerj-query   # Finished `release` profile in ~59s
```

## Checks

- [x] `cargo fmt --all` — `cargo fmt -p xerj-query -- --check` clean; `cargo clippy -p xerj-query` no warnings
- [x] Scoped release build: `cargo build --release -p xerj-query` (Finished, ~59s)
- [x] `cargo test -p xerj-query` passes (187 passed; 0 failed)
- [ ] ES-YAML conformance suite — **Not run** (see below)
- [ ] New ES-compatible behaviour has a matching YAML case — I added a Rust unit test (`ampm_twelve_hour_tests`) on the date-resolution path rather than a YAML case; happy to add a `hh:mm a` range case under `engine/tests/es-compat-yaml/yaml/` if you'd prefer that form
- [x] Docs updated if user-visible behaviour changed — behaviour now matches the existing docstring; no doc change needed
- [ ] Non-trivial audit — N/A: single-branch logic fix in one function, no operational/runnable-recipe surface

**Not run:** the full ES-YAML conformance suite (`es-yaml-runner`) — I did not build the full engine test crate. I ran the `xerj-query` unit suite, which exercises `compile_formats` → `resolve_date_bound_str` (the exact date-resolution path this touches) directly, and all 187 tests pass.

## Provenance

- **Written by:** an AI coding agent (Claude, via Claude Code), run by @winklemad, who reviewed every line and answers for it.
- **Verified** (commands run, output observed):
  - `resolve_date_bound_str("12:30 AM", false, compile_formats("hh:mm a"))` → before: `Some("1970-01-01T12:30:00.000Z")`; after: `Some("1970-01-01T00:30:00.000Z")`.
  - `cargo test -p xerj-query` → 187 passed / 0 failed (was 186 + the new test); `cargo fmt --check`, `cargo clippy`, `cargo build --release -p xerj-query` all clean.
- **Assumed** (not tested, and what would falsify it):
  - This fix restores correct **`h` + `a` AM/PM** behaviour only. java.time's other hour letters are collapsed into one 0–23 `Hour` token here, so `K` (hour-of-am-pm 0–11) and `k` (clock-hour-of-day 1–24, where `"24:00"` should be `00:00`) remain a **separate, broader gap** I did **not** address. Falsifiable by a `format: "kk:mm"` value `"24:00"` test.
- **Not run:** the ES-YAML conformance suite, as noted above.