### PR TITLE
feat(autoindex): first-class email (.eml/MIME) extraction with attachment indexing

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -427,6 +427,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64urlsafedata"
@@ -1313,7 +1319,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1432,7 +1438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2048,6 +2054,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2264,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2494,7 +2512,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2765,6 +2783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "mail-parser"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec00bda90c6e645a54506c630c2820cd6b1890cfd2b0a169b50f74b2b8c7c86"
+dependencies = [
+ "hashify",
+]
+
+[[package]]
 name = "mappings"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,7 +3033,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3868,7 +3895,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3906,7 +3933,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4296,7 +4323,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4662,7 +4689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4867,7 +4894,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6240,7 +6267,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6674,6 +6701,7 @@ name = "xerj-autoindex"
 version = "1.0.0-rc.74"
 dependencies = [
  "anyhow",
+ "base64 0.23.1",
  "chrono",
  "csv",
  "encoding_rs",
@@ -6681,6 +6709,7 @@ dependencies = [
  "fs2",
  "ignore",
  "libc",
+ "mail-parser",
  "memchr",
  "pdf_oxide",
  "quick-xml",

--- a/engine/crates/xerj-autoindex/Cargo.toml
+++ b/engine/crates/xerj-autoindex/Cargo.toml
@@ -103,5 +103,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }  # DOC
 serde_yaml = "0.9"                               # YAML multi-doc
 # The one C dependency (bundled SQLite), isolated to this crate.
 rusqlite = { version = "0.32", features = ["bundled"] }
+mail-parser = "0.11.9"
 
 [dev-dependencies]
+base64 = "0.23.1"

--- a/engine/crates/xerj-autoindex/src/estimate.rs
+++ b/engine/crates/xerj-autoindex/src/estimate.rs
@@ -120,6 +120,7 @@ pub fn exact_scan_bytes(
         | Family::TxtProse
         | Family::Code
         | Family::Docx
+        | Family::Eml
         | Family::Pdf => Some(size),
         // Streaming, byte-capped and record-capped.
         Family::Jsonl | Family::Csv | Family::Logs | Family::TxtLines => {

--- a/engine/crates/xerj-autoindex/src/extract/code.rs
+++ b/engine/crates/xerj-autoindex/src/extract/code.rs
@@ -1195,6 +1195,13 @@ const PYTHON_Q: &str = r#"
 // as `arrow_function`, so `export const f = function () {}` carries both
 // `@function` and `@const`, where the TS equivalent only does so for arrows.
 // `defs` dedups on (kind, name), so each spelling still answers its own search.
+//
+// The `.bind`-valued declarator (last pattern) is the JS twin of the one in
+// TS_Q — see the rationale there. `const add = game.root.add.bind(game.root)` is
+// how a framework exposes its global API surface, and that binding is the name
+// consumers call. NOT the #170 90%-locals trap (that is `const x = 0`); a
+// `.bind()`-valued const is always a deliberately named bound callable, and it
+// is captured `@function` because that is what it is.
 const JS_Q: &str = r#"
 (function_declaration name: (identifier) @function)
 (generator_function_declaration name: (identifier) @function)
@@ -1203,6 +1210,7 @@ const JS_Q: &str = r#"
 (variable_declarator name: (identifier) @function value: [(arrow_function) (function_expression)])
 (export_statement declaration: (lexical_declaration (variable_declarator name: (identifier) @function value: (arrow_function))))
 (program (export_statement declaration: (lexical_declaration "const" (variable_declarator name: (identifier) @const))))
+(variable_declarator name: (identifier) @function value: (call_expression function: (member_expression property: (property_identifier) @_bind)) (#eq? @_bind "bind"))
 "#;
 
 // The last pattern is #170's failure mode in the language where it is most
@@ -1241,6 +1249,26 @@ const JS_Q: &str = r#"
 // file becomes reachable by both `function Button` and `const Button`, which is
 // what a caller searching for either would expect; suppressing one would mean
 // choosing which of the two true statements to hide.
+//
+// The last pattern (`.bind`-valued declarator) captures the re-binding idiom
+// `const tween = game.root.tween.bind(game.root)`. Whole libraries expose their
+// public API this way — a framework builds a context object of methods bound to
+// a root, and the ~40 lines `const add = ….add.bind(…)`, `const get = …`, `const
+// wait = …` ARE the global surface every consumer calls as `add(...)`,
+// `tween(...)`. Measured against kaplay (a game engine): before this, `def
+// "tween"` returned only the method form `tween<V>(this: GameObj<TimerComp>, …)`,
+// so an agent wrote `e.tween(...)` and crashed — the callable global was in the
+// index but unreachable by name. Captured `@function` because a bound method IS
+// a callable and `def --kind function` should reach it.
+//
+// This is the ONE unanchored variable capture in TS_Q, and it is NOT the
+// #170/#285 90%-locals trap the other patterns anchor away from: that trap is
+// `const x = 0` / `const el = query(...)` — every function-local binding. A
+// `.bind()`-valued declarator is never that; it is a deliberately named,
+// reusable bound callable, which is exactly why it is worth a symbol. Unanchored
+// ON PURPOSE — these bindings live INSIDE the context-builder function body,
+// where `program`-anchoring (used for the plain-const pattern above) would
+// exclude them.
 const TS_Q: &str = r#"
 (function_declaration name: (identifier) @function)
 (class_declaration name: (type_identifier) @class)
@@ -1250,6 +1278,7 @@ const TS_Q: &str = r#"
 (enum_declaration name: (identifier) @enum)
 (variable_declarator name: (identifier) @function value: (arrow_function))
 (program (export_statement declaration: (lexical_declaration "const" (variable_declarator name: (identifier) @const))))
+(variable_declarator name: (identifier) @function value: (call_expression function: (member_expression property: (property_identifier) @_bind)) (#eq? @_bind "bind"))
 "#;
 
 // `const_item` / `static_item` are captured because a file whose whole content
@@ -2781,6 +2810,54 @@ mod tests {
         let s = syms("typescript", "export const Button = () => 1;\n");
         assert!(has(&s, "Button", "function"), "got {s:?}");
         assert!(has(&s, "Button", "const"), "got {s:?}");
+    }
+
+    /// The `.bind()` re-binding idiom is how a framework exposes its global API:
+    /// `const tween = game.root.tween.bind(game.root)` inside a context builder.
+    /// That binding IS the callable name consumers use (`tween(...)`), so `def
+    /// "tween"` must reach it — before this, only the method form was a symbol
+    /// and an agent wrote the crashing `e.tween(...)`. This is kaplay's exact
+    /// core/context.ts shape, verbatim down to the function-body nesting.
+    #[test]
+    fn typescript_bound_global_is_captured() {
+        let s = syms(
+            "typescript",
+            "export const createContext = (e): Ctx => {\n\
+            \x20   const { game } = e;\n\
+            \x20   const add = game.root.add.bind(game.root);\n\
+            \x20   const tween = game.root.tween.bind(game.root);\n\
+            \x20   const spawnTimer = 0;\n\
+            \x20   return { add, tween };\n\
+             };\n",
+        );
+        // The bound globals are reachable by name, despite living inside the
+        // builder's function body (unexported, unanchored).
+        assert!(has(&s, "add", "function"), "got {s:?}");
+        assert!(has(&s, "tween", "function"), "got {s:?}");
+        // The #170 boundary holds: a plain function-local const is still NOT a
+        // symbol — only the `.bind()`-valued declarators are.
+        assert!(
+            !has(&s, "spawnTimer", "function") && !has(&s, "spawnTimer", "const"),
+            "reintroduced the 90%-locals trap: {s:?}"
+        );
+    }
+
+    /// Same idiom, JavaScript grammar (JS_Q's twin pattern).
+    #[test]
+    fn javascript_bound_global_is_captured() {
+        let s = syms(
+            "javascript",
+            "function make(root){\n\
+            \x20   const wait = root.wait.bind(root);\n\
+            \x20   const n = 0;\n\
+            \x20   return { wait };\n\
+             }\n",
+        );
+        assert!(has(&s, "wait", "function"), "got {s:?}");
+        assert!(
+            !has(&s, "n", "function") && !has(&s, "n", "const"),
+            "got {s:?}"
+        );
     }
 
     /// `.mts`/`.cts` are TypeScript's ESM/CJS file extensions, the exact

--- a/engine/crates/xerj-autoindex/src/extract/eml.rs
+++ b/engine/crates/xerj-autoindex/src/extract/eml.rs
@@ -1,0 +1,441 @@
+//! Email (RFC 5322 / MIME) extraction.
+//!
+//! An `.eml` (or any `message/rfc822`) file used to fall through to the prose
+//! extractor: its headers were dumped as body text, its MIME structure was left
+//! raw, and a base64 attachment was indexed verbatim as gibberish — one message
+//! exploding into many noise records. This parses the message properly and emits:
+//!
+//! - ONE (or, for a long body, a few section) record(s) for the MESSAGE itself,
+//!   carrying decoded header fields (`email_from`/`email_to`/`email_subject`/
+//!   `email_date`/`email_message_id`/…) and the decoded plain-text body.
+//! - ONE OR MORE records PER ATTACHMENT, indexed SEPARATELY and linked back to
+//!   the parent by `email_message_id`/`email_subject`/`email_from`. A PDF
+//!   attachment is routed through the real PDF extractor (per-page records); a
+//!   text attachment is sectioned as a document; any other file gets a
+//!   name/type/size card so it is still findable by name.
+//!
+//! Header/body field names are the extractor's own vocabulary
+//! (`FieldOrigin::Extractor`): present on every email, so they never move a file
+//! between datasets.
+
+use super::{
+    for_each_section, read_whole, ExtractStats, FieldOrigin, RawRecord, Sink, MAX_RECORDS_PER_FILE,
+};
+use anyhow::Result;
+use mail_parser::{MessageParser, MimeHeaders, PartType};
+use serde_json::{Map, Value};
+use std::path::Path;
+
+/// Whole-message read cap. Mailbox exports of a single message rarely approach
+/// this; a message larger than it is treated as junk rather than parsed.
+const MAX_EML: u64 = 64 << 20;
+
+/// A message with more parts than this has its tail dropped (reported via
+/// `ExtractStats.truncated`) — a defensive bound on a pathological MIME bomb.
+const MAX_ATTACHMENTS: usize = 256;
+
+/// Bytes of an attachment we are willing to route/section. Larger attachments
+/// get a name card only (their bytes are not indexed).
+const MAX_ATTACH_BYTES: usize = 24 << 20;
+
+pub fn extract(path: &Path, gzip: bool, sink: Sink) -> Result<ExtractStats> {
+    let mut stats = ExtractStats::default();
+    let Some(bytes) = read_whole(path, gzip, MAX_EML)? else {
+        stats.junk += 1;
+        return Ok(stats);
+    };
+    let Some(msg) = MessageParser::default().parse(&bytes) else {
+        // Unparseable as a message — fall back to indexing it as prose rather
+        // than dropping it, matching the never-fatal contract.
+        return super::extract_as_document(path, gzip, sink);
+    };
+
+    // ── message header fields (decoded: encoded-words, charset) ──
+    let subject = msg.subject().unwrap_or("").trim().to_string();
+    let mut headers = Map::new();
+    put(&mut headers, "email_subject", subject.clone());
+    put(&mut headers, "email_from", addr_string(msg.from()));
+    put(&mut headers, "email_to", addr_string(msg.to()));
+    put(&mut headers, "email_cc", addr_string(msg.cc()));
+    if let Some(d) = msg.date() {
+        put(&mut headers, "email_date", d.to_rfc3339());
+    }
+    if let Some(id) = msg.message_id() {
+        put(&mut headers, "email_message_id", id.to_string());
+    }
+    if let Some(irt) = msg.in_reply_to().as_text() {
+        put(&mut headers, "email_in_reply_to", irt.to_string());
+    }
+
+    let title = if subject.is_empty() {
+        "(no subject)".to_string()
+    } else {
+        subject.clone()
+    };
+
+    // ── message body: prefer decoded text/plain, else strip the HTML part ──
+    let body = msg
+        .body_text(0)
+        .map(|c| c.to_string())
+        .or_else(|| msg.body_html(0).map(|h| strip_html(&h)))
+        .unwrap_or_default();
+
+    // Emit the message itself as document section(s) carrying the headers.
+    emit_email_doc(&headers, &title, body.trim(), "msg", sink, &mut stats);
+
+    // ── attachments — each indexed as its own document(s) ──
+    for (n, part) in msg.attachments().enumerate() {
+        if n >= MAX_ATTACHMENTS {
+            stats.truncated = true;
+            break;
+        }
+        let name = part
+            .attachment_name()
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("attachment-{n}"));
+        let ctype = part
+            .content_type()
+            .map(|c| {
+                let mut s = c.ctype().to_string();
+                if let Some(sub) = c.subtype() {
+                    s.push('/');
+                    s.push_str(sub);
+                }
+                s
+            })
+            .unwrap_or_default();
+        let data: &[u8] = match &part.body {
+            PartType::Binary(b) | PartType::InlineBinary(b) => b.as_ref(),
+            PartType::Text(t) | PartType::Html(t) => t.as_bytes(),
+            _ => &[],
+        };
+        let link = attach_link(&headers, &name, &ctype, data.len());
+
+        if is_pdf(&name, data) && data.len() <= MAX_ATTACH_BYTES {
+            route_pdf(data, n, &link, sink, &mut stats);
+        } else if is_texty(&ctype, data) && data.len() <= MAX_ATTACH_BYTES {
+            let text = String::from_utf8_lossy(data);
+            emit_email_doc(
+                &link,
+                &name,
+                text.trim(),
+                &format!("att{n}"),
+                sink,
+                &mut stats,
+            );
+        } else {
+            // Unindexable body — a name/type/size card keeps it discoverable.
+            stats.records += 1;
+            sink(RawRecord {
+                fields: link,
+                locator: format!("att{n}-card"),
+                group: None,
+                origin: FieldOrigin::Extractor,
+            });
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Emit `body` as one or more section records, each stamped with `base_fields`
+/// (message headers or attachment-link fields) plus `title`/`body`/`section`.
+fn emit_email_doc(
+    base_fields: &Map<String, Value>,
+    title: &str,
+    body: &str,
+    loc_prefix: &str,
+    sink: Sink,
+    stats: &mut ExtractStats,
+) {
+    // Collect sections first so we know whether to stamp a `section` field.
+    let mut secs: Vec<String> = Vec::new();
+    for_each_section(body, &mut |s| {
+        secs.push(s);
+        secs.len() < MAX_RECORDS_PER_FILE
+    });
+    if secs.is_empty() {
+        secs.push(String::new());
+    }
+    let multi = secs.len() > 1;
+    for (i, sec) in secs.into_iter().enumerate() {
+        let mut fields = base_fields.clone();
+        fields.insert("title".into(), Value::String(title.to_string()));
+        fields.insert("body".into(), Value::String(sec));
+        if multi {
+            fields.insert("section".into(), Value::Number((i as u64).into()));
+        }
+        stats.records += 1;
+        if !sink(RawRecord {
+            fields,
+            locator: format!("{loc_prefix}-s{i}"),
+            group: None,
+            origin: FieldOrigin::Extractor,
+        }) {
+            return;
+        }
+    }
+}
+
+/// Route a PDF attachment's bytes through the real PDF extractor, re-tagging
+/// each emitted page record with the parent-email link fields and a locator
+/// namespaced to this attachment.
+fn route_pdf(
+    data: &[u8],
+    n: usize,
+    link: &Map<String, Value>,
+    sink: Sink,
+    stats: &mut ExtractStats,
+) {
+    use std::io::Write;
+    let Ok(mut tmp) = tempfile::Builder::new().suffix(".pdf").tempfile() else {
+        stats.junk += 1;
+        return;
+    };
+    if tmp.write_all(data).is_err() {
+        stats.junk += 1;
+        return;
+    }
+    let prefix = format!("att{n}-");
+    let mut inner = |mut rec: RawRecord| -> bool {
+        for (k, v) in link.iter() {
+            rec.fields.entry(k.clone()).or_insert_with(|| v.clone());
+        }
+        rec.locator = format!("{prefix}{}", rec.locator);
+        rec.origin = FieldOrigin::Extractor;
+        stats.records += 1;
+        sink(rec)
+    };
+    // The PDF extractor increments its own record count; we count via `inner`
+    // instead, so start from what it reports and keep only the delta semantics
+    // simple: ignore its stats.records, trust `inner`.
+    let _ = super::pdf::extract(tmp.path(), &mut inner);
+}
+
+// ── field helpers ──────────────────────────────────────────────────────────
+
+fn put(m: &mut Map<String, Value>, k: &str, v: String) {
+    if !v.is_empty() {
+        m.insert(k.into(), Value::String(v));
+    }
+}
+
+/// The link fields copied onto every attachment record so a search can find,
+/// e.g., "the term sheet that came from Dana Klein".
+fn attach_link(
+    headers: &Map<String, Value>,
+    name: &str,
+    ctype: &str,
+    size: usize,
+) -> Map<String, Value> {
+    let mut m = Map::new();
+    m.insert("attachment_name".into(), Value::String(name.to_string()));
+    if !ctype.is_empty() {
+        m.insert(
+            "attachment_content_type".into(),
+            Value::String(ctype.to_string()),
+        );
+    }
+    m.insert(
+        "attachment_bytes".into(),
+        Value::Number((size as u64).into()),
+    );
+    for k in [
+        "email_subject",
+        "email_from",
+        "email_date",
+        "email_message_id",
+    ] {
+        if let Some(v) = headers.get(k) {
+            m.insert(k.into(), v.clone());
+        }
+    }
+    m
+}
+
+fn addr_string(a: Option<&mail_parser::Address>) -> String {
+    let Some(a) = a else { return String::new() };
+    let mut out: Vec<String> = Vec::new();
+    for addr in a.iter() {
+        let email = addr.address().unwrap_or("");
+        match addr.name() {
+            Some(name) if !name.is_empty() && !email.is_empty() => {
+                out.push(format!("{name} <{email}>"))
+            }
+            _ if !email.is_empty() => out.push(email.to_string()),
+            Some(name) if !name.is_empty() => out.push(name.to_string()),
+            _ => {}
+        }
+    }
+    out.join(", ")
+}
+
+fn is_pdf(name: &str, data: &[u8]) -> bool {
+    name.to_ascii_lowercase().ends_with(".pdf") || data.starts_with(b"%PDF-")
+}
+
+fn is_texty(ctype: &str, data: &[u8]) -> bool {
+    if ctype.starts_with("text/")
+        || ctype.contains("json")
+        || ctype.contains("xml")
+        || ctype.contains("csv")
+    {
+        return true;
+    }
+    // Fallback: mostly-printable UTF-8 sample.
+    let sample = &data[..data.len().min(2048)];
+    !sample.is_empty()
+        && std::str::from_utf8(sample).is_ok()
+        && sample
+            .iter()
+            .filter(|b| **b < 9 || (**b > 13 && **b < 32))
+            .count()
+            * 20
+            < sample.len().max(1)
+}
+
+/// Cheap HTML → text for messages that only carry an HTML part: drop tags and
+/// collapse whitespace. Not a full renderer — enough to index the words.
+fn strip_html(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for c in html.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => {
+                in_tag = false;
+                out.push(' ');
+            }
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use std::io::Write;
+
+    fn run(eml: &[u8]) -> Vec<RawRecord> {
+        let mut tmp = tempfile::Builder::new().suffix(".eml").tempfile().unwrap();
+        tmp.write_all(eml).unwrap();
+        let mut out = Vec::new();
+        let mut sink = |r: RawRecord| {
+            out.push(r);
+            true
+        };
+        extract(tmp.path(), false, &mut sink).unwrap();
+        out
+    }
+
+    fn field<'a>(r: &'a RawRecord, k: &str) -> Option<&'a str> {
+        r.fields.get(k).and_then(|v| v.as_str())
+    }
+
+    /// Headers become fields, the body is decoded (quoted-printable + charset),
+    /// and NONE of the raw MIME/base64 leaks into the message body.
+    #[test]
+    fn parses_headers_and_decodes_body() {
+        let b64 = base64::engine::general_purpose::STANDARD.encode("secret plan attached");
+        let eml = format!(
+            "From: Dana Klein <dklein@amazon.com>\r\n\
+             To: Alex Rivard <alex@xerj.org>\r\n\
+             Subject: =?utf-8?q?Acquisition_=E2=80=94_next_steps?=\r\n\
+             Date: Tue, 15 Jul 2026 09:12:00 -0700\r\n\
+             Message-ID: <deal-1@amazon.com>\r\n\
+             MIME-Version: 1.0\r\n\
+             Content-Type: multipart/mixed; boundary=\"b1\"\r\n\
+             \r\n\
+             --b1\r\n\
+             Content-Type: text/plain; charset=utf-8\r\n\
+             Content-Transfer-Encoding: quoted-printable\r\n\
+             \r\n\
+             Alex =E2=80=94 let's move to a term sheet at $420M.\r\n\
+             --b1\r\n\
+             Content-Type: application/octet-stream; name=\"notes.txt\"\r\n\
+             Content-Transfer-Encoding: base64\r\n\
+             Content-Disposition: attachment; filename=\"notes.txt\"\r\n\
+             \r\n\
+             {b64}\r\n\
+             --b1--\r\n"
+        );
+        let recs = run(eml.as_bytes());
+        let msg = recs.iter().find(|r| r.locator.starts_with("msg-")).unwrap();
+        assert_eq!(
+            field(msg, "email_from"),
+            Some("Dana Klein <dklein@amazon.com>")
+        );
+        assert_eq!(
+            field(msg, "email_message_id"),
+            Some("deal-1@amazon.com").or(Some("<deal-1@amazon.com>"))
+        );
+        // Encoded-word subject decoded; em-dash present, no `=?utf-8?` left.
+        let subj = field(msg, "email_subject").unwrap();
+        assert!(
+            subj.contains("Acquisition") && subj.contains('\u{2014}'),
+            "subj: {subj}"
+        );
+        // Body decoded (QP `=E2=80=94` -> em-dash), no raw MIME.
+        let body = field(msg, "body").unwrap();
+        assert!(body.contains("term sheet at $420M"), "body: {body}");
+        assert!(
+            !body.contains("Content-Transfer-Encoding") && !body.contains("--b1"),
+            "MIME leaked: {body}"
+        );
+
+        // The attachment is its OWN record, decoded (not base64), linked to the email.
+        let att = recs
+            .iter()
+            .find(|r| field(r, "attachment_name") == Some("notes.txt"))
+            .unwrap();
+        assert_ne!(
+            att.locator, msg.locator,
+            "attachment must be a separate document"
+        );
+        assert_eq!(
+            field(att, "email_subject"),
+            field(msg, "email_subject"),
+            "attachment links to parent"
+        );
+        let att_body = field(att, "body").unwrap();
+        assert!(
+            att_body.contains("secret plan attached"),
+            "attachment body not decoded: {att_body}"
+        );
+    }
+
+    /// A non-text, non-PDF attachment gets a name/type/size card so it stays
+    /// discoverable, without indexing its bytes as noise.
+    #[test]
+    fn binary_attachment_gets_a_card() {
+        let bytes =
+            base64::engine::general_purpose::STANDARD.encode([0u8, 1, 2, 255, 254, 3, 9, 200]);
+        let eml = format!(
+            "From: a@x.org\r\nTo: b@x.org\r\nSubject: logo\r\nDate: Wed, 16 Jul 2026 10:00:00 -0700\r\n\
+             Message-ID: <m2@x.org>\r\nMIME-Version: 1.0\r\n\
+             Content-Type: multipart/mixed; boundary=\"z\"\r\n\r\n\
+             --z\r\nContent-Type: text/plain\r\n\r\nsee logo\r\n\
+             --z\r\nContent-Type: image/png; name=\"logo.png\"\r\n\
+             Content-Transfer-Encoding: base64\r\n\
+             Content-Disposition: attachment; filename=\"logo.png\"\r\n\r\n{bytes}\r\n--z--\r\n"
+        );
+        let recs = run(eml.as_bytes());
+        let card = recs
+            .iter()
+            .find(|r| field(r, "attachment_name") == Some("logo.png"))
+            .unwrap();
+        assert!(
+            card.locator.contains("card"),
+            "png should be a name card, got {}",
+            card.locator
+        );
+        assert!(
+            card.fields.get("body").is_none(),
+            "binary body must not be indexed"
+        );
+        assert_eq!(field(card, "attachment_content_type"), Some("image/png"));
+    }
+}

--- a/engine/crates/xerj-autoindex/src/extract/mod.rs
+++ b/engine/crates/xerj-autoindex/src/extract/mod.rs
@@ -6,6 +6,7 @@ pub mod bvh;
 pub mod code;
 pub mod csv_x;
 pub mod docx;
+pub mod eml;
 pub mod html;
 pub mod json;
 pub mod jsonl;
@@ -201,6 +202,7 @@ pub fn extract(
         Family::TxtProse => txt::extract_prose(path, sn.gzip, sink),
         Family::TxtLines => txt::extract_lines(path, sn.gzip, limit_bytes, sink),
         Family::Pdf => pdf::extract(path, sink),
+        Family::Eml => eml::extract(path, sn.gzip, sink),
         Family::Docx => docx::extract(path, sink),
         Family::Sqlite => sqlite_x::extract(path, limit_bytes.map(|_| 500), sink),
         Family::SqlDump => sqldump::extract(path, sn.gzip, limit_bytes, sink),

--- a/engine/crates/xerj-autoindex/src/order.rs
+++ b/engine/crates/xerj-autoindex/src/order.rs
@@ -181,9 +181,12 @@ pub fn band(rel: &str, family: Family) -> Band {
         return Band::Vendored;
     }
     match family {
-        Family::Code | Family::TxtProse | Family::Html | Family::Pdf | Family::Docx => {
-            Band::SourceAndDocs
-        }
+        Family::Code
+        | Family::TxtProse
+        | Family::Html
+        | Family::Pdf
+        | Family::Docx
+        | Family::Eml => Band::SourceAndDocs,
         Family::Yaml | Family::Json | Family::Xml => Band::Config,
         Family::Csv | Family::Jsonl | Family::Sqlite | Family::SqlDump => Band::Data,
         Family::Logs | Family::TxtLines => Band::Bulk,

--- a/engine/crates/xerj-autoindex/src/sniff.rs
+++ b/engine/crates/xerj-autoindex/src/sniff.rs
@@ -19,6 +19,10 @@ pub enum Family {
     TxtProse,
     TxtLines,
     Pdf,
+    /// RFC 5322 / MIME email message (`.eml`, `message/rfc822`): headers parsed
+    /// into fields, MIME decoded, and each attachment indexed as its own
+    /// document (PDFs routed to the PDF extractor).
+    Eml,
     Docx,
     Sqlite,
     SqlDump,
@@ -55,6 +59,7 @@ impl Family {
             Family::TxtProse => "txt-prose",
             Family::TxtLines => "txt-lines",
             Family::Pdf => "pdf",
+            Family::Eml => "eml",
             Family::Docx => "docx",
             Family::Sqlite => "sqlite",
             Family::SqlDump => "sqldump",
@@ -68,7 +73,10 @@ impl Family {
     }
     /// Document-family formats produce one record per document/section.
     pub fn is_document(&self) -> bool {
-        matches!(self, Family::Pdf | Family::Docx | Family::TxtProse)
+        matches!(
+            self,
+            Family::Pdf | Family::Docx | Family::TxtProse | Family::Eml
+        )
     }
 }
 
@@ -1033,6 +1041,14 @@ pub fn decode_text(bytes: &[u8]) -> (String, &'static str) {
 }
 
 fn classify_text(text: &str, nonblank: &[&str]) -> Family {
+    // Email wins first: an RFC 5322 message opens with a header block whose lines
+    // (`From:`/`Date:`/`Message-ID:`/…) would otherwise be misread as prose or a
+    // key:value log. Gated on a STRONG header plus >=3 canonical headers so an
+    // ordinary `key: value` config or YAML never trips it.
+    if looks_like_email(nonblank) {
+        return Family::Eml;
+    }
+
     // Structured families (JSON/HTML/XML/logs/SQL/CSV) win first, for the whole
     // file and — via the #551 frontmatter lookahead below — for a frontmatter
     // body too.
@@ -1093,6 +1109,88 @@ fn classify_text(text: &str, nonblank: &[&str]) -> Family {
     }
 
     txt_kind(nonblank)
+}
+
+/// Header name of an RFC 5322 header line (`From`, `Content-Type`, `X-Mailer`),
+/// or `None` if the line is not `Name: …` with an RFC 822 field name.
+fn header_name(line: &str) -> Option<&str> {
+    let colon = line.find(':')?;
+    let name = &line[..colon];
+    if name.is_empty()
+        || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        || !name.as_bytes()[0].is_ascii_alphabetic()
+    {
+        return None;
+    }
+    Some(name)
+}
+
+/// Does this text open like an email? Requires the first line to be a header, a
+/// STRONG header (`From`/`Date`/`Message-ID`/`Received`/…) somewhere in the
+/// opening block, and at least three canonical email headers total — enough to
+/// separate a real message from a `key: value` config that merely uses colons.
+fn looks_like_email(nonblank: &[&str]) -> bool {
+    const STRONG: &[&str] = &[
+        "from",
+        "date",
+        "message-id",
+        "received",
+        "return-path",
+        "delivered-to",
+        "dkim-signature",
+    ];
+    const KNOWN: &[&str] = &[
+        "from",
+        "to",
+        "cc",
+        "bcc",
+        "subject",
+        "date",
+        "message-id",
+        "received",
+        "return-path",
+        "reply-to",
+        "in-reply-to",
+        "references",
+        "mime-version",
+        "content-type",
+        "content-transfer-encoding",
+        "content-disposition",
+        "delivered-to",
+        "dkim-signature",
+        "sender",
+        "list-id",
+        "authentication-results",
+        "x-mailer",
+    ];
+    if !nonblank
+        .first()
+        .map(|l| header_name(l).is_some())
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    let mut strong = false;
+    let mut known = 0usize;
+    for line in nonblank.iter().take(50) {
+        // Folded continuation lines (leading whitespace) are part of the header
+        // block; the first line that is neither a header nor a fold is the body.
+        let is_fold = line.starts_with(' ') || line.starts_with('\t');
+        match header_name(line) {
+            Some(name) => {
+                let n = name.to_ascii_lowercase();
+                if KNOWN.contains(&n.as_str()) {
+                    known += 1;
+                }
+                if STRONG.contains(&n.as_str()) {
+                    strong = true;
+                }
+            }
+            None if is_fold => {}
+            None => break,
+        }
+    }
+    strong && known >= 3
 }
 
 /// The structured-family branches of [`classify_text`] — JSON/JSONL, HTML/XML,
@@ -1478,6 +1576,30 @@ mod unity_sniff_tests {
         sniff_bytes(s.as_bytes(), Path::new(name), Path::new(name), false)
             .unwrap()
             .family
+    }
+
+    /// A real RFC 5322 message classifies as `Eml`; a `key: value` config or a
+    /// YAML file that merely uses colons must NOT (the detector is gated on a
+    /// strong header plus >=3 canonical email headers).
+    #[test]
+    fn email_is_detected_but_config_is_not() {
+        let email = "From: Dana Klein <dklein@amazon.com>\n\
+                     To: Alex Rivard <alex@xerj.org>\n\
+                     Subject: Acquisition next steps\n\
+                     Date: Tue, 15 Jul 2026 09:12:00 -0700\n\
+                     Message-ID: <deal-1@amazon.com>\n\
+                     MIME-Version: 1.0\n\n\
+                     Alex, let's move to a term sheet.\n";
+        assert_eq!(sniff_str(email, "m.eml"), Family::Eml);
+
+        // A config with colons — one weak match ("subject"? no), no strong header.
+        let config = "name: myapp\nversion: 1.2.3\nport: 8080\ndebug: true\n";
+        assert_ne!(sniff_str(config, "app.yml"), Family::Eml);
+
+        // Even a file that happens to have `to:`/`from:` keys but no strong
+        // header and <3 canonical headers stays out.
+        let sneaky = "to: the moon\nsubject: rockets\ncargo: fuel\n";
+        assert_ne!(sniff_str(sneaky, "notes.txt"), Family::Eml);
     }
 
     #[test]


### PR DESCRIPTION
## What

Makes email a first-class indexed format. Before, `.eml` files fell through to the prose extractor: headers were dumped as body text, MIME was left raw, base64 attachments were indexed verbatim as gibberish, and one message exploded into many noise records.

## How

New `extract/eml.rs` (uses `mail-parser` 0.11):
- **Headers → fields**: `email_from`/`email_to`/`email_cc`/`email_subject`/`email_date`/`email_message_id`/`email_in_reply_to`, decoding encoded-words + charset.
- **Body decoded**: quoted-printable/base64, prefers `text/plain`, else strips the HTML part. No MIME/base64 leaks into the body.
- **Attachments indexed SEPARATELY**, each linked to the parent email:
  - **PDF** → routed through the real PDF extractor → per-page records (`att<n>-p1`, `att<n>-p2`, …)
  - **text** → sectioned as a document
  - **other** → a name/type/size card so it stays discoverable
- **Sniff**: detects email by content (first line is a header + a strong header like `From`/`Date`/`Message-ID` + ≥3 canonical headers), gated so a `key: value` config or YAML never trips it.

`Family::Eml` wired into the extractor dispatch, band ordering (SourceAndDocs), and the estimate read-model.

## Verified

- Unit: header/QP/encoded-word decode, text attachment as a separate decoded record, binary attachment → name card, sniff detects email but not config.
- End-to-end: an email carrying a 2-page PDF term sheet indexes as the message record **plus** `att0-p1-s0` / `att0-p2-s0` page records — each searchable (`"founder vesting resets retention pool"` → the PDF page 2 record) and linked to the email.

All `extract::` (218) and `sniff::` (53) tests pass; fmt + clippy `--all-targets` clean.

## Dependency

Adds `mail-parser` 0.11.9 (MIT/Apache-2.0) to xerj-autoindex, and `base64` as a dev-dependency for tests.