### PR TITLE
Add winklemad to .contributors (sign the CLA)

### DIFF
--- a/.contributors
+++ b/.contributors
@@ -6,5 +6,6 @@
   "pradaev",
   "SebTardif",
   "Nicolas0315",
-  "MavenRain"
+  "MavenRain",
+  "winklemad"
 ]


### PR DESCRIPTION
I have read [CLA.md](https://github.com/xerj-org/xerj/blob/main/CLA.md) and agree to it. This PR from my own account (@winklemad) is my signature, per the process the CLA bot describes on #920.

Adds my GitHub username to `.contributors`. This unblocks #920 (`fix: convert 12 AM to hour 0 in the 12-hour date format`).